### PR TITLE
docs: stop advertising stable React 19 support in front-of-house docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Vite plugin that transforms React components into native ESM modules with Reac
 ## Install
 
 ```bash
-npm install -D vite-plugin-react-server react@19 react-dom@19
+npm install -D vite-plugin-react-server react@experimental react-dom@experimental
 ```
 
 ## Minimal Example
@@ -96,7 +96,7 @@ vitePluginReactServer({
 ## Requirements
 
 - Node.js 23.7.0+
-- React 19+ or experimental
+- React experimental channel (`react@experimental` / `react-dom@experimental`). Stable React 19.x is **not yet supported** — the vendored `react-server-dom-esm` reads `TaintRegistryPendingRequests` from React's server internals, and the taint registry is only exposed on the experimental channel today. See [React Compatibility](./docs/react-type-compatibility.md) for the full story; stable support is tracked separately and is gated on upstream React landing the taint API in the stable build.
 - Vite 6+
 
 ## TypeScript

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,10 +3,10 @@
 ## Install
 
 ```bash
-npm install -D vite-plugin-react-server react@19 react-dom@19
+npm install -D vite-plugin-react-server react@experimental react-dom@experimental
 ```
 
-React 19+ or experimental required. The ESM transport (`react-server-dom-esm`) is vendored — no separate install needed.
+React from the **experimental** channel is required. Stable React 19.x is not yet supported — the vendored `react-server-dom-esm` reads taint-registry internals that only exist on the experimental channel. See [React Compatibility](./react-type-compatibility.md) for the full story. The ESM transport (`react-server-dom-esm`) is vendored — no separate install needed.
 
 ## Create a Page
 


### PR DESCRIPTION
## Summary
Brings the README and Getting Started doc in line with the actual React-version requirement.

`README.md` and `docs/getting-started.md` both still showed:
- Install: `npm install -D vite-plugin-react-server react@19 react-dom@19`
- Requirements: "React 19+ or experimental"

Neither has been accurate since v1.4.6 — the vendored \`react-server-dom-esm\` reads \`TaintRegistryPendingRequests\` from React's server internals (\`__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE\`), and the taint registry is only exposed on the experimental channel. Stable React 19.x crashes with \`Cannot read properties of undefined (reading 'add')\` at \`new RequestInstance(...)\` during the static build path (see \`cjs/react-server-dom-esm-server.node.production.js:645\`).

\`docs/react-type-compatibility.md\` and \`docs/releasing.md\` already carry the correct, detailed story. This PR just brings the front door in sync:

- Install snippet → \`react@experimental react-dom@experimental\`
- Requirements line → explicit "experimental only," with a link through to \`react-type-compatibility.md\` as the single source of truth.

## Test plan
- [x] Read \`react-type-compatibility.md\` — confirmed it already documents the exact constraint (taint registry, lr4 cross-reference, peerDep range)
- [x] Spot-checked against today's mmc PR #90 probe, where stable React 19.2.6 reproduces the crash and experimental React 0.0.0-experimental-d5736f09-20260507 builds cleanly
- [ ] Reviewer sanity-checks the wording reads cleanly without context

Closes nothing on the GitHub side; tracked under \`bd-2zj\` in the mission-control beads.