### PR TITLE
fix(dev:ssr): restart worker on CSS module edits so stale class hashes don't persist

### DIFF
--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -90,9 +90,19 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       
       // Normalize paths for comparison (handle both absolute and relative)
       const normalizedFile = file.replace(projectRoot, '').replace(/^\/+/, '');
-      const isSourceFile = normalizedFile.startsWith(moduleBase + '/') && 
+      const isInModuleBase = normalizedFile.startsWith(moduleBase + '/');
+      const isSourceFile = isInModuleBase &&
         (file.endsWith('.tsx') || file.endsWith('.ts') || file.endsWith('.jsx') || file.endsWith('.js'));
-      
+      // CSS edits in dev:ssr must also trigger the worker-restart path: the SSR
+      // worker imports compiled CSS modules through Node's loader, which caches
+      // by URL. Vite re-transforming the file does nothing for already-imported
+      // modules in the worker — without invalidating + restarting, the next
+      // page render reuses the pre-edit class hashes (bd-5rk). dev:rsc doesn't
+      // need this because rendering happens in the main process and goes through
+      // Vite's invalidated server module graph (plugin.server.ts hotUpdate).
+      const isCssFile = isInModuleBase &&
+        (file.endsWith('.css') || file.endsWith('.scss') || file.endsWith('.sass') || file.endsWith('.less'));
+
       // Skip client components — let @vitejs/plugin-react handle them with Fast Refresh
       const isClientFile = isSourceFile && (() => {
         // Check filename pattern (.client.tsx, etc.) — matches isClientComponentByName
@@ -102,10 +112,11 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
           return /^\s*["']use client["']/.test(head.split('\n')[0]);
         } catch { return false; }
       })();
-      
+
       const isServerFile = isSourceFile && !isClientFile;
-      
-      if (isServerFile && hmrHandler) {
+      const shouldInvalidateWorker = isServerFile || isCssFile;
+
+      if (shouldInvalidateWorker && hmrHandler) {
         isProcessingHmr = true;
 
         try {
@@ -165,8 +176,8 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
           server.config.logger.error(`[vite-plugin-react-server] Error handling HMR update: ${error}`);
           isProcessingHmr = false;
         }
-      } else if (isServerFile && !hmrHandler) {
-        server.config.logger.warn(`[vite-plugin-react-server] Server file changed but HMR handler not available yet: ${file}`);
+      } else if (shouldInvalidateWorker && !hmrHandler) {
+        server.config.logger.warn(`[vite-plugin-react-server] Source file changed but HMR handler not available yet: ${file}`);
       }
       
       // Don't suppress — plugin.server.ts hotUpdate handles page reload prevention

--- a/test/e2e/dev-ssr-css-hmr.spec.ts
+++ b/test/e2e/dev-ssr-css-hmr.spec.ts
@@ -97,16 +97,12 @@ test.afterAll(async () => {
   }
 });
 
-// Currently failing — bd-5rk reproduces consistently in dev:ssr against
-// bidoof-template: the CSS-module class hash doesn't change across the
-// edit (`_Home_1yxem_1` → `_Home_1yxem_1`) and the rendered font-size
-// stays at the pre-edit value even after page.reload(). Looks like the
-// SSR-side compiled CSS-module output is being cached past the source
-// edit. The fix is tracked separately; this test is marked .fail() so
-// the suite stays green while documenting the known regression — if
-// somebody fixes the underlying bug, this test will start "failing as
-// passing" and need its annotation removed.
-test.fail("dev:ssr applies CSS-module edits after reload (bd-5rk)", async ({ page }) => {
+// bd-5rk regression: in dev:ssr the SSR worker imports compiled CSS modules
+// through Node's loader, which caches by URL. Before the fix, CSS edits did
+// not trigger a worker restart, so reloading the page re-rendered with the
+// pre-edit class hashes. Fix lives in plugin/dev-server/plugin.client.ts
+// (CSS files now route through the same worker-invalidation path as .ts/.tsx).
+test("dev:ssr applies CSS-module edits after reload (bd-5rk)", async ({ page }) => {
   await page.goto(BASE_URL + "/");
 
   // The .Home class hash-name varies; target the outermost Home-prefixed div.


### PR DESCRIPTION
## Summary

- In dev:ssr mode, editing a `*.module.css` file did not take effect after a full `page.reload()` — the class hash and computed styles stayed at their pre-edit values.
- Root cause: `plugin/dev-server/plugin.client.ts`'s `hotUpdate` filtered source-file detection to `.ts/.tsx/.js/.jsx`, so CSS edits skipped the worker-invalidation + restart path entirely. The SSR worker keeps its own Node-cached CSS-module imports, so the next render reuses the stale compiled output.
- Fix: add a parallel `isCssFile` check (`.css/.scss/.sass/.less`) under the same `isInModuleBase` gate and route those edits through the existing `sendHmrUpdate` → `markModulesInvalidated` flow. The next request restarts the worker, clearing Node's module cache. dev:rsc was unaffected (rendering is main-process and `plugin.server.ts`'s `hotUpdate` already invalidates the server environment's module graph for all source files including CSS).

## Test plan

The `dev-ssr-css-hmr.spec.ts` regression added in #39 (annotated `test.fail()`) is flipped to a regular `test()` and now passes. Full e2e sweep:

- [x] `test/e2e/dev-ssr-css-hmr.spec.ts` — 1 passed (was failing-as-expected before fix)
- [x] `test/e2e/hmr.spec.ts` — 10 passed (no regression on the CSS HMR + RSC refetch + server-action paths)
- [x] `test/e2e/navigation.spec.ts` — 6 passed
- [x] `test/e2e/dev-ssr-server-actions.spec.ts` — 2 passed

Total: 19/19 e2e specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)