### PR TITLE
chore: bump version to 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
## Summary

Patch release containing the dev:rsc + dev:ssr fix from #49:

- **`fix(dev:rsc)`** — `configureReactServer.server.ts` page/root module-load catches no longer swallow under `verbose: false`; they route through `handleError({ critical: true, log: true })` and honour `panicThreshold`.
- **`fix(dev:ssr)`** — same swallow pattern fixed in the worker (`messageHandler.server.tsx` `loadComponentsWithCache`). The outermost worker catch now signals stream end via `effectiveHandlers.onEnd("worker/rsc")` so the response completes instead of hanging when a fatal failure happens before any data flows.
- Worker load-failure paths now route through `plugin/error/handleError.ts` for log dedup and panic elevation, matching the rest of the plugin.
- Regression test: `test/dev/page-module-load-error-surface.test.ts` passes under both `--conditions react-server` and the default client condition.

## Test plan

- [x] `npm test` (test:both) — 158 client + 448 server pass, ran 8 cold-cache iterations clean
- [x] `npm run build` clean
- [ ] Pre-publish: linked-demo verification (`bidoof-template`, `mmc`) per `CLAUDE.md` release protocol — to be run by maintainer before `npm publish` (2FA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)