### PR TITLE
docs: client-component packages need a client boundary (drop false direct-server-import claim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ dist/
 
 `dist/static/` is a complete static site. `dist/client/` and `dist/server/` are ESM modules you can import in your own Express/Hono/Node server.
 
-## Third-party `"use client"` packages
+## Third-party client-component packages
 
-Component libraries like Chakra UI, MUI, Mantine, react-aria, and framer-motion ship per-file `"use client"` directives in their compiled output, the same convention Next.js's App Router relies on. vprs honors those directives so you can `import { Heading } from "@chakra-ui/react"` directly inside a server component — no user-authored `.client.tsx` wrapper needed.
+Component libraries like Chakra UI, MUI, Mantine, react-aria, and framer-motion are **client-only** — their components rely on React context/state and must run inside a client boundary, the same constraint they carry under Next.js's App Router. Use them within a `"use client"` component (commonly a small provider wrapper); they can't be imported directly into a server component. This isn't a vprs limitation — e.g. [Chakra's own Next.js App Router guide](https://v2.chakra-ui.com/getting-started/nextjs-app-guide) requires wrapping `ChakraProvider` in a `'use client'` component.
 
-Detection is automatic: any package with `react` in its `peerDependencies` is treated as a client-package on build start (using [`vitefu.crawlFrameworkPkgs`](https://github.com/svitejs/vitefu)). Two escape hatches if needed:
+vprs auto-detects these so they're treated correctly at build start: any package with `react` in its `peerDependencies` is classified as a client package (using [`vitefu.crawlFrameworkPkgs`](https://github.com/svitejs/vitefu)). Two escape hatches if needed:
 
 ```ts
 vitePluginReactServer({


### PR DESCRIPTION
## Summary

The README's "Third-party \`\"use client\"\` packages" section claimed you can `import { Heading } from "@chakra-ui/react"` **directly inside a server component, no wrapper needed**. That's false for client-only libraries.

Chakra UI v2 is client-only by design — its [own Next.js App Router guide](https://v2.chakra-ui.com/getting-started/nextjs-app-guide) states *"Chakra UI only works in client-side components"* and requires wrapping `ChakraProvider` in a `'use client'` component. So a server component importing Chakra throwing under the `react-server` condition is **expected RSC behavior in any framework**, not a vprs defect.

Reworded to:
- Client-only component libraries must be used within a `"use client"` boundary (matching their own RSC guidance, with a link to Chakra's guide).
- Kept the accurate description of vprs's `react`-in-peerDeps client-package auto-detection (`vitefu.crawlFrameworkPkgs`) + the `clientPackages` / `excludeClientPackages` escape hatches.

Docs-only; no code change.

## Background

Downstream (mission-control) had filed this as a P1 vprs bug ("use-client not honored, Chakra throws"). On inspection it's a docs over-claim, not a functional bug — the standard client-boundary wrapper is the correct, expected pattern everywhere. That issue is being closed as not-a-bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)