### PR TITLE
fix: disable ssr-manifest emission by default

### DIFF
--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -575,7 +575,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
           },
           ssr: ssr,
           manifest: config.build?.manifest ?? `.vite/manifest.json`,
-          ssrManifest: config.build?.ssrManifest ?? `.vite/ssr-manifest.json`,
+          ssrManifest: config.build?.ssrManifest ?? false,
           ssrEmitAssets: config.build?.ssrEmitAssets ?? true,
           cssCodeSplit:
             typeof config.build?.cssCodeSplit === "boolean"
@@ -620,7 +620,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
           minify: minify,
           ssr: ssr,
           manifest: config.build?.manifest ?? `.vite/manifest.json`,
-          ssrManifest: config.build?.ssrManifest ?? `.vite/ssr-manifest.json`,
+          ssrManifest: config.build?.ssrManifest ?? false,
           ssrEmitAssets:
             typeof config.build?.ssrEmitAssets === "boolean"
               ? config.build?.ssrEmitAssets

--- a/plugin/environments/resolveEnvironmentConfig.ts
+++ b/plugin/environments/resolveEnvironmentConfig.ts
@@ -225,7 +225,7 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
           target: config.build?.target ?? "esnext",
           minify: config.build?.minify ?? true,
           manifest: config.build?.manifest ?? `.vite/manifest.json`,
-          ssrManifest: config.build?.ssrManifest ?? `.vite/ssr-manifest.json`,
+          ssrManifest: config.build?.ssrManifest ?? false,
           ssrEmitAssets: config.build?.ssrEmitAssets ?? true,
           cssCodeSplit:
             typeof config.build?.cssCodeSplit === "boolean"
@@ -253,7 +253,7 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
           target: config.build?.target ?? "esnext", // Use esnext for pure ESM - no helpers needed
           minify: config.build?.minify ?? true,
           manifest: config.build?.manifest ?? `.vite/manifest.json`,
-          ssrManifest: config.build?.ssrManifest ?? `.vite/ssr-manifest.json`,
+          ssrManifest: config.build?.ssrManifest ?? false,
           ssrEmitAssets:
             typeof config.build?.ssrEmitAssets === "boolean"
               ? config.build?.ssrEmitAssets


### PR DESCRIPTION
## Summary

Defaults `build.ssrManifest` to `false` in `resolveUserConfig` and `resolveEnvironmentConfig` (4 sites total) instead of `.vite/ssr-manifest.json`.

## Why

The SSR manifest written at `.vite/ssr-manifest.json` contains absolute filesystem paths into `node_modules`, leaking the host's home directory and project structure to anyone who can fetch the deployed static output.

vprs's own runtime never reads this manifest — every internal caller of `tryManifest` already passes `ssrManifest: false`. So emitting it serves no functional purpose for the plugin while creating an information-disclosure footgun for users who deploy static output without realising it's there.

Users who actually want the Vite SSR manifest can opt in explicitly by setting `build.ssrManifest` in their config.

## Test plan

- [x] `npm run build` — clean
- [x] Existing test suite green on this branch

## Scope

Part of v1.5.1 (alongside the dev:ssr HMR WS event fix and a bd-w4t test fixture fix).