### PR TITLE
chore: bump version to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
## Summary

- Bump `package.json` + `package-lock.json` from 1.5.1 → 1.5.2.
- Tag `v1.5.2` is already pushed (points at this commit `cbf8356`); this PR aligns origin/main with the released tag so future branches see the right version baseline.
- Scope: release commit only, no code changes.

## Release notes (1.5.2)

- **fix(dev:ssr)**: restart worker on CSS module edits so stale class hashes don't persist (#41) — `*.module.css` edits in dev:ssr now invalidate the worker's Node-cached imports; previously a full `page.reload()` re-rendered with the pre-edit class hashes.

## Test plan

- [x] Tag `v1.5.2` already pushed to origin
- [ ] Merge this PR to bring origin/main in sync with the tag
- [ ] `npm publish` (user-driven; not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)