### PR TITLE
fix(config): auto-select server vs client createHandlerOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/plugin/config/index.ts
+++ b/plugin/config/index.ts
@@ -24,17 +24,37 @@ export { resolveAutoDiscover } from "./autoDiscover/resolveAutoDiscover.js";
 
 /**
  * Main handler options creation (auto-selects environment)
- * 
- * RECOMMENDED: Use this for most cases - it automatically chooses the right implementation
- * based on your current environment (react-server vs react-client).
- * 
+ *
+ * RECOMMENDED: Use this for most cases - it automatically chooses the right
+ * implementation based on the current resolve condition (react-server vs
+ * react-client). Under the react-server condition, RSC rendering happens
+ * inline; under react-client, the client implementation spawns an RSC worker
+ * (with the react-server condition) when needed and proxies the stream back.
+ *
  * Example:
  * ```typescript
  * import { createHandlerOptions } from "../config/index.js";
  * const handlerOptions = await createHandlerOptions("/about", options);
  * ```
  */
-export { createHandlerOptions } from "./createHandlerOptions.server.js";
+import { createHandlerOptions as _createHandlerOptionsServer } from "./createHandlerOptions.server.js";
+import { createHandlerOptions as _createHandlerOptionsClient } from "./createHandlerOptions.client.js";
+import { getCondition } from "./getCondition.js";
+import type {
+  CreateHandlerOptionsParams,
+} from "./createHandlerOptions.types.js";
+import type { CreateHandlerOptions } from "../types.js";
+
+export const createHandlerOptions = async (
+  route: string,
+  options: CreateHandlerOptionsParams = {}
+): Promise<CreateHandlerOptions> => {
+  const impl =
+    getCondition() === "react-server"
+      ? _createHandlerOptionsServer
+      : _createHandlerOptionsClient;
+  return impl(route, options);
+};
 
 /**
  * Handler options creation (environment-specific, when you need explicit control)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,18 +32,12 @@ export default defineConfig({
       "**/dist/**",
       "**/cypress/**",
       "**/.{idea,git,cache,output,temp}/**",
-      // The unit, server, and streams suites all reach for the
-      // `react-server.test` Vitest environment and call into modules that
-      // require the react-server resolve condition. Running them under
-      // `test:client` (which doesn't set NODE_OPTIONS='--conditions
-      // react-server') yields "No stashed userOptions found for environment:
-      // react-server.test" — they belong to `test:server` / `test:both`.
+      // The unit and server suites are gated on the react-server resolve
+      // condition (they import from react-server-only paths). Streams stay
+      // included in both modes — the worker mechanism handles RSC rendering
+      // from a react-client process via spawning a react-server worker.
       ...(getCondition() !== "react-server"
-        ? [
-            "test/unit/**/*.test.*",
-            "test/server/**/*.test.*",
-            "test/streams/**/*.test.*",
-          ]
+        ? ["test/unit/**/*.test.*", "test/server/**/*.test.*"]
         : []),
     ],
   },


### PR DESCRIPTION
## Summary

\`vite-plugin-react-server/config\`'s \`createHandlerOptions\` had a doc comment claiming "auto-selects environment" but actually re-exported the server implementation unconditionally:

```ts
export { createHandlerOptions } from "./createHandlerOptions.server.js";
```

The server implementation hardcodes the lookup envId to \`getEnvironmentId("react-server", mode)\`. Calling it from a react-client process (e.g. \`test/streams\` running under \`test:client\`) errors with:

> No stashed userOptions found for environment: react-server.test. Make sure resolveOptions() has been called first.

…because \`resolveOptions\` had stashed under \`react-client.test\`.

## Change

Make the wrapper actually do what its comment says: look at the current \`getCondition()\` at call time and dispatch to the right impl.

```ts
export const createHandlerOptions = async (route, options = {}) => {
  const impl =
    getCondition() === "react-server"
      ? _createHandlerOptionsServer
      : _createHandlerOptionsClient;
  return impl(route, options);
};
```

The client implementation spawns an RSC worker (under the react-server condition) when it needs to render an RSC stream and proxies the result back, so streams now work end-to-end from a react-client process without a manual worker setup in the call site.

## Side-effect

\`test/streams/**\` was excluded from \`test:client\` in #28 as a workaround for this same issue. With the wrapper fixed, the exclusion is no longer needed — drop it. \`test:client\` now picks up the streams suite again, all 4 tests green.

## Verification

- \`test:client\` (no react-server condition): **152 passed, 4 skipped, 0 failed** (was 148/4/0 with the streams exclusion — the four streams cases come back online).
- \`test:server\`: **428 passed, 3 skipped, 0 failed**.
- \`test:unit\`: **277 passed, 0 failed**.
- The streams suite alone in client mode (\`vitest run test/streams\`): all green, RSC stream completes with 6 chunks / 4968 bytes from a react-client process via the spawned worker.

Bumps version to **1.4.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)