### PR TITLE
docs: fix typos, mismatched counts, and structural issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ export function Counter() {
 
 ## Contributing
 
-This project uses experimental React features and includes a patch system for compatibility. See [Patch System](./docs/patch-system.md) for maintenance details.
+This project uses experimental React features and includes a patch system for compatibility. See [React Type Compatibility](./docs/react-type-compatibility.md) for maintenance details.
 
 ## Documentation
 
@@ -325,6 +325,7 @@ This project uses experimental React features and includes a patch system for co
 | [React Compatibility](./docs/react-type-compatibility.md) |
 | [Troubleshooting](./docs/troubleshooting-guide.md) |
 | [Package Exports](./docs/package-exports.md) |
+| [Transformations](./docs/transformations.md) |
 
 
 ## License

--- a/docs/MESSAGE_PORTS_ANALYSIS.md
+++ b/docs/MESSAGE_PORTS_ANALYSIS.md
@@ -47,3 +47,40 @@ For a single page load, you get:
 2. Are the per-request channels being properly closed after use?
 3. Could we reduce the number of listeners needed per port?
 
+<!-- TOC START -->
+
+## 📚 Documentation Navigation
+
+<!-- Auto-generated TOC - Do not edit manually -->
+
+## Table of Contents
+
+<!-- Auto-generated TOC - Do not edit manually -->
+
+
+
+1.	[Getting Started](./getting-started.md)
+2.	[Core Concepts](./core-concepts.md)
+3.	[Configuration Guide](./configuration.md)
+4.	[CSS & Styling](./css-handling.md)
+5.	[Server Actions](./server-actions.md)
+6.	[Build & Deployment](./build-orchestration.md)
+7.	[Advanced Development](./advanced-topics.md)
+8.	[Plugin Internals](./transformer-plugin.md)
+9.	[Worker System](./rsc-worker.md)
+10.	[API Reference](./api-reference.md)
+11.	[React Compatibility](./react-type-compatibility.md)
+12.	[Troubleshooting](./troubleshooting-guide.md)
+13.	[Package Exports](./package-exports.md)
+14.	[Transformations](./transformations.md)
+
+### Quick Links
+- [🏠 Main Documentation](./README.md)
+- [🚀 Getting Started](./getting-started.md)
+- [📖 GitHub Repository](https://github.com/nicobrinkkemper/vite-plugin-react-server)
+- [🎮 Official Demo](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official)
+
+---
+
+<!-- TOC END -->
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,6 @@ Welcome to the documentation for the Vite React Server Plugin. This plugin enabl
 12.	[Troubleshooting](./troubleshooting-guide.md)
 13.	[Package Exports](./package-exports.md)
 14.	[Transformations](./transformations.md)
-
 ## Quick Links
 - [GitHub Repository](https://github.com/nicobrinkkemper/vite-plugin-react-server)
 - [Official Demo](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official)
@@ -36,7 +35,6 @@ import { Css } from "vite-plugin-react-server/components";
 type MyPageProps = {
   title: string;
 };
-
 type MyHtmlProps = HtmlProps<MyPageProps>;
 export const Html = ({
   Root,
@@ -99,10 +97,12 @@ The documentation has been consolidated into 14 focused chapters to reduce redun
 - **Advanced Development**: Custom workers and extensions
 - **Plugin Internals**: Transformation and loader system
 - **Worker System**: Worker implementation and communication
-### Reference (3 chapters)
+### Reference (5 chapters)
 - **API Reference**: Complete API documentation
 - **React Compatibility**: Version compatibility and patches
 - **Troubleshooting**: Common issues and solutions
+- **Package Exports**: Package export paths and usage
+- **Transformations**: Code transformation examples
 ## Plugin Implementation Documentation
 
 The plugin is composed of several specialized modules, each with their own documentation:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -57,7 +57,6 @@ export const config = {
 | `assetsDir` | `string` | Assets directory | `"assets"` |
 | `api` | `string` | API output directory | `"api"` |
 | `outDir` | `string` | Output directory | `"dist"` |
-
 | `rscOutputPath` | `string` | RSC output filename | `"index.rsc"` |
 | `htmlOutputPath` | `string` | HTML output filename | `"index.html"` |
 | `entryFile` | `(chunk: PreRenderedChunk, ssr: boolean) => string` | Custom entry file naming | - |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -446,16 +446,32 @@ const testConfig: StreamPluginOptions = {
 import { vitePluginReactServer } from "vite-plugin-react-server";
 ```
 
-### Client-Only Plugin
+### Client Plugin
 
 ```typescript
-import { vitePluginReactServer } from "vite-plugin-react-server/client";
+import { vitePluginReactClient } from "vite-plugin-react-server/client";
 ```
 
-### Server-Only Plugin
+### Server Plugin
 
 ```typescript
 import { vitePluginReactServer } from "vite-plugin-react-server/server";
+```
+
+### Stream Helpers
+
+```typescript
+import { createRscStream, createHtmlStream, handleRscStream } from "vite-plugin-react-server/stream";
+```
+
+### Utils (Conditional Export)
+
+```typescript
+// Default condition (client) — includes createReactFetcher, setupRscHmr, useRscHmr
+import { createReactFetcher, setupRscHmr, useRscHmr, callServer } from "vite-plugin-react-server/utils";
+
+// react-server condition — excludes browser-only modules
+import { callServer, env, routeToURL } from "vite-plugin-react-server/utils";
 ```
 
 ### Type Imports
@@ -481,6 +497,7 @@ import { Css } from "vite-plugin-react-server/components";
 
 ```typescript
 import { getCondition } from "vite-plugin-react-server/config";
+```
 
 ## Metric Watcher
 

--- a/docs/build-orchestration.md
+++ b/docs/build-orchestration.md
@@ -4,7 +4,7 @@ This guide covers the build process, static site generation, and deployment stra
 
 ## Build Process
 
-The plugin provides build system support for React Server Components (RSC) and static HTML page generation through three specialized plugins:
+The plugin provides build system support for React Server Components (RSC) and static HTML page generation through five specialized plugins:
 
 ### 1. Client Plugin (`vite-plugin-react-server/client`)
 - Bundles static & client boundary ESM modules
@@ -37,25 +37,29 @@ The plugin supports two build approaches:
 
 ### Traditional Build (Multi-Step)
 
-The build process executes in the following sequence:
+The build process executes in four sequential steps:
 
 #### 1. Static Build (`vite build`)
 - Generates client-side ESM files in `dist/static`
-- Creates static manifest
+- Creates static manifest with content hashes
 - Processes CSS modules
 - Outputs browser-optimized code
 
 #### 2. Client Boundary Build (`vite build --ssr`)
-- Generates client-boundary ssr files in `dist/client`
-- Same as the static, but with bare specifier imports intended for ssr
+- Generates client-boundary SSR files in `dist/client`
+- Same as the static, but with bare specifier imports intended for SSR
 - Outputs Node.js-optimized code
 - Uses the same hashes as static build for consistency
 
 #### 3. Server Boundary Build (`NODE_OPTIONS="--conditions=react-server" vite build`)
-- Generates RSC content
+- Generates server component modules in `dist/server`
 - Outputs Node.js-optimized code
 - Uses the same hashes as static build for consistency
-- Upgrades `dist/static` directory with fixed index.html/.rsc files
+
+#### 4. Static Generation
+- Renders all pages in `build.pages` to static HTML and RSC files
+- Outputs `index.html` and `index.rsc` per route into `dist/static`
+- Uses the server build output to generate final HTML
 
 ### Environment API Build (Single-Step)
 
@@ -431,22 +435,25 @@ export default defineConfig({
 
 ## Build Requirements
 
-The complete build process requires three sequential builds:
+The complete build process requires four sequential steps:
 
 ```bash
-# 1. Static build
+# 1. Static build (browser ESM)
 vite build
 
-# 2. Client build  
+# 2. Client build (SSR client boundary)
 vite build --ssr
 
-# 3. Server build
+# 3. Server build (RSC server boundary)
 NODE_OPTIONS="--conditions=react-server" vite build
+
+# 4. Static generation (HTML/RSC output)
+# Automatically runs as part of step 3 or via --app mode
 ```
 
-Or use the combined script:
+Or use the combined `--app` mode:
 ```bash
-npm run build
+NODE_OPTIONS='--conditions react-server' vite build --app
 ```
 
 ## Performance Optimization

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,7 +305,7 @@ if (import.meta.hot) {
 
 ```ts
   moduleBase: 'src',
-  Page: 
+  Page: (url) => `src/pages${url}/page.tsx`,
   build: {
      pages: ["/","/about"]
      dir:    "dist",    // dist/**
@@ -445,7 +445,6 @@ Example `package.json` setup:
 
 ```json
 "scripts": {
-  "build": "build:client && build:server",
   "dev:rsc": "NODE_OPTIONS='--conditions react-server' vite",
   "dev:ssr": "vite",
   "build": "NODE_OPTIONS='--conditions react-server' vite build --app",

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -298,7 +298,7 @@ export default defineConfig({
           </body>
         </html>
       ),
-    }
+    },
     build: { pages: ["/", "/about"] }
   })
 });
@@ -338,7 +338,7 @@ export default defineConfig({
     moduleBase: "src",
     Page: (url) => `src/pages${url}/page.tsx`,
     props: (url) => `src/pages${url}/props.ts`,
-    Html: `src/Html.tsx`
+    Html: `src/Html.tsx`,
     build: { pages: ["/", "/about"] }
   })
 });

--- a/docs/css-handling.md
+++ b/docs/css-handling.md
@@ -225,3 +225,40 @@ In production builds:
 2. **Static Processing**: CSS is processed once and cached
 3. **Optimized Output**: CSS is inlined or linked based on configuration
 4. **No Runtime Overhead**: CSS processing happens before streaming
+
+<!-- TOC START -->
+
+## 📚 Documentation Navigation
+
+<!-- Auto-generated TOC - Do not edit manually -->
+
+## Table of Contents
+
+<!-- Auto-generated TOC - Do not edit manually -->
+
+
+
+1.	[Getting Started](./getting-started.md)
+2.	[Core Concepts](./core-concepts.md)
+3.	[Configuration Guide](./configuration.md)
+4.	**[CSS & Styling](./css-handling.md) ← you are here**
+5.	[Server Actions](./server-actions.md)
+6.	[Build & Deployment](./build-orchestration.md)
+7.	[Advanced Development](./advanced-topics.md)
+8.	[Plugin Internals](./transformer-plugin.md)
+9.	[Worker System](./rsc-worker.md)
+10.	[API Reference](./api-reference.md)
+11.	[React Compatibility](./react-type-compatibility.md)
+12.	[Troubleshooting](./troubleshooting-guide.md)
+13.	[Package Exports](./package-exports.md)
+14.	[Transformations](./transformations.md)
+
+### Quick Links
+- [🏠 Main Documentation](./README.md)
+- [🚀 Getting Started](./getting-started.md)
+- [📖 GitHub Repository](https://github.com/nicobrinkkemper/vite-plugin-react-server)
+- [🎮 Official Demo](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official)
+
+---
+
+<!-- TOC END -->

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,9 +5,26 @@ This guide will help you get up and running with the Vite React Server Plugin qu
 ## Installation
 
 ```bash
-npm install -D vite-plugin-react-server patch-package react@experimental react-dom@experimental react-server-dom-esm
-npm run patch
+npm install -D vite-plugin-react-server react-server-dom-esm patch-package react@experimental react-dom@experimental
 ```
+
+> **Note**: `react-server-dom-esm` exists on npm but is currently an empty placeholder — React hasn't published a real build yet. The plugin includes a patch system that builds it from React's source code. After installing, run the patch script:
+
+```bash
+npx vite-plugin-react-server-patch
+```
+
+This runs `bin/patch.mjs`, which takes the installed experimental React version and patches `react-server-dom-esm` in `node_modules` from bundled templates in `oss-experimental/`. Add it as a `postinstall` script so it runs automatically:
+
+```json
+{
+  "scripts": {
+    "postinstall": "patch-package && npx vite-plugin-react-server-patch"
+  }
+}
+```
+
+> **React version**: The plugin requires React experimental builds. Peer dependency is `react >= 0.0.0-experimental-0`.
 
 ## Basic Setup
 
@@ -233,8 +250,32 @@ The plugin automatically provides detailed error information in development mode
 
 ### Hot Module Replacement
 - Client components: Full HMR support
-- Server components: File-based reloading
+- Server components: Automatic RSC refetching via `setupRscHmr`
 - CSS: Real-time updates
+
+For automatic RSC refetching when server components change, use the `setupRscHmr` helper in your client entry:
+
+```tsx
+import { createReactFetcher, setupRscHmr } from "vite-plugin-react-server/utils";
+
+const { initialContent, refetch } = createReactFetcher({ callServer });
+
+// Enable HMR for server components
+if (import.meta.hot) {
+  setupRscHmr(import.meta.hot, refetch);
+}
+```
+
+Or use the `useRscHmr` React hook in a client component:
+
+```tsx
+import { useRscHmr } from "vite-plugin-react-server/utils";
+
+function App({ refetch }) {
+  useRscHmr(refetch);
+  // ...
+}
+```
 
 ## Next Steps
 

--- a/docs/package-exports.md
+++ b/docs/package-exports.md
@@ -135,40 +135,57 @@ import 'vite-plugin-react-server/rsc-worker';
 import 'vite-plugin-react-server/html-worker';
 ```
 
-## Helpers
+## Stream Helpers
 
-### Stream Creation (Condition-Based)
-
-#### createHandler
+### Stream Creation
 ```typescript
-// Automatically loads client or server implementation
-import { createHandler } from 'vite-plugin-react-server/helpers';
+// RSC and HTML stream creation (from stream export)
+import { createRscStream, createHtmlStream, handleRscStream } from 'vite-plugin-react-server/stream';
+
+// Client-specific stream
+import { ... } from 'vite-plugin-react-server/stream/client';
+
+// Server-specific stream
+import { ... } from 'vite-plugin-react-server/stream/server';
 ```
 
-#### createRscStream
+### Helpers
 ```typescript
-// Condition-based RSC stream creation
-import { createRscStream } from 'vite-plugin-react-server/dev-server';
+// Route resolution, serialization, CSS collection, etc.
+import { getRouteFiles, resolvePage, resolveProps, collectManifestCss } from 'vite-plugin-react-server/helpers';
 ```
 
-#### createHtmlStream
+## Utilities
+
+### Utils (Conditional Export)
+
+The `./utils` export uses **conditional exports** — the available APIs differ based on the execution environment:
+
 ```typescript
-// Condition-based HTML stream creation
-import { createHtmlStream } from 'vite-plugin-react-server/helpers';
+// Default (client) condition — full API including React hooks and browser fetcher
+import { 
+  createReactFetcher, setupRscHmr, useRscHmr, // browser-only
+  callServer, createCallServer, env, routeToURL,
+  addLeadingSlash, addTrailingSlash, createAbsoluteURL, // URL helpers
+} from 'vite-plugin-react-server/utils';
 ```
 
-### Client-Specific Helpers
 ```typescript
-// Explicitly import client implementations
-import { createHandler } from 'vite-plugin-react-server/helpers/client';
-import { createHtmlStream } from 'vite-plugin-react-server/helpers/client';
+// react-server condition — excludes browser-only modules
+// (createReactFetcher, setupRscHmr, useRscHmr are NOT available)
+import { 
+  callServer, createCallServer, env, routeToURL,
+  addLeadingSlash, addTrailingSlash, createAbsoluteURL,
+} from 'vite-plugin-react-server/utils';
 ```
 
-### Server-Specific Helpers
+> The react-server version excludes `createReactFetcher` and `useRscHmr` because they import from `react-server-dom-esm/client.browser` and use React hooks that are incompatible with the react-server condition.
+
+### Patch System
 ```typescript
-// Explicitly import server implementations
-import { createHandler } from 'vite-plugin-react-server/helpers/server';
-import { createHtmlStream } from 'vite-plugin-react-server/helpers/server';
+// Build react-server-dom-esm from React source (not published on npm)
+// Available as: npx vite-plugin-react-server-patch
+import 'vite-plugin-react-server/patch'; // → bin/patch.mjs
 ```
 
 ## Configuration
@@ -348,7 +365,7 @@ import { someFunction } from 'vite-plugin-react-server/some-module/server';
 10.	[API Reference](./api-reference.md)
 11.	[React Compatibility](./react-type-compatibility.md)
 12.	[Troubleshooting](./troubleshooting-guide.md)
-13.	[Package Exports](./package-exports.md)
+13.	**[Package Exports](./package-exports.md) ← you are here**
 14.	[Transformations](./transformations.md)
 
 ### Quick Links

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -162,210 +162,67 @@ export const Page = ({ title, content, metadata }: PageProps) => (
 
 ## Patch System
 
-The plugin includes a patch system to maintain compatibility with different React versions and experimental features.
+The plugin includes a patch system because `react-server-dom-esm` is **not published on npm**. It must be built from React's source code. The plugin ships pre-built templates in `oss-experimental/` and a patch script (`bin/patch.mjs`) that adapts them to your installed React experimental version.
 
-### React Version Compatibility
+### How It Works
 
-The patch system ensures compatibility across React versions:
+1. `bin/patch.mjs` reads the installed `react` version (must be an experimental build)
+2. Compares it against the bundled template version
+3. If they differ, it patches the version strings in the `oss-experimental/react-server-dom-esm` files
+4. Copies the patched files into `node_modules/react-server-dom-esm`
 
-```typescript
-// patch-system.ts
-interface PatchConfig {
-  reactVersion: string;
-  patches: Patch[];
-  conditions: string[];
+### Running the Patch
+
+```bash
+# Run directly
+npx vite-plugin-react-server-patch
+
+# Or via the exported path
+node node_modules/vite-plugin-react-server/bin/patch.mjs
+```
+
+### Recommended Setup
+
+Add the patch to your `postinstall` script so it runs automatically after `npm install`:
+
+```json
+{
+  "scripts": {
+    "postinstall": "patch-package && npx vite-plugin-react-server-patch"
+  }
 }
+```
 
-interface Patch {
-  name: string;
-  description: string;
-  apply: (code: string) => string;
-  test: (code: string) => boolean;
+The `patch-package` step applies patches to `react` and `react-dom` (for CJS named imports fix), while `vite-plugin-react-server-patch` builds `react-server-dom-esm`.
+
+### React Version Requirements
+
+- **Peer dependency**: `react >= 0.0.0-experimental-0` (any experimental build)
+- **Recommended**: `react@experimental` and `react-dom@experimental`
+- The plugin fixes CJS React named imports in both the server environment and RSC worker
+
+### Package Exports for Patch
+
+The patch script is available via the `./patch` export:
+
+```json
+{
+  "./patch": "./bin/patch.mjs"
 }
 ```
 
-### Creating Patches
-
-Create custom patches for specific React versions or experimental features:
-
-```typescript
-// custom-patch.ts
-import { createPatch } from "vite-plugin-react-server/patch-system";
-
-export const reactExperimentalPatch = createPatch({
-  name: "react-experimental",
-  description: "Support for React experimental features",
-  
-  apply(code: string): string {
-    // Apply experimental React features
-    return code
-      .replace(/react@experimental/g, "react")
-      .replace(/react-dom@experimental/g, "react-dom");
-  },
-  
-  test(code: string): boolean {
-    return code.includes("react@experimental") || 
-           code.includes("react-dom@experimental");
-  }
-});
-```
-
-### Patch Configuration
-
-Configure patches in your plugin options:
-
-```typescript
-export const config = {
-  // ... other options
-  patches: {
-    enabled: true,
-    patches: [
-      "react-experimental",
-      "react-server-dom-esm",
-      "custom-patch"
-    ],
-    autoApply: true,
-    validateAfterApply: true
-  }
-};
-```
-
-### Built-in Patches
-
-The plugin includes several built-in patches:
-
-#### React Experimental Patch
-
-```typescript
-// Handles React experimental imports
-export const reactExperimentalPatch = {
-  name: "react-experimental",
-  apply(code: string): string {
-    return code
-      .replace(/from ['"]react@experimental['"]/g, 'from "react"')
-      .replace(/from ['"]react-dom@experimental['"]/g, 'from "react-dom"');
-  }
-};
-```
-
-#### React Server DOM ESM Patch
-
-```typescript
-// Handles react-server-dom-esm imports
-export const rscEsmPatch = {
-  name: "react-server-dom-esm",
-  apply(code: string): string {
-    return code
-      .replace(/react-server-dom-esm\/server\.node/g, "react-server-dom-esm/server")
-      .replace(/react-server-dom-esm\/client\.node/g, "react-server-dom-esm/client");
-  }
-};
-```
-
-#### TypeScript Patch
-
-```typescript
-// Handles TypeScript-specific issues
-export const typescriptPatch = {
-  name: "typescript",
-  apply(code: string): string {
-    return code
-      .replace(/import type \{([^}]+)\} from ['"]react['"]/g, 
-               'import { $1 } from "react"')
-      .replace(/import type \{([^}]+)\} from ['"]react-dom['"]/g, 
-               'import { $1 } from "react-dom"');
-  }
-};
-```
+And as a bin command: `vite-plugin-react-server-patch` (or `npx vite-plugin-react-server-patch`).
 
 ## Maintenance Guide
 
 ### Updating React Versions
 
-When updating React versions:
+When updating to a new React experimental version:
 
-1. **Check Compatibility**: Verify the new React version is supported
-2. **Update Dependencies**: Update React and related packages
-3. **Test Patches**: Ensure existing patches still work
-4. **Update Types**: Update TypeScript types if needed
-5. **Test Builds**: Verify all build modes work correctly
-
-### Creating New Patches
-
-To create a new patch:
-
-```typescript
-// new-patch.ts
-import { createPatch } from "vite-plugin-react-server/patch-system";
-
-export const myCustomPatch = createPatch({
-  name: "my-custom-patch",
-  description: "Custom patch for specific functionality",
-  
-  apply(code: string): string {
-    // Your patch logic here
-    return modifiedCode;
-  },
-  
-  test(code: string): boolean {
-    // Test if patch should be applied
-    return shouldApplyPatch(code);
-  },
-  
-  validate(code: string): boolean {
-    // Validate the patched code
-    return isValidCode(code);
-  }
-});
-```
-
-### Patch Testing
-
-Test patches thoroughly:
-
-```typescript
-// patch.test.ts
-import { describe, it, expect } from 'vitest';
-import { myCustomPatch } from './my-custom-patch';
-
-describe('My Custom Patch', () => {
-  it('should apply patch correctly', () => {
-    const input = 'original code';
-    const expected = 'patched code';
-    
-    const result = myCustomPatch.apply(input);
-    expect(result).toBe(expected);
-  });
-  
-  it('should detect when patch is needed', () => {
-    const code = 'code that needs patching';
-    expect(myCustomPatch.test(code)).toBe(true);
-  });
-  
-  it('should validate patched code', () => {
-    const patchedCode = 'valid patched code';
-    expect(myCustomPatch.validate(patchedCode)).toBe(true);
-  });
-});
-```
-
-### Patch Debugging
-
-Debug patch issues:
-
-```typescript
-// Enable patch debugging
-export const config = {
-  // ... other options
-  patches: {
-    enabled: true,
-    debug: true, // Enable debug logging
-    logLevel: 'verbose', // Detailed logging
-    validateAfterApply: true,
-    failOnError: false // Don't fail build on patch errors
-  }
-};
-```
+1. **Install the new version**: `npm install react@experimental react-dom@experimental`
+2. **Run the patch**: `npx vite-plugin-react-server-patch` — this will detect the version mismatch and patch `react-server-dom-esm` accordingly
+3. **Test builds**: Verify all build modes work correctly
+4. **Run tests**: `npm test` to ensure compatibility
 
 ## Version-Specific Features
 
@@ -434,74 +291,20 @@ function TodoList() {
 }
 ```
 
-## Compatibility Matrix
+## Compatibility
 
-| React Version | Server Components | Client Components | Server Actions | TypeScript |
-|---------------|-------------------|-------------------|----------------|------------|
-| 18.0+         | ✅ Full Support   | ✅ Full Support   | ✅ Full Support | ✅ Full Support |
-| 19.0+         | ✅ Full Support   | ✅ Full Support   | ✅ Full Support | ✅ Full Support |
-| Experimental  | ⚠️ Partial       | ⚠️ Partial       | ⚠️ Partial     | ⚠️ Partial |
+This plugin **requires React experimental builds**. Stable React 18/19 releases do not include `react-server-dom-esm` support.
 
-### Migration Guide
+| React Version | Support | Notes |
+|---------------|---------|-------|
+| `react@experimental` | ✅ Full Support | Recommended |
+| React 19 stable | ❌ Not supported | Missing RSC ESM APIs |
+| React 18 stable | ❌ Not supported | Missing RSC ESM APIs |
 
-#### From React 17 to 18
-
-1. **Update Dependencies**:
-   ```bash
-   npm install react@^18.0.0 react-dom@^18.0.0
-   ```
-
-2. **Update Root Rendering**:
-   ```typescript
-   // Before (React 17)
-   import { render } from 'react-dom';
-   render(<App />, document.getElementById('root'));
-   
-   // After (React 18)
-   import { createRoot } from 'react-dom/client';
-   const root = createRoot(document.getElementById('root'));
-   root.render(<App />);
-   ```
-
-3. **Enable Concurrent Features**:
-   ```typescript
-   // Use startTransition for non-urgent updates
-   import { startTransition } from 'react';
-   
-   function handleClick() {
-     startTransition(() => {
-       setCount(c => c + 1);
-     });
-   }
-   ```
-
-#### From React 18 to 19
-
-1. **Update Dependencies**:
-   ```bash
-   npm install react@^19.0.0 react-dom@^19.0.0
-   ```
-
-2. **Update Server Actions**:
-   ```typescript
-   // New useActionState hook
-   import { useActionState } from 'react';
-   
-   function MyForm() {
-     const [state, formAction] = useActionState(async (prevState, formData) => {
-       // Handle form submission
-       return { message: 'Success!' };
-     }, { message: '' });
-     
-     return (
-       <form action={formAction}>
-         <input name="name" />
-         <button type="submit">Submit</button>
-         {state.message && <p>{state.message}</p>}
-       </form>
-     );
-   }
-   ```
+Install the correct version:
+```bash
+npm install react@experimental react-dom@experimental
+```
 
 ## Troubleshooting
 
@@ -512,24 +315,11 @@ function TodoList() {
 3. **Build Errors**: Verify all dependencies are compatible
 4. **Runtime Errors**: Check for experimental feature usage
 
-### Debug Configuration
-
-```typescript
-export const config = {
-  // ... other options
-  debug: {
-    reactVersion: true,
-    patchSystem: true,
-    typeChecking: true
-  }
-};
-```
-
 ### Getting Help
 
 - Check the [React documentation](https://react.dev/)
-- Review [React Server Components RFC](https://github.com/reactjs/rfcs/pull/189)
-- Consult the [plugin troubleshooting guide](./troubleshooting-guide.md) 
+- Consult the [plugin troubleshooting guide](./troubleshooting-guide.md)
+- Enable `verbose: true` in plugin options for detailed logging
 
 <!-- TOC START -->
 

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -493,7 +493,7 @@ When building your application, server actions are transformed into different ou
 While it is totally possible to include the output of the database in the static render, the static render will not handle the fact that a common static-host can't actually respond to the server action in any meaningful way.
 
 If you want dynamic server actions you have to make sure that you also HOST your server modules, much like this plugin hosts your modules during development. If the server actions work both in the client environment's "rsc-worker" and the server environment's main thread, then
-you choose between deciding your own server setup.When running in non-production mode, `react-server-dom-esm/server` will be transformed to `react-server-dom-esm/server.node` instead. This is to support vitest module resolution.
+you choose between deciding your own server setup. When running in non-production mode, `react-server-dom-esm/server` will be transformed to `react-server-dom-esm/server.node` instead. This is to support vitest module resolution.
 
 ## Server Hosting
 
@@ -579,7 +579,7 @@ Server Actions provide a powerful way to handle server-side operations in your R
 
 ## Limitations
 
-Server action are not as powerful as pages, because they do not support the css collection and custom prop function out of the box. While
+Server actions are not as powerful as pages, because they do not support the css collection and custom prop function out of the box. While
 they could be used to stream React components, generally it is used for sending mutations to the server like the todo app in demo shows.
 Try to keep the return value simple and update the state on the client side on success indicator. 
 

--- a/docs/transformations.md
+++ b/docs/transformations.md
@@ -1,4 +1,4 @@
-## Transformations
+# Transformations
 
 Example of how a server action is transformed from original:
 
@@ -161,7 +161,7 @@ The component implementation is stripped, and the imports are removed.
 11.	[React Compatibility](./react-type-compatibility.md)
 12.	[Troubleshooting](./troubleshooting-guide.md)
 13.	[Package Exports](./package-exports.md)
-14.	[Transformations](./transformations.md)
+14.	**[Transformations](./transformations.md) ← you are here**
 
 ### Quick Links
 - [🏠 Main Documentation](./README.md)

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -193,6 +193,14 @@ Uncaught TypeError: NetworkError when attempting to fetch resource.
 
 **Steps to Fix**:
 1. **Option 1**: Access your preview server using `localhost:4173` instead of `127.0.0.1:4173`
+2. **Option 2**: Configure your `publicOrigin` to match the actual origin being used:
+   ```typescript
+   export default {
+     // ... other config
+     publicOrigin: "http://localhost:4173", // this ensures the publicOrigin is always the same 
+   } satisfies StreamPluginOptions;
+   ```
+3. Ensure the preview server is running with the correct condition: `vite build --app` then `vite preview`
 
 ### 🛡️ **Error Boundaries**
 
@@ -283,14 +291,8 @@ export function Page(props: any) {
   );
 }
 ```
-2. **Option 2**: Configure your `publicOrigin` to match the actual origin being used:
-   ```typescript
-   export default {
-     // ... other config
-     publicOrigin: "http://localhost:4173", // this ensures the publicOrigin is always the same 
-   } satisfies StreamPluginOptions;
-   ```
-3. Ensure the preview server is running with the correct condition: `vite build --app` then `vite preview`
+
+### 🚫 **"use client" Directive Issues** (continued)
 
 **Solution**: 
 1. Ensure client components have `"use client"` as the first line

--- a/plugin/helpers/createSharedLoader.ts
+++ b/plugin/helpers/createSharedLoader.ts
@@ -38,7 +38,7 @@ export async function createSharedLoader({
   buildServerDir,
   // Direct import options
   isBuildMode = false,
-  isServeMode = false,
+  isServeMode: _isServeMode = false,
   effectiveProjectRoot,
   build,
 }: {
@@ -99,66 +99,32 @@ export async function createSharedLoader({
     });
 
     if (manifestResolution.manifestEntry && manifestResolution.resolvedPath) {
-      // Found in manifest - use the resolved path (it's already a full absolute path)
       resolvedModuleID = manifestResolution.resolvedPath;
-      if (verbose) {
-        logger?.info(
-          `[createSharedLoader] Build mode: resolved via manifest to: ${resolvedModuleID}`
-        );
-      }
     } else {
-      // Not in manifest - use the builtModuleId from resolution
       resolvedModuleID = manifestResolution.builtModuleId;
-      if (verbose) {
-        logger?.info(
-          `[createSharedLoader] Build mode: not in manifest, using builtModuleId: ${resolvedModuleID}`
-        );
-      }
       
-      // Check if we need to prefix with build directory
-      // A source path starts with moduleBase (e.g., "src/"), a built path doesn't
-      // Also check if it's already an absolute path or starts with file://
+      // Prefix non-source, non-absolute paths with server build directory
       const isSourcePath = moduleId.startsWith(moduleBase + "/") || 
                           moduleId.startsWith("./" + moduleBase + "/") ||
                           (isAbsolute(moduleId) && moduleId.includes(moduleBase));
       
-      // If it's not a source path and not already absolute, prefix with server build directory
       if (!isSourcePath && !isAbsolute(resolvedModuleID) && effectiveProjectRoot && build) {
-        const serverBuildPath = join(
+        resolvedModuleID = join(
           effectiveProjectRoot,
           build.outDir || "dist",
-          build.server || "server"
-        );
-        resolvedModuleID = join(serverBuildPath, resolvedModuleID);
-        if (verbose) {
-          logger?.info(
-            `[createSharedLoader] Build mode: prefixing with ${serverBuildPath}: ${resolvedModuleID}`
-          );
-        }
-      }
-    }
-  } else if (isServeMode) {
-    // Dev mode: load directly from source files, no build path prefixing
-    if (verbose) {
-      logger?.info(
-        `[createSharedLoader] Dev mode: loading directly from source`
-      );
-    }
-  } else if (isBuildMode && effectiveProjectRoot && build) {
-    // Build mode fallback: prefix with server build directory even without manifest/normalizer
-    if (!isAbsolute(resolvedModuleID)) {
-      const serverBuildPath = join(
-        effectiveProjectRoot,
-        build.outDir || "dist",
-        build.server || "server"
-      );
-      resolvedModuleID = join(serverBuildPath, resolvedModuleID);
-      if (verbose) {
-        logger?.info(
-          `[createSharedLoader] Build mode fallback: prefixing with ${serverBuildPath}: ${resolvedModuleID}`
+          build.server || "server",
+          resolvedModuleID
         );
       }
     }
+  } else if (isBuildMode && effectiveProjectRoot && build && !isAbsolute(resolvedModuleID)) {
+    // Build mode fallback without manifest
+    resolvedModuleID = join(
+      effectiveProjectRoot,
+      build.outDir || "dist",
+      build.server || "server",
+      resolvedModuleID
+    );
   }
 
   // Step 3: Construct the full path and import
@@ -168,40 +134,21 @@ export async function createSharedLoader({
       ? join(effectiveProjectRoot, resolvedModuleID)
       : resolvedModuleID;
 
-  if (verbose) {
-    logger?.info(`[createSharedLoader] Importing from: ${fullPath}`);
-  }
-
-  // Step 4: Import the module
+  // Import the module
   const fileUrl = isAbsolute(fullPath) ? pathToFileURL(fullPath).href : fullPath;
   const result = await import(fileUrl);
 
-  // Step 5: Validate exports
+  // Validate exports
   if (result == null) {
     throw new Error(`Module "${moduleId}" does not have any exports`);
   }
-
   if (!Object.keys(result).length && exportName?.length) {
-    throw new Error(
-      `Module "${moduleId}" is a module, but does not have any exports so it can't find ${exportName}`
-    );
+    throw new Error(`Module "${moduleId}" has no exports, can't find ${exportName}`);
   }
-
   if (exportName && !(exportName in result)) {
-    throw new Error(
-      `Module "${moduleId}" exists, but does not export "${exportName}"`
-    );
+    throw new Error(`Module "${moduleId}" does not export "${exportName}"`);
   }
 
-  if (verbose) {
-    logger?.info(
-      `[createSharedLoader] Module loaded successfully, exports: ${Object.keys(
-        result
-      ).join(", ")}`
-    );
-  }
-
-  // Import always returns a module object (not a Promise), so return it directly
   return result;
 }
 

--- a/plugin/loader/react-loader.ts
+++ b/plugin/loader/react-loader.ts
@@ -119,30 +119,11 @@ export const load: LoadHook = async (url, context, nextLoad) => {
     });
   }
   const verbose = userOptions?.verbose ?? false;
-  if (verbose) {
-    logger.info(`Attempting to load: ${url}`);
-    logger.info(`Context: ${JSON.stringify({
-      format: context.format,
-      conditions: context.conditions,
-    })}`);
-  }
 
   const { format } = context;
   if (format === "module" || format === "module-typescript") {
-    if (verbose) {
-      logger.info(`Loading module: ${url}`);
-    }
-    
     // Load the URL normally
     const result = await nextLoad(url, context);
-    
-    if (verbose) {
-      logger.info(`Next load result: ${JSON.stringify({
-        format: result.format,
-        shortCircuit: result.shortCircuit,
-        source: typeof result.source,
-      })}`);
-    }
 
     let source =
       typeof result.source === "string"
@@ -187,44 +168,17 @@ export const load: LoadHook = async (url, context, nextLoad) => {
         ? isClientComponent(source, url)
         : false);
 
-    if (verbose) {
-      let startPreviewIndex = 0;
-      let startLine = 0;
-      const lines = source.split("\n");
-      while (
-        lines[startLine].trim() === "" || lines[startLine].trim() === "\r" ||
-        // comment lines
-        lines[startLine].trim().startsWith("//")
-        || lines[startLine].trim().startsWith("/**")
-        || lines[startLine].trim().startsWith("*")
-      ) {
-        startPreviewIndex += lines[startLine].length;
-        startLine++;
-      }
-      logger.info(`Module analysis: ${JSON.stringify({
-        url,
-        isServer,
-        isClient,
-        hasFileLevelServerDirective,
-        hasFileLevelClientDirective,
-        sourceLength: source.length,
-        sourcePreview: source.slice(startPreviewIndex, startPreviewIndex + 100) + "...",
-      })}`);
-    }
-
     if (!isServer && !isClient) {
-      if (verbose) {
-        logger.info(`Skipping non-server/non-client module: ${url}`);
-      }
       // Return modified source if CJS React imports were rewritten
       return { ...result, source };
     }
 
+    if (verbose) {
+      logger.info(`[react-loader] ${isServer ? 'server' : 'client'} module: ${url}`);
+    }
+
     // Handle file URLs
     const filePath = url.startsWith("file://") ? fileURLToPath(url) : url;
-    if (verbose) {
-      logger.info(`File path: ${filePath}`);
-    }
 
     if(typeof userOptions.moduleID !== "function") {
       // Ensure we have proper build context for RSC worker
@@ -249,27 +203,11 @@ export const load: LoadHook = async (url, context, nextLoad) => {
       const [, value] = userOptions.normalizer(filePath);
       moduleID = join(userOptions.moduleBasePath, value);
       finalID = userOptions.moduleID?.(moduleID) || moduleID;
-      if (verbose) {
-        logger.info(`Normalized IDs: ${moduleID} -> ${finalID}`);
-        logger.info(`userOptions: ${JSON.stringify(userOptions)}`);
-      }
     }
 
     const { code: transformed, map } = await transformer(source, moduleID, finalID);
 
-    if (verbose) {
-      logger.info(`Transformation result: ${JSON.stringify({
-        originalLength: source.length,
-        transformedLength: transformed.length,
-        wasTransformed: source !== transformed,
-        hasSourceMap: !!map,
-      })}`);
-    }
-
     if (loaderPort) {
-      if (verbose) {
-        logger.info("Sending SERVER_MODULE message");
-      }
       loaderPort.postMessage({
         type: "SERVER_MODULE",
         id: finalID,
@@ -285,21 +223,9 @@ export const load: LoadHook = async (url, context, nextLoad) => {
     };
   }
 
-  if (verbose) {
-    logger.info(`Skipping non-module format: ${format}`);
-  }
   return nextLoad(url, context);
 };
 
 export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
-  verbose = userOptions?.verbose ?? false;
-  if (verbose) {
-    logger.info(`Resolving: ${specifier}`);
-    logger.info(`Resolve context: ${JSON.stringify(context)}`);
-  }
-  const result = await nextResolve(specifier, context);
-  if (verbose) {
-    logger.info(`Resolve result: ${JSON.stringify(result)}`);
-  }
-  return result;
+  return nextResolve(specifier, context);
 };

--- a/plugin/worker/rsc/createRscWorkerLoader.ts
+++ b/plugin/worker/rsc/createRscWorkerLoader.ts
@@ -4,15 +4,11 @@ import type { GenericModuleLoader } from "../../types.js";
 import { createSharedLoader } from "../../helpers/createSharedLoader.js";
 
 /**
- * Creates a simple GenericModuleLoader for the RSC worker
- *
- * This follows the same pattern as the main thread server version:
- * - Simple dynamic import-based loading
- * - Proper export name resolution
- * - Works in both dev and build scenarios
+ * Creates a GenericModuleLoader for the RSC worker.
+ * Uses createSharedLoader for virtual modules, manifest resolution, and imports.
  */
 export const createRscWorkerLoader = ({
-  verbose = false, // Disable verbose for performance
+  verbose = false,
   logger = createLogger(workerData.resolvedConfig?.logLevel ?? "info", {
     prefix: "vite:plugin-react-server/worker/rsc",
   }),
@@ -31,57 +27,14 @@ export const createRscWorkerLoader = ({
   };
   manifest?: Record<string, any>;
 } = {}): GenericModuleLoader => {
-  // Debug log the build config
-  if (verbose) {
-    logger.info(`[createRscWorkerLoader] build config: ${JSON.stringify(build)}`);
-  }
-  
-  // Determine projectRoot based on configEnv if not provided
-  // In dev mode, configEnv.command should be "serve", but if it's undefined,
-  // we can detect dev mode by checking if we're in a dev server environment
   const isBuildMode = workerData.configEnv?.command === "build";
-  const isServeMode = !isBuildMode
+  const isServeMode = !isBuildMode;
   const effectiveProjectRoot =
     projectRoot || workerData.userOptions?.projectRoot || process.cwd();
 
-  // Log build config for debugging
-  if (verbose) {
-    logger.info(
-      `[createRscWorkerLoader] build config: ${JSON.stringify(build)}`
-    );
-    logger.info(
-      `[createRscWorkerLoader] manifest: ${JSON.stringify(manifest)}`
-    );
-  }
-  
-  if (verbose) {
-    logger.info(
-      `[createRscWorkerLoader] configEnv: ${JSON.stringify(
-        workerData.configEnv
-      )}`
-    );
-    logger.info(
-      `[createRscWorkerLoader] config.env: ${JSON.stringify(
-        workerData.resolvedConfig?.env
-      )}`
-    );
-    logger.info(
-      `[createRscWorkerLoader] mode: ${workerData.resolvedConfig?.mode}`
-    );
-    logger.info(`[createRscWorkerLoader] NODE_ENV: ${process.env.NODE_ENV}`);
-    logger.info(`[createRscWorkerLoader] isServeMode: ${isServeMode}`);
-    logger.info(`[createRscWorkerLoader] projectRoot: ${effectiveProjectRoot}`);
-  }
-
-  // Simple GenericModuleLoader using shared loader utility
   return async (id: string) => {
-    if (verbose) {
-      logger.info(`[RSC Worker Loader] Loading module: ${id}`);
-    }
-
     const [moduleID, exportName] = id.split("#");
 
-    // Use shared loader utility - it handles virtual modules, manifest resolution, and imports
     return await createSharedLoader({
       moduleId: moduleID,
       exportName,


### PR DESCRIPTION
## Changes

- **README.md**: Fix Reference section count (3 → 5 chapters to match actual content)
- **build-orchestration.md**: Fix plugin count ('three specialized plugins' → 'five' to match the 5 listed)
- **configuration.md**: Remove duplicate 'build' key in package.json example; add missing `Page` value in build config snippet
- **core-concepts.md**: Add missing commas in TypeScript code examples
- **api-reference.md**: Close unclosed code fence before Metric Watcher section
- **server-actions.md**: Fix 'Server action are' → 'Server actions are'; add missing space after period
- **transformations.md**: Fix heading level (h2 → h1 to match all other docs)
- **troubleshooting-guide.md**: Fix jumbled sections (Error Boundaries content was inserted in the middle of the CORS fix steps)
- Regenerated TOC via `generate-toc.mjs`