### PR TITLE
fix(bd-lr4): pin peerDeps to experimental React channel — v1.4.7

### DIFF
--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -2,17 +2,27 @@
 
 ## Supported Versions
 
+The plugin vendors a build of `react-server-dom-esm` whose internals (taint registries on `ReactSharedInternalsServer`, etc.) are tied to React's experimental release channel. Stable React 19.x doesn't expose the same internals — see bd-lr4.
+
 | React Version | Support | Notes |
 |---------------|---------|-------|
-| React 19+ stable | ✅ Full Support | Recommended |
-| `react@experimental` | ✅ Full Support | Bleeding edge features |
+| `react@experimental` (any `0.0.0-experimental-*` prerelease) | ✅ Supported | The vendored `oss-experimental/react-server-dom-esm` matches React's experimental internals |
+| React 19+ stable | ❌ Not supported (yet) | Stable React's `ReactSharedInternalsServer` is missing the taint registries the vendored rsd-esm reads at module init, causing `Cannot read properties of undefined (reading 'add')` in `RequestInstance` during the static build path. A future plugin version will ship per-React-channel loader builds — tracked separately. |
 | React 18 stable | ❌ Not supported | Missing RSC APIs |
 
 ```bash
-npm install react@19 react-dom@19
+npm install react@experimental react-dom@experimental
 ```
 
-**Peer dependency**: `react >= 0.0.0-experimental-0` (accepts React 19+ and experimental).
+For reproducibility, pin a specific experimental SHA — for example, the version the plugin is currently developed against:
+
+```bash
+npm install react@0.0.0-experimental-f93b9fd4-20251217 react-dom@0.0.0-experimental-f93b9fd4-20251217
+```
+
+**Peer dependency**: `react: ">=0.0.0-experimental-0 <1.0.0"`. The upper bound rejects stable React (19.x, 20.x) so npm warns instead of resolving silently to a broken pairing. Any 0.0.0 prerelease (experimental, canary, next) satisfies the lower bound.
+
+> Earlier 1.4.x docs claimed "React 19+ stable: Full Support." That was incorrect — local development with `file:` link masked the mismatch by hoisting the plugin's own experimental React into the consumer. npm-installed consumers crashed in the static build path. See bd-lr4.
 
 ## Vendored ESM Transport
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -62,6 +62,8 @@ npx playwright test test/e2e/hmr.spec.ts
 
 **If any of 1a–1d fails, do not publish.** File a `bd` issue and bisect to the introducing commit. A regression that is already on `main` but not yet released is still a release-blocker — it ships to consumers the moment you `npm publish`.
 
+> ⚠️ **`file:` link masks React version mismatches.** Linked demos resolve `react`/`react-dom` against the plugin's own `node_modules`, which means whatever experimental React is installed inside `vite-plugin-react-server/` gets hoisted into the consumer for free. A demo that pins stable React 19 in its own `package.json` will *still* run against the plugin's experimental React under `file:` link, and never exercise the actual stable-React path. To verify a release works for npm consumers — not just `file:`-link consumers — also `npm pack` the tarball and install it into a clean fixture before publishing. Skipping this is what let v1.4.6 ship broken on stable React (bd-lr4).
+
 ## 2. Bump the version
 
 ```bash

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -8,8 +8,8 @@
       "name": "vite-plugin-react-server-hello-world",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^19.2.5",
-        "react-dom": "^19.2.5",
+        "react": "0.0.0-experimental-f93b9fd4-20251217",
+        "react-dom": "0.0.0-experimental-f93b9fd4-20251217",
         "vite-plugin-react-server": "file:../.."
       },
       "devDependencies": {
@@ -20,7 +20,7 @@
       }
     },
     "../..": {
-      "version": "1.4.5",
+      "version": "1.4.7",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -58,8 +58,8 @@
         "node": "^23.7.0"
       },
       "peerDependencies": {
-        "react": ">=0.0.0-experimental-0",
-        "react-dom": ">=0.0.0-experimental-0",
+        "react": ">=0.0.0-experimental-0 <1.0.0",
+        "react-dom": ">=0.0.0-experimental-0 <1.0.0",
         "vite": "*"
       },
       "peerDependenciesMeta": {
@@ -979,9 +979,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -1047,24 +1047,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "0.0.0-experimental-f93b9fd4-20251217",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-f93b9fd4-20251217.tgz",
+      "integrity": "sha512-pHZOYztrFX7PACNOy/ifXFKrltYIoFXiBixaOqG8LoIXdIFWrAXazbE/QvV+ZIGny19e3MwIlRmDI06OCPx1Jg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "0.0.0-experimental-f93b9fd4-20251217",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-f93b9fd4-20251217.tgz",
+      "integrity": "sha512-JWopOzRvOL8/WyPucssWRIHW4SEj4AeRxsKI3RjatswQGnYM2ZsUE92vaH+6CW6JRRWA0tb6X6qfI7Qd6vw+nw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "scheduler": "0.0.0-experimental-f93b9fd4-20251217"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "0.0.0-experimental-f93b9fd4-20251217"
       }
     },
     "node_modules/rollup": {
@@ -1113,9 +1113,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "version": "0.0.0-experimental-f93b9fd4-20251217",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-f93b9fd4-20251217.tgz",
+      "integrity": "sha512-NAufgjQBtR6CiT5BhY1mK1gN8zszRjERrWER4FeBLONZN3F4rVODepp5Cqq7y0x7E1XdGSQAZriAlLenrPguMg==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -7,8 +7,8 @@
     "dev": "vite"
   },
   "dependencies": {
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
+    "react": "0.0.0-experimental-f93b9fd4-20251217",
+    "react-dom": "0.0.0-experimental-f93b9fd4-20251217",
     "vite-plugin-react-server": "file:../.."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",
@@ -381,8 +381,8 @@
   },
   "homepage": "https://github.com/nicobrinkkemper/vite-plugin-react-server#readme",
   "peerDependencies": {
-    "react": ">=0.0.0-experimental-0",
-    "react-dom": ">=0.0.0-experimental-0",
+    "react": ">=0.0.0-experimental-0 <1.0.0",
+    "react-dom": ">=0.0.0-experimental-0 <1.0.0",
     "vite": "*"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

- Tighten `peerDependencies.react`/`react-dom` from `>=0.0.0-experimental-0` to `>=0.0.0-experimental-0 <1.0.0` so npm hard-fails (`ERESOLVE`) when vprs is paired with stable React 19.x. Any `0.0.0-experimental-*` prerelease still satisfies it.
- Walk back the **"React 19+ stable: Full Support"** claim in `docs/react-type-compatibility.md`. The vendored `react-server-dom-esm` is keyed to experimental React's `ReactSharedInternalsServer` shape; stable React doesn't expose the taint registries it reads at module init, causing `Cannot read properties of undefined (reading 'add')` in `RequestInstance` during the static build path.
- Repin `examples/hello-world` to the experimental React the plugin is actually developed against (`0.0.0-experimental-f93b9fd4-20251217`) and regenerate the lockfile. Yesterday's stable-React pin there only worked because `file:../..` hoisted the plugin's experimental React into the example — exactly the masking effect that caused this regression to ship.
- `docs/releasing.md`: add a callout that `file:` link masks React-version mismatches, and recommend `npm pack` + clean-fixture install in the publish protocol so this can't recur silently.
- Bump `1.4.6 → 1.4.7`.

Closes bd-lr4.

## Why

v1.4.6 was published with a peer-dep range that quietly accepted stable React 19, while the vendored rsd-esm only works against experimental React. Linked demos masked it by hoisting experimental React from the plugin's own `node_modules`. Anyone npm-installing vprs with stable React 19.x got a silent crash deep inside `RequestInstance`.

This PR makes the broken pairing fail loudly at install time instead of at static-build time. Fixing the underlying limitation (shipping a stable-React rsd-esm build) is a separate, larger effort tracked in beads.

## Test plan

- [x] `npm run build` — green (~700ms)
- [x] `npm pack`, install tarball into `/tmp` fixture with `react@19.2.5` → `ERESOLVE` (loud fail, expected)
- [x] `npm pack`, install tarball with `react@0.0.0-experimental-f93b9fd4-20251217` → clean install
- [x] `examples/hello-world` lockfile regenerated against new pin
- [ ] Maintainer: `npm test` (full test:both) before publish
- [ ] Maintainer: link `bidoof-template` and `mmc` per `docs/releasing.md` § 1c, verify both build cleanly
- [ ] Maintainer: `npm publish` (2FA — human step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)