### PR TITLE
fix(bd-5xu): don't cache pageProps across requests in RSC worker

### DIFF
--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -243,7 +243,17 @@ async function loadComponentsWithCache(options: {
     // Track if we need to load props separately (when Page is cached but props for this URL aren't)
     let needToLoadProps = false;
     
-    // Check cache first, but only if not invalidated
+    // Check cache first, but only if not invalidated.
+    //
+    // bd-5xu (2026-04-30): we cache the Page component (a stable function from
+    // the source file) but NOT the props result. Props functions read mutable
+    // server state — DB rows, in-memory stores, request-scoped data — and a
+    // cross-request cache silently serves stale data after a server action
+    // mutates that state. The pre-bd-5xu code keyed pageProps by URL and only
+    // invalidated on file change, so e.g. deleting a todo via a server action
+    // was correctly persisted to the DB but the next /todos/index.rsc still
+    // returned the pre-delete cached props. dev:rsc didn't go through this
+    // worker path so it didn't repro there. Always reload props in dev.
     if (hasCachedComponent(pageId) && !isPageInvalidated) {
       PageComponent = getCachedComponent(pageId);
       if (verbose) {
@@ -251,27 +261,16 @@ async function loadComponentsWithCache(options: {
           `[rsc-worker] Using cached Page component from: ${pagePath}`
         );
       }
-      
-      // Also check props cache if propsPath exists (skip if resolvedPageProps provided)
-      // CRITICAL: Include URL in cache key for props - dynamic routes return different props per URL
+
       if (propsPath && !resolvedPageProps) {
+        // Props are intentionally NOT cached across requests — see comment
+        // above. Drop any pre-existing cache entry from older versions, then
+        // fall through to the separate-load path below.
         const propsId = `${propsPath}#${propsExportName}@${normalizedUrl}`;
-        const isPropsInvalidated = isModuleInvalidated(propsPath);
-        if (hasCachedComponent(propsId) && !isPropsInvalidated) {
-          pageProps = getCachedComponent(propsId);
-          if (verbose) {
-            logger?.info(
-              `[rsc-worker] Using cached pageProps from: ${propsPath} for URL: ${url}`
-            );
-          }
-        } else {
-          // Props invalidated or not cached for this URL - need to reload
-          if (isPropsInvalidated && hasCachedComponent(propsId)) {
-            clearCachedComponent(propsId);
-          }
-          // Mark that we need to load props separately
-          needToLoadProps = true;
+        if (hasCachedComponent(propsId)) {
+          clearCachedComponent(propsId);
         }
+        needToLoadProps = true;
       } else if (resolvedPageProps) {
         if (verbose) {
           logger?.info(
@@ -325,25 +324,16 @@ async function loadComponentsWithCache(options: {
             pageProps = pageAndPropsResult.pageProps;
           }
 
-          // Cache the components
+          // Cache the Page component (stable across requests). Props are
+          // not cached — see bd-5xu note above for why.
           cacheComponent(pageId, PageComponent);
-
-          if (propsPath) {
-            // CRITICAL: Include URL in cache key for props - dynamic routes return different props per URL
-            const propsId = `${propsPath}#${propsExportName}@${normalizedUrl}`;
-            cacheComponent(propsId, pageProps);
-          }
 
           if (verbose) {
             logger?.info(
               `[rsc-worker] Loaded and cached PageComponent from: ${pagePath}`
             );
             if (propsPath) {
-              logger?.info(
-                `[rsc-worker] Loaded and cached pageProps from: ${propsPath}`
-              );
-            }
-            if (verbose) {
+              logger?.info(`[rsc-worker] Loaded fresh pageProps from: ${propsPath}`);
               logger?.info(`[rsc-worker] Loaded pageProps:`, pageProps);
             }
           }
@@ -392,14 +382,11 @@ async function loadComponentsWithCache(options: {
         
         if (pageAndPropsResult.type === "success") {
           pageProps = pageAndPropsResult.pageProps;
-          
-          // Cache the props for this URL
-          const propsId = `${propsPath}#${propsExportName}@${normalizedUrl}`;
-          cacheComponent(propsId, pageProps);
-          
+
+          // Props are not cached across requests — see bd-5xu note earlier.
           if (verbose) {
             logger?.info(
-              `[rsc-worker] Loaded and cached pageProps for URL: ${url}`
+              `[rsc-worker] Loaded fresh pageProps for URL: ${url}`
             );
           }
         } else {

--- a/test/e2e/dev-ssr-server-actions.spec.ts
+++ b/test/e2e/dev-ssr-server-actions.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression test for bd-5xu (2026-04-30):
+ *
+ *   Browser-driven server actions appeared to succeed under `dev:ssr` but
+ *   their effect was invisible after a page refresh. Root cause: the RSC
+ *   worker's messageHandler cached the result of calling props() across
+ *   requests, keyed by URL. Server actions write to mutable state that
+ *   props() reads, so the next /todos/index.rsc still served the pre-action
+ *   pageProps. dev:rsc didn't go through the same worker code path so it
+ *   didn't repro there — and `playwright.config.ts` only exercises dev:rsc,
+ *   so e2e was clean while dev:ssr silently lied.
+ *
+ * This spec spawns its own bidoof-template dev server WITHOUT
+ * `--conditions react-server` (the dev:ssr path), drives a real browser
+ * to delete a todo, refreshes, and asserts the deletion is reflected.
+ *
+ * It does NOT use the global `webServer` in `playwright.config.ts`. That
+ * one stays on the dev:rsc path for the existing HMR/navigation specs.
+ */
+import { test, expect } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bidoofDir = join(__dirname, "../../../bidoof-template");
+const dbPath = join(bidoofDir, "todos.db");
+// Pick a random high port to avoid collisions with the global webServer
+// (3200) and with stale vite processes left by an aborted prior run.
+const PORT = 32000 + Math.floor(Math.random() * 1000);
+const BASE_URL = `http://localhost:${PORT}`;
+
+let server: ChildProcess | undefined;
+
+function seedTodos(titles: string[]): void {
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(
+      `CREATE TABLE IF NOT EXISTS todos (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT NOT NULL,
+        completed INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      ) STRICT`,
+    );
+    db.prepare("DELETE FROM todos").run();
+    const insert = db.prepare("INSERT INTO todos (title) VALUES (?)");
+    for (const title of titles) insert.run(title);
+  } finally {
+    db.close();
+  }
+}
+
+function readTodos(): { id: number; title: string }[] {
+  const db = new DatabaseSync(dbPath);
+  try {
+    return db.prepare("SELECT id, title FROM todos ORDER BY id").all() as {
+      id: number;
+      title: string;
+    }[];
+  } finally {
+    db.close();
+  }
+}
+
+async function waitForServer(url: string, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
+}
+
+test.beforeAll(async () => {
+  // dev:ssr-equivalent: NO --conditions react-server in NODE_OPTIONS.
+  // The plugin runs in client-mode and spawns the RSC worker with the
+  // condition flipped — that worker is the one that previously cached
+  // props across requests and silently dropped action effects.
+  server = spawn("npx", ["vite", "--port", String(PORT), "--strictPort"], {
+    cwd: bidoofDir,
+    shell: true,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: "",
+      NODE_ENV: "development",
+      BASE_URL: "/",
+      PUBLIC_ORIGIN: BASE_URL,
+      FORCE_COLOR: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  server.stdout?.on("data", (d) => process.stdout.write(`[dev:ssr] ${d}`));
+  server.stderr?.on("data", (d) => process.stderr.write(`[dev:ssr] ${d}`));
+
+  // Re-optimizing deps + plugin warm-up regularly takes 20-40s when the
+  // global webServer is also coming up in parallel; the default 30s hook
+  // budget is too tight on cold runs.
+  await waitForServer(BASE_URL, 60_000);
+}, 90_000);
+
+test.afterAll(async () => {
+  if (server && !server.killed) {
+    server.kill("SIGTERM");
+    await new Promise<void>((r) => {
+      const t = setTimeout(() => r(), 2000);
+      server!.once("exit", () => {
+        clearTimeout(t);
+        r();
+      });
+    });
+  }
+});
+
+test.describe("server actions persist under dev:ssr (bd-5xu)", () => {
+  test("delete-then-refresh reflects the deletion", async ({ page }) => {
+    seedTodos(["alpha", "beta", "gamma"]);
+    expect(readTodos().map((t) => t.title)).toEqual(["alpha", "beta", "gamma"]);
+
+    await page.goto(`${BASE_URL}/todos`, { waitUntil: "networkidle" });
+    const titlesBefore = await page
+      .locator("li")
+      .allTextContents()
+      .then((arr) => arr.map((t) => t.replace(/\s+/g, " ").trim()));
+    expect(titlesBefore.length).toBe(3);
+    expect(titlesBefore.some((t) => t.startsWith("alpha"))).toBe(true);
+
+    await page
+      .locator("button:has-text('×'), button:has-text('Delete')")
+      .first()
+      .click();
+    // Wait for the action POST to round-trip.
+    await page.waitForTimeout(1500);
+
+    // DB must reflect the delete: alpha is gone, beta/gamma remain.
+    const dbAfterAction = readTodos().map((t) => t.title);
+    expect(dbAfterAction).toEqual(["beta", "gamma"]);
+
+    // The page on hard reload must agree with the DB. Pre-bd-5xu this
+    // returned cached pageProps and showed alpha back.
+    await page.reload({ waitUntil: "networkidle" });
+    const titlesAfter = await page
+      .locator("li")
+      .allTextContents()
+      .then((arr) => arr.map((t) => t.replace(/\s+/g, " ").trim()));
+    expect(titlesAfter.length).toBe(2);
+    expect(titlesAfter.some((t) => t.startsWith("alpha"))).toBe(false);
+    expect(titlesAfter.some((t) => t.startsWith("beta"))).toBe(true);
+    expect(titlesAfter.some((t) => t.startsWith("gamma"))).toBe(true);
+  });
+
+  test("RSC route returns fresh props on every request (no cross-request cache)", async () => {
+    seedTodos(["one", "two", "three"]);
+
+    const first = await fetch(`${BASE_URL}/todos/index.rsc`, {
+      headers: { Accept: "text/x-component" },
+    });
+    const firstBody = await first.text();
+    expect(firstBody).toContain('"title":"one"');
+    expect(firstBody).toContain('"title":"two"');
+    expect(firstBody).toContain('"title":"three"');
+
+    // Mutate DB out of band (simulating any server action effect).
+    const db = new DatabaseSync(dbPath);
+    db.prepare("DELETE FROM todos WHERE title = 'one'").run();
+    db.close();
+
+    const second = await fetch(`${BASE_URL}/todos/index.rsc`, {
+      headers: { Accept: "text/x-component" },
+    });
+    const secondBody = await second.text();
+    expect(secondBody).not.toContain('"title":"one"');
+    expect(secondBody).toContain('"title":"two"');
+    expect(secondBody).toContain('"title":"three"');
+  });
+});


### PR DESCRIPTION
## Summary

Browser-driven server actions under `dev:ssr` returned `{success: true}` and actually wrote to disk (DB row deleted, etc.), but a page refresh re-rendered with stale data and the mutation looked like it was lost. Discovered while end-to-end testing #30 against `bidoof-template`.

## Root cause

`plugin/worker/rsc/messageHandler.server.tsx` keyed `pageProps` by URL and cached the result of calling `props()` across requests, only invalidating on file changes. `props()` reads mutable server state (DB rows, in-memory stores), so the next `/<route>/index.rsc` request served the pre-action props.

`dev:rsc` didn't repro because it goes through `configureReactServer.server.ts`, not the worker's `messageHandler.server.tsx`. That's also why the existing `playwright.config.ts` (which only exercises `dev:rsc`) showed 9/9 green while the bug shipped.

## Fix

Keep caching the **Page component** (stable across requests without an HMR file change) but always re-resolve **pageProps**. `props()` now runs once per request — same as the `dev:rsc` path has done all along. Performance impact is one function call + whatever the user's `props()` does.

Changes in `plugin/worker/rsc/messageHandler.server.tsx`:
- Drop the `hasCachedComponent(propsId)` check. Any pre-existing entry from older versions is cleared, then we fall through to the load path.
- Drop the two `cacheComponent(propsId, pageProps)` writes.

## Guard rail

`test/e2e/dev-ssr-server-actions.spec.ts` (new) drives a real browser through the delete-then-refresh flow under `dev:ssr` (NO `--conditions react-server`). It also asserts that two sequential `/todos/index.rsc` fetches return fresh DB state when the DB is mutated out of band between them. Self-hosted dev server on a random port — does not reuse the global webServer in `playwright.config.ts`, which stays on `dev:rsc` for the existing HMR/navigation specs.

## Verification

| Gate | Result |
|---|---|
| `npm run test:client` | 154 passed, 4 skipped (no new skips) |
| `npm run test:server` | 430 passed, 3 skipped (no new skips) |
| `npx playwright test test/e2e/dev-ssr-server-actions.spec.ts` | 2 / 2 pass |
| Linked bidoof-template under dev:ssr: real browser delete + refresh | row gone, both UI and DB |
| Linked bidoof-template under dev:ssr: 2 sequential `/todos/index.rsc` with DB mutation between | second fetch reflects mutation |
| Linked bidoof-template under dev:rsc | unchanged (didn't use the cache anyway) |

Bidoof restored to committed `^1.4.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)