### PR TITLE
feat(dev:ssr): ModuleRunner-based fetch transport (default-on, opt-out via VPRS_RUNNER=0)

### DIFF
--- a/plugin/dev-server/collectRunnerCss.ts
+++ b/plugin/dev-server/collectRunnerCss.ts
@@ -1,0 +1,142 @@
+import type {
+  EnvironmentModuleGraph,
+  EnvironmentModuleNode,
+  ModuleNode,
+  ViteDevServer,
+  Logger,
+} from "vite";
+
+const CSS_EXT = /\.(css|scss|sass|less|styl|stylus|pcss|postcss)(\?|$)/;
+
+export type CollectedCss = { id: string; code: string };
+
+/**
+ * Walks the Vite server environment's module graph from `pagePath` and
+ * returns the raw CSS code of every CSS module reachable from it.
+ *
+ * Replaces the rsc-worker's Node ESM CSS loader for runner mode: the
+ * runner bypasses Node's import resolver, so the loader never fires.
+ * The main thread has visibility into the same module graph and can
+ * collect CSS deterministically once `runner.import(pagePath)` has
+ * caused Vite to transform the page and its deps.
+ */
+export async function collectRunnerCss(
+  server: ViteDevServer,
+  pagePath: string,
+  projectRoot: string,
+  logger: Logger,
+  verbose = false
+): Promise<CollectedCss[]> {
+  const env = server.environments?.["server"];
+  if (!env) {
+    if (verbose) logger.warn(`[collectRunnerCss] no server environment`);
+    return [];
+  }
+
+  const moduleGraph: EnvironmentModuleGraph = env.moduleGraph;
+  const candidates = [
+    pagePath,
+    pagePath.startsWith("/") ? pagePath : `/${pagePath}`,
+    pagePath.startsWith(projectRoot) ? pagePath : `${projectRoot}/${pagePath}`,
+  ];
+
+  let pageModule: EnvironmentModuleNode | ModuleNode | undefined;
+  for (const url of candidates) {
+    pageModule = await moduleGraph.getModuleByUrl(url);
+    if (pageModule) break;
+  }
+
+  // Fallback: scan idToModuleMap for an entry whose id endsWith the pagePath.
+  // Vite keys server-env modules by full absolute path with optional query.
+  if (!pageModule) {
+    const idMap = (moduleGraph as any).idToModuleMap as
+      | Map<string, EnvironmentModuleNode>
+      | undefined;
+    if (idMap) {
+      for (const [id, node] of idMap.entries()) {
+        if (id.endsWith(pagePath) || id.endsWith(`/${pagePath}`)) {
+          pageModule = node;
+          break;
+        }
+      }
+    }
+  }
+
+  if (!pageModule) {
+    if (verbose) {
+      logger.warn(
+        `[collectRunnerCss] no module for pagePath: ${pagePath} (tried: ${candidates.join(", ")}; graph size: ${
+          (moduleGraph as any).idToModuleMap?.size ?? "?"
+        })`
+      );
+    }
+    return [];
+  }
+  if (verbose) {
+    logger.info(`[collectRunnerCss] resolved page module: ${pageModule.id}`);
+  }
+
+  const seen = new Set<string>();
+  const out: CollectedCss[] = [];
+
+  const walk = async (mod: EnvironmentModuleNode | ModuleNode) => {
+    if (!mod?.id || seen.has(mod.id)) return;
+    seen.add(mod.id);
+
+    if (CSS_EXT.test(mod.id)) {
+      try {
+        const transformed = await env.transformRequest(`${mod.id}?inline`);
+        if (transformed?.code) {
+          const code = transformed.code;
+          // Vite transforms `.css?inline` modules with different framings:
+          // - SSR runner output: `const __vite_ssr_export_default__ = "...";`
+          // - plain ESM output:  `export default "...";`
+          // - legacy module API: `__vite__cssModules.default = "...";`
+          const exportMatch =
+            code.match(/__vite_ssr_export_default__\s*=\s*("(?:\\.|[^"\\])*")/) ??
+            code.match(/export\s+default\s+("(?:\\.|[^"\\])*")/) ??
+            code.match(/__vite__cssModules\.default\s*=\s*("(?:\\.|[^"\\])*")/);
+          if (exportMatch) {
+            const raw = JSON.parse(exportMatch[1]);
+            if (typeof raw === "string" && raw.length > 0) {
+              out.push({ id: mod.id, code: raw });
+            } else if (verbose) {
+              logger.warn(`[collectRunnerCss] inline default empty for ${mod.id}`);
+            }
+          } else if (verbose) {
+            logger.warn(
+              `[collectRunnerCss] could not find inline export in transform for ${mod.id} (codeLen=${code.length})`
+            );
+          }
+        } else if (verbose) {
+          logger.warn(`[collectRunnerCss] no transformed code for ${mod.id}?inline`);
+        }
+      } catch (err) {
+        if (verbose) {
+          logger.warn(
+            `[collectRunnerCss] failed to inline ${mod.id}: ${String(err)}`
+          );
+        }
+      }
+    }
+
+    if (mod.importedModules) {
+      for (const imported of mod.importedModules as Iterable<
+        EnvironmentModuleNode | ModuleNode
+      >) {
+        if (imported && typeof imported === "object" && "id" in imported) {
+          await walk(imported);
+        }
+      }
+    }
+  };
+
+  await walk(pageModule);
+
+  if (verbose) {
+    logger.info(
+      `[collectRunnerCss] collected ${out.length} CSS file(s) for ${pagePath}`
+    );
+  }
+  return out;
+}

--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -18,10 +18,18 @@ import { pipeToResponse } from "../helpers/pipeToResponse.js";
 // This allows us to restart the worker on the next request to clear Node.js module cache
 let hasInvalidatedModules = false;
 
+const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] === "1";
+
 /**
- * Mark that modules have been invalidated - worker will be restarted on next request
+ * Mark that modules have been invalidated - worker will be restarted on next request.
+ * When the experimental ModuleRunner path is active (VPRS_RUNNER=1) the worker
+ * keeps its Vite runner cache invalidated per-module via the HMR_UPDATE handler,
+ * so the heavyweight worker restart can be skipped.
  */
 export function markModulesInvalidated(): void {
+  if (isRunnerEnabled()) {
+    return;
+  }
   hasInvalidatedModules = true;
 }
 

--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -18,13 +18,13 @@ import { pipeToResponse } from "../helpers/pipeToResponse.js";
 // This allows us to restart the worker on the next request to clear Node.js module cache
 let hasInvalidatedModules = false;
 
-const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] === "1";
+const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] !== "0";
 
 /**
  * Mark that modules have been invalidated - worker will be restarted on next request.
- * When the experimental ModuleRunner path is active (VPRS_RUNNER=1) the worker
- * keeps its Vite runner cache invalidated per-module via the HMR_UPDATE handler,
- * so the heavyweight worker restart can be skipped.
+ * The Vite ModuleRunner is enabled by default; the worker keeps its runner cache
+ * invalidated via the HMR_UPDATE handler, so the heavyweight worker restart can
+ * be skipped. Opt out with `VPRS_RUNNER=0` to fall back to the legacy restart path.
  */
 export function markModulesInvalidated(): void {
   if (isRunnerEnabled()) {

--- a/plugin/dev-server/handleRunnerFetch.server.ts
+++ b/plugin/dev-server/handleRunnerFetch.server.ts
@@ -1,0 +1,79 @@
+import type { MessagePort } from "node:worker_threads";
+import { fetchModule, type Logger, type ViteDevServer } from "vite";
+
+import type {
+  RunnerPortRequest,
+  RunnerPortResponse,
+} from "../worker/rsc/createRunnerTransport.js";
+
+type InvokePayload = {
+  type: "custom";
+  event: "vite:invoke";
+  data: { name: string; id: string; data: any[] };
+};
+
+export function attachRunnerFetchHandler(
+  port: MessagePort,
+  server: ViteDevServer,
+  logger: Logger,
+  verbose = false
+): () => void {
+  const handler = async (msg: RunnerPortRequest) => {
+    if (!msg || msg.__vprs !== "runner-request") return;
+    const { requestId, payload } = msg;
+    try {
+      const invoke = payload as InvokePayload;
+      if (
+        invoke?.type !== "custom" ||
+        invoke?.event !== "vite:invoke" ||
+        !invoke.data
+      ) {
+        throw new Error(
+          `[runner-fetch] unexpected payload: ${JSON.stringify(payload)}`
+        );
+      }
+      const { name, data } = invoke.data;
+      if (name !== "fetchModule") {
+        throw new Error(`[runner-fetch] unsupported method: ${name}`);
+      }
+      const env = server.environments?.["server"];
+      if (!env) {
+        throw new Error("[runner-fetch] server environment not initialized");
+      }
+      const [url, importer, options] = data;
+      const result = await fetchModule(env, url, importer, options);
+      const response: RunnerPortResponse = {
+        __vprs: "runner-response",
+        requestId,
+        result: { result },
+      };
+      port.postMessage(response);
+    } catch (error: any) {
+      if (verbose) {
+        logger.error(
+          `[runner-fetch] error: ${error?.message ?? String(error)}`,
+          { error: error instanceof Error ? error : new Error(String(error)) }
+        );
+      }
+      const response: RunnerPortResponse = {
+        __vprs: "runner-response",
+        requestId,
+        result: {
+          error: {
+            name: error?.name,
+            message: String(error?.message ?? error),
+            stack: error?.stack,
+          },
+        },
+      };
+      port.postMessage(response);
+    }
+  };
+
+  port.on("message", handler);
+  port.start();
+
+  return () => {
+    port.off("message", handler);
+  };
+}

--- a/plugin/dev-server/handleRunnerFetch.server.ts
+++ b/plugin/dev-server/handleRunnerFetch.server.ts
@@ -4,7 +4,10 @@ import { fetchModule, type Logger, type ViteDevServer } from "vite";
 import type {
   RunnerPortRequest,
   RunnerPortResponse,
+  RpcRequest,
+  RpcResponse,
 } from "../worker/rsc/createRunnerTransport.js";
+import { collectRunnerCss } from "./collectRunnerCss.js";
 
 type InvokePayload = {
   type: "custom";
@@ -18,8 +21,13 @@ export function attachRunnerFetchHandler(
   logger: Logger,
   verbose = false
 ): () => void {
-  const handler = async (msg: RunnerPortRequest) => {
-    if (!msg || msg.__vprs !== "runner-request") return;
+  const handler = async (msg: RunnerPortRequest | RpcRequest) => {
+    if (!msg) return;
+    if (msg.__vprs === "rpc-request") {
+      await handleRpc(msg as RpcRequest);
+      return;
+    }
+    if (msg.__vprs !== "runner-request") return;
     const { requestId, payload } = msg;
     try {
       const invoke = payload as InvokePayload;
@@ -64,6 +72,53 @@ export function attachRunnerFetchHandler(
             message: String(error?.message ?? error),
             stack: error?.stack,
           },
+        },
+      };
+      port.postMessage(response);
+    }
+  };
+
+  const handleRpc = async (msg: RpcRequest) => {
+    const { requestId, method, args } = msg;
+    if (verbose) {
+      logger.info(
+        `[runner-rpc] received: method=${method} requestId=${requestId}`
+      );
+    }
+    try {
+      let result: unknown;
+      if (method === "collectCss") {
+        const [pagePath, projectRoot] = args as [string, string];
+        result = await collectRunnerCss(
+          server,
+          pagePath,
+          projectRoot,
+          logger,
+          verbose
+        );
+      } else {
+        throw new Error(`[runner-rpc] unsupported method: ${method}`);
+      }
+      const response: RpcResponse = {
+        __vprs: "rpc-response",
+        requestId,
+        result,
+      };
+      port.postMessage(response);
+    } catch (error: any) {
+      if (verbose) {
+        logger.error(
+          `[runner-rpc] ${method} failed: ${error?.message ?? String(error)}`,
+          { error: error instanceof Error ? error : new Error(String(error)) }
+        );
+      }
+      const response: RpcResponse = {
+        __vprs: "rpc-response",
+        requestId,
+        error: {
+          name: error?.name,
+          message: String(error?.message ?? error),
+          stack: error?.stack,
         },
       };
       port.postMessage(response);

--- a/plugin/dev-server/restartWorker.client.ts
+++ b/plugin/dev-server/restartWorker.client.ts
@@ -18,7 +18,7 @@ let currentErrorHandler: ((error: any) => void) | null = null;
 let currentRunnerChannel: MessageChannel | null = null;
 let currentRunnerDetach: (() => void) | null = null;
 
-const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] === "1";
+const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] !== "0";
 
 export const restartWorker: RestartWorkerFn = async function _restartWorker({
   server,

--- a/plugin/dev-server/restartWorker.client.ts
+++ b/plugin/dev-server/restartWorker.client.ts
@@ -8,12 +8,17 @@ import type { RestartWorkerFn } from "../react-client/types.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
 import { handleError } from "../error/handleError.js";
 import { setMaxListenersOnPort, unrefPort } from "../stream/setMaxListeners.js";
+import { attachRunnerFetchHandler } from "./handleRunnerFetch.server.js";
 
 let currentWorker: Worker | null = null;
 let isRestarting = false;
 let currentHmrChannel: MessageChannel | null = null;
 let currentMessageHandler: ((event: Event) => void) | null = null;
 let currentErrorHandler: ((error: any) => void) | null = null;
+let currentRunnerChannel: MessageChannel | null = null;
+let currentRunnerDetach: (() => void) | null = null;
+
+const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] === "1";
 
 export const restartWorker: RestartWorkerFn = async function _restartWorker({
   server,
@@ -41,6 +46,17 @@ export const restartWorker: RestartWorkerFn = async function _restartWorker({
       currentHmrChannel.port1.close();
       currentHmrChannel.port2.close();
       currentHmrChannel = null;
+    }
+
+    // Clean up the runner channel + fetch handler from any prior worker
+    if (currentRunnerDetach) {
+      currentRunnerDetach();
+      currentRunnerDetach = null;
+    }
+    if (currentRunnerChannel) {
+      currentRunnerChannel.port1.close();
+      currentRunnerChannel.port2.close();
+      currentRunnerChannel = null;
     }
 
     // Clean up any existing event listeners on the main HMR channel
@@ -105,6 +121,26 @@ export const restartWorker: RestartWorkerFn = async function _restartWorker({
       server.config.logger.info(`[restartWorker] configEnv.mode: ${configEnv?.mode}`);
     }
 
+    let runnerPortForWorker: MessageChannel["port2"] | undefined;
+    const transferList: any[] = [workerHmrChannel.port2];
+    if (isRunnerEnabled()) {
+      const runnerChannel = new MessageChannel();
+      currentRunnerChannel = runnerChannel;
+      setMaxListenersOnPort(runnerChannel.port1, maxListeners);
+      setMaxListenersOnPort(runnerChannel.port2, maxListeners);
+      unrefPort(runnerChannel.port1);
+      unrefPort(runnerChannel.port2);
+      const logger = server.config.customLogger || server.config.logger;
+      currentRunnerDetach = attachRunnerFetchHandler(
+        runnerChannel.port1,
+        server,
+        logger,
+        Boolean(userOptions.verbose)
+      );
+      runnerPortForWorker = runnerChannel.port2;
+      transferList.push(runnerChannel.port2);
+    }
+
     const workerResult = await createWorker({
       projectRoot: userOptions.projectRoot || server.config.root,
       workerPath: userOptions.rscWorkerPath,
@@ -124,8 +160,9 @@ export const restartWorker: RestartWorkerFn = async function _restartWorker({
         reactVersion: React.version,
         id: "worker/rsc",
         serverManifest: {}, // staticManifest removed from AutoDiscoveredFiles
+        runnerPort: runnerPortForWorker,
       },
-      transferList: [workerHmrChannel.port2], // Transfer the port properly
+      transferList,
     });
     
     if (workerResult.type === "success") {

--- a/plugin/helpers/createSharedLoader.ts
+++ b/plugin/helpers/createSharedLoader.ts
@@ -1,6 +1,7 @@
 import { join, isAbsolute } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Logger } from "vite";
+import type { ModuleRunner } from "vite/module-runner";
 import type { InputNormalizer } from "../types.js";
 import { resolveVirtualAndNodeModules } from "./resolveVirtualAndNodeModules.js";
 import { resolveModuleFromManifest } from "./resolveModuleFromManifest.js";
@@ -41,6 +42,7 @@ export async function createSharedLoader({
   isServeMode: _isServeMode = false,
   effectiveProjectRoot,
   build,
+  moduleRunner,
 }: {
   moduleId: string;
   exportName?: string;
@@ -66,6 +68,12 @@ export async function createSharedLoader({
     static?: string;
     outDir?: string;
   };
+  /**
+   * Optional Vite ModuleRunner. When provided in dev:ssr mode the worker
+   * pulls project source through Vite's runner instead of Node's native
+   * import(), so file edits invalidate per-module without a worker restart.
+   */
+  moduleRunner?: ModuleRunner | null;
 }): Promise<Record<string, any>> {
   // Step 1: Handle virtual modules and node_modules first (if enabled)
   if (resolveVirtual) {
@@ -128,15 +136,30 @@ export async function createSharedLoader({
   }
 
   // Step 3: Construct the full path and import
-  const fullPath = isAbsolute(resolvedModuleID) 
-    ? resolvedModuleID 
-    : effectiveProjectRoot 
+  const fullPath = isAbsolute(resolvedModuleID)
+    ? resolvedModuleID
+    : effectiveProjectRoot
       ? join(effectiveProjectRoot, resolvedModuleID)
       : resolvedModuleID;
 
-  // Import the module
-  const fileUrl = isAbsolute(fullPath) ? pathToFileURL(fullPath).href : fullPath;
-  const result = await import(fileUrl);
+  // Step 3a: If a Vite ModuleRunner is available, prefer it for project source.
+  // Vendored / node_modules paths are already handled by resolveVirtualAndNodeModules
+  // earlier, so anything reaching this point in dev:ssr is project source.
+  let result: Record<string, any>;
+  if (
+    moduleRunner != null &&
+    !isBuildMode &&
+    effectiveProjectRoot &&
+    isAbsolute(fullPath) &&
+    fullPath.startsWith(effectiveProjectRoot)
+  ) {
+    if (verbose) logger?.info(`[shared-loader] runner.import: ${fullPath}`);
+    result = (await moduleRunner.import(fullPath)) as Record<string, any>;
+  } else {
+    // Import the module via Node's native ESM loader.
+    const fileUrl = isAbsolute(fullPath) ? pathToFileURL(fullPath).href : fullPath;
+    result = await import(fileUrl);
+  }
 
   // Validate exports
   if (result == null) {

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -139,6 +139,7 @@ export type CreateWorkerOptions = {
     serverPipeableStreamOptions?: any;
     clientPipeableStreamOptions?: any;
     hmrPort?: MessagePort;
+    runnerPort?: MessagePort;
   };
   transferList?: TransferListItem[];
   logger?: Logger;

--- a/plugin/worker/rsc/createRscWorkerLoader.ts
+++ b/plugin/worker/rsc/createRscWorkerLoader.ts
@@ -2,6 +2,7 @@ import { createLogger, type Logger } from "vite";
 import { workerData } from "node:worker_threads";
 import type { GenericModuleLoader } from "../../types.js";
 import { createSharedLoader } from "../../helpers/createSharedLoader.js";
+import { getRunner } from "./runnerInstance.js";
 
 /**
  * Creates a GenericModuleLoader for the RSC worker.
@@ -52,6 +53,7 @@ export const createRscWorkerLoader = ({
       isServeMode,
       effectiveProjectRoot,
       build,
+      moduleRunner: isServeMode ? getRunner() : null,
     });
   };
 };

--- a/plugin/worker/rsc/createRunnerTransport.ts
+++ b/plugin/worker/rsc/createRunnerTransport.ts
@@ -1,0 +1,45 @@
+import type { MessagePort } from "node:worker_threads";
+import type { ModuleRunnerTransport } from "vite/module-runner";
+
+export type RunnerPortRequest = {
+  __vprs: "runner-request";
+  requestId: number;
+  payload: unknown;
+};
+
+export type RunnerPortResponse = {
+  __vprs: "runner-response";
+  requestId: number;
+  result: { result: unknown } | { error: unknown };
+};
+
+export function createRunnerTransport(port: MessagePort): ModuleRunnerTransport {
+  let nextId = 1;
+  const pending = new Map<
+    number,
+    (value: { result: unknown } | { error: unknown }) => void
+  >();
+
+  port.on("message", (msg: RunnerPortResponse) => {
+    if (!msg || msg.__vprs !== "runner-response") return;
+    const resolve = pending.get(msg.requestId);
+    if (!resolve) return;
+    pending.delete(msg.requestId);
+    resolve(msg.result);
+  });
+
+  return {
+    async invoke(payload) {
+      return new Promise((resolve) => {
+        const requestId = nextId++;
+        pending.set(requestId, resolve as any);
+        const req: RunnerPortRequest = {
+          __vprs: "runner-request",
+          requestId,
+          payload,
+        };
+        port.postMessage(req);
+      });
+    },
+  };
+}

--- a/plugin/worker/rsc/createRunnerTransport.ts
+++ b/plugin/worker/rsc/createRunnerTransport.ts
@@ -13,26 +13,66 @@ export type RunnerPortResponse = {
   result: { result: unknown } | { error: unknown };
 };
 
-export function createRunnerTransport(port: MessagePort): ModuleRunnerTransport {
-  let nextId = 1;
-  const pending = new Map<
+export type RpcRequest = {
+  __vprs: "rpc-request";
+  requestId: number;
+  method: string;
+  args: unknown[];
+};
+
+export type RpcResponse = {
+  __vprs: "rpc-response";
+  requestId: number;
+  result?: unknown;
+  error?: { name?: string; message: string; stack?: string };
+};
+
+export type RpcInvoker = <T = unknown>(method: string, args: unknown[]) => Promise<T>;
+
+export type RunnerTransportBundle = {
+  transport: ModuleRunnerTransport;
+  rpc: RpcInvoker;
+};
+
+export function createRunnerTransport(port: MessagePort): RunnerTransportBundle {
+  let nextRunnerId = 1;
+  let nextRpcId = 1;
+  const runnerPending = new Map<
     number,
     (value: { result: unknown } | { error: unknown }) => void
   >();
+  const rpcPending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: unknown) => void }
+  >();
 
-  port.on("message", (msg: RunnerPortResponse) => {
-    if (!msg || msg.__vprs !== "runner-response") return;
-    const resolve = pending.get(msg.requestId);
-    if (!resolve) return;
-    pending.delete(msg.requestId);
-    resolve(msg.result);
+  port.on("message", (msg: RunnerPortResponse | RpcResponse) => {
+    if (!msg) return;
+    if (msg.__vprs === "runner-response") {
+      const resolve = runnerPending.get(msg.requestId);
+      if (!resolve) return;
+      runnerPending.delete(msg.requestId);
+      resolve(msg.result);
+    } else if (msg.__vprs === "rpc-response") {
+      const pending = rpcPending.get(msg.requestId);
+      if (!pending) return;
+      rpcPending.delete(msg.requestId);
+      if (msg.error) {
+        const err = new Error(msg.error.message);
+        if (msg.error.name) err.name = msg.error.name;
+        if (msg.error.stack) err.stack = msg.error.stack;
+        pending.reject(err);
+      } else {
+        pending.resolve(msg.result);
+      }
+    }
   });
 
-  return {
+  const transport: ModuleRunnerTransport = {
     async invoke(payload) {
       return new Promise((resolve) => {
-        const requestId = nextId++;
-        pending.set(requestId, resolve as any);
+        const requestId = nextRunnerId++;
+        runnerPending.set(requestId, resolve as any);
         const req: RunnerPortRequest = {
           __vprs: "runner-request",
           requestId,
@@ -42,4 +82,26 @@ export function createRunnerTransport(port: MessagePort): ModuleRunnerTransport 
       });
     },
   };
+
+  const rpc: RpcInvoker = async <T = unknown>(
+    method: string,
+    args: unknown[]
+  ): Promise<T> => {
+    return new Promise<T>((resolve, reject) => {
+      const requestId = nextRpcId++;
+      rpcPending.set(requestId, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      const req: RpcRequest = {
+        __vprs: "rpc-request",
+        requestId,
+        method,
+        args,
+      };
+      port.postMessage(req);
+    });
+  };
+
+  return { transport, rpc };
 }

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -26,6 +26,7 @@ import {
   isModuleInvalidated,
   clearAllCachedComponents,
 } from "./state.server.js";
+import { getRunner } from "./runnerInstance.js";
 import {
   combineCssFiles,
   processInlineCssForState,
@@ -1252,7 +1253,25 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             `[rsc-worker] HMR_UPDATE: Cleared all cached components from temporaryReferences`
           );
         }
-        
+
+        // Invalidate the Vite ModuleRunner cache when the experimental
+        // runner path is in use. We clear the entire runner cache: the
+        // EvaluatedModules graph doesn't track reverse deps (importers),
+        // so invalidating just the changed file would leave consumers
+        // (e.g. a page.tsx that imports the edited *.module.css) holding
+        // a stale module reference with the old class-name hashes. The
+        // clear is still much cheaper than a full worker restart because
+        // there's no Node startup, register-vendor.js, or loader re-init.
+        const runner = getRunner();
+        if (runner) {
+          runner.clearCache();
+          if (verbose) {
+            logger?.info(
+              `[rsc-worker] HMR_UPDATE: runner cache cleared (trigger: ${filePath})`
+            );
+          }
+        }
+
         // Also clear headless stream errors since we're reloading
         headlessStreamErrors.clear();
         

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -26,7 +26,7 @@ import {
   isModuleInvalidated,
   clearAllCachedComponents,
 } from "./state.server.js";
-import { getRunner } from "./runnerInstance.js";
+import { getRunner, getRpc } from "./runnerInstance.js";
 import {
   combineCssFiles,
   processInlineCssForState,
@@ -770,6 +770,37 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             description: `Module resolution for route ${msg.options.route}`,
           });
           effectiveHandlers.onMetrics(msg.id, moduleResolutionMetric);
+        }
+
+        // Runner-mode CSS collection: the worker's Node ESM CSS loader
+        // never fires for runner-loaded modules, so the global cssFiles
+        // Map stays empty. Ask the main thread to walk Vite's server
+        // module graph for the page (populated as a side effect of the
+        // runner.import we just finished) and push the raw CSS code back.
+        // We feed each entry through addCssFileContent so it merges into
+        // the same global state the loader used to produce.
+        const rpc = getRpc();
+        if (rpc && msg.options.pagePath) {
+          try {
+            const cssFileUserOptions = getUserOptions();
+            const collected = (await rpc<
+              Array<{ id: string; code: string }>
+            >("collectCss", [msg.options.pagePath, projectRoot])) || [];
+            for (const { id, code } of collected) {
+              addCssFileContent(id, code, cssFileUserOptions);
+            }
+            if (verbose) {
+              logger?.info(
+                `[rsc-worker] runner CSS bridge: collected ${collected.length} file(s) for ${msg.options.pagePath}`
+              );
+            }
+          } catch (err) {
+            if (verbose) {
+              logger?.warn(
+                `[rsc-worker] runner CSS bridge failed: ${String(err)}`
+              );
+            }
+          }
         }
 
         // Process CSS files using unified CSS processor

--- a/plugin/worker/rsc/rsc-worker.development.ts
+++ b/plugin/worker/rsc/rsc-worker.development.ts
@@ -18,7 +18,7 @@ import { serializeError } from "../../error/serializeError.js";
 import { setMaxListenersOnPort, unrefPort } from "../../stream/setMaxListeners.js";
 import { ModuleRunner, ESModulesEvaluator } from "vite/module-runner";
 import { createRunnerTransport } from "./createRunnerTransport.js";
-import { setRunner, isRunnerEnabled } from "./runnerInstance.js";
+import { setRunner, setRpc, isRunnerEnabled } from "./runnerInstance.js";
 
 // Initialize worker
 if (!parentPort) {
@@ -245,7 +245,7 @@ try {
       setMaxListenersOnPort(workerData.runnerPort, 500);
       unrefPort(workerData.runnerPort);
       workerData.runnerPort.start();
-      const transport = createRunnerTransport(workerData.runnerPort);
+      const { transport, rpc } = createRunnerTransport(workerData.runnerPort);
       const runner = new ModuleRunner(
         {
           transport,
@@ -255,6 +255,7 @@ try {
         new ESModulesEvaluator()
       );
       setRunner(runner);
+      setRpc(rpc);
       if (workerData.verbose) {
         logger.info("ModuleRunner initialized (VPRS_RUNNER=1)");
       }

--- a/plugin/worker/rsc/rsc-worker.development.ts
+++ b/plugin/worker/rsc/rsc-worker.development.ts
@@ -16,6 +16,9 @@ import { handleError } from "../../error/handleError.js";
 import { sendMessage } from "../sendMessage.js";
 import { serializeError } from "../../error/serializeError.js";
 import { setMaxListenersOnPort, unrefPort } from "../../stream/setMaxListeners.js";
+import { ModuleRunner, ESModulesEvaluator } from "vite/module-runner";
+import { createRunnerTransport } from "./createRunnerTransport.js";
+import { setRunner, isRunnerEnabled } from "./runnerInstance.js";
 
 // Initialize worker
 if (!parentPort) {
@@ -233,6 +236,32 @@ try {
 
   // HMR port handling is disabled in dev server mode to avoid DataCloneError
   // TODO: Re-enable HMR when transfer list issues are resolved
+
+  // Experimental: ModuleRunner-based fetch transport. Enabled with VPRS_RUNNER=1.
+  // Replaces Node's native import() for project source so dev:ssr no longer
+  // needs a worker restart on each save.
+  if (!isBuildMode && isRunnerEnabled() && workerData.runnerPort) {
+    try {
+      setMaxListenersOnPort(workerData.runnerPort, 500);
+      unrefPort(workerData.runnerPort);
+      workerData.runnerPort.start();
+      const transport = createRunnerTransport(workerData.runnerPort);
+      const runner = new ModuleRunner(
+        {
+          transport,
+          hmr: false,
+          sourcemapInterceptor: false,
+        },
+        new ESModulesEvaluator()
+      );
+      setRunner(runner);
+      if (workerData.verbose) {
+        logger.info("ModuleRunner initialized (VPRS_RUNNER=1)");
+      }
+    } catch (err) {
+      logger.error(`Failed to initialize ModuleRunner: ${String(err)}`);
+    }
+  }
 
   // Notify parent that we're ready
   parentPort!.postMessage({

--- a/plugin/worker/rsc/runnerInstance.ts
+++ b/plugin/worker/rsc/runnerInstance.ts
@@ -1,0 +1,15 @@
+import type { ModuleRunner } from "vite/module-runner";
+
+let runner: ModuleRunner | null = null;
+
+export function setRunner(instance: ModuleRunner): void {
+  runner = instance;
+}
+
+export function getRunner(): ModuleRunner | null {
+  return runner;
+}
+
+export function isRunnerEnabled(): boolean {
+  return process.env["VPRS_RUNNER"] === "1";
+}

--- a/plugin/worker/rsc/runnerInstance.ts
+++ b/plugin/worker/rsc/runnerInstance.ts
@@ -20,6 +20,11 @@ export function getRpc(): RpcInvoker | null {
   return rpc;
 }
 
+/**
+ * The Vite ModuleRunner path is enabled by default. Set `VPRS_RUNNER=0`
+ * to fall back to the legacy Node-import-based loader if the runner
+ * ever causes problems for a specific project.
+ */
 export function isRunnerEnabled(): boolean {
-  return process.env["VPRS_RUNNER"] === "1";
+  return process.env["VPRS_RUNNER"] !== "0";
 }

--- a/plugin/worker/rsc/runnerInstance.ts
+++ b/plugin/worker/rsc/runnerInstance.ts
@@ -1,6 +1,8 @@
 import type { ModuleRunner } from "vite/module-runner";
+import type { RpcInvoker } from "./createRunnerTransport.js";
 
 let runner: ModuleRunner | null = null;
+let rpc: RpcInvoker | null = null;
 
 export function setRunner(instance: ModuleRunner): void {
   runner = instance;
@@ -8,6 +10,14 @@ export function setRunner(instance: ModuleRunner): void {
 
 export function getRunner(): ModuleRunner | null {
   return runner;
+}
+
+export function setRpc(invoker: RpcInvoker): void {
+  rpc = invoker;
+}
+
+export function getRpc(): RpcInvoker | null {
+  return rpc;
 }
 
 export function isRunnerEnabled(): boolean {


### PR DESCRIPTION
## Summary

Adds a [Vite ModuleRunner](https://vitejs.dev/guide/api-environment-runtimes#modulerunner)-based fetch path for the rsc-worker in dev:ssr mode. Project source is loaded through Vite's transform pipeline instead of Node's native ESM cache, so module-graph invalidation works per-module — eliminating the worker restart dev:ssr CSS edits used to trigger (~500ms hit per save).

**Default-on** in 1.6.0. Falls back to the 1.5.3 codepath when `VPRS_RUNNER=0` is set in the environment (escape hatch in case a project hits a runner-specific edge case).

## What's in the runner path

- **Transport:** `plugin/worker/rsc/createRunnerTransport.ts` — implements `ModuleRunnerTransport.invoke` over a Node `MessagePort`, multiplexed with a vprs-side RPC protocol (`__vprs` message tag).
- **Fetch handler:** `plugin/dev-server/handleRunnerFetch.server.ts` — main-thread side resolves the runner's `fetchModule` invokes by calling `fetchModule(server.environments.server, …)`.
- **Runner:** `plugin/worker/rsc/rsc-worker.development.ts` — instantiates `new ModuleRunner({ transport, hmr: false }, new ESModulesEvaluator())` once per worker spawn.
- **Loader fork:** `plugin/helpers/createSharedLoader.ts` — when a `moduleRunner` is supplied and the resolved id is project source, uses `runner.import(id)`. Vendored modules (`oss-experimental/react-server-dom-esm` via `--import register-vendor.js`) and node_modules continue to use Node's native ESM — they don't go through Vite's pipeline and shouldn't.
- **HMR cache invalidation:** `plugin/worker/rsc/messageHandler.server.tsx` `HMR_UPDATE` handler calls `runner.clearCache()`. Per-module invalidation isn't enough — `EvaluatedModules` has no reverse-deps map, so a CSS-module edit must also re-evaluate the page.tsx that imported it (otherwise the consumer holds the stale class-name hashes).
- **Worker-restart skip:** `markModulesInvalidated` is a no-op when the runner is active. The runner cache clear above is the moral equivalent at a fraction of the cost.

## The CSS bridge

vprs collects CSS via a Node ESM loader (`register(cssLoaderPath, …)`) that intercepts `import "*.css"` calls flowing through Node's native `import()` and posts CSS_FILE messages back to the worker, feeding the `cssFiles` Map in `state.server.ts`. The runner bypasses Node's import resolver entirely, so the loader never fires for runner-loaded modules.

Rather than rewire the loader, this PR collects CSS on the main thread from Vite's server-environment module graph (which `runner.import(pagePath)` populates as a side effect of every `fetchModule` call):

- New file: `plugin/dev-server/collectRunnerCss.ts` — walks `server.environments.server.moduleGraph` from the page module, transforms each reachable `*.module.css` via `env.transformRequest("<id>?inline")`, extracts the raw CSS string from the SSR transform's `__vite_ssr_export_default__ = "…"` binding.
- Worker calls `rpc.collectCss(pagePath)` after `loadComponentsWithCache` returns in the INIT handler. Each returned `{id, code}` goes through `addCssFileContent` so it merges into the same global `cssFiles` Map the loader used to populate. Rendering picks up the styles unchanged.

The `<Css cssFiles={…}/>` JSX prop is a renderer — it consumes whichever Map is handed to it and emits style/link tags. The runner-mode CSS bridge populates that Map the same way the loader used to, so existing component code is unchanged.

## Test plan

- [x] `npm run build` — type-check + vite build pass.
- [x] `npm run test:dev` — 27/27 vitest dev tests pass (both with the runner enabled and `VPRS_RUNNER=0`).
- [x] `npm run test:e2e` against linked `bidoof-template`:
  - [x] Default (runner on) — 20/20 playwright tests pass. dev:ssr CSS edits land without worker restart. Class hashes rotate per edit (`_Home_1yxem_1 → _Home_sctwz_1`) confirming the cache invalidation cycle is working end-to-end.
  - [x] `VPRS_RUNNER=0` (opt-out fallback) — 20/20 pass, no regression from 1.5.3.

## Known follow-ups (out of scope for this PR)

- Drop the now-dormant Node ESM CSS/tsx loader registrations from `rsc-worker.development.ts` (currently wasted setup work, not incorrect — runner-loaded modules never hit them).
- Quantify the dev:ssr CSS-edit latency improvement (target was matching dev:rsc's instant invalidation; e2e proves correctness, not speed).
- Parameterize the vitest dev suite to exercise both dev:rsc and dev:ssr — currently only the playwright e2e suite catches dev:ssr-specific issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)