### PR TITLE
test(dev): add CSS-module coverage so the dev test suite catches runner bridge regressions

### DIFF
--- a/test/dev/css-hmr.test.ts
+++ b/test/dev/css-hmr.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type ViteDevServer } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { testUserOptions } from "../test-config";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { setupTestProject } from "../setup.js";
+
+/**
+ * Tests for CSS module handling in dev mode.
+ *
+ * Runs under both dev:rsc (test:server, with `--conditions react-server`)
+ * and dev:ssr (test:client, without) — same source, two transports.
+ *
+ * Catches the class of regression that surfaced during the 1.6.0
+ * ModuleRunner work: rendered HTML had the right hashed class name but
+ * no stylesheet attached, because the rsc-worker's CSS collection path
+ * was bypassed. None of the other test/dev specs *asserted* anything
+ * about CSS, so the regression only showed up in the playwright e2e.
+ */
+
+let server: ViteDevServer | undefined;
+const port = 3120;
+const testDir = resolve(__dirname, "../fixtures/css-hmr.test");
+const cssPath = join(testDir, "src/page/test.module.css");
+let originalCss = "";
+
+describe("CSS module handling in dev", () => {
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+    // Reuse the standard fixture (it already imports a *.module.css from
+    // src/page/page.tsx). Snapshot the CSS so the second test can mutate
+    // it deterministically.
+    await setupTestProject(testDir);
+    originalCss = await readFile(cssPath, "utf-8");
+
+    server = await createServer({
+      mode: "test",
+      root: testDir,
+      plugins: [
+        vitePluginReactServer({
+          ...testUserOptions,
+          projectRoot: testDir,
+        }),
+      ],
+      server: { port, strictPort: true },
+      logLevel: "warn",
+      cacheDir: join(process.cwd(), "node_modules", `.vite-test-${port}`),
+    });
+    await server.listen();
+  }, 30000);
+
+  afterAll(async () => {
+    if (originalCss) {
+      try {
+        await writeFile(cssPath, originalCss);
+      } catch {
+        // Fixture dir is removed below anyway.
+      }
+    }
+    await server?.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("references the imported CSS module in the rendered response", async () => {
+    const res = await fetch(`http://localhost:${port}/`, {
+      headers: { Accept: "text/x-component" },
+    });
+    expect(res.ok).toBe(true);
+    const body = await res.text();
+    // CSS-modules hashes the local class — exact hash varies, but the
+    // prefix is deterministic. setupPageTSX defines `.test` and `.shared`.
+    expect(body).toMatch(/_test_/);
+    // vprs's CSS collection must produce a tag for the imported sheet,
+    // either inlined as <style> or via a <link rel="stylesheet" href=…>.
+    // Without the collection path populating cssFiles, the class name
+    // renders but nothing carries the rule, leaving the page unstyled.
+    expect(body).toMatch(/test\.module\.css/);
+  }, 20000);
+
+  it("serves the latest CSS bytes after the source file is edited", async () => {
+    // Prime the module graph so Vite has transformed the page + the CSS
+    // module at least once.
+    await fetch(`http://localhost:${port}/`, {
+      headers: { Accept: "text/x-component" },
+    });
+
+    const before = await fetch(
+      `http://localhost:${port}/src/page/test.module.css?direct`
+    );
+    expect(before.ok).toBe(true);
+    // setupPageTSX writes `.test {color: red}` initially.
+    expect(await before.text()).toMatch(/color:\s*red/);
+
+    await writeFile(
+      cssPath,
+      `.test {color: rgb(0, 0, 255)}\n.shared {background: white}\n.unused {display: none}`
+    );
+    // Allow Vite's file watcher to fire and the worker (in dev:ssr) to
+    // invalidate its runner cache.
+    await sleep(1500);
+
+    const after = await fetch(
+      `http://localhost:${port}/src/page/test.module.css?direct`
+    );
+    expect(after.ok).toBe(true);
+    const afterBody = await after.text();
+    expect(afterBody).toContain("rgb(0, 0, 255)");
+    expect(afterBody).not.toMatch(/color:\s*red/);
+  }, 20000);
+});


### PR DESCRIPTION
## Summary

Adds `test/dev/css-hmr.test.ts` — a small spec that proves the dev rendering pipeline emits a stylesheet reference for an imported `.module.css` and serves edits to that file fresh.

## Why this exists

`test/dev/*` already runs in both dev:rsc and dev:ssr today (CI invokes `test-all` → `test:server` with `--conditions react-server` + `test:client` without). The gap was assertions, not coverage: none of the existing specs *asserted* anything about CSS handling. That's how the 1.6.0 ModuleRunner CSS-bridge regression slipped past the vitest suite — fixtures imported CSS modules, the response just didn't carry the rule, and no test was checking.

This spec closes that gap:

1. Page that imports `./test.module.css` is rendered → response must contain the hashed class name (`_test_…`) and a reference to the stylesheet (`test.module.css`). Without the CSS collection path populating `cssFiles`, the class name renders but no `<link>` / `<style>` is emitted.
2. The source CSS is mutated and the client refetches `<id>.css?direct` → response must contain the new bytes and not the old.

Reuses `setupTestProject`'s existing fixture (already imports `src/page/test.module.css`) instead of adding a parallel one that would drift.

## Test plan

- [x] Passes under `NODE_OPTIONS='--conditions react-server' vitest run test/dev/css-hmr.test.ts` (dev:rsc).
- [x] Passes under `vitest run test/dev/css-hmr.test.ts` (dev:ssr, runner default-on).
- [x] Full `test/dev` suite green in both modes: 8 files / 29 tests (was 7 / 27 before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)