### PR TITLE
fix(dev:ssr): live CSS HMR for server-collected stylesheets + gate verbose logs

### DIFF
--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -277,7 +277,9 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
           hasInvalidatedModules = false; // Reset flag after creating worker
         } else if (hasInvalidatedModules) {
           // Worker exists but modules are invalidated - restart to clear Node.js cache
-          logger.info(`[configureRequestHandler] Modules invalidated, restarting worker to clear Node.js module cache...`);
+          if (handlerOptions.verbose) {
+            logger.info(`[configureRequestHandler] Modules invalidated, restarting worker to clear Node.js module cache...`);
+          }
           currentWorker = await restartWorker({
             server,
             autoDiscoveredFiles,

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -125,7 +125,18 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
           }
 
           // CRITICAL: Send HMR_UPDATE message to worker to invalidate modules
-          // This clears component caches, but Node.js's ES module cache persists
+          // This clears component caches, but Node.js's ES module cache persists —
+          // the request handler triggers a worker restart on the next request
+          // (see configureRequestHandler.client.ts hasInvalidatedModules check).
+          //
+          // For CSS edits the restart is the slow path: in dev:ssr that adds a
+          // ~few-hundred-ms flash on every CSS save that dev:rsc doesn't have.
+          // We accept that for now because skipping the restart leaves the
+          // worker holding stale class-name hashes for any CSS module that
+          // server components imported directly (bidoof Card.module.css
+          // pattern) — page renders broken until next "real" invalidation.
+          // Proper fix is worker-side per-module cache-busting; tracked as a
+          // follow-up.
           hmrHandler.sendHmrUpdate(file);
 
           // Notify the browser to refetch the RSC stream. In dev:rsc the
@@ -187,13 +198,14 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
           isProcessingHmr = false;
         }
 
-        // For CSS edits in dev:ssr, suppress Vite's default full-reload —
-        // useRscHmr handles the visual update by cache-busting matching
-        // <link> tags. Without this return [], Vite emits its `page reload`
-        // event right after our HMR send, defeating the smooth update.
-        // For .ts/.tsx server-file edits we still want to fall through to
-        // Vite's normal handling (no return) so module-level invalidation
-        // remains intact for any client consumer of the file.
+        // For CSS edits in dev:ssr, suppress Vite's default behavior. Vite's
+        // fallback for module-graph-untracked CSS is a full page reload, and
+        // even tracked CSS modules in dev:ssr can fall back to reload because
+        // vprs renders them server-side via the <Css cssFiles={...}/> pattern
+        // (the client never directly imports them, so @vitejs/plugin-react's
+        // CSS HMR isn't reachable). useRscHmr handles both shapes:
+        //  - inlined <style>: refetch brings new content
+        //  - <link href=…>:   refreshCssLinks cache-busts the URL
         if (isCssFile) return [];
       } else if (shouldInvalidateWorker && !hmrHandler) {
         if (userOptions.verbose) {

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -120,7 +120,9 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
         isProcessingHmr = true;
 
         try {
-          server.config.logger.info(`[vite-plugin-react-server] File changed: ${file}, sending HMR update...`);
+          if (userOptions.verbose) {
+            server.config.logger.info(`[vite-plugin-react-server] File changed: ${file}, sending HMR update...`);
+          }
 
           // CRITICAL: Send HMR_UPDATE message to worker to invalidate modules
           // This clears component caches, but Node.js's ES module cache persists
@@ -132,13 +134,15 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
           // never loads that orchestrator, so without sending the event here
           // the worker invalidates correctly but the browser keeps showing
           // pre-edit content — `useRscHmr` listens for this event and only
-          // refetches on receipt.
+          // refetches on receipt. For CSS files the consumer's <link> tag
+          // still points at the same URL after the edit, so we tag the event
+          // so the client also cache-busts matching stylesheets.
           server.ws.send({
             type: "custom",
             event: "vite-plugin-react-server:server-component-update",
-            data: { file: normalizedFile, path: file },
+            data: { file: normalizedFile, path: file, kind: isCssFile ? "css" : "component" },
           });
-          
+
           // CRITICAL: Node.js caches ES modules, so we need to restart the worker
           // to clear the module cache. Debounce restarts to prevent recursion.
           if (hmrHandler.restart) {
@@ -146,14 +150,18 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
             if (restartTimeout) {
               clearTimeout(restartTimeout);
             }
-            
+
             // Debounce worker restart to prevent recursion
             // Wait 500ms after the last file change before restarting
             restartTimeout = setTimeout(async () => {
               try {
-                server.config.logger.info(`[vite-plugin-react-server] Restarting worker to clear Node.js module cache...`);
+                if (userOptions.verbose) {
+                  server.config.logger.info(`[vite-plugin-react-server] Restarting worker to clear Node.js module cache...`);
+                }
                 await hmrHandler!.restart!();
-                server.config.logger.info(`[vite-plugin-react-server] Worker restarted successfully`);
+                if (userOptions.verbose) {
+                  server.config.logger.info(`[vite-plugin-react-server] Worker restarted successfully`);
+                }
               } catch (error) {
                 server.config.logger.error(`[vite-plugin-react-server] Failed to restart worker: ${error}`);
               } finally {
@@ -167,7 +175,9 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
           } else {
             // No restart function available yet - worker hasn't been created
             // This is expected if hotUpdate fires before the first request
-            server.config.logger.warn(`[vite-plugin-react-server] Restart function not available yet - worker will be created on next request`);
+            if (userOptions.verbose) {
+              server.config.logger.warn(`[vite-plugin-react-server] Restart function not available yet - worker will be created on next request`);
+            }
             setTimeout(() => {
               isProcessingHmr = false;
             }, 100);
@@ -176,10 +186,21 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
           server.config.logger.error(`[vite-plugin-react-server] Error handling HMR update: ${error}`);
           isProcessingHmr = false;
         }
+
+        // For CSS edits in dev:ssr, suppress Vite's default full-reload —
+        // useRscHmr handles the visual update by cache-busting matching
+        // <link> tags. Without this return [], Vite emits its `page reload`
+        // event right after our HMR send, defeating the smooth update.
+        // For .ts/.tsx server-file edits we still want to fall through to
+        // Vite's normal handling (no return) so module-level invalidation
+        // remains intact for any client consumer of the file.
+        if (isCssFile) return [];
       } else if (shouldInvalidateWorker && !hmrHandler) {
-        server.config.logger.warn(`[vite-plugin-react-server] Source file changed but HMR handler not available yet: ${file}`);
+        if (userOptions.verbose) {
+          server.config.logger.warn(`[vite-plugin-react-server] Source file changed but HMR handler not available yet: ${file}`);
+        }
       }
-      
+
       // Don't suppress — plugin.server.ts hotUpdate handles page reload prevention
     },
   };

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -51,18 +51,31 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
             return /^\s*["']use client["']/.test(head.split('\n')[0]);
           } catch { return false; }
         })();
-        
+
         if (isClient) return; // Let Fast Refresh handle client components
-        
+
+        // CSS files that aren't imported via the client module graph (vprs's
+        // <Css cssFiles={...}/> pattern collects them server-side) aren't
+        // tracked by Vite's CSS HMR, so a content edit leaves the <link>
+        // tag's href unchanged. Tag the event so useRscHmr knows to refresh
+        // matching link tags by cache-busting their href.
+        const kind: 'css' | 'component' =
+          file.endsWith('.css') || file.endsWith('.scss') ||
+          file.endsWith('.sass') || file.endsWith('.less')
+            ? 'css'
+            : 'component';
+
         // Server component changed — send RSC refetch event to client
         // Only do this once (from client env) to avoid duplicate events
-        server.config.logger.info(`[vite-plugin-react-server] File changed (RSC refetch): ${normalizedFile}`);
+        if (userOptions.verbose) {
+          server.config.logger.info(`[vite-plugin-react-server] File changed (RSC refetch): ${normalizedFile}`);
+        }
         server.ws.send({
           type: 'custom',
           event: 'vite-plugin-react-server:server-component-update',
-          data: { file: normalizedFile, path: file },
+          data: { file: normalizedFile, path: file, kind },
         });
-        
+
         return []; // Don't trigger client-side page reload
       }
       

--- a/plugin/dev-server/virtualRscHmrPlugin.ts
+++ b/plugin/dev-server/virtualRscHmrPlugin.ts
@@ -19,20 +19,31 @@ export { RSC_HMR_EVENT };
 // file. Server-collected CSS (vprs's <Css cssFiles={...}/> pattern) isn't in
 // the client module graph, so Vite's native CSS HMR never fires for these —
 // the <link> URL doesn't change and the browser keeps the cached stylesheet.
-// Matching is path-tail based because the href is typically absolute
-// (/src/css/foo.module.css) while data.file/data.path can be either form.
+// data.file is the project-relative path (eg "src/css/9mmc.module.css") and
+// the link href is a URL whose pathname ends with the same suffix.
+// We also fall back to basename matching to handle edge cases where the
+// project-relative form doesn't appear verbatim in the href.
 function refreshCssLinks(data) {
-  const file = data && (data.path || data.file);
-  if (!file) return false;
-  const tail = String(file).split(/[\\\\/]/).filter(Boolean).join('/');
+  if (!data) return false;
+  const rel = String(data.file || '').replace(/^[\\\\/]+/, '');
+  if (!rel) return false;
+  const basename = rel.split(/[\\\\/]/).pop();
   const links = document.querySelectorAll('link[rel="stylesheet"]');
   let refreshed = 0;
   for (const link of links) {
     const href = link.getAttribute('href');
     if (!href) continue;
-    // Strip query, normalize for tail match
-    const hrefPath = href.split('?')[0];
-    if (!hrefPath.endsWith(tail)) continue;
+    let pathname;
+    try {
+      pathname = new URL(href, window.location.origin).pathname;
+    } catch {
+      pathname = href.split('?')[0];
+    }
+    const matches =
+      pathname.endsWith('/' + rel) ||
+      pathname.endsWith(rel) ||
+      (basename && pathname.endsWith('/' + basename));
+    if (!matches) continue;
     const url = new URL(href, window.location.origin);
     url.searchParams.set('t', String(Date.now()));
     link.setAttribute('href', url.pathname + url.search);

--- a/plugin/dev-server/virtualRscHmrPlugin.ts
+++ b/plugin/dev-server/virtualRscHmrPlugin.ts
@@ -15,6 +15,32 @@ const RSC_HMR_EVENT = 'vite-plugin-react-server:server-component-update';
 
 export { RSC_HMR_EVENT };
 
+// Cache-bust every <link rel="stylesheet"> whose href references the changed
+// file. Server-collected CSS (vprs's <Css cssFiles={...}/> pattern) isn't in
+// the client module graph, so Vite's native CSS HMR never fires for these —
+// the <link> URL doesn't change and the browser keeps the cached stylesheet.
+// Matching is path-tail based because the href is typically absolute
+// (/src/css/foo.module.css) while data.file/data.path can be either form.
+function refreshCssLinks(data) {
+  const file = data && (data.path || data.file);
+  if (!file) return false;
+  const tail = String(file).split(/[\\\\/]/).filter(Boolean).join('/');
+  const links = document.querySelectorAll('link[rel="stylesheet"]');
+  let refreshed = 0;
+  for (const link of links) {
+    const href = link.getAttribute('href');
+    if (!href) continue;
+    // Strip query, normalize for tail match
+    const hrefPath = href.split('?')[0];
+    if (!hrefPath.endsWith(tail)) continue;
+    const url = new URL(href, window.location.origin);
+    url.searchParams.set('t', String(Date.now()));
+    link.setAttribute('href', url.pathname + url.search);
+    refreshed++;
+  }
+  return refreshed > 0;
+}
+
 export function useRscHmr(refetch, options = {}) {
   const { verbose = true, filter } = options;
 
@@ -22,7 +48,10 @@ export function useRscHmr(refetch, options = {}) {
     (data) => {
       if (filter && !filter(data)) return;
       if (verbose) {
-        console.log('[RSC HMR] Server component updated:', data.file);
+        console.log('[RSC HMR] Server component updated:', data.file, data.kind ? '(' + data.kind + ')' : '');
+      }
+      if (data && data.kind === 'css') {
+        refreshCssLinks(data);
       }
       refetch(window.location.pathname);
     },
@@ -46,7 +75,10 @@ export function setupRscHmr(options = {}) {
   if (typeof import.meta.hot === 'undefined') return;
   import.meta.hot.on(RSC_HMR_EVENT, async (data) => {
     if (verbose) {
-      console.log('[RSC HMR] Server component updated:', data.file);
+      console.log('[RSC HMR] Server component updated:', data.file, data.kind ? '(' + data.kind + ')' : '');
+    }
+    if (data && data.kind === 'css') {
+      refreshCssLinks(data);
     }
     if (onUpdate === 'reload') {
       window.location.reload();
@@ -55,7 +87,9 @@ export function setupRscHmr(options = {}) {
     if (onUpdate) {
       try { await onUpdate(data); }
       catch (error) { console.error('[RSC HMR] Error in onUpdate handler:', error); window.location.reload(); }
-    } else {
+    } else if (!data || data.kind !== 'css') {
+      // For non-CSS updates without a handler, fall back to reload.
+      // For CSS updates, refreshCssLinks already handled it visually.
       window.location.reload();
     }
   });

--- a/plugin/utils/useRscHmr.ts
+++ b/plugin/utils/useRscHmr.ts
@@ -3,6 +3,29 @@ import { RSC_HMR_EVENT } from "./createReactFetcher.js";
 import type { RscHmrData } from "./createReactFetcher.js";
 import { env } from "./env.js";
 
+// Mirror of refreshCssLinks in virtualRscHmrPlugin.ts (see comment there).
+// Cache-busts any <link rel="stylesheet"> whose href matches the changed file
+// — server-collected CSS isn't in the client module graph so Vite's native
+// CSS HMR never fires for these, and the <link> URL doesn't change on edit.
+function refreshCssLinks(data: RscHmrData): boolean {
+  const file = (data && ((data as { path?: string }).path || data.file)) as string | undefined;
+  if (!file || typeof document === "undefined") return false;
+  const tail = String(file).split(/[\\/]/).filter(Boolean).join("/");
+  const links = document.querySelectorAll('link[rel="stylesheet"]');
+  let refreshed = 0;
+  links.forEach((link) => {
+    const href = link.getAttribute("href");
+    if (!href) return;
+    const hrefPath = href.split("?")[0];
+    if (!hrefPath?.endsWith(tail)) return;
+    const url = new URL(href, window.location.origin);
+    url.searchParams.set("t", String(Date.now()));
+    link.setAttribute("href", url.pathname + url.search);
+    refreshed++;
+  });
+  return refreshed > 0;
+}
+
 /**
  * React hook for RSC HMR (Hot Module Replacement).
  * 
@@ -48,8 +71,12 @@ export function useRscHmr(
   const handler = useCallback(
     (data: RscHmrData) => {
       if (filter && !filter(data)) return;
+      const kind = (data as { kind?: string }).kind;
       if (verbose) {
-        console.log('[RSC HMR] Server component updated:', data.file);
+        console.log('[RSC HMR] Server component updated:', data.file, kind ? `(${kind})` : '');
+      }
+      if (kind === 'css') {
+        refreshCssLinks(data);
       }
       refetch(window.location.pathname);
     },

--- a/plugin/utils/useRscHmr.ts
+++ b/plugin/utils/useRscHmr.ts
@@ -4,20 +4,31 @@ import type { RscHmrData } from "./createReactFetcher.js";
 import { env } from "./env.js";
 
 // Mirror of refreshCssLinks in virtualRscHmrPlugin.ts (see comment there).
-// Cache-busts any <link rel="stylesheet"> whose href matches the changed file
-// — server-collected CSS isn't in the client module graph so Vite's native
-// CSS HMR never fires for these, and the <link> URL doesn't change on edit.
+// data.file is the project-relative path (eg "src/css/9mmc.module.css") and
+// the link href is a URL whose pathname ends with the same suffix.
+// Falls back to basename matching for edge cases where the project-relative
+// form doesn't appear verbatim in the href.
 function refreshCssLinks(data: RscHmrData): boolean {
-  const file = (data && ((data as { path?: string }).path || data.file)) as string | undefined;
-  if (!file || typeof document === "undefined") return false;
-  const tail = String(file).split(/[\\/]/).filter(Boolean).join("/");
+  if (!data || typeof document === "undefined") return false;
+  const rel = String(data.file || "").replace(/^[\\/]+/, "");
+  if (!rel) return false;
+  const basename = rel.split(/[\\/]/).pop();
   const links = document.querySelectorAll('link[rel="stylesheet"]');
   let refreshed = 0;
   links.forEach((link) => {
     const href = link.getAttribute("href");
     if (!href) return;
-    const hrefPath = href.split("?")[0];
-    if (!hrefPath?.endsWith(tail)) return;
+    let pathname: string;
+    try {
+      pathname = new URL(href, window.location.origin).pathname;
+    } catch {
+      pathname = href.split("?")[0] ?? "";
+    }
+    const matches =
+      pathname.endsWith("/" + rel) ||
+      pathname.endsWith(rel) ||
+      (!!basename && pathname.endsWith("/" + basename));
+    if (!matches) return;
     const url = new URL(href, window.location.origin);
     url.searchParams.set("t", String(Date.now()));
     link.setAttribute("href", url.pathname + url.search);

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -1224,10 +1224,11 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
           routes: (msg as any).routes || [],
         });
         
-        // Always log HMR updates for debugging
-        logger?.info(
-          `[rsc-worker] HMR_UPDATE: Invalidated module ${normalizedPath} (from ${filePath})`
-        );
+        if (verbose) {
+          logger?.info(
+            `[rsc-worker] HMR_UPDATE: Invalidated module ${normalizedPath} (from ${filePath})`
+          );
+        }
         
         // CRITICAL: Clear ALL caches when files change
         // This ensures fresh components are loaded instead of cached ones

--- a/test/e2e/dev-ssr-css-hmr.spec.ts
+++ b/test/e2e/dev-ssr-css-hmr.spec.ts
@@ -80,8 +80,17 @@ test.beforeAll(async () => {
   await waitForServer(BASE_URL, 60_000);
 }, 90_000);
 
+test.afterEach(async () => {
+  // Restore the CSS between tests — both tests edit the same file, and
+  // without restoration the second test inherits the first's 60px state
+  // and its 50px precondition fails.
+  if (originalCss !== undefined) {
+    await writeFile(cssFile, originalCss);
+  }
+});
+
 test.afterAll(async () => {
-  // Always restore the CSS, even if the test bailed mid-edit.
+  // Final restore in case the last afterEach was skipped (e.g. test bailed).
   if (originalCss !== undefined) {
     await writeFile(cssFile, originalCss);
   }
@@ -143,12 +152,12 @@ test("dev:ssr applies CSS-module edits live without a manual reload", async ({ p
   const home = page.locator('div[class*="Home"]').first();
   await expect(home).toHaveCSS("font-size", "50px");
 
-  // Track navigation events: if Vite's full-reload fallback fires, we'll
-  // see a `framenavigated` to the same URL — that would be a failure mode
-  // for this test (functional but not HMR).
-  let navigations = 0;
-  page.on("framenavigated", () => {
-    navigations++;
+  // Stamp the window so we can detect a full page reload — a reload
+  // creates a fresh window object and the marker disappears. This is
+  // more precise than `framenavigated`, which can fire for things other
+  // than full reloads (history.replaceState, link href tweaks, etc.).
+  await page.evaluate(() => {
+    (window as unknown as { __hmrLiveMarker?: number }).__hmrLiveMarker = Date.now();
   });
 
   const updated = originalCss!.replace("font-size: 50px", "font-size: 60px");
@@ -157,8 +166,10 @@ test("dev:ssr applies CSS-module edits live without a manual reload", async ({ p
   // No page.reload() — wait for the rule to apply via HMR.
   await expect(home).toHaveCSS("font-size", "60px", { timeout: 10_000 });
 
-  // The HMR path should not have triggered a full page navigation. We
-  // allow zero here — any non-zero count means Vite's full-reload fallback
-  // fired or the test framework navigated, both of which defeat live HMR.
-  expect(navigations).toBe(0);
+  // If the window was wiped, a full reload happened — that defeats live HMR.
+  const markerStillPresent = await page.evaluate(() => {
+    return typeof (window as unknown as { __hmrLiveMarker?: number })
+      .__hmrLiveMarker === "number";
+  });
+  expect(markerStillPresent).toBe(true);
 });

--- a/test/e2e/dev-ssr-css-hmr.spec.ts
+++ b/test/e2e/dev-ssr-css-hmr.spec.ts
@@ -129,3 +129,36 @@ test("dev:ssr applies CSS-module edits after reload (bd-5rk)", async ({ page }) 
   // applied" — the home div still has *some* Home-prefixed class.
   await expect(home).toHaveAttribute("class", /Home/);
 });
+
+// Live-HMR variant: edit the CSS and expect the rule to apply *without* a
+// page.reload(). Before this fix, plugin.client.ts's hotUpdate for CSS files
+// fired vprs's WS event but didn't return [], so Vite emitted its default
+// `vite:beforeFullReload` event right after — the browser did a hard reload,
+// which is functional but not HMR. plugin.client.ts now returns [] for CSS
+// edits to suppress that reload, and useRscHmr's `kind: 'css'` branch
+// cache-busts <link rel="stylesheet"> tags so the new rules apply live.
+test("dev:ssr applies CSS-module edits live without a manual reload", async ({ page }) => {
+  await page.goto(BASE_URL + "/");
+
+  const home = page.locator('div[class*="Home"]').first();
+  await expect(home).toHaveCSS("font-size", "50px");
+
+  // Track navigation events: if Vite's full-reload fallback fires, we'll
+  // see a `framenavigated` to the same URL — that would be a failure mode
+  // for this test (functional but not HMR).
+  let navigations = 0;
+  page.on("framenavigated", () => {
+    navigations++;
+  });
+
+  const updated = originalCss!.replace("font-size: 50px", "font-size: 60px");
+  await writeFile(cssFile, updated);
+
+  // No page.reload() — wait for the rule to apply via HMR.
+  await expect(home).toHaveCSS("font-size", "60px", { timeout: 10_000 });
+
+  // The HMR path should not have triggered a full page navigation. We
+  // allow zero here — any non-zero count means Vite's full-reload fallback
+  // fired or the test framework navigated, both of which defeat live HMR.
+  expect(navigations).toBe(0);
+});


### PR DESCRIPTION
## Summary

When CSS is collected server-side via vprs's `<Css cssFiles={...}/>` component (as opposed to a client-side `import "./foo.module.css"`), live CSS HMR was broken in dev:ssr and noisy in both modes. Two distinct fixes plus a logging cleanup:

### 1. Suppress Vite's full-reload fallback for CSS in dev:ssr

`plugin/dev-server/plugin.client.ts`'s `hotUpdate` previously fell through to Vite's default after sending vprs's WS event. For CSS edits where the file isn't tracked by the client module graph, Vite emits a `vite:beforeFullReload` event right after — symptom: `[vite] (client) page reload src/css/9mmc.module.css` in the logs and a hard page navigation in the browser. The new code returns `[]` for CSS files so Vite suppresses the reload; useRscHmr handles the visual update.

### 2. Cache-bust matching `<link rel="stylesheet">` tags in useRscHmr

The browser's `<link href="/src/css/foo.module.css">` URL didn't change across the edit, so the browser kept the cached stylesheet even after the WS event fired. `useRscHmr`'s handler now branches on `data.kind` (`'css'` vs `'component'`); for CSS edits it walks `document.querySelectorAll('link[rel=\"stylesheet\"]')`, matches by path-tail (handles absolute and relative hrefs), and updates `href` with `?t=Date.now()`. Browser refetches, new rules apply live.

Both `plugin.client.ts` (dev:ssr orchestrator) and `plugin.server.ts` (dev:rsc orchestrator) now tag the WS event payload with `kind`. Existing useRscHmr consumers on 1.5.2 keep their behavior — the field is additive.

### 3. Gate previously-ungated dev-mode logs behind `verbose`

These all fired on every file save regardless of `verbose: false`:

- `plugin.client.ts`: `File changed: ... sending HMR update...`
- `plugin.client.ts`: `Restart function not available yet`
- `plugin.client.ts`: `Restarting worker to clear Node.js module cache`
- `plugin.client.ts`: `Worker restarted successfully`
- `plugin.server.ts`: `File changed (RSC refetch): ...`
- `configureRequestHandler.client.ts`: `Modules invalidated, restarting...`
- `worker/rsc/messageHandler.server.tsx`: `HMR_UPDATE: Invalidated module`

Errors and warnings about actual failures stay ungated.

## Test plan

- [x] `npm run build:types` clean
- [x] `npm run build` produces dist cleanly
- [x] Existing `dev-ssr-css-hmr.spec.ts` (reload-based regression) still asserts the bd-5rk fix
- [x] New `dev-ssr-css-hmr.spec.ts` spec asserts live HMR works without `page.reload()` and tracks `framenavigated` to catch silent full-reload fallbacks
- [ ] (manual, on consumer side) mmc `npm run dev:ssr`, edit a `*.module.css`, observe styles update without page navigation
- [ ] (manual, on consumer side) mmc `npm run dev:rsc`, edit a `*.module.css`, observe styles update via RSC refetch + link cache-bust
- [ ] (manual, on consumer side) bidoof unaffected — its tracked-import CSS HMR continues working in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)