### PR TITLE
test(e2e): fix HMR-todos-page test stranded by GitHub Pages branch

### DIFF
--- a/test/e2e/hmr.spec.ts
+++ b/test/e2e/hmr.spec.ts
@@ -65,27 +65,34 @@ test.describe('HMR in bidoof-template', () => {
   test('server component change updates todos page', async ({ page }) => {
     const pageFile = join(bidoofDir, 'src/page/todos/page.tsx');
     const originalContent = await readFile(pageFile, 'utf-8');
-    
+
     try {
       await page.goto('/todos/');
-      
+
       // Verify initial content
       await expect(page.locator('h1')).toContainText('Todo');
-      
+
       // Verify the marker doesn't exist yet
       await expect(page.locator('[data-testid="hmr-marker"]')).toHaveCount(0);
 
-      // Modify the server component — add a visible marker element
+      // Modify the server component — add a visible marker element.
+      // Target `<TodoList` (which only exists in the non-GitHub-Pages
+      // branch) rather than the back-link, which now also appears inside
+      // the `if (isGithubPages)` early-return branch added in
+      // bidoof-template PR #60 (f87c49d). String.prototype.replace only
+      // hits the first occurrence, which is the dead branch in dev mode
+      // — the rendered page never gets the marker and the test times
+      // out waiting for it.
       const updatedContent = originalContent.replace(
-        '<Link to="/" className={styles["Link"]}> back </Link>',
-        '<Link to="/" className={styles["Link"]}> back </Link>\n      <div data-testid="hmr-marker">HMR Updated</div>'
+        '<TodoList',
+        '<div data-testid="hmr-marker">HMR Updated</div>\n      <TodoList'
       );
       await writeFile(pageFile, updatedContent);
-      
+
       // Wait for the update
       await page.waitForSelector('[data-testid="hmr-marker"]', { timeout: 15000 });
       await expect(page.locator('[data-testid="hmr-marker"]')).toContainText('HMR Updated');
-      
+
     } finally {
       await writeFile(pageFile, originalContent);
     }


### PR DESCRIPTION
## Summary
\`server component change updates todos page\` (\`test/e2e/hmr.spec.ts:65\`) has been silently failing on main since bidoof-template PR #60 (\`f87c49d\`, 2026-05-02) added an \`if (isGithubPages)\` early-return branch with its own copy of \`<Link to=\"/\" ...> back </Link>\`. The test does:

\`\`\`ts
originalContent.replace(
  '<Link to=\"/\" className={styles[\"Link\"]}> back </Link>',
  '<Link ...> back </Link>\\n      <div data-testid=\"hmr-marker\">HMR Updated</div>'
)
\`\`\`

\`String.prototype.replace\` only mutates the first occurrence — which is now inside the GitHub Pages dead branch (\`isGithubPages\` is falsy in dev), so the rendered output is unchanged and the marker never appears. Test times out at 15s waiting for it.

Sibling test \`server component change triggers RSC refetch (not full reload)\` (line 18) is unaffected because it edits \`src/page/page.tsx\`, which has only one match.

## Fix
Target \`<TodoList\` instead. That component is only used in the live (non-GitHub-Pages) branch, so the marker lands where dev actually renders. Added a comment explaining the trap to keep the next refactor from reintroducing it.

## Verification
Before:
\`\`\`
$ npx playwright test --grep 'server component change updates todos'
  1 failed
\`\`\`

After:
\`\`\`
$ npx playwright test --grep 'server component change updates todos'
  1 passed (3.0s)
\`\`\`

Found while running the HMR suite during work on bd-vvi/bd-5rk (vprs PR #39).