### PR TITLE
refactor(dev:ssr): drop legacy non-runner paths + Node ESM loader registrations

### DIFF
--- a/plugin/dev-server/configureReactServer.client.ts
+++ b/plugin/dev-server/configureReactServer.client.ts
@@ -36,7 +36,6 @@ export const configureReactServer: CreateReactWorkerServerFn =
       // Worker cleanup would be handled by the worker management
     });
 
-    let restartFn: (() => Promise<void>) | null = null;
     let currentWorker: any = null;
 
     // Configure the worker request handler (sets up middleware)
@@ -65,22 +64,18 @@ export const configureReactServer: CreateReactWorkerServerFn =
       resolvedConfig,
       onWorkerCreated: (worker: any, restart?: () => Promise<void>) => {
         currentWorker = worker;
-        if (restart) {
-          restartFn = restart;
-        }
         if (onWorkerCreated) {
           onWorkerCreated(worker, restart);
         }
       },
     });
-    
-    // Return object with restart function and HMR update sender for hotUpdate
+
     return {
-      restart: restartFn,
       sendHmrUpdate: (file: string, routes?: string[]) => {
         if (currentWorker) {
-          // CRITICAL: In development mode, HMR port is disabled, so send directly to worker
-          // Send HMR_UPDATE message to worker through parentPort (postMessage)
+          // Notify the worker that a file changed. The worker's HMR_UPDATE
+          // handler invalidates the ModuleRunner cache so the next import
+          // re-fetches transformed code through Vite's pipeline.
           const normalizedPath = file.replace(userOptions.projectRoot || server.config.root, '').replace(/^\/+/, '');
           currentWorker.postMessage({
             type: "HMR_UPDATE",
@@ -89,17 +84,9 @@ export const configureReactServer: CreateReactWorkerServerFn =
             routes: routes || [],
             timestamp: Date.now(),
           } satisfies any);
-          
-          // Mark that modules have been invalidated - worker will be restarted on next request
-          // This is necessary because Node.js caches ES modules and the only way to clear
-          // that cache is to restart the worker
-          // Use dynamic import to avoid circular dependency
-          import("./configureRequestHandler.client.js").then(({ markModulesInvalidated }) => {
-            markModulesInvalidated();
-          });
-          
+
           if (verbose) {
-            logger?.info(`[createReactWorkerServer] Sent HMR_UPDATE for ${file} to worker, marked for restart`);
+            logger?.info(`[createReactWorkerServer] Sent HMR_UPDATE for ${file} to worker`);
           }
         }
       },

--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -14,25 +14,6 @@ import { getNodeEnv } from "../config/getNodeEnv.js";
 import { setupGlobalErrorHandler, cleanupGlobalErrorHandler } from "../error/setupGlobalErrorHandler.js";
 import { pipeToResponse } from "../helpers/pipeToResponse.js";
 
-// Shared state to track if modules have been invalidated
-// This allows us to restart the worker on the next request to clear Node.js module cache
-let hasInvalidatedModules = false;
-
-const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] !== "0";
-
-/**
- * Mark that modules have been invalidated - worker will be restarted on next request.
- * The Vite ModuleRunner is enabled by default; the worker keeps its runner cache
- * invalidated via the HMR_UPDATE handler, so the heavyweight worker restart can
- * be skipped. Opt out with `VPRS_RUNNER=0` to fall back to the legacy restart path.
- */
-export function markModulesInvalidated(): void {
-  if (isRunnerEnabled()) {
-    return;
-  }
-  hasInvalidatedModules = true;
-}
-
 /**
  * Configures the worker request handler.
  * @param server - The Vite dev server
@@ -270,10 +251,10 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
         res.setHeader("Expires", "0");
 
         const userOnMetrics = handlerOptions.onMetrics;
-        
-        // CRITICAL: If modules have been invalidated, restart the worker to clear Node.js's ES module cache
-        // This ensures file changes are picked up even on refresh
-        // Node.js caches ES modules, and the only way to clear that cache is to restart the worker
+
+        // Spawn the worker lazily on the first request. The ModuleRunner
+        // handles per-module invalidation via the HMR_UPDATE message
+        // handler, so a long-lived worker can keep serving across edits.
         if (!currentWorker) {
           currentWorker = await restartWorker({
             server,
@@ -282,23 +263,6 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
             configEnv: configEnv,
             hmrChannel,
           });
-          hasInvalidatedModules = false; // Reset flag after creating worker
-        } else if (hasInvalidatedModules) {
-          // Worker exists but modules are invalidated - restart to clear Node.js cache
-          if (handlerOptions.verbose) {
-            logger.info(`[configureRequestHandler] Modules invalidated, restarting worker to clear Node.js module cache...`);
-          }
-          currentWorker = await restartWorker({
-            server,
-            autoDiscoveredFiles,
-            userOptions: serializedUserOptions,
-            configEnv: configEnv,
-            hmrChannel,
-          });
-          hasInvalidatedModules = false; // Reset flag after restarting
-        } else {
-          // Worker already exists and no invalidations - reuse it
-          // Note: unified worker streams handle their own listeners
         }
         if (!currentWorker) {
           throw new Error("Failed to start worker");

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -28,9 +28,8 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
   
 
   let configEnv: ConfigEnv | undefined;
-  let hmrHandler: { restart: (() => Promise<void>) | null; sendHmrUpdate: (file: string, routes?: string[]) => void } | null = null;
+  let hmrHandler: { sendHmrUpdate: (file: string, routes?: string[]) => void } | null = null;
   let isProcessingHmr = false; // Prevent recursive HMR updates
-  let restartTimeout: NodeJS.Timeout | null = null; // Debounce worker restarts
 
   return {
     name: "vite-plugin-react-server:dev-server-client",
@@ -93,13 +92,9 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       const isInModuleBase = normalizedFile.startsWith(moduleBase + '/');
       const isSourceFile = isInModuleBase &&
         (file.endsWith('.tsx') || file.endsWith('.ts') || file.endsWith('.jsx') || file.endsWith('.js'));
-      // CSS edits in dev:ssr must also trigger the worker-restart path: the SSR
-      // worker imports compiled CSS modules through Node's loader, which caches
-      // by URL. Vite re-transforming the file does nothing for already-imported
-      // modules in the worker — without invalidating + restarting, the next
-      // page render reuses the pre-edit class hashes (bd-5rk). dev:rsc doesn't
-      // need this because rendering happens in the main process and goes through
-      // Vite's invalidated server module graph (plugin.server.ts hotUpdate).
+      // CSS edits route through the same worker-invalidation path so the
+      // ModuleRunner cache drops every reachable CSS module before the
+      // next render asks for class-name hashes.
       const isCssFile = isInModuleBase &&
         (file.endsWith('.css') || file.endsWith('.scss') || file.endsWith('.sass') || file.endsWith('.less'));
 
@@ -124,19 +119,9 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
             server.config.logger.info(`[vite-plugin-react-server] File changed: ${file}, sending HMR update...`);
           }
 
-          // CRITICAL: Send HMR_UPDATE message to worker to invalidate modules
-          // This clears component caches, but Node.js's ES module cache persists —
-          // the request handler triggers a worker restart on the next request
-          // (see configureRequestHandler.client.ts hasInvalidatedModules check).
-          //
-          // For CSS edits the restart is the slow path: in dev:ssr that adds a
-          // ~few-hundred-ms flash on every CSS save that dev:rsc doesn't have.
-          // We accept that for now because skipping the restart leaves the
-          // worker holding stale class-name hashes for any CSS module that
-          // server components imported directly (bidoof Card.module.css
-          // pattern) — page renders broken until next "real" invalidation.
-          // Proper fix is worker-side per-module cache-busting; tracked as a
-          // follow-up.
+          // Tell the worker to invalidate. Its HMR_UPDATE handler clears the
+          // ModuleRunner cache so the next import re-fetches transformed code
+          // through Vite — no worker restart needed.
           hmrHandler.sendHmrUpdate(file);
 
           // Notify the browser to refetch the RSC stream. In dev:rsc the
@@ -154,45 +139,11 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
             data: { file: normalizedFile, path: file, kind: isCssFile ? "css" : "component" },
           });
 
-          // CRITICAL: Node.js caches ES modules, so we need to restart the worker
-          // to clear the module cache. Debounce restarts to prevent recursion.
-          if (hmrHandler.restart) {
-            // Clear any pending restart
-            if (restartTimeout) {
-              clearTimeout(restartTimeout);
-            }
-
-            // Debounce worker restart to prevent recursion
-            // Wait 500ms after the last file change before restarting
-            restartTimeout = setTimeout(async () => {
-              try {
-                if (userOptions.verbose) {
-                  server.config.logger.info(`[vite-plugin-react-server] Restarting worker to clear Node.js module cache...`);
-                }
-                await hmrHandler!.restart!();
-                if (userOptions.verbose) {
-                  server.config.logger.info(`[vite-plugin-react-server] Worker restarted successfully`);
-                }
-              } catch (error) {
-                server.config.logger.error(`[vite-plugin-react-server] Failed to restart worker: ${error}`);
-              } finally {
-                restartTimeout = null;
-                // Reset flag after restart completes
-                setTimeout(() => {
-                  isProcessingHmr = false;
-                }, 100);
-              }
-            }, 500); // 500ms debounce
-          } else {
-            // No restart function available yet - worker hasn't been created
-            // This is expected if hotUpdate fires before the first request
-            if (userOptions.verbose) {
-              server.config.logger.warn(`[vite-plugin-react-server] Restart function not available yet - worker will be created on next request`);
-            }
-            setTimeout(() => {
-              isProcessingHmr = false;
-            }, 100);
-          }
+          // The runner takes care of per-module invalidation, so the only
+          // thing left to clear here is the local processing flag.
+          setTimeout(() => {
+            isProcessingHmr = false;
+          }, 100);
         } catch (error) {
           server.config.logger.error(`[vite-plugin-react-server] Error handling HMR update: ${error}`);
           isProcessingHmr = false;

--- a/plugin/dev-server/restartWorker.client.ts
+++ b/plugin/dev-server/restartWorker.client.ts
@@ -18,8 +18,6 @@ let currentErrorHandler: ((error: any) => void) | null = null;
 let currentRunnerChannel: MessageChannel | null = null;
 let currentRunnerDetach: (() => void) | null = null;
 
-const isRunnerEnabled = (): boolean => process.env["VPRS_RUNNER"] !== "0";
-
 export const restartWorker: RestartWorkerFn = async function _restartWorker({
   server,
   autoDiscoveredFiles,
@@ -121,25 +119,22 @@ export const restartWorker: RestartWorkerFn = async function _restartWorker({
       server.config.logger.info(`[restartWorker] configEnv.mode: ${configEnv?.mode}`);
     }
 
-    let runnerPortForWorker: MessageChannel["port2"] | undefined;
-    const transferList: any[] = [workerHmrChannel.port2];
-    if (isRunnerEnabled()) {
-      const runnerChannel = new MessageChannel();
-      currentRunnerChannel = runnerChannel;
-      setMaxListenersOnPort(runnerChannel.port1, maxListeners);
-      setMaxListenersOnPort(runnerChannel.port2, maxListeners);
-      unrefPort(runnerChannel.port1);
-      unrefPort(runnerChannel.port2);
-      const logger = server.config.customLogger || server.config.logger;
-      currentRunnerDetach = attachRunnerFetchHandler(
-        runnerChannel.port1,
-        server,
-        logger,
-        Boolean(userOptions.verbose)
-      );
-      runnerPortForWorker = runnerChannel.port2;
-      transferList.push(runnerChannel.port2);
-    }
+    const runnerChannel = new MessageChannel();
+    currentRunnerChannel = runnerChannel;
+    setMaxListenersOnPort(runnerChannel.port1, maxListeners);
+    setMaxListenersOnPort(runnerChannel.port2, maxListeners);
+    unrefPort(runnerChannel.port1);
+    unrefPort(runnerChannel.port2);
+    const fetchHandlerLogger =
+      server.config.customLogger || server.config.logger;
+    currentRunnerDetach = attachRunnerFetchHandler(
+      runnerChannel.port1,
+      server,
+      fetchHandlerLogger,
+      Boolean(userOptions.verbose)
+    );
+    const runnerPortForWorker = runnerChannel.port2;
+    const transferList: any[] = [workerHmrChannel.port2, runnerChannel.port2];
 
     const workerResult = await createWorker({
       projectRoot: userOptions.projectRoot || server.config.root,

--- a/plugin/dev-server/types.ts
+++ b/plugin/dev-server/types.ts
@@ -32,7 +32,6 @@ export type CreateReactWorkerServerFn = (props: {
   resolvedConfig: ResolvedConfig;
   onWorkerCreated?: (worker: any, restart?: () => Promise<void>) => void;
 }) => {
-  restart: (() => Promise<void>) | null;
   sendHmrUpdate: (file: string, routes?: string[]) => void;
 } | null;
 

--- a/plugin/worker/rsc/rsc-worker.development.ts
+++ b/plugin/worker/rsc/rsc-worker.development.ts
@@ -18,7 +18,7 @@ import { serializeError } from "../../error/serializeError.js";
 import { setMaxListenersOnPort, unrefPort } from "../../stream/setMaxListeners.js";
 import { ModuleRunner, ESModulesEvaluator } from "vite/module-runner";
 import { createRunnerTransport } from "./createRunnerTransport.js";
-import { setRunner, setRpc, isRunnerEnabled } from "./runnerInstance.js";
+import { setRunner, setRpc } from "./runnerInstance.js";
 
 // Initialize worker
 if (!parentPort) {
@@ -234,13 +234,10 @@ try {
     // Can't send via parentPort since that's what failed, so just log
   });
 
-  // HMR port handling is disabled in dev server mode to avoid DataCloneError
-  // TODO: Re-enable HMR when transfer list issues are resolved
-
-  // Experimental: ModuleRunner-based fetch transport. Enabled with VPRS_RUNNER=1.
-  // Replaces Node's native import() for project source so dev:ssr no longer
-  // needs a worker restart on each save.
-  if (!isBuildMode && isRunnerEnabled() && workerData.runnerPort) {
+  // ModuleRunner-based fetch transport for project source. Replaces Node's
+  // native import() so dev:ssr invalidates per-module instead of restarting
+  // the worker on every save.
+  if (!isBuildMode && workerData.runnerPort) {
     try {
       setMaxListenersOnPort(workerData.runnerPort, 500);
       unrefPort(workerData.runnerPort);
@@ -257,7 +254,7 @@ try {
       setRunner(runner);
       setRpc(rpc);
       if (workerData.verbose) {
-        logger.info("ModuleRunner initialized (VPRS_RUNNER=1)");
+        logger.info("ModuleRunner initialized");
       }
     } catch (err) {
       logger.error(`Failed to initialize ModuleRunner: ${String(err)}`);

--- a/plugin/worker/rsc/rsc-worker.development.ts
+++ b/plugin/worker/rsc/rsc-worker.development.ts
@@ -1,20 +1,10 @@
-import { parentPort, MessageChannel, workerData } from "node:worker_threads";
+import { parentPort, workerData } from "node:worker_threads";
 import { messageHandler } from "./messageHandler.server.js";
-import { register } from "node:module";
 import { register as registerTsx } from "tsx/esm/api";
-import { resolve } from "node:path";
-import { pluginRoot } from "../../root.js";
 import type { ReadyMessage } from "../types.js";
-import type {
-  CssFileMessage,
-  InitializedEnvLoaderMessage,
-  InitializedReactLoaderMessage,
-} from "./types.js";
-import { DEFAULT_CONFIG } from "../../config/defaults.js";
 import { createLogger } from "vite";
 import { handleError } from "../../error/handleError.js";
 import { sendMessage } from "../sendMessage.js";
-import { serializeError } from "../../error/serializeError.js";
 import { setMaxListenersOnPort, unrefPort } from "../../stream/setMaxListeners.js";
 import { ModuleRunner, ESModulesEvaluator } from "vite/module-runner";
 import { createRunnerTransport } from "./createRunnerTransport.js";
@@ -25,209 +15,35 @@ if (!parentPort) {
   throw new Error("This module must be run as a worker");
 }
 
-// In test mode, we want errors to propagate up immediately
 const logger = createLogger(workerData.resolvedConfig?.logLevel ?? "info", {
   prefix: "rsc-worker",
 });
 
-// Increase max listeners on parentPort to prevent warnings
 // parentPort handles all messages, so needs a higher limit
 if (parentPort) {
   setMaxListenersOnPort(parentPort, 500);
 }
 
-// Handle all messages through the unified messageHandler
 parentPort?.on("message", messageHandler);
 
-// Set up loader message handlers
-const cssLoaderMessageHandler = (msg: CssFileMessage) => {
-  messageHandler(msg);
-};
-
-const envLoaderMessageHandler = (msg: InitializedEnvLoaderMessage) => {
-  messageHandler(msg);
-};
-
-const reactLoaderMessageHandler = (msg: InitializedReactLoaderMessage) => {
-  messageHandler(msg);
-};
-
 try {
-  // Check if we're in build mode - if so, skip loader registration since files are already built
   const isBuildMode =
     workerData.configEnv?.command === "build" ||
     workerData.resolvedConfig?.mode === "production";
-  const isDevServerMode = workerData.configEnv?.command === "serve";
 
   if (workerData.verbose) {
-    if (isBuildMode) {
-      logger.info(
-        "Build mode detected - skipping loader registration since files are already built"
-      );
-    } else if (isDevServerMode) {
-      logger.info(
-        "Development/dev server mode detected - registering loaders for source file processing"
-      );
-    }
+    logger.info(
+      isBuildMode
+        ? "Build mode detected - files are already built, skipping tsx hook"
+        : "Development/dev server mode detected"
+    );
   }
 
-  // Create channels for each loader
-  const reactLoaderChannel = new MessageChannel();
-  const cssLoaderChannel = new MessageChannel();
-  const envLoaderChannel = new MessageChannel();
-  
-  // Increase max listeners to prevent warnings during development
-  setMaxListenersOnPort(reactLoaderChannel.port1, 500);
-  setMaxListenersOnPort(reactLoaderChannel.port2, 500);
-  setMaxListenersOnPort(cssLoaderChannel.port1, 500);
-  setMaxListenersOnPort(cssLoaderChannel.port2, 500);
-  setMaxListenersOnPort(envLoaderChannel.port1, 500);
-  setMaxListenersOnPort(envLoaderChannel.port2, 500);
-
-  // Unref all ports so they don't keep the event loop alive
-  unrefPort(reactLoaderChannel.port1);
-  unrefPort(reactLoaderChannel.port2);
-  unrefPort(cssLoaderChannel.port1);
-  unrefPort(cssLoaderChannel.port2);
-  unrefPort(envLoaderChannel.port1);
-  unrefPort(envLoaderChannel.port2);
-
-  // Set up message handlers before transferring ports (only needed if not in build mode)
-  if (!isBuildMode) {
-    reactLoaderChannel.port2.on("message", reactLoaderMessageHandler);
-    reactLoaderChannel.port2.on("messageerror", (error: Error) => {
-      logger.error("React loader message serialization failed.", { error });
-      if (parentPort) {
-        parentPort.postMessage({
-          type: "ERROR",
-          id: "react-loader",
-          error: {
-            message: "Message serialization failed in react loader",
-            name: "MessageError",
-            stack: undefined,
-          },
-        });
-      }
-    });
-
-    cssLoaderChannel.port2.on("message", cssLoaderMessageHandler);
-    cssLoaderChannel.port2.on("messageerror", (error) => {
-      logger.error("CSS loader message serialization failed.", { error });
-      if (parentPort) {
-        parentPort.postMessage({
-          type: "ERROR",
-          id: "css-loader",
-          error: serializeError(error),
-        });
-      }
-    });
-
-    envLoaderChannel.port2.on("message", envLoaderMessageHandler);
-    envLoaderChannel.port2.on("messageerror", (error) => {
-      logger.error("Env loader message serialization failed.", { error });
-      if (parentPort) {
-        parentPort.postMessage({
-          type: "ERROR",
-          id: "env-loader",
-          error: serializeError(error),
-        });
-      }
-    });
-  }
-
-  // Use projectRoot for loader paths, fallback to resolvedConfig.root
-  const projectRoot =
-    workerData.userOptions?.projectRoot || workerData.resolvedConfig?.root;
-
-  const reactLoaderPath =
-    "file://" +
-    (workerData.userOptions.reactLoaderPath
-      ? resolve(projectRoot, workerData.userOptions.reactLoaderPath)
-      : resolve(projectRoot, DEFAULT_CONFIG.REACT_LOADER_PATH));
-  const cssLoaderPath =
-    "file://" +
-    (workerData.userOptions.cssLoaderPath
-      ? resolve(projectRoot, workerData.userOptions.cssLoaderPath)
-      : resolve(projectRoot, DEFAULT_CONFIG.CSS_LOADER_PATH));
-  const envLoaderPath =
-    "file://" +
-    (workerData.userOptions.envLoaderPath
-      ? resolve(projectRoot, workerData.userOptions.envLoaderPath)
-      : resolve(projectRoot, DEFAULT_CONFIG.ENV_LOADER_PATH));
-
-  // Only register loaders if not in build mode
-  if (!isBuildMode) {
-    try {
-      register(cssLoaderPath, {
-        parentURL: pluginRoot,
-        data: {
-          id: "css-loader",
-          port: cssLoaderChannel.port1,
-          userOptions: workerData.userOptions,
-          resolvedConfig: workerData.resolvedConfig,
-        },
-        transferList: [cssLoaderChannel.port1],
-      });
-    } catch (e) {
-      const handledError = handleError({
-        error: e,
-        logger,
-        panicThreshold: workerData.userOptions.panicThreshold,
-        context: `register(${cssLoaderPath})`,
-      });
-      if (handledError != null) throw handledError;
-    }
-
-    // Register tsx
-    registerTsx();
-
-    try {
-      // Register loaders with their ports
-      register(reactLoaderPath, {
-        parentURL: pluginRoot,
-        data: {
-          id: "react-loader",
-          port: reactLoaderChannel.port1,
-          userOptions: workerData.userOptions,
-          resolvedConfig: workerData.resolvedConfig,
-        },
-        transferList: [reactLoaderChannel.port1],
-      });
-    } catch (e) {
-      const handledError = handleError({
-        error: e,
-        logger,
-        panicThreshold: workerData.userOptions.panicThreshold,
-        context: `register(${reactLoaderPath})`,
-      });
-      if (handledError != null) throw handledError;
-    }
-
-    // Register env-loader (ensure this the last)
-    try {
-      register(envLoaderPath, {
-        parentURL: pluginRoot,
-        data: {
-          id: "env-loader",
-          port: envLoaderChannel.port1,
-          resolvedConfig: workerData.resolvedConfig,
-          userOptions: workerData.userOptions,
-        },
-        transferList: [envLoaderChannel.port1],
-      });
-    } catch (e) {
-      const handledError = handleError({
-        error: e,
-        logger,
-        panicThreshold: workerData.userOptions.panicThreshold,
-        context: `register(${envLoaderPath})`,
-      });
-      if (handledError != null) throw handledError;
-    }
-  } else {
-    // In build mode, just register tsx for basic TypeScript support
-    registerTsx();
-  }
+  // Keep the tsx hook around for the rare non-runner import path where a
+  // module that isn't transformed by Vite (e.g. a vendored dependency that
+  // ships .ts sources) still needs TypeScript stripping. Runner-loaded
+  // modules receive code that's already been through Vite's transform.
+  registerTsx();
 
   parentPort!.on("messageerror", (error: Error) => {
     logger.error("Parent port message serialization failed.", { error });

--- a/plugin/worker/rsc/runnerInstance.ts
+++ b/plugin/worker/rsc/runnerInstance.ts
@@ -19,12 +19,3 @@ export function setRpc(invoker: RpcInvoker): void {
 export function getRpc(): RpcInvoker | null {
   return rpc;
 }
-
-/**
- * The Vite ModuleRunner path is enabled by default. Set `VPRS_RUNNER=0`
- * to fall back to the legacy Node-import-based loader if the runner
- * ever causes problems for a specific project.
- */
-export function isRunnerEnabled(): boolean {
-  return process.env["VPRS_RUNNER"] !== "0";
-}


### PR DESCRIPTION
## Summary

Two-commit cleanup now that the ModuleRunner is the only dev:ssr path. Internal-only — no public API change beyond the undocumented \`VPRS_RUNNER\` env var no longer being read.

### Commit 1 — drop the legacy non-runner code paths (63e70ab)

- \`VPRS_RUNNER\` env-var check + the three \`isRunnerEnabled()\` callsites.
- \`markModulesInvalidated()\` + \`hasInvalidatedModules\` flag + restart-on-invalidation branch (\`HMR_UPDATE\` covers this now).
- The debounced 500ms \`hmrHandler.restart()\` call in \`plugin.client.ts\`.
- \`restartFn\` / \`.restart\` plumbing through \`configureReactServer.client.ts\` and the \`CreateReactWorkerServerFn\` return type.

-116 net.

### Commit 2 — drop the Node ESM CSS/react/env loader registrations (e05d180)

- \`register(cssLoaderPath, …)\` — CSS now flows through main-thread \`collectRunnerCss\`.
- \`register(reactLoaderPath, …)\` — Vite's pipeline already splits client/server modules.
- \`register(envLoaderPath, …)\` — Vite's pipeline already inlines \`import.meta.env\` values.
- The three associated MessageChannels + listener wire-up + handler shims.

Kept: \`registerTsx()\` as a cheap fallback for the rare vendored module that ships \`.ts\` sources, and the \`CSS_FILE\` / \`SERVER_MODULE\` / \`MODULE_REQUEST\` handlers in \`messageHandler.server.tsx\` (dead-but-cheap branches in a switch).

-184 net.

### Combined

\~-300 lines removed; +55 added (mostly updated comments + the simplified runner-only flow). Worker startup is visibly less wired.

## Test plan

- [x] \`npm run build\` — green.
- [x] \`npm run test:dev\` — 29/29 under both \`--conditions react-server\` and no condition.
- [x] \`npm run test:e2e\` against linked bidoof-template — 20/20.

## Version

1.7.0 candidate. Even though the env var was undocumented, removing observable behavior (someone *could* have been setting \`VPRS_RUNNER=0\`) makes minor cleaner than patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)