### PR TITLE
fix(bd-w4t): defuse Invalid URL in page2 test fixture + add regression test

### DIFF
--- a/test/dev/props-variations.test.ts
+++ b/test/dev/props-variations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { createServer } from "vite";
+import { createServer, createLogger } from "vite";
 import { vitePluginReactServer } from "vite-plugin-react-server";
 import { testUserOptions } from "../test-config.js";
 import { mkdir, rm } from "node:fs/promises";
@@ -16,16 +16,35 @@ let server,
   response2: RSCStreamResponse;
 const testDir = resolve(__dirname, "../fixtures/props-variations.test");
 
+// Capture every error/warn log the plugin emits during this test's lifecycle.
+// Used by the bd-w4t regression test to assert that a sub-route RSC request
+// does not surface any error logs (the symptom of the original bug).
+const recordedErrors: string[] = [];
+const recordedWarns: string[] = [];
+
 describe("RSC Server", () => {
   beforeAll(async () => {
     // Clean up and create test directory
     await rm(testDir, { recursive: true, force: true });
     await mkdir(testDir, { recursive: true });
     await setupTestProjectPropsVariations(testDir);
+    // Custom logger that tees every error/warn into recordedErrors/recordedWarns.
+    const customLogger = createLogger("info", { allowClearScreen: false });
+    const origError = customLogger.error.bind(customLogger);
+    const origWarn = customLogger.warn.bind(customLogger);
+    customLogger.error = (msg, opts) => {
+      recordedErrors.push(typeof msg === "string" ? msg : String(msg));
+      origError(msg, opts);
+    };
+    customLogger.warn = (msg, opts) => {
+      recordedWarns.push(typeof msg === "string" ? msg : String(msg));
+      origWarn(msg, opts);
+    };
     // Start the server
     server = await createServer({
       mode: "test",
       root: testDir,
+      customLogger,
       plugins: [
         vitePluginReactServer({
           ...testUserOptions,
@@ -119,5 +138,16 @@ describe("RSC Server", () => {
     // Verify the response contains page content
     expect(response2.result).toContain("Home Page for");
     // Server environment shows undefined values as $undefined in RSC stream, which is expected
+  });
+
+  it("does not emit RSC render error logs for the sub-route request (bd-w4t regression)", () => {
+    // bd-w4t: prior to the fixture fix, every run of this file logged
+    //   [client] RSC render error for /page2: Invalid URL
+    // because the page2 fixture called new URL() on undefined props.
+    // Catch any regression of that pattern at the logger boundary.
+    const rscRenderErrors = recordedErrors.filter((m) =>
+      /RSC render error/.test(m)
+    );
+    expect(rscRenderErrors).toEqual([]);
   });
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -541,14 +541,22 @@ return (
 );
 }`
   );
-  // Create a test page component
+  // Create a test page component.
+  // Default `url` to "/page2" so the page renders even when the test
+  // configures `props: undefined` (the "no props at all" case). The
+  // original fixture used `url` undefined in a `new URL(...)` constructor,
+  // which threw `TypeError: Invalid URL` and surfaced as a per-run
+  // `[client] RSC render error for /page2: Invalid URL` log (bd-w4t).
+  // The `new URL(...)` call has been removed entirely — the test only
+  // asserts that "Home Page for ..." appears in the rendered output, and
+  // the URL parsing was incidental.
   await writeFile(
     resolve(testDir, "src", "page2", "page.tsx"),
     `import React from "react";
-export function Page({url, propsEnv = import.meta.env}) {
+export function Page({url = "/page2", propsEnv = import.meta.env}) {
 return (
   <div>
-    <h1>Home Page for {new URL(import.meta.env.BASE_URL + url, import.meta.env.PUBLIC_ORIGIN + import.meta.env.BASE_URL).pathname}</h1>
+    <h1>Home Page for {url}</h1>
     <p>Base URL: {propsEnv.BASE_URL}</p>
     <p>Public: {propsEnv.PUBLIC_ORIGIN}</p>
     <p>Mode: {import.meta.env.MODE}</p>


### PR DESCRIPTION
## Summary

Closes [bd-w4t]: the `[client] RSC render error for /page2: Invalid URL` log that was emitted on every run of `test/dev/props-variations.test.ts`. The bug was in the test fixture itself, not the plugin.

## What I found

The bd-w4t bead pointed at three suspect files in the plugin (`plugin/utils/urls.ts`, `createPluginOrchestrator.ts`, `createWorker.ts`) as probable culprits for the `Invalid URL` throw. To narrow it down I temporarily added a stack-trace dump to `handleRscStream.client.ts`'s `ERROR` handler and re-ran the test. The stack was:

```
TypeError: Invalid URL
    at new URL (node:internal/url:818:25)
    at Page (test/fixtures/props-variations.test/src/page2/page.tsx:2)
    at react-stack-bottom-frame (...react-server-dom-esm-server.node.development.js)
```

The throw site is in the **test fixture's page2 component**, written by `setupTestProjectPropsVariations` in `test/setup.ts`:

```tsx
export function Page({url, propsEnv = import.meta.env}) {
return (
  <div>
    <h1>Home Page for {new URL(import.meta.env.BASE_URL + url, import.meta.env.PUBLIC_ORIGIN + import.meta.env.BASE_URL).pathname}</h1>
```

The test configures `props: undefined` (it's literally the "should handle no props at all" case), so `url` is undefined. Both `BASE_URL + url` and `PUBLIC_ORIGIN + BASE_URL` then string-concatenate `undefined` (`PUBLIC_ORIGIN` is also unset in the test env), producing inputs that `new URL` can't parse.

So the plugin was correctly surfacing a real render exception thrown by the page — the bug was that the fixture page never handled the no-props case it was supposedly testing.

## Fix

1. **Default `url` to `"/page2"`** in the fixture so the no-props case renders.
2. **Drop the `new URL(...)` parsing** entirely. The test only asserts that `"Home Page for"` appears in the rendered output and `"page2/page.tsx"` appears in the React debug info — the URL parsing was incidental and is what threw.

## Regression test

Per the bd-w4t acceptance criterion (*"A regression test in test/dev/ exercises a sub-route RSC request and asserts no error log is emitted"*), this PR adds:

- A `customLogger` in `beforeAll` that tees every `logger.error` call into a recorded list.
- A new test `"does not emit RSC render error logs for the sub-route request (bd-w4t regression)"` that filters the recorded errors for `/RSC render error/` and asserts the result is empty.

## Test plan

- [x] `npx vitest run test/dev/props-variations.test.ts` — 4/4 pass, no `RSC render error` log on stderr (re-ran 3x for stability).

## Scope

Part of v1.5.1 alongside #35 (dev:ssr HMR WS event) and #36 (ssr-manifest default off).

[bd-w4t]: https://github.com/nicobrinkkemper/geitje-bot-mission-control (private bead — vprs Invalid URL race in RSC worker for sub-route requests)