### PR TITLE
fix: clean up HMR handlers, request info bugs, and .client.tsx detection

### DIFF
--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -78,16 +78,8 @@ export const configureReactServer: ConfigureReactServerFn =
       }
       activeStreams.clear();
       activeControllers.clear();
-    });
 
-    // Handle restart completion
-    server.ws.on("full-reload", () => {
-      isRestarting = false;
-      logger.info("[vite-plugin-react-server] ✅ Server restart completed");
-    });
-
-    // Fallback: reset restart flag after a timeout
-    server.ws.on("restart", () => {
+      // Fallback: reset restart flag after a timeout
       setTimeout(() => {
         if (isRestarting) {
           isRestarting = false;
@@ -96,6 +88,12 @@ export const configureReactServer: ConfigureReactServerFn =
           );
         }
       }, 5000); // 5 second timeout
+    });
+
+    // Handle restart completion
+    server.ws.on("full-reload", () => {
+      isRestarting = false;
+      logger.info("[vite-plugin-react-server] ✅ Server restart completed");
     });
 
     const loader = async (id: string) => {
@@ -550,7 +548,6 @@ export const configureReactServer: ConfigureReactServerFn =
 
         res.statusCode = 500;
         res.setHeader("Content-Type", "text/x-component; charset=utf-8");
-        res.setHeader("Content-Length", "0"); // Will be updated after streaming
         
         // Note: Worker cleanup is handled by the response close handler
       }

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -95,6 +95,8 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       
       // Skip client components — let @vitejs/plugin-react handle them with Fast Refresh
       const isClientFile = isSourceFile && (() => {
+        // Check filename pattern (.client.tsx, etc.) — matches isClientComponentByName
+        if (/\.client\.(js|ts|jsx|tsx)$/.test(file)) return true;
         try {
           const head = readFileSync(file, 'utf-8').slice(0, 200);
           return /^\s*["']use client["']/.test(head.split('\n')[0]);

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -44,6 +44,8 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
       if (envName === 'client') {
         // Check if it's a client component — let Fast Refresh handle it
         const isClient = (file.endsWith('.tsx') || file.endsWith('.ts') || file.endsWith('.jsx') || file.endsWith('.js')) && (() => {
+          // Check filename pattern (.client.tsx, .client.ts, etc.) — matches isClientComponentByName
+          if (/\.client\.(js|ts|jsx|tsx)$/.test(file)) return true;
           try {
             const head = readFileSync(file, 'utf-8').slice(0, 200);
             return /^\s*["']use client["']/.test(head.split('\n')[0]);
@@ -76,55 +78,6 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
         }
       }
       return [];
-    },
-    handleHotUpdate({ file, server }: { file: string; server: ViteDevServer }) {
-      const moduleBase = userOptions.moduleBase || "src";
-      const projectRoot = userOptions.projectRoot || server.config.root;
-      const normalizedFile = file.replace(projectRoot, '').replace(/^\/+/, '');
-      const isSourceFile = normalizedFile.startsWith(moduleBase + '/') && 
-        (file.endsWith('.tsx') || file.endsWith('.ts') || file.endsWith('.jsx') || file.endsWith('.js'));
-      
-      // Skip client components — let @vitejs/plugin-react handle them
-      // with Fast Refresh (preserves component-level state).
-      const isClientFile = isSourceFile && (() => {
-        try {
-          const head = readFileSync(file, 'utf-8').slice(0, 200);
-          return /^\s*["']use client["']/.test(head.split('\n')[0]);
-        } catch { return false; }
-      })();
-      
-      if (isSourceFile && !isClientFile) {
-        server.config.logger.info(`[vite-plugin-react-server] File changed (RSC refetch): ${normalizedFile}`);
-        
-        // Send custom HMR event so client can refetch RSC stream
-        server.ws.send({
-          type: 'custom',
-          event: 'vite-plugin-react-server:server-component-update',
-          data: {
-            file: normalizedFile,
-            path: file,
-          },
-        });
-        
-        // Invalidate the server module so next request gets fresh content
-        const mod = server.environments['server']?.moduleGraph?.getModulesByFile(file);
-        if (mod) {
-          for (const m of mod) {
-            server.environments['server']?.moduleGraph?.invalidateModule(m);
-          }
-        }
-        
-        // Return empty array to prevent Vite's default full-page reload
-        // The client will refetch the RSC stream via the custom event
-        return [];
-      }
-      
-      if (isClientFile) {
-        // Client components are handled by @vitejs/plugin-react (Fast Refresh)
-        // or Vite's client-side HMR. Return empty to prevent the server
-        // environment from triggering a full page reload.
-        return [];
-      }
     },
   };
 

--- a/plugin/helpers/requestInfo.ts
+++ b/plugin/helpers/requestInfo.ts
@@ -118,7 +118,6 @@ export function requestInfo(
     hasHtmlHeader ||
     (isFolder &&
       !hasRscHeader &&
-      !hasRscQueryParam &&
       !isRsc &&
       !isJsRequest &&
       !isFormActionRequest));
@@ -181,7 +180,7 @@ export function requestInfo(
     if (mimeType) {
       contentType = mimeType + "; charset=utf-8";
     } else {
-      contentType = "application/octet-stream; charset=utf-8";
+      contentType = "application/octet-stream";
     }
   }
 


### PR DESCRIPTION
## Changes

Six bug fixes found during code review:

### HMR System
- **Remove deprecated `handleHotUpdate`** — was duplicating the Vite 6 `hotUpdate` handler in `plugin.server.ts`, causing double WS events and module invalidations on every file save
- **Add `.client.tsx` filename pattern detection** — HMR plugins only checked for `"use client"` directive, but the transformer also treats `.client.tsx` files as client components via `isClientComponentByName`. Without this, `.client.tsx` files without the directive got RSC refetch instead of Fast Refresh
- **Merge duplicate `restart` listeners** — two separate `server.ws.on('restart')` handlers in `configureReactServer.server.ts`, now one

### Request Handling
- **Remove `charset=utf-8` from `application/octet-stream`** — charset doesn't apply to binary content types
- **Remove redundant `hasRscQueryParam` check** — was checked twice in `isHtmlRequest` condition
- **Remove broken `Content-Length: 0`** — error handler set this header with a comment about updating it later, but HTTP headers can't be changed after sending

### Testing
All 15 Playwright e2e tests pass.