### PR TITLE
fix(dev:ssr): emit server-component-update WS event so browser refetches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -107,16 +107,26 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       
       if (isServerFile && hmrHandler) {
         isProcessingHmr = true;
-        
+
         try {
           server.config.logger.info(`[vite-plugin-react-server] File changed: ${file}, sending HMR update...`);
-          
+
           // CRITICAL: Send HMR_UPDATE message to worker to invalidate modules
           // This clears component caches, but Node.js's ES module cache persists
           hmrHandler.sendHmrUpdate(file);
-          
-          // NOTE: The WS event to notify the client is sent by the hotUpdate hook
-          // in plugin.server.ts — don't duplicate it here.
+
+          // Notify the browser to refetch the RSC stream. In dev:rsc the
+          // equivalent send lives in plugin.server.ts's hmrPlugin, which only
+          // runs under the react-server orchestrator. dev:ssr (this plugin)
+          // never loads that orchestrator, so without sending the event here
+          // the worker invalidates correctly but the browser keeps showing
+          // pre-edit content — `useRscHmr` listens for this event and only
+          // refetches on receipt.
+          server.ws.send({
+            type: "custom",
+            event: "vite-plugin-react-server:server-component-update",
+            data: { file: normalizedFile, path: file },
+          });
           
           // CRITICAL: Node.js caches ES modules, so we need to restart the worker
           // to clear the module cache. Debounce restarts to prevent recursion.


### PR DESCRIPTION
## Summary

In dev:ssr the file-change pipeline did the right thing on the server side — `sendHmrUpdate` to the worker, module invalidation, worker restart on next request — but never told the browser to refetch. The browser's `useRscHmr` listens for the custom event `vite-plugin-react-server:server-component-update` and only refetches the RSC stream on receipt; without the event firing, the browser kept rendering the pre-edit payload even though `/index.rsc` was now serving fresh content.

dev:rsc has the equivalent send in `plugin.server.ts`'s `hmrPlugin`, but that plugin only loads under the react-server orchestrator. dev:ssr loads `plugin.client.ts`, which never registered the equivalent event emitter. Move the `server.ws.send` into `plugin.client.ts`'s `hotUpdate` so it fires regardless of which orchestrator is active.

## Why this matters

The README's "Minimal Example" gives new users `npx vite` (= dev:ssr) as the dev command. Without this fix, anyone following the README hits a dev mode where saving a server component appears to do nothing — content is served correctly on the next request but the open browser tab keeps the stale render.

## Verification

Built `1.5.1` locally, `npm pack`'d, installed in geitje-bot-mission-control's `app/` with `--no-save`, ran `npm run dev` (= dev:ssr):

- Pre-fix: edit `src/page/page.tsx` to add a string to a Canvas prop → curling `/index.rsc` returns the new content (server-side is fine), but a real browser keeps showing the pre-edit page.
- Post-fix: same edit → server logs the file change, sends the WS event, browser's `useRscHmr` triggers refetch, page updates without reload.

Tests still green:
- `test:server` → 67 files / 444 passed / 3 skipped
- `test:client` → 39 files / 154 passed / 4 skipped

## Ship as

`1.5.1` — bug-fix patch, no API changes, no behavior changes anywhere besides the new WS event firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)