### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Bumps \`package.json\` + \`package-lock.json\` to 1.7.0 ahead of the
\`npm publish\` cut. Picks up #47 (drops the legacy non-runner code
paths and the Node ESM loader registrations now that the ModuleRunner
is the sole dev:ssr loader).

Minor (not patch) because #47 removes the undocumented but observable
\`VPRS_RUNNER\` env var.

Tag \`v1.7.0\` will be added after merge to match the v1.6.x cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)