### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Bumps `package.json` + `package-lock.json` to 1.6.0 ahead of the
`npm publish` cut. Picks up #44 (ModuleRunner-based fetch transport
for dev:ssr, default-on with `VPRS_RUNNER=0` opt-out).

Tag `v1.6.0` will be added after merge to match the v1.5.x cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)