### PR TITLE
V1.1 refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.1.0",
+  "version": "1.1.5",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",
@@ -143,6 +143,5 @@
   "bin": {
     "check-react-version": "./scripts/check-react-version.mjs",
     "patch": "./bin/patch.mjs"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/plugin/config/autoDiscover/resolveBuildPages.ts
+++ b/plugin/config/autoDiscover/resolveBuildPages.ts
@@ -11,7 +11,7 @@ export async function resolveBuildPages({
   userOptions,
 }: {
   pages: string[];
-  userOptions: Pick<ResolvedUserOptions, "Page" | "props" | "build" | "moduleBase" | "projectRoot" | "normalizer">;
+  userOptions: Pick<ResolvedUserOptions, "Page" | "props" | "build" | "moduleBase" | "projectRoot" | "normalizer" | "moduleBasePath">;
 }): Promise<ResolvedBuildPages> {
   // Check if pages array has changed
   const pagesChanged =

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -374,9 +374,7 @@ export const resolveOptions = <
 
   const moduleRootPath =
     typeof options.moduleRootPath === "string"
-      ? options.moduleRootPath.startsWith(projectRoot)
-        ? options.moduleRootPath
-        : join(projectRoot, options.moduleRootPath)
+      ? options.moduleRootPath
       : join(projectRoot, outDir, client)
   // Worker and loader paths
   const rscWorkerPath =

--- a/plugin/config/resolveUrlOption.ts
+++ b/plugin/config/resolveUrlOption.ts
@@ -1,29 +1,38 @@
-import type { ResolvedUserOptions } from '../types.js';
+import type { ResolvedUserOptions } from "../types.js";
 
 type ResolvePageAndPropsOptionsSuccess<T extends "Page" | "props"> = {
   [optionName in T]: string;
-} & {type: "success"; error?:never}
+} & { type: "success"; error?: never };
 
 type ResolvePageAndPropsOptionsError<T extends "Page" | "props"> = {
   [optionName in T]?: never;
-} & { type: "error"; error: Error }
+} & { type: "error"; error: Error };
 
 export async function resolveUrlOption<T extends "Page" | "props">(
-  options: Pick<ResolvedUserOptions, T>,
+  options: Pick<ResolvedUserOptions, T | "moduleBasePath">,
   optionName: T,
   url: string
-): Promise<ResolvePageAndPropsOptionsSuccess<T> | ResolvePageAndPropsOptionsError<T>> {
+): Promise<
+  ResolvePageAndPropsOptionsSuccess<T> | ResolvePageAndPropsOptionsError<T>
+> {
   try {
     switch (typeof options[optionName]) {
       case "function":
-        const result = options[optionName](url);
-        if(typeof result === "string") {
+        const result = options[optionName](
+          // quick normalization to make it easier to work with dynamic moduleBasePaths (so that you don't have to change the Page/props function)
+          options.moduleBasePath !== "" &&
+            options.moduleBasePath !== "/" &&
+            url.startsWith(options.moduleBasePath)
+            ? url.slice(options.moduleBasePath.length)
+            : url
+        );
+        if (typeof result === "string") {
           return { type: "success", [optionName]: result };
         }
-        if(result instanceof Promise) {
+        if (result instanceof Promise) {
           try {
             const promiseResult = await result;
-            if(typeof promiseResult === "string") {
+            if (typeof promiseResult === "string") {
               return { type: "success", [optionName]: promiseResult };
             }
           } catch (error) {
@@ -40,4 +49,4 @@ export async function resolveUrlOption<T extends "Page" | "props">(
   } catch (error) {
     return { type: "error", error: error as Error };
   }
-} 
+}

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -174,7 +174,7 @@ export function resolveUserConfig({
         "process.env.VITE_DEV": `"${mode === "development" ? "1" : "0"}"`,
         "process.env.VITE_PROD": `"${mode === "production" ? "1" : "0"}"`,
         "process.env.VITE_MODE": `"${mode}"`,
-        "process.env.VITE_BASE": `"${
+        "process.env.VITE_BASE_URL": `"${
           userOptions.moduleBasePath === "" ||
           userOptions.moduleBasePath === "/"
             ? "/"

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -34,7 +34,7 @@ export function resolveUserConfig({
       : Boolean(configEnv.isSsrBuild) || condition === "react-server";
   const envDir =
     condition === "react-client" && ssr
-      ? userOptions.build.client
+      ? join(userOptions.build.client, userOptions.moduleBasePath)
       : condition === "react-client"
       ? userOptions.build.static
       : userOptions.build.server;
@@ -101,6 +101,7 @@ export function resolveUserConfig({
       ...config,
       root: root,
       mode: mode,
+      base: userOptions.moduleBasePath,
       resolve: {
         ...config.resolve,
         external: config.resolve?.external ?? [
@@ -160,15 +161,32 @@ export function resolveUserConfig({
       ...config,
       root: root,
       mode: mode,
+      base: userOptions.moduleBasePath,
       resolve: {
         ...config.resolve,
         externalConditions: config.resolve?.externalConditions ?? [
           "react-server",
         ],
       },
+      define: {
+        ...config.define,
+        "process.env.VITE_SSR": `"1"`,
+        "process.env.VITE_DEV": `"${mode === "development" ? "1" : "0"}"`,
+        "process.env.VITE_PROD": `"${mode === "production" ? "1" : "0"}"`,
+        "process.env.VITE_MODE": `"${mode}"`,
+        "process.env.VITE_BASE": `"${
+          userOptions.moduleBasePath === "" ||
+          userOptions.moduleBasePath === "/"
+            ? "/"
+            : !userOptions.moduleBasePath.endsWith("/")
+            ? userOptions.moduleBasePath + "/"
+            : userOptions.moduleBasePath
+        }"`,
+      },
       ssr: {
         ...config.ssr,
         target: config.ssr?.target ?? "node",
+
         resolve: {
           ...config.ssr?.resolve,
           externalConditions: config.ssr?.resolve?.externalConditions ?? [

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -34,7 +34,7 @@ export function resolveUserConfig({
       : Boolean(configEnv.isSsrBuild) || condition === "react-server";
   const envDir =
     condition === "react-client" && ssr
-      ? join(userOptions.build.client, userOptions.moduleBasePath)
+      ? userOptions.build.client
       : condition === "react-client"
       ? userOptions.build.static
       : userOptions.build.server;

--- a/plugin/helpers/createRscStream.tsx
+++ b/plugin/helpers/createRscStream.tsx
@@ -1,6 +1,6 @@
 import { React, ReactDOMServer } from "../vendor.server.js";
 import type { CreateHandlerOptions, StreamMetrics } from "../types.js";
-
+import { join } from "node:path";
 export function createRscStream<
   T,
   C extends React.ComponentType<T>,
@@ -45,7 +45,7 @@ export function createRscStream<
   const startTime = performance.now()
   const htmlIsFragment = Html == React.Fragment;
   const url =
-    moduleBaseURL !== "" ? new URL(route, moduleBaseURL).toString() : route;
+    moduleBaseURL !== "" ? new URL(join(route, moduleBasePath), moduleBaseURL).toString() : route;
   let errorCount = 0;
   let streamError: Error | null = null;
 

--- a/plugin/helpers/requestToRoute.ts
+++ b/plugin/helpers/requestToRoute.ts
@@ -1,0 +1,23 @@
+import type { CreateHandlerOptions } from "../types.js";
+
+export function requestToRoute(
+  req: {url?: string},
+  handlerOptions: Pick<CreateHandlerOptions, "moduleBasePath" | "build">
+) {
+  let route = req.url?.replace("/" + handlerOptions.build.rscOutputPath, "");
+  if (typeof route !== "string") {
+    return route;
+  }
+  if (
+    route.startsWith(handlerOptions.moduleBasePath)
+  ) {
+    route = route.slice(handlerOptions.moduleBasePath.length);
+  }
+  if (!route || route === "") {
+    route = "/";
+  }
+  if (!route.startsWith("/")) {
+    route = "/" + route;
+  }
+  return route;
+}

--- a/plugin/html.tsx
+++ b/plugin/html.tsx
@@ -6,9 +6,11 @@ export const Html = ({
   CssCollector,
   cssFiles,
   globalCss,
+  moduleBasePath,
 }: React.PropsWithChildren<HtmlProps>) => (
   <html>
     <head>
+      {moduleBasePath !== "" && <base href={moduleBasePath} />}
       <CssCollectorElements cssFiles={globalCss} />
     </head>
     <body>

--- a/plugin/react-client/plugin.ts
+++ b/plugin/react-client/plugin.ts
@@ -76,6 +76,7 @@ export function reactClientPlugin(options: StreamPluginOptions): Plugin {
     async configureServer(server) {
       // Create HMR message channel
       hmrChannel = new MessageChannel();
+
       await configureWorkerRequestHandler({
         server,
         autoDiscoveredFiles,

--- a/plugin/react-client/server.ts
+++ b/plugin/react-client/server.ts
@@ -8,7 +8,6 @@ import type {
   RscWorkerOutputMessage,
   RscRenderMessage,
 } from "../worker/types.js";
-import { join } from "node:path";
 import type { Worker as NodeWorker } from "node:worker_threads";
 import { MessageChannel } from "node:worker_threads";
 import {
@@ -17,6 +16,7 @@ import {
 } from "../helpers/serializeUserOptions.js";
 import { createWorker } from "../worker/createWorker.js";
 import { getRouteFiles } from "../helpers/getRouteFiles.js";
+import { requestToRoute } from "../helpers/requestToRoute.js";
 
 let currentWorker: NodeWorker | null = null;
 let isRestarting = false;
@@ -169,7 +169,7 @@ export function handleWorkerRscStream(
 export async function configureWorkerRequestHandler({
   server,
   autoDiscoveredFiles,
-  userOptions,
+  userOptions: _userOptions,
   hmrChannel,
 }: {
   server: ViteDevServer;
@@ -177,15 +177,30 @@ export async function configureWorkerRequestHandler({
   userOptions: ResolvedUserOptions;
   hmrChannel: MessageChannel;
 }) {
-  if(server.config.root !== userOptions.projectRoot) {
-    server.config.logger.error("[react-client] Project root mismatch", {
-      error: new Error(`Server root ${server.config.root} does not match user options root ${userOptions.projectRoot}`)
-    });
-    return;
-  }
+  let {
+    // remove these
+    moduleBaseURL: _moduleBaseURL,
+    projectRoot: _projectRoot,
+    ...handlerUserOptions
+  } = _userOptions;
+  const handlerOptions = Object.assign({}, handlerUserOptions, {
+    moduleBaseURL:
+      typeof server.config.server.host === "string"
+        ? `${server.config.server.https ? "https" : "http"}://${
+            server.config.server.host
+          }:${server.config.server.port}`
+        : "",
+    moduleBasePath:
+      server.config.base === "/"
+        ? ""
+        : server.config.base.endsWith("/")
+        ? server.config.base.slice(0, -1)
+        : server.config.base,
+    projectRoot: server.config.root,
+  });
 
   // Start the worker
-  await restartWorker(server, autoDiscoveredFiles, userOptions, hmrChannel);
+  await restartWorker(server, autoDiscoveredFiles, handlerOptions, hmrChannel);
 
   // Create the request handler
   const handler: RequestHandler = async (req, res, next) => {
@@ -197,18 +212,24 @@ export async function configureWorkerRequestHandler({
       }
 
       // Get the route from the request
-      let route = req.url;
-      if (!route || route === "") route = "/";
+      let route = requestToRoute(req, {
+        moduleBasePath: handlerOptions.moduleBasePath,
+        build: handlerOptions.build
+      });
+      if (!route) {
+        return next();
+      }
       // in the case of the no build.pages and a async Page and or props userOption, we need to await those
       // if they are already autoDiscovered then the promise will resolve immediately
       const routeFiles = await getRouteFiles(
         route,
         autoDiscoveredFiles,
-        userOptions
+        handlerOptions
       );
       if (routeFiles.type === "error") {
-        server.config.logger.error("[react-client] Error getting route files", {
+        server.config.logger.error(routeFiles.error.message, {
           error: routeFiles.error,
+          timestamp: true,
         });
         return next();
       }
@@ -218,12 +239,8 @@ export async function configureWorkerRequestHandler({
       res.setHeader("Content-Type", "text/x-component; charset=utf-8");
       res.setHeader("Transfer-Encoding", "chunked");
       res.setHeader("Connection", "keep-alive");
-      let timeout = setTimeout(() => {
-        server.config.logger.error("[react-client] RSC render timeout");
-        res.end();
-      }, 5000);
       const serializedUserOptions = serializedOptions(
-        userOptions,
+        handlerOptions,
         autoDiscoveredFiles
       );
       const stream = handleWorkerRscStream(currentWorker, {
@@ -234,37 +251,42 @@ export async function configureWorkerRequestHandler({
         propsPath: props,
         // override these at all times to ensure the settings will work for the dev server
         projectRoot: server.config.root,
-        moduleRootPath: join(server.config.root, userOptions.moduleBase),
-        moduleBaseURL: "",
-        moduleBasePath: "",
         build: serializedUserOptions.build,
         manifest: autoDiscoveredFiles.staticManifest,
         cssFiles: new Map(),
         globalCss: new Map(),
       });
+      const writeStream = new WritableStream({
+        write(chunk) {
+          res.write(chunk);
+        },
+
+        close() {
+          clearTimeout(timeout);
+          res.end();
+        },
+        abort() {
+          clearTimeout(timeout);
+          // Restart worker on error
+          restartWorker(
+            server,
+            autoDiscoveredFiles,
+            handlerOptions,
+            hmrChannel
+          );
+          res.end();
+        },
+      })
+      let timeout = setTimeout(() => {
+        server.config.logger.error("[react-client] RSC render timeout");
+        res.end();
+      }, 5000);
 
       // Pipe the stream to the response
-      stream.pipeTo(
-        new WritableStream({
-          write(chunk) {
-            res.write(chunk);
-          },
-
-          close() {
-            clearTimeout(timeout);
-            res.end();
-          },
-          abort() {
-            clearTimeout(timeout);
-            // Restart worker on error
-            restartWorker(server, autoDiscoveredFiles, userOptions, hmrChannel);
-            res.end();
-          },
-        })
-      );
+      stream.pipeTo(writeStream);
     } catch (error) {
       if (error instanceof Error) {
-        server.config.logger.error("[react-client] Error handling request", {
+        server.config.logger.error(error.message, {
           error,
         });
       }

--- a/plugin/react-server/server.ts
+++ b/plugin/react-server/server.ts
@@ -1,4 +1,4 @@
-import type {  Manifest, ViteDevServer } from "vite";
+import type { Manifest, ViteDevServer } from "vite";
 import type { ServerResponse } from "http";
 import type { AutoDiscoveredFiles, ResolvedUserOptions } from "../types.js";
 import { createEventHandler } from "../helpers/createEventHandler.js";
@@ -10,7 +10,7 @@ import React from "react";
 export async function configureReactServer({
   server,
   autoDiscoveredFiles,
-  userOptions,
+  userOptions: _userOptions,
   serverManifest,
 }: {
   server: ViteDevServer;
@@ -20,6 +20,31 @@ export async function configureReactServer({
 }) {
   const activeStreams = new Set<ServerResponse>();
 
+  const {
+    Html: _UserHtmlComponent,
+    onEvent,
+    // remove these
+    moduleBaseURL: _moduleBaseURL,
+    moduleBasePath: _moduleBasePath,
+    projectRoot: _projectRoot,
+    ...handlerUserOptions
+  } = _userOptions;
+
+  const handlerOptions = Object.assign({}, handlerUserOptions, {
+    moduleBaseURL:
+      typeof server.config.server.host === "string"
+        ? `${server.config.server.https ? "https" : "http"}://${
+            server.config.server.host
+          }:${server.config.server.port}`
+        : "",
+    moduleBasePath:
+      server.config.base === "/"
+        ? ""
+        : server.config.base.endsWith("/")
+        ? server.config.base.slice(0, -1)
+        : server.config.base,
+    projectRoot: server.config.root,
+  });
   // Handle Vite server restarts
   server.ws.on("restart", (path) => {
     console.log(
@@ -41,9 +66,20 @@ export async function configureReactServer({
   server.middlewares.use(async (req, res, next) => {
     try {
       if (req.headers.accept !== "text/x-component") return next();
-      let route = req.url?.replace('/'+userOptions.build.rscOutputPath, "");
+      let route = req.url?.replace("/" + handlerOptions.build.rscOutputPath, "");
+      if(!route?.startsWith(handlerOptions.moduleBasePath)) {
+        next();
+      } else {
+        route  = route.slice(handlerOptions.moduleBasePath.length);
+      }
+      if(typeof route !== "string" ) {
+        throw new Error("req.url is not a string");
+      }
       if (!route || route === "") {
         route = "/";
+      }
+      if(!route.startsWith("/")) {
+        route = "/" + route;
       }
       if (!autoDiscoveredFiles.urlMap.has(route)) {
         return next();
@@ -52,26 +88,19 @@ export async function configureReactServer({
       const pagePath = routeFiles.page;
       const propsPath = routeFiles.props;
 
-      const {
-        Html: _UserHtmlComponent,
-        onEvent,
-        // remove these
-        moduleBaseURL,
-        ...handlerUserOptions
-      } = userOptions;
       // Create a unified event handler
       await server.warmupRequest(pagePath);
       const eventHandler = createEventHandler(onEvent);
       const cssFilesResult = await collectViteModuleGraphCss({
         moduleGraph: server.moduleGraph,
         pagePath,
-        loader: (i)=>server.ssrLoadModule(i, {fixStacktrace: true}),
-        // explicitly set to empty string, because we let vite handle the resolving during development
-        moduleBaseURL: "",
-        moduleBasePath: userOptions.moduleBasePath,
-        moduleRootPath: userOptions.moduleRootPath,
-        projectRoot: userOptions.projectRoot,
-        css: userOptions.css,
+        loader: (i) => server.ssrLoadModule(i, { fixStacktrace: true }),
+        // explicitly set for development server
+        moduleBaseURL: handlerOptions.moduleBaseURL,
+        moduleBasePath: handlerOptions.moduleBasePath,
+        moduleRootPath: handlerOptions.moduleRootPath,
+        projectRoot: handlerOptions.projectRoot,
+        css: handlerOptions.css,
         parentUrl: pagePath,
       });
       if (cssFilesResult.type === "skip") {
@@ -85,8 +114,8 @@ export async function configureReactServer({
         propsPath,
         route,
         loader: server.ssrLoadModule,
-        pageExportName: userOptions.pageExportName ?? "default",
-        propsExportName: userOptions.propsExportName ?? "default",
+        pageExportName: handlerOptions.pageExportName ?? "default",
+        propsExportName: handlerOptions.propsExportName ?? "default",
       });
       if (pageAndPropsResult.type === "error") {
         throw pageAndPropsResult.error;
@@ -95,9 +124,9 @@ export async function configureReactServer({
         return next();
       }
       const { PageComponent, pageProps } = pageAndPropsResult;
-      // Create the headless RSC stream directly
+      // Create the headless RSC stream directly;
       const rscResult = await createHandler({
-        ...handlerUserOptions,
+        ...handlerOptions,
         PageComponent: PageComponent,
         pageProps: pageProps,
         logger: server.config.logger,
@@ -110,8 +139,6 @@ export async function configureReactServer({
         pagePath,
         propsPath,
         cssFiles: cssFilesResult.cssFiles ?? new Map(),
-        // explicitly set to empty string, because we let vite handle the resolving during development
-        moduleBaseURL: "",
         globalCss: new Map(),
       });
       if (rscResult.type === "success") {

--- a/plugin/react-static/plugin.ts
+++ b/plugin/react-static/plugin.ts
@@ -161,8 +161,7 @@ export function reactStaticPlugin(options: StreamPluginOptions): VitePlugin<{
           root: userOptions.projectRoot,
           outDir: join(
             userOptions.build.outDir,
-            userOptions.build.client,
-            userOptions.moduleBasePath
+            userOptions.build.client
           ),
           ssrManifest: false,
         });

--- a/plugin/react-static/plugin.ts
+++ b/plugin/react-static/plugin.ts
@@ -138,6 +138,7 @@ export function reactStaticPlugin(options: StreamPluginOptions): VitePlugin<{
       timing.renderStart = Date.now();
     },
 
+
     async writeBundle(options, bundle) {
       try {
         const bundleManifest = getBundleManifest<false>({
@@ -158,7 +159,11 @@ export function reactStaticPlugin(options: StreamPluginOptions): VitePlugin<{
 
         const clientManifestResult = await tryManifest({
           root: userOptions.projectRoot,
-          outDir: join(userOptions.build.outDir, userOptions.build.client),
+          outDir: join(
+            userOptions.build.outDir,
+            userOptions.build.client,
+            userOptions.moduleBasePath
+          ),
           ssrManifest: false,
         });
         if (clientManifestResult.type === "error") {
@@ -268,7 +273,16 @@ export function reactStaticPlugin(options: StreamPluginOptions): VitePlugin<{
         const pipeableStreamOptions = {
           ...userOptions.pipeableStreamOptions,
           bootstrapModules: [
-            ...(indexHtml ? [indexHtml] : []),
+            ...(indexHtml
+              ? [
+                  userOptions.moduleBaseURL !== ""
+                    ? new URL(
+                        join(userOptions.moduleBasePath, indexHtml),
+                        userOptions.moduleBaseURL
+                      ).href
+                    : join(userOptions.moduleBasePath, indexHtml),
+                ]
+              : []),
             ...(userOptions.pipeableStreamOptions?.bootstrapModules ?? []),
           ],
         };
@@ -279,31 +293,37 @@ export function reactStaticPlugin(options: StreamPluginOptions): VitePlugin<{
         );
         // Create worker
         if (!worker) {
+          const viteEnvPrefix = typeof resolvedConfig.envPrefix === 'string' ? resolvedConfig.envPrefix : Array.isArray(resolvedConfig.envPrefix) ? resolvedConfig.envPrefix[0] : 'VITE_'
           const workerResult = await createWorker({
             projectRoot: userOptions.projectRoot,
             workerPath: userOptions.htmlWorkerPath,
             currentCondition: "react-server",
             reverseCondition: "react-client",
+            envPrefix: viteEnvPrefix,
             workerData: {
               resolvedConfig: serializeResolvedConfig(resolvedConfig),
-              userOptions: serializedUserOptions,
+              userOptions: {
+                ...serializedUserOptions,
+              },
             },
           });
           if (workerResult.type === "error") {
             throw workerResult.error;
           } else if (workerResult.type === "skip") {
-            this.environment.logger.info("Worker not created, skipping static build");
+            this.environment.logger.info(
+              "Worker not created, skipping static build"
+            );
             return;
           } else {
             worker = workerResult.worker;
           }
         }
         // Render pages
-        const { onEvent, ...rest } = userOptions;
+        const { onEvent, ...handlerOptions } = userOptions;
         const renderPagesGenerator = renderPages(
           autoDiscoveredFiles!,
           {
-            ...rest,
+            ...handlerOptions,
             loader: buildLoader,
             worker: worker,
             logger: createLogger(),
@@ -329,7 +349,7 @@ export function reactStaticPlugin(options: StreamPluginOptions): VitePlugin<{
             },
             globalCss: globalCss,
           },
-          cssFilesByPage,
+          cssFilesByPage
         );
 
         // Process render results
@@ -344,11 +364,13 @@ export function reactStaticPlugin(options: StreamPluginOptions): VitePlugin<{
         if (!finalResult) {
           throw new Error("No render result produced");
         }
-        finalResult.streamMetrics.duration = Math.round(performance.now() - finalResult.streamMetrics.startTime);
-        
-      this.environment.logger.info(`Rendered ${finalResult.completedRoutes.size} unique routes in ${
-        finalResult.streamMetrics.duration
-      }ms`);
+        finalResult.streamMetrics.duration = Math.round(
+          performance.now() - finalResult.streamMetrics.startTime
+        );
+
+        this.environment.logger.info(
+          `Rendered ${finalResult.completedRoutes.size} unique routes in ${finalResult.streamMetrics.duration}ms`
+        );
 
         // Update timing
         timing.render = Date.now() - (timing.renderStart ?? timing.start);

--- a/plugin/react-static/renderPage.ts
+++ b/plugin/react-static/renderPage.ts
@@ -44,7 +44,6 @@ export async function* renderPage(
     } satisfies CreateHandlerOptions;
     // Create streams with CSS files
     const [rscFull, rscHeadless] = await renderStreams(newHandlerOptions);
-
     // Handle stream creation errors
     if (rscFull.type !== "success") {
       yield {

--- a/plugin/transformer/plugin.client.ts
+++ b/plugin/transformer/plugin.client.ts
@@ -37,6 +37,15 @@ export function reactTransformPlugin(options: StreamPluginOptions): Plugin {
   if (resolvedOptionsResult.type === "error") throw resolvedOptionsResult.error;
   userOptions = resolvedOptionsResult.userOptions;
   let staticManifest: Manifest;
+  const getID = (id: string) => {
+    if(userOptions.moduleBasePath !== '' && !id.startsWith(userOptions.moduleBasePath)) {
+      id = join(userOptions.moduleBasePath, id);
+    }
+    if(!id.startsWith('/')) {
+      id = '/' + id;
+    }
+    return id;
+  }
   return {
     name: "vite:react-server-action-transform",
     enforce: "pre",
@@ -73,13 +82,14 @@ export function reactTransformPlugin(options: StreamPluginOptions): Plugin {
       }
       if (isServer && isBuild) {
         const [key] = userOptions.normalizer(id);
-        id = "/" + key + ".js";
+        id = key + ".js";
       }
-      const transformed = await transformModuleIfNeeded(code, id, null);
+      const finalID = getID(id);
+      const transformed = await transformModuleIfNeeded(code, finalID, null);
       if (!transformed) return null;
       return {
         code: transformed,
-        id: id,
+        id: finalID,
         map: null,
       };
     },

--- a/plugin/transformer/plugin.server.ts
+++ b/plugin/transformer/plugin.server.ts
@@ -38,6 +38,15 @@ export function reactTransformPlugin(options: StreamPluginOptions): Plugin {
 
   let staticManifest: Manifest;
 
+  const getID = (id: string) => {
+    if(userOptions.moduleBasePath !== '' && !id.startsWith(userOptions.moduleBasePath)) {
+      id = join(userOptions.moduleBasePath, id);
+    }
+    if(!id.startsWith('/')) {
+      id = '/' + id;
+    }
+    return id;
+  }
   return {
     name: "vite:react-server-transform",
     enforce: "pre", // Run before Vite's transforms
@@ -59,12 +68,12 @@ export function reactTransformPlugin(options: StreamPluginOptions): Plugin {
       if (!ssr) return null;
       if (!userOptions.autoDiscover.modulePattern(id)) return null;
       if (!code.match('"use client"')) return null;
-
+    
       if (isBuild) {
         const [key, value] = userOptions.normalizer(id);
         if (staticManifest) {
           if (value in staticManifest) {
-            id = '/' + staticManifest[value].file;
+            id = staticManifest[value].file
           } else {
             const hash = this.emitFile({
               id,
@@ -75,15 +84,16 @@ export function reactTransformPlugin(options: StreamPluginOptions): Plugin {
             // get fileName from hash
 
             const fileName = this.getFileName(hash);
-            id = '/' + fileName;
+            id = fileName;
           }
         } else {
           throw new Error(`Client manifest not found.`);
         }
       }
+      const finalID = getID(id);
       const transformed = await transformModuleIfNeeded(
         code,
-        id,
+        finalID,
         // Pass null for nextLoad since we don't need module loading in the plugin
         null
       );

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -95,7 +95,7 @@ export async function createWorker(
       [envPrefix + "MODE"]: mode,
       [envPrefix + "PROD"]: mode === "production" ? "1" : "0",
       [envPrefix + "SSR"]: "true",
-      [envPrefix + "BASE"]:
+      [envPrefix + "BASE_URL"]:
         options.workerData.userOptions.moduleBasePath === "" ||
         options.workerData.userOptions.moduleBasePath === "/"
           ? "/"

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -1,7 +1,7 @@
 import {
   Worker,
   type ResourceLimits,
-  type TransferListItem
+  type TransferListItem,
 } from "node:worker_threads";
 import { getMode, getNodePath } from "../config/getPaths.js";
 import { getCondition } from "../config/getCondition.js";
@@ -14,6 +14,7 @@ export type CreateWorkerOptions = {
   currentCondition?: "react-server" | "react-client";
   nodePath?: string;
   nodeOptions?: string[];
+  envPrefix?: string;
   mode?: "production" | "development";
   reverseCondition?: string;
   maxListeners?: number;
@@ -50,6 +51,7 @@ export async function createWorker(
     projectRoot = process.cwd(),
     nodePath = getNodePath(projectRoot),
     currentCondition = getCondition(),
+    envPrefix = "VITE_",
     reverseCondition = currentCondition === "react-server"
       ? "react-client"
       : "react-server",
@@ -61,7 +63,7 @@ export async function createWorker(
       maxYoungGenerationSizeMb: 64,
     },
     htmlChunkSize = 8 * 1024,
-    transferList = []
+    transferList = [],
   } = options;
   let workerPathWithDefault =
     typeof workerPath === "string" ? workerPath : undefined;
@@ -78,20 +80,10 @@ export async function createWorker(
   // Ensure worker uses the same React version
   const workerData = {
     ...options.workerData,
-    importMeta: {
-      env: {
-        DEV: mode === 'development' ? 'true' : 'false',
-        MODE: mode,
-        PROD: mode === 'production' ? 'true' : 'false',
-        SSR: true,
-        BASE_URL: '/',
-      },
-    },
     reactVersion: React.version,
   };
 
   try {
-
     // Ensure consistent NODE_ENV between main thread and worker
     const isTestEnv =
       process.env["VITEST"] || process.env["NODE_ENV"] === "test";
@@ -99,12 +91,17 @@ export async function createWorker(
 
     const env = {
       ...process.env,
-      BASE_URL: '/',
-      VITE_DEV: mode === 'development' ? '1' : '0',
-      VITE_MODE: mode,
-      VITE_PROD: mode === 'production' ? '1' : '0',
-      VITE_SSR: 'true',
-      VITE_BASE_URL: '/',
+      [envPrefix + "DEV"]: mode === "development" ? "1" : "0",
+      [envPrefix + "MODE"]: mode,
+      [envPrefix + "PROD"]: mode === "production" ? "1" : "0",
+      [envPrefix + "SSR"]: "true",
+      [envPrefix + "BASE"]:
+        options.workerData.userOptions.moduleBasePath === "" ||
+        options.workerData.userOptions.moduleBasePath === "/"
+          ? "/"
+          : !options.workerData.userOptions.moduleBasePath.endsWith("/")
+          ? options.workerData.userOptions.moduleBasePath + "/"
+          : options.workerData.userOptions.moduleBasePath,
       NODE_ENV: nodeEnv,
       NODE_PATH: nodePath,
       NODE_OPTIONS: process.env["NODE_OPTIONS"]?.includes(reverseCondition)
@@ -140,10 +137,12 @@ export async function createWorker(
         worker.once("message", (msg) => {
           if (msg.type === "READY") {
             clearTimeout(timeout);
-            if(msg.env !== nodeEnv) {
+            if (msg.env !== nodeEnv) {
               reject({
                 type: "error",
-                error: new Error(`Worker environment mismatch: ${msg.env} !== ${nodeEnv}`),
+                error: new Error(
+                  `Worker environment mismatch: ${msg.env} !== ${nodeEnv}`
+                ),
                 workerPath: workerPathWithDefault,
               } satisfies CreateWorkerError);
             }
@@ -185,4 +184,3 @@ export async function createWorker(
     return error as CreateWorkerError;
   }
 }
-


### PR DESCRIPTION
Final clean up and double check that using the github pages workflow from "the official demo", you can see all the trial and errors there. I might make those callServer and createReactFetcher part of the plugin, since users aren't supposed to use react-server-dom-esm/client.browser directly, as it is for meta frameworks only, and this is kind of becoming one. And it's working! yay.. some final thoughts, for later reference, here's the output:
```sh
~/code/bidoof-template$ npm run build

> vite-plugin-react-server-demo-official@1.0.0 build
> npm run build:static && npm run build:client && npm run build:server


> vite-plugin-react-server-demo-official@1.0.0 build:static
> vite build

vite v6.3.2 building for production...
✓ 39 modules transformed.
dist/static/index.html                                     0.49 kB │ gzip:  0.27 kB
dist/static/.vite/manifest.json                            2.58 kB │ gzip:  0.55 kB
dist/static/.vite/ssr-manifest.json                        2.73 kB │ gzip:  0.48 kB
dist/static/css/globalStyles-3TIGQ31r.css                  0.10 kB │ gzip:  0.11 kB
dist/static/css/404-BDoW3a6w.css                           0.19 kB │ gzip:  0.16 kB
dist/static/css/home-B6hRzeLR.css                          0.43 kB │ gzip:  0.24 kB
dist/static/css/bidoof-DTqseNx_.css                        0.56 kB │ gzip:  0.30 kB
dist/static/css/404.module-Wi6ObHFF.js                     0.08 kB │ gzip:  0.08 kB
dist/static/server-DB4S1P1H.js                             0.13 kB │ gzip:  0.13 kB
dist/static/css/home.module-S0-KudVn.js                    0.14 kB │ gzip:  0.13 kB
dist/static/css/bidoof.module-BhOHy9Kd.js                  0.23 kB │ gzip:  0.16 kB
dist/static/components/Counter.client-CHp9Zt0j.js          0.25 kB │ gzip:  0.20 kB
dist/static/_ErrorMessage-og0BIAd5.js                      0.26 kB │ gzip:  0.19 kB
dist/static/components/ErrorBoundary.client-DPSZPBVT.js    0.55 kB │ gzip:  0.31 kB
dist/static/components/Link.client-CS6gQKYw.js             0.63 kB │ gzip:  0.39 kB
dist/static/index-DGpQ_hbG.js                              0.84 kB │ gzip:  0.48 kB
dist/static/_index-CJpi6NGz.js                             8.97 kB │ gzip:  3.43 kB
dist/static/client-C4tEoQZ2.js                           243.26 kB │ gzip: 75.83 kB
✓ built in 636ms

> vite-plugin-react-server-demo-official@1.0.0 build:client
> vite build --ssr

vite v6.3.2 building SSR bundle for production...
✓ 15 modules transformed.
dist/client/.vite/ssr-manifest.json                      0.46 kB
dist/client/index.html                                   0.83 kB
dist/client/.vite/manifest.json                          1.95 kB
dist/client/css/globalStyles-3TIGQ31r2.css               0.10 kB
dist/client/css/404-BDoW3a6w.css                         0.19 kB
dist/client/css/home-B6hRzeLR.css                        0.43 kB
dist/client/css/bidoof-DTqseNx_.css                      0.56 kB
dist/client/css/404.module-Wi6ObHFF.js                   0.12 kB
dist/client/css/home.module-S0-KudVn.js                  0.20 kB
dist/client/css/bidoof.module-BhOHy9Kd.js                0.32 kB
dist/client/server-DB4S1P1H.js                           0.33 kB
dist/client/components/Counter.client-CHp9Zt0j.js        0.41 kB
dist/client/_ErrorMessage.js                             0.43 kB
dist/client/components/ErrorBoundary.client-DPSZPBVT.js  0.82 kB
dist/client/components/Link.client-CS6gQKYw.js           0.96 kB
dist/client/client-C4tEoQZ2.js                           3.91 kB
✓ built in 105ms

> vite-plugin-react-server-demo-official@1.0.0 build:server
> NODE_OPTIONS='--conditions=react-server' vite build --ssr

vite v6.3.2 building SSR bundle for production...
✓ 23 modules transformed.
dist/server/.vite/ssr-manifest.json                      0.77 kB
dist/server/.vite/manifest.json                          3.49 kB
dist/server/css/globalStyles-3TIGQ31r2.css               0.10 kB
dist/server/css/404-BDoW3a6w.css                         0.19 kB
dist/server/css/home-B6hRzeLR.css                        0.43 kB
dist/server/css/bidoof-DTqseNx_.css                      0.56 kB
dist/server/css/404.module-Wi6ObHFF.js                   0.11 kB
dist/server/server-DB4S1P1H.js                           0.18 kB
dist/server/css/home.module-S0-KudVn.js                  0.19 kB
dist/server/page/404/props.js                            0.24 kB
dist/server/css/bidoof.module-BhOHy9Kd.js                0.31 kB
dist/server/page/props.js                                0.33 kB
dist/server/page/error-example/props.js                  0.35 kB
dist/server/components/Link.client-CS6gQKYw.js           0.60 kB
dist/server/components/Counter.client-CHp9Zt0j.js        0.62 kB
dist/server/components/ErrorBoundary.client-DPSZPBVT.js  0.65 kB
dist/server/page/404/page.js                             0.77 kB
dist/server/page/error-example/page.js                   0.84 kB
dist/server/page/bidoof/page.js                          2.05 kB
dist/server/page/page.js                                 2.07 kB
dist/server/page/bidoof/props.js                         2.17 kB
dist/server/client-C4tEoQZ2.js                           4.22 kB
Rendered 4 unique routes in 110ms
✓ built in 292ms
```
This three build step config is the client boundary, server boundary and static site generation.

You can visit here https://nicobrinkkemper.github.io/vite-plugin-react-server-demo-official/
