### PR TITLE
fix: use bootstrapModules instead of bootstrapScripts for ESM entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -464,18 +464,18 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         const indexHtml = staticManifest?.["index.html"]?.file;
         const serverPipeableStreamOptions = {
           ...userOptions.serverPipeableStreamOptions,
-          bootstrapScripts: [
+          bootstrapModules: [
             ...(indexHtml ? [baseURL(indexHtml)] : []),
-            ...(userOptions.serverPipeableStreamOptions?.bootstrapScripts ??
+            ...(userOptions.serverPipeableStreamOptions?.bootstrapModules ??
               []),
           ],
         };
         userOptions.serverPipeableStreamOptions = serverPipeableStreamOptions;
         const clientPipeableStreamOptions = {
           ...userOptions.clientPipeableStreamOptions,
-          bootstrapScripts: [
+          bootstrapModules: [
             ...(indexHtml ? [baseURL(indexHtml)] : []),
-            ...(userOptions.clientPipeableStreamOptions?.bootstrapScripts ??
+            ...(userOptions.clientPipeableStreamOptions?.bootstrapModules ??
               []),
           ],
         };

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -322,7 +322,7 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         const indexHtml = staticManifest?.["index.html"]?.file;
         const serverPipeableStreamOptions = {
           ...userOptions.serverPipeableStreamOptions,
-          bootstrapScripts: [
+          bootstrapModules: [
             ...(indexHtml ? [baseURL(indexHtml)] : []),
             ...(userOptions.serverPipeableStreamOptions?.bootstrapModules ??
               []),
@@ -331,9 +331,9 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         userOptions.serverPipeableStreamOptions = serverPipeableStreamOptions;
         const clientPipeableStreamOptions = {
           ...userOptions.clientPipeableStreamOptions,
-          bootstrapScripts: [
+          bootstrapModules: [
             ...(indexHtml ? [baseURL(indexHtml)] : []),
-            ...(userOptions.clientPipeableStreamOptions?.bootstrapScripts ??
+            ...(userOptions.clientPipeableStreamOptions?.bootstrapModules ??
               []),
           ],
         };

--- a/plugin/stream/createRenderToPipeableStreamHandler.client.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.client.ts
@@ -80,8 +80,8 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
 
     // Create the React HTML stream using ReactDOMServer.renderToPipeableStream
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream(reactElements, {
-      bootstrapScripts:
-        clientPipeableStreamOptions?.bootstrapScripts || [],
+      bootstrapModules:
+        clientPipeableStreamOptions?.bootstrapModules || [],
       onShellReady() {
         if (verbose) {
           logger?.info(


### PR DESCRIPTION
React's `renderToPipeableStream` has two bootstrap options:
- `bootstrapScripts`: injects `<script src="..." async>` (no `type="module"`)
- `bootstrapModules`: injects `<script type="module" src="..." async>`

The build output is ESM (`import` declarations), so `bootstrapModules` is required. Using `bootstrapScripts` caused browser errors:
```
Uncaught SyntaxError: import declarations may only appear at top level of a module
```

Fixed in:
- `plugin/react-static/plugin.server.ts`
- `plugin/react-static/plugin.client.ts`
- `plugin/stream/createRenderToPipeableStreamHandler.client.ts`

All 630 tests still passing.