### PR TITLE
feat(build): host directive-detected "use client" modules (drop .client. filename requirement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ dist/
 
 `dist/static/` is a complete static site. `dist/client/` and `dist/server/` are ESM modules you can import in your own Express/Hono/Node server.
 
+## Client components
+
+Mark a client component with a top-of-file `"use client"` directive. The
+`.client.` filename suffix is **optional** — a first-party module that starts
+with `"use client"` is detected, hosted, and emitted as a client chunk in the
+static (`--app`) build, so you can import it directly into a server component:
+
+```tsx
+// src/components/Counter.tsx  ← no `.client.` suffix needed
+"use client";
+import { useState } from "react";
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}
+```
+
+Detection is by directive position (top of file, the same rule React enforces),
+not by a substring match. The `.client.` convention still works as a visual
+marker. See [Getting Started](./docs/getting-started.md#the-client-filename-is-optional).
+
 ## Third-party client-component packages
 
 Component libraries like Chakra UI, MUI, Mantine, react-aria, and framer-motion are **client-only** — their components rely on React context/state and must run inside a client boundary, the same constraint they carry under Next.js's App Router. Use them within a `"use client"` component (commonly a small provider wrapper); they can't be imported directly into a server component. This isn't a vprs limitation — e.g. [Chakra's own Next.js App Router guide](https://v2.chakra-ui.com/getting-started/nextjs-app-guide) requires wrapping `ChakraProvider` in a `'use client'` component.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,6 +170,35 @@ export const Page = () => (
 );
 ```
 
+### The `.client.` filename is optional
+
+A top-of-file `"use client"` directive is enough — the `.client.` filename
+suffix is **not** required. A first-party module that starts with
+`"use client"` is detected, hosted, and emitted as a client chunk in the
+static (`--app`) build exactly like a `.client.tsx` file:
+
+```tsx
+// src/components/Counter.tsx  ← no `.client.` suffix
+"use client";
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}
+```
+
+```tsx
+// src/page.tsx (a server component)
+import { Counter } from "./components/Counter.js";
+// ...renders <Counter /> as a client reference
+```
+
+Detection is by directive position (the directive must be at the very top of
+the file, the same rule React enforces), not by a substring match — a module
+that merely mentions the word "client" is not treated as a client component.
+The `.client.` convention still works and is handy as a visual marker.
+
 ## Add an HTML Shell
 
 ```tsx

--- a/plugin/config/autoDiscover/createDirectiveClientAutoDiscover.ts
+++ b/plugin/config/autoDiscover/createDirectiveClientAutoDiscover.ts
@@ -1,0 +1,77 @@
+import type { ResolvedUserOptions } from "../../types.js";
+import { glob, readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { sourceHasTopLevelClientDirective } from "../../loader/directives/sourceHasTopLevelClientDirective.js";
+
+/**
+ * Auto-discovers first-party client modules detected by a top-of-file
+ * `"use client"` DIRECTIVE rather than the `.client.` filename convention.
+ *
+ * Why this exists: `createGlobAutoDiscover("**\/*.client.*")` only finds
+ * filename-convention client modules. A directive-only client module
+ * (e.g. `src/components/Counter.tsx` starting with `"use client"`) was never
+ * added as a client/SSR build input, so it was NOT emitted to `dist/client`.
+ * The server build's `registerClientReference` then pointed its hosted
+ * moduleID at a file that didn't exist, and the html-worker's import 404'd at
+ * SSG-render time.
+ *
+ * Adding these modules as build inputs makes Vite emit them to `dist/client`
+ * at preserved-module paths that line up with the hashed/hosted moduleIDs
+ * generated in `createTransformerPlugin`.
+ *
+ * Detection is structural (`sourceHasTopLevelClientDirective`), never the
+ * naive "contains the word client" substring test.
+ */
+export function createDirectiveClientAutoDiscover(
+  modulePattern = "**/*.{tsx,jsx,mts,cts,ts,js,mjs,cjs}"
+) {
+  return async function _directiveClientAutoDiscover({
+    inputs,
+    userOptions,
+  }: {
+    inputs: Record<string, string>;
+    userOptions: Pick<
+      ResolvedUserOptions,
+      "moduleBase" | "projectRoot" | "normalizer"
+    >;
+  }) {
+    const baseDir = resolve(userOptions.projectRoot, userOptions.moduleBase);
+    const absolutePattern = resolve(baseDir, modulePattern);
+
+    let allFiles: AsyncIterable<string>;
+    try {
+      allFiles = glob(absolutePattern);
+    } catch {
+      return inputs;
+    }
+
+    for await (const file of allFiles) {
+      // Skip files already covered by the `.client.` filename convention —
+      // `createGlobAutoDiscover` discovers those separately.
+      if (/\.client\.[cm]?[jt]sx?$/.test(file)) continue;
+      // Never treat dependencies as first-party client inputs.
+      if (file.includes("node_modules")) continue;
+
+      let source: string;
+      try {
+        source = await readFile(file, "utf-8");
+      } catch {
+        continue;
+      }
+
+      if (!sourceHasTopLevelClientDirective(source)) continue;
+
+      const relativePath = file
+        .replace(baseDir, "")
+        .replace(/^\/+/, "");
+      const [key, value] = userOptions.normalizer(
+        join(userOptions.moduleBase, relativePath)
+      );
+      if (!inputs[key]) {
+        inputs[key] = value;
+      }
+    }
+
+    return inputs;
+  };
+}

--- a/plugin/config/autoDiscover/resolveAutoDiscover.ts
+++ b/plugin/config/autoDiscover/resolveAutoDiscover.ts
@@ -4,6 +4,7 @@ import { resolveBuildPages } from "./resolveBuildPages.js";
 import { resolvePages } from "../resolvePages.js";
 import type { Logger, ResolvedConfig } from "vite";
 import { createGlobAutoDiscover } from "./createGlobAutoDiscover.js";
+import { createDirectiveClientAutoDiscover } from "./createDirectiveClientAutoDiscover.js";
 import { customWorkerFiles } from "./customWorkerFiles.js";
 import { pageAndPropFiles } from "./pageAndPropFiles.js";
 
@@ -105,6 +106,9 @@ export const resolveAutoDiscover: ResolveAutoDiscoverFn =
       };
     }
     const clientFiles = createGlobAutoDiscover(userOptions.autoDiscover.clientEntry);
+    // First-party modules detected by a top-of-file `"use client"` directive
+    // (no `.client.` suffix) must also be emitted to dist/client.
+    const directiveClientFiles = createDirectiveClientAutoDiscover();
     const serverFiles = createGlobAutoDiscover(userOptions.autoDiscover.serverEntry);
     const cssFiles = createGlobAutoDiscover(userOptions.autoDiscover.cssEntry);
     const jsonFiles = createGlobAutoDiscover(userOptions.autoDiscover.jsonEntry);
@@ -123,6 +127,10 @@ export const resolveAutoDiscover: ResolveAutoDiscoverFn =
       userOptions,
     });
     const clientInputs = await clientFiles({
+      inputs: {},
+      userOptions,
+    });
+    const directiveClientInputs = await directiveClientFiles({
       inputs: {},
       userOptions,
     });
@@ -174,6 +182,7 @@ export const resolveAutoDiscover: ResolveAutoDiscoverFn =
     const clientInputsCollection = {
       ...configInputRecord,
       ...clientInputs,
+      ...directiveClientInputs,
       ...clientEntry,
       ...cssInputs,
     };

--- a/plugin/config/createModuleID.ts
+++ b/plugin/config/createModuleID.ts
@@ -2,6 +2,7 @@ import type { ResolvedUserOptions } from "../types.js";
 import { replaceExtension } from "./extMap.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { DEFAULT_CONFIG } from "./defaults.js";
+import { hasFileLevelClientDirective } from "../loader/directives/hasFileLevelClientDirective.js";
 import type { ConfigEnv } from "vite";
 import { sep, resolve, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
@@ -45,8 +46,36 @@ export const createDefaultModuleID = (
   // Virtual pattern for excluding virtual modules from hashing
   const virtualPattern = autoDiscover?.virtualPattern ?? DEFAULT_CONFIG.AUTO_DISCOVER.virtualPattern;
   
-  // Client component pattern for hashing
+  // Client component pattern for hashing (filename convention).
   const clientPattern = /\.client\.[cm]?[jt]sx?$/;
+
+  // A module is a client component (and therefore must get a hosted,
+  // `moduleBasePath`-prefixed moduleID) if ANY of:
+  //   1. an explicit `isClientByDirective` override is passed (the transformer
+  //      computes this with Rollup's JSX/TS-aware `this.parse`, which is the
+  //      authoritative detection — see createTransformerPlugin),
+  //   2. its filename matches the `.client.` convention, OR
+  //   3. it declares a top-of-file `"use client"` directive that this function
+  //      can detect on its own from `sourceContent`.
+  //
+  // The directive checks are robust (acorn + analyzeDirectives), never the
+  // naive substring matcher. NOTE: this function's own acorn parser (case 3)
+  // cannot parse raw TSX (JSX + TS types), so the transformer passes the
+  // override (case 1) for the build path. Case 3 still covers already-parseable
+  // sources and keeps the function correct when called standalone.
+  //
+  // This is what lets directive-only client modules (no `.client.` suffix,
+  // e.g. node_modules libs that ship `"use client"`) be hosted in the static
+  // build instead of throwing "Attempted to load a Client Module outside the
+  // hosted root".
+  const isClientComponentId = (
+    id: string,
+    sourceContent?: string,
+    isClientByDirective?: boolean
+  ) =>
+    isClientByDirective === true ||
+    clientPattern.test(id) ||
+    hasFileLevelClientDirective(sourceContent);
 
   // Clean hash API that mimics Rollup's behavior
   const createRollupLikeHash = (content: string, hashCharacters: 'base36' | 'base64' | 'hex' = 'base36') => {
@@ -73,7 +102,12 @@ export const createDefaultModuleID = (
   };
 
   // Hash function for client components - same logic as resolveOptions.ts
-  const hash = (input: string | null, _ssr: boolean, sourceContent?: string) => {
+  const hash = (
+    input: string | null,
+    _ssr: boolean,
+    sourceContent?: string,
+    isClientByDirective?: boolean
+  ) => {
     if (!input) return "";
     if (new RegExp(/\.(node|d\.ts)$/).test(input)) {
       return input;
@@ -94,8 +128,15 @@ export const createDefaultModuleID = (
       return input;
     }
     
-    // Only hash client components - server files should not be hashed
-    const isClientComponent = clientPattern.test(input);
+    // Only hash client components - server files should not be hashed.
+    // Recognize the `.client.` filename convention, a top-of-file
+    // `"use client"` directive (when source content is available), or an
+    // explicit directive override threaded from the transformer.
+    const isClientComponent = isClientComponentId(
+      input,
+      sourceContent,
+      isClientByDirective
+    );
 
     if (!isClientComponent) {
       return input;
@@ -143,7 +184,11 @@ export const createDefaultModuleID = (
   const serverDist = isBuild ? join(build?.outDir || "dist", build?.server || "server") : "";
   const buildDirs = isBuild ? [serverDist, ssrClientDist, staticClientDist] : [];
 
-  return (id: string, sourceContent?: string) => {
+  return (
+    id: string,
+    sourceContent?: string,
+    isClientByDirective?: boolean
+  ) => {
     // For transformer usage (when we're in build mode and processing server components),
     // we want to strip build directory prefixes to get relative paths
     // This ensures the RSC stream contains paths that can be resolved by the HTML transform
@@ -165,8 +210,13 @@ export const createDefaultModuleID = (
         }
       }
       
-      // For client components in build mode, transform source paths to built paths
-      const isClientComponent = clientPattern.test(id);
+      // For client components in build mode, transform source paths to built paths.
+      // Directive-detected client modules (no `.client.` suffix) are hosted too.
+      const isClientComponent = isClientComponentId(
+        id,
+        sourceContent,
+        isClientByDirective
+      );
       if (isClientComponent) {
         // Transform source path to built client path
         let transformedId = id;
@@ -183,7 +233,7 @@ export const createDefaultModuleID = (
         
         
         // Step 3: Apply hashing for client components
-        transformedId = hash(transformedId, false, sourceContent);
+        transformedId = hash(transformedId, false, sourceContent, isClientByDirective);
         
         // Step 4: Ensure paths start with moduleBasePath
         if (moduleBasePath && !transformedId.startsWith(moduleBasePath)) {
@@ -227,8 +277,13 @@ export const createDefaultModuleID = (
     
     // Step 6: Apply extension mapping
     // ALWAYS replace extensions for client components (browser can't import .tsx)
-    // For other files, only replace in build mode
-    const isClientComponent = clientPattern.test(id);
+    // For other files, only replace in build mode.
+    // Directive-detected client modules count as client components too.
+    const isClientComponent = isClientComponentId(
+      id,
+      sourceContent,
+      isClientByDirective
+    );
     if (isBuild || isClientComponent) {
       id = replaceExtension(id, {
         build: { extensionMap: build.extensionMap },
@@ -242,7 +297,7 @@ export const createDefaultModuleID = (
     
     // Step 8: Apply hashing for client components (only in production builds, not dev)
     if (shouldHash) {
-      id = hash(id, false, sourceContent);
+      id = hash(id, false, sourceContent, isClientByDirective);
     }
     
     // For client components, ensure no leading slash to allow proper relative resolution

--- a/plugin/config/createModuleID.ts
+++ b/plugin/config/createModuleID.ts
@@ -225,7 +225,28 @@ export const createDefaultModuleID = (
         if (removeModuleBase && transformedId.startsWith(moduleBase + sep)) {
           transformedId = transformedId.slice(moduleBase.length + sep.length);
         }
-        
+
+        // Step 1b: Match the build's entryFile name normalization for
+        // DIRECTIVE-detected client modules. The emitted chunk name comes from
+        // `entryFile` → `normalizer(n.name)`, which strips one trailing
+        // ".segment" unless it's `.client`/`.server`. For a compound filename
+        // like `view/View.generated.tsx` that collapses to `view/View`, but
+        // this moduleID otherwise keeps `.generated` — so the registered client
+        // reference (`view/View.generated-<hash>.js`) wouldn't match the emitted
+        // chunk (`view/View-<hash>.js`) → ERR_MODULE_NOT_FOUND at SSG render.
+        // `.client.`-named modules are unaffected (the normalizer preserves
+        // that suffix, and so do we). Single-segment names have nothing to strip.
+        if (isClientByDirective) {
+          const noExt = transformedId.replace(/\.[cm]?[jt]sx?$/, "");
+          if (!noExt.endsWith(".client") && !noExt.endsWith(".server")) {
+            const lastDot = noExt.lastIndexOf(".");
+            if (lastDot > noExt.lastIndexOf("/")) {
+              transformedId =
+                noExt.slice(0, lastDot) + transformedId.slice(noExt.length);
+            }
+          }
+        }
+
         // Step 2: Apply extension mapping for build
         transformedId = replaceExtension(transformedId, {
           build: { extensionMap: build.extensionMap },

--- a/plugin/error/augmentClientReferenceError.ts
+++ b/plugin/error/augmentClientReferenceError.ts
@@ -1,0 +1,64 @@
+/**
+ * Augments the opaque react-server-dom-esm client-reference failures that
+ * surface during static (`--app`) prerender with an actionable explanation.
+ *
+ * Two failure modes share the same root cause — a client module whose hosted
+ * moduleID is wrong — but react-server-dom-esm reports them without context:
+ *
+ *   1. "Attempted to load a Client Module outside the hosted root."
+ *      Thrown by `serializeClientReference` when a client reference's `$$id`
+ *      does not start with the bundler's baseURL (`moduleBasePath`). Happens
+ *      when a `"use client"` module wasn't hosted (`/`-prefixed) — e.g. a
+ *      directive-only client module that the build didn't recognize.
+ *
+ *   2. "Cannot find module '<dist/client>/…'"
+ *      Thrown when the html-worker imports the hosted moduleID but no file was
+ *      emitted there — e.g. a directive-only client module that was hosted but
+ *      never added as a client/SSR build input.
+ *
+ * Neither message names the offending module (the id is discarded inside the
+ * vendored lib for case 1), so we attach the most actionable guidance we can:
+ * the likely cause and the fact that directive-only `"use client"` modules are
+ * supported, including the resolved path we *can* see for case 2.
+ */
+export function augmentClientReferenceError(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+
+  const message = error.message || "";
+
+  const isHostedRootError = message.includes(
+    "Client Module outside the hosted root"
+  );
+  // Only treat "Cannot find module" as client-reference-related when it points
+  // into a build's client output directory (that's where client refs resolve).
+  const missingClientModule =
+    message.startsWith("Cannot find module") &&
+    /[\\/](client|static)[\\/]/.test(message);
+
+  if (!isHostedRootError && !missingClientModule) return error;
+
+  if ((error as { vprsClientReferenceAugmented?: boolean })
+      .vprsClientReferenceAugmented) {
+    return error;
+  }
+
+  const detail = isHostedRootError
+    ? [
+        "A client module's moduleID is not hosted (it does not start with the configured `moduleBasePath`).",
+        "This usually means a `\"use client\"` module was not recognized as a client reference and got a raw, unhosted moduleID.",
+        "Directive-detected `\"use client\"` modules (no `.client.` filename) ARE supported — ensure the module declares the directive at the very top of the file.",
+      ].join(" ")
+    : [
+        "A hosted client reference points at a file that was not emitted to the client build output.",
+        "This usually means a directive-only `\"use client\"` module was hosted but not added as a client/SSR build input.",
+      ].join(" ");
+
+  const augmented = new Error(
+    `${message}\n\n[vite-plugin-react-server] ${detail}`
+  );
+  augmented.stack = error.stack;
+  (augmented as { cause?: unknown }).cause = error;
+  (augmented as { vprsClientReferenceAugmented?: boolean })
+    .vprsClientReferenceAugmented = true;
+  return augmented;
+}

--- a/plugin/error/index.ts
+++ b/plugin/error/index.ts
@@ -3,3 +3,4 @@ export { logError } from "./logError.js";
 export { handleError } from "./handleError.js";
 export { shouldPanic, PANIC_SYMBOL, isPanic } from "./shouldPanic.js";
 export { shouldCausePanic, handlePanicThreshold, isPanicError } from "./panicThresholdHandler.js";
+export { augmentClientReferenceError } from "./augmentClientReferenceError.js";

--- a/plugin/loader/directives/hasFileLevelClientDirective.ts
+++ b/plugin/loader/directives/hasFileLevelClientDirective.ts
@@ -1,0 +1,62 @@
+import { parse } from "../parse.js";
+import { analyzeDirectives } from "./analyzeDirectives.js";
+import type { Program } from "acorn";
+
+/**
+ * Robustly detect whether `source` declares a *file-level* `"use client"`
+ * directive (top-of-file, before any real code — the React contract).
+ *
+ * Why this exists: the build's moduleID hosting used to key client-component
+ * detection purely off the `.client.[jt]sx?` filename pattern. First-party
+ * modules that declare `"use client"` via DIRECTIVE but lack the `.client.`
+ * suffix got a raw, unhosted moduleID, so react-server-dom-esm's
+ * `serializeClientReference` threw "Attempted to load a Client Module outside
+ * the hosted root" during prerender.
+ *
+ * Detection MUST be robust. The naive `isClientComponentByCode`
+ * (`code.match(/(\.|\/)?client(\.|\/)?/)`) substring-matches the word "client"
+ * anywhere — variables, comments, import paths — and would mis-host server
+ * modules as client refs, breaking the build. We instead parse with acorn and
+ * reuse `analyzeDirectives`, whose `fileLevel.type === "client"` is the source
+ * of truth for a top-of-file `"use client"` directive (it validates position
+ * via the AST, the same way the transformer does).
+ *
+ * Performance: parsing is gated behind a cheap substring pre-check so server
+ * files (the common case) never hit the parser.
+ *
+ * @param source   Original module source content.
+ * @param parseFn  Optional AST producer (e.g. Rollup's `this.parse`). Falls
+ *                 back to the plugin's own acorn-based `parse` when omitted.
+ */
+export function hasFileLevelClientDirective(
+  source: string | undefined,
+  parseFn?: (source: string) => Program
+): boolean {
+  if (!source) return false;
+  // Cheap gate: no "use client" text at all → definitely not a client module.
+  // (Substring match here is only a *pre-filter*; the AST check below is what
+  // actually decides, so false positives from this gate are harmless.)
+  if (!source.includes("use client")) return false;
+
+  try {
+    const ast = parseFn
+      ? parseFn(source)
+      : (parse(source).ast as unknown as Program);
+    const directiveInfo = analyzeDirectives(ast, source);
+    if (directiveInfo.fileLevel?.type !== "client") return false;
+    // Reject a MISPLACED directive: `analyzeDirectives` still records a
+    // file-level entry for a `"use client";` string statement that appears
+    // after real code, but flags it with a placement warning. React's
+    // contract requires the directive at the very top, so only a properly
+    // placed one counts as a real file-level client directive.
+    const misplaced = directiveInfo.warnings.some((w) =>
+      w.message.includes("must be at the top of the file")
+    );
+    return !misplaced;
+  } catch {
+    // If parsing fails for any reason, fall back to "not a client module".
+    // The filename-based check still applies upstream, so a genuine
+    // `.client.tsx` module is unaffected by a parse failure here.
+    return false;
+  }
+}

--- a/plugin/loader/directives/index.ts
+++ b/plugin/loader/directives/index.ts
@@ -2,6 +2,8 @@ export * from "./addLocalExportedNames.js";
 export * from "./getExports.js";
 export * from "./analyzeDirectives.js";
 export * from "./analyzeModule.js";
+export * from "./hasFileLevelClientDirective.js";
+export * from "./sourceHasTopLevelClientDirective.js";
 export * from "./collectExports.js";
 export * from "./getFunctionBody.js";
 export * from "./getFunctionName.js";

--- a/plugin/loader/directives/sourceHasTopLevelClientDirective.ts
+++ b/plugin/loader/directives/sourceHasTopLevelClientDirective.ts
@@ -1,0 +1,89 @@
+/**
+ * Detect a top-of-file `"use client"` directive in RAW source text (including
+ * untranspiled TSX, which the acorn-based detectors can't parse).
+ *
+ * Used during build-time auto-discovery, where we must scan first-party
+ * `.tsx/.ts/.jsx/.js` files on disk to decide which directive-only client
+ * modules to emit to `dist/client`. We can't run the JSX/TS-aware Rollup
+ * parser there (no plugin context), so we apply React's own structural
+ * contract directly: a file-level `"use client"` must be a string-literal
+ * statement at the very top of the module, before any real code.
+ *
+ * This is deliberately stricter than the naive `code.match(/client/)`
+ * substring check (which flags any module mentioning the word "client"):
+ *   - leading whitespace, line (`//`) and block (`/* *\/`) comments are
+ *     skipped (they're allowed above a directive),
+ *   - a leading `"use strict"` prologue is tolerated (real libraries ship
+ *     `"use strict"; "use client";`),
+ *   - the directive must then be the first actual statement.
+ * Anything else (an import, a variable, the word "client" in a comment or
+ * identifier) yields false.
+ */
+export function sourceHasTopLevelClientDirective(source: string): boolean {
+  if (!source.includes("use client")) return false;
+
+  let i = 0;
+  const n = source.length;
+
+  const skipTrivia = () => {
+    for (;;) {
+      // Whitespace (incl. newlines, BOM)
+      while (i < n && /\s/.test(source[i]!)) i++;
+      if (i + 1 < n && source[i] === "/" && source[i + 1] === "/") {
+        // Line comment
+        i += 2;
+        while (i < n && source[i] !== "\n") i++;
+        continue;
+      }
+      if (i + 1 < n && source[i] === "/" && source[i + 1] === "*") {
+        // Block comment
+        i += 2;
+        while (i + 1 < n && !(source[i] === "*" && source[i + 1] === "/")) i++;
+        i += 2;
+        continue;
+      }
+      break;
+    }
+  };
+
+  // Read a single string-literal directive at the current position, returning
+  // its value (without quotes) or null if the next token isn't a string.
+  const readStringLiteral = (): string | null => {
+    const quote = source[i];
+    if (quote !== '"' && quote !== "'") return null;
+    let j = i + 1;
+    let value = "";
+    while (j < n) {
+      const ch = source[j]!;
+      if (ch === "\\") {
+        // Skip escaped char (directives never contain escapes, but be safe)
+        value += source[j + 1] ?? "";
+        j += 2;
+        continue;
+      }
+      if (ch === quote) {
+        // Move cursor past the closing quote and an optional `;`
+        i = j + 1;
+        while (i < n && /[\s;]/.test(source[i]!)) i++;
+        return value;
+      }
+      value += ch;
+      j++;
+    }
+    return null;
+  };
+
+  skipTrivia();
+  // Tolerate a leading "use strict" (or any prologue string directive) above
+  // the "use client" directive.
+  for (let guard = 0; guard < 4; guard++) {
+    const mark = i;
+    const literal = readStringLiteral();
+    if (literal === null) return false;
+    if (literal === "use client") return true;
+    // Some other prologue directive (e.g. "use strict") — keep scanning.
+    if (i === mark) return false; // no progress, bail
+    skipTrivia();
+  }
+  return false;
+}

--- a/plugin/loader/types.ts
+++ b/plugin/loader/types.ts
@@ -23,7 +23,11 @@ export type LoaderConfig = {
   isClientComponentCode: (code: string, moduleId?: string, transformedModuleId?: string) => boolean;
   isClientComponentByCode: (code: string) => boolean;
   isClientComponentByName: (moduleId: string, transformedModuleId?: string) => boolean;
-  moduleID: (moduleId: string, sourceContent?: string) => string;
+  moduleID: (
+    moduleId: string,
+    sourceContent?: string,
+    isClientByDirective?: boolean
+  ) => string;
   parse: ParseFn;
   verbose?: boolean;
   logger?: Logger;

--- a/plugin/stream/createRenderToPipeableStreamHandler.server.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.server.ts
@@ -2,6 +2,7 @@ import { createElementWithReact } from "../helpers/createElementWithReact.js";
 import { React, ReactDOMServer } from "../vendor/vendor.server.js";
 import { assertReactServer } from "../config/getCondition.js";
 import { handleError } from "../error/handleError.js";
+import { augmentClientReferenceError } from "../error/augmentClientReferenceError.js";
 import { createStreamMetrics } from "../helpers/metrics.js";
 import type { CreateRenderToPipeableStreamHandlerFn } from "./createRenderToPipeableStreamHandler.types.js";
 
@@ -121,7 +122,11 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       const pipeableStreamOptions = {
         ...serverPipeableStreamOptions,
 
-        onError(error: unknown) {
+        onError(rawError: unknown) {
+          // Add actionable context to opaque client-reference failures
+          // ("outside the hosted root" / missing client-dir module) before
+          // anything else sees the error.
+          const error = augmentClientReferenceError(rawError);
           // Always log: stream errors otherwise vanish silently and the only
           // user-visible symptom is an empty/half RSC response.
           logger?.error(
@@ -162,7 +167,8 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
           // Call the original onError handler if it exists
           serverPipeableStreamOptions.onError?.(error);
         },
-        onShellError(error: unknown) {
+        onShellError(rawError: unknown) {
+          const error = augmentClientReferenceError(rawError);
           // Always log: shell errors mean nothing has been flushed to the
           // client yet, so without a log there's no signal at all.
           logger?.error(
@@ -249,7 +255,8 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
           handlerOptions.moduleBasePath || "",
           pipeableStreamOptions
         );
-      } catch (error) {
+      } catch (rawError) {
+        const error = augmentClientReferenceError(rawError);
         if (verbose) {
           logger?.error(
             `[createRscStream:${route}] Synchronous error from React rendering: ${error}`
@@ -330,7 +337,8 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
         elements: finalChildren,
         metrics: createStreamMetrics(), // Provide empty metrics object
       };
-    } catch (error) {
+    } catch (rawError) {
+      const error = augmentClientReferenceError(rawError);
       if (verbose) {
         logger?.error(
           `[createRscStream:${route}] Error in RSC stream creation: ${error}`

--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -14,6 +14,7 @@ import { resolveRegExp } from "../config/resolveRegExp.js";
 import { userProjectRoot } from "../root.js";
 import { createDefaultModuleID } from "../config/createModuleID.js";
 import { buildClientPackagesPattern } from "../clientPackages/index.js";
+import { analyzeDirectives } from "../loader/directives/analyzeDirectives.js";
 
 export interface TransformerPluginOptions {
   name: string;
@@ -279,28 +280,66 @@ export const createTransformerPlugin = (
             originalSourceContent = code;
           }
 
+          // Robustly determine whether this module is a client reference by a
+          // top-of-file `"use client"` DIRECTIVE (not by the `.client.`
+          // filename). We parse the (post-esbuild) `code` with Rollup's
+          // JSX-aware `this.parse` and reuse `analyzeDirectives` — its
+          // `fileLevel.type === "client"` is the source of truth. This is the
+          // ROBUST detector; we deliberately avoid the naive
+          // `isClientComponentByCode` substring matcher, which flags any module
+          // containing the word "client" and would mis-host server modules.
+          let isClientByDirective = false;
+          try {
+            if (code.includes("use client")) {
+              const ast = this.parse(code, {
+                allowReturnOutsideFunction: true,
+                jsx: true,
+              }) as Program;
+              const directiveInfo = analyzeDirectives(ast, code);
+              const misplaced = directiveInfo.warnings.some((w) =>
+                w.message.includes("must be at the top of the file")
+              );
+              isClientByDirective =
+                directiveInfo.fileLevel?.type === "client" && !misplaced;
+            }
+          } catch {
+            // Parse failure → fall back to filename/content detection inside
+            // the moduleID function. A genuine `.client.tsx` is unaffected.
+            isClientByDirective = false;
+          }
+
           // Use the original normalized path for moduleID function calls
-          // This ensures registerClientReference calls use the correct paths
+          // This ensures registerClientReference calls use the correct paths.
+          // Pass `isClientByDirective` so the moduleID function applies the
+          // hosted-path transform (strip moduleBase → extension map → hash →
+          // moduleBasePath prefix) to directive-only client modules that have
+          // no `.client.` suffix — the default moduleID can't parse raw TSX to
+          // detect the directive itself.
           let finalModuleID = runtimeResolvedUserOptions.loader?.moduleID
             ? runtimeResolvedUserOptions.loader.moduleID(
                 normalizedPath,
-                originalSourceContent
+                originalSourceContent,
+                isClientByDirective
               )
             : normalizedPath;
 
-          // Whitelisted node_modules client packages: the default moduleID
-          // doesn't recognize them as client components (no `.client.[jt]sx?`
-          // suffix) and returns the bare `node_modules/...` path. The RSC
-          // runtime rejects ids that don't start with the bundler's baseURL
-          // ("Attempted to load a Client Module outside the hosted root"), so
-          // prefix with `/` here. The path keeps `node_modules/` because the
-          // SSR-env build (with `noExternal: clientPackages`) emits each
-          // bundled "use client" module to `dist/client/node_modules/<pkg>/…`,
-          // and the html-worker materializes client refs by importing
-          // `<dist/client>/<moduleID>` — keeping the segment lets the import
-          // resolve to disk.
+          // Client references must be HOSTED: their moduleID has to start with
+          // the bundler's baseURL or react-server-dom-esm's
+          // `serializeClientReference` throws "Attempted to load a Client
+          // Module outside the hosted root". The html-worker then materializes
+          // each ref by importing `<dist/client>/<moduleID>`, so the leading
+          // `/` is what makes that resolve to disk.
+          //
+          // This covers two cases the default moduleID returns unprefixed:
+          //   1. whitelisted node_modules client packages (no `.client.`
+          //      suffix; bundled to `dist/client/node_modules/<pkg>/…` via
+          //      `noExternal: clientPackages`), and
+          //   2. first-party directive-only client modules (no `.client.`
+          //      suffix; emitted to `dist/client/<path>` by the SSR build —
+          //      see resolveClientReferencesPlugin's input collection).
+          const needsHosting = isWhitelistedClientPackage || isClientByDirective;
           if (
-            isWhitelistedClientPackage &&
+            needsHosting &&
             typeof finalModuleID === "string" &&
             !finalModuleID.startsWith("/")
           ) {

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -423,7 +423,13 @@ export type ResolvedUserOptions = {
   Html: StreamPluginOptions["Html"]; // Unresolved: can be string, function
   Root: StreamPluginOptions["Root"]; // Unresolved: can be string, function
   normalizer: InputNormalizer;
-  moduleID: ((id: string, sourceContent?: string) => string) | undefined;
+  moduleID:
+    | ((
+        id: string,
+        sourceContent?: string,
+        isClientByDirective?: boolean
+      ) => string)
+    | undefined;
   onMetrics: OnMetrics | undefined;
   // different for client/server so can't be typed
   pipeableStreamOptions: any;
@@ -899,7 +905,11 @@ export interface StreamPluginOptions<
   onMetrics?: OnMetrics;
   onEvent?: OnEvent<Interface>;
   normalizer?: InputNormalizer;
-  moduleID?: (id: string, sourceContent?: string) => string;
+  moduleID?: (
+    id: string,
+    sourceContent?: string,
+    isClientByDirective?: boolean
+  ) => string;
   verbose?: boolean;
   rscTimeout?: number; // Timeout in milliseconds for RSC operations
   htmlTimeout?: number; // Timeout in milliseconds for HTML generation operations

--- a/test/examples/directive-client-build.test.ts
+++ b/test/examples/directive-client-build.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { setupDirectiveClientProject } from "../setup.js";
+import { getSharedBuild, SharedBuildResult } from "./shared-build.js";
+
+/**
+ * Regression test for hosting directive-detected `"use client"` modules in the
+ * static (`--app`) build.
+ *
+ * The fixture's client component (`src/components/Counter.tsx`) is recognized
+ * ONLY by its top-of-file `"use client"` directive — its filename does not
+ * match the `.client.` convention. Before the fix, the static build gave it a
+ * raw, unhosted moduleID and react-server-dom-esm rejected the client
+ * reference at serialize time. After the fix:
+ *
+ *  - the build completes (no panic),
+ *  - the RSC stream contains a serialized client reference (an `I` import
+ *    chunk) for the directive-only module,
+ *  - the client component is emitted as a chunk so the hosted moduleID
+ *    resolves to a real file.
+ */
+describe("Directive-detected client module in static build", () => {
+  let buildResult: SharedBuildResult;
+
+  beforeAll(async () => {
+    buildResult = await getSharedBuild(
+      "directive-client-project",
+      "directive-client-build",
+      {
+        setupProject: setupDirectiveClientProject,
+        pages: ["/"],
+        // Surface any RSC serialization error as a build failure so the test
+        // fails loudly if hosting regresses.
+        panicThreshold: "all_errors",
+        verbose: false,
+      }
+    );
+  }, 30000);
+
+  it("builds without failing on the directive-only client module", () => {
+    // A rejected client reference would have surfaced as a route.error and,
+    // with panicThreshold "all_errors", thrown out of getSharedBuild.
+    expect(buildResult).toBeDefined();
+    const routeErrors = buildResult.events.filter(
+      (e: any) => e.type === "route.error"
+    );
+    expect(routeErrors).toHaveLength(0);
+  });
+
+  it("emits HTML and RSC for the page", () => {
+    const htmlFiles = buildResult.htmlFiles();
+    const rscFiles = buildResult.rscFiles();
+    expect(htmlFiles.length).toBeGreaterThan(0);
+    expect(rscFiles.length).toBeGreaterThan(0);
+
+    // The page's server-rendered shell should be present.
+    expect(htmlFiles[0][1]).toContain("Directive Client Test");
+  });
+
+  it("serializes the directive-only module as a hosted client reference", () => {
+    const rscFiles = buildResult.rscFiles();
+    const rscContent = rscFiles.map(([, content]) => content).join("\n");
+
+    // react-server-dom-esm emits client references as `I` import chunks, e.g.
+    //   1:I["/components/Counter-<hash>.js",[],"Counter"]
+    // The reference must point at the directive-only module by name.
+    expect(rscContent).toMatch(/I\[/);
+    expect(rscContent).toContain("Counter");
+  });
+
+  it("emits the directive-only client module as a client chunk", () => {
+    const clientFileNames = buildResult.clientChunks().map(([name]) => name);
+    const staticFileNames = buildResult.staticChunks().map(([name]) => name);
+    const allClientLike = [...clientFileNames, ...staticFileNames];
+
+    // The hosted moduleID points at an emitted Counter chunk; if it were
+    // missing, the html-worker's import of the client ref would 404 at
+    // SSG-render time.
+    expect(allClientLike.some((name) => /Counter/.test(name))).toBe(true);
+  });
+});

--- a/test/examples/directive-client-build.test.ts
+++ b/test/examples/directive-client-build.test.ts
@@ -77,4 +77,19 @@ describe("Directive-detected client module in static build", () => {
     // SSG-render time.
     expect(allClientLike.some((name) => /Counter/.test(name))).toBe(true);
   });
+
+  it("hosts a compound-filename (X.Y.tsx) directive-only client module", () => {
+    // `Widget.fancy.tsx`: the build's entryFile name-normalization collapses
+    // the middle `.fancy` segment (→ `Widget`). The client-reference moduleID
+    // must collapse it identically, or the ref points at `Widget.fancy-<hash>.js`
+    // while the emitted chunk is `Widget-<hash>.js` → ERR_MODULE_NOT_FOUND at
+    // SSG render. (The "builds without failing" test above, run with
+    // panicThreshold "all_errors", also catches the mismatch: before the fix
+    // the compound module's hosted reference pointed at a never-emitted file.)
+    const allClientLike = [
+      ...buildResult.clientChunks().map(([name]) => name),
+      ...buildResult.staticChunks().map(([name]) => name),
+    ];
+    expect(allClientLike.some((name) => /Widget/.test(name))).toBe(true);
+  });
 });

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -479,6 +479,61 @@ export async function setupTestProject(testDir: string) {
   await setupPageTSX2(testDir);
 }
 
+/**
+ * Project whose client component is detected purely by a top-of-file
+ * `"use client"` DIRECTIVE — its filename (`Counter.tsx`) deliberately does
+ * NOT match the `.client.` convention. This reproduces the static-build bug
+ * where directive-only client modules got a raw, unhosted moduleID and
+ * react-server-dom-esm's `serializeClientReference` rejected the reference
+ * ("Attempted to load a Client Module outside the hosted root"). After the
+ * fix, the page builds and the client reference serializes correctly.
+ */
+export async function setupDirectiveClientProject(testDir: string) {
+  await setupIndexHTML(testDir);
+  await mkdir(resolve(testDir, "src/components"), { recursive: true });
+  await mkdir(resolve(testDir, "src/page"), { recursive: true });
+
+  // Directive-only client component. No `.client.` suffix on purpose.
+  await writeFile(
+    resolve(testDir, "src/components/Counter.tsx"),
+    `"use client";
+import React from "react";
+const { useState } = React;
+
+export function Counter({ start = 0 }: { start?: number }) {
+  const [count, setCount] = useState(start);
+  return (
+    <button data-testid="counter" onClick={() => setCount((c) => c + 1)}>
+      Count: {count}
+    </button>
+  );
+}
+`
+  );
+
+  // Server page imports the directive-only client component.
+  await writeFile(
+    resolve(testDir, "src/page/page.tsx"),
+    `import React from "react";
+import { Counter } from "../components/Counter.js";
+
+export function Page(props: any) {
+  return (
+    <div>
+      <h1>Directive Client Test</h1>
+      <Counter start={props.start ?? 0} />
+    </div>
+  );
+}
+`
+  );
+
+  await writeFile(
+    resolve(testDir, "src/page/props.ts"),
+    `export const props = (url: string) => ({ start: 5, url });`
+  );
+}
+
 export async function setupTestProjectEnv(testDir: string) {
   await setupIndexHTML(testDir);
   await setupPageTSX2(testDir);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -511,17 +511,35 @@ export function Counter({ start = 0 }: { start?: number }) {
 `
   );
 
-  // Server page imports the directive-only client component.
+  // Directive-only client component with a COMPOUND filename (no `.client.`
+  // suffix). Regression: the build's entryFile name-normalization strips the
+  // middle `.fancy` segment (→ `Widget`), while the moduleID must collapse it
+  // the same way, or the hosted client reference points at a file that was
+  // never emitted (ERR_MODULE_NOT_FOUND at SSG render).
+  await writeFile(
+    resolve(testDir, "src/components/Widget.fancy.tsx"),
+    `"use client";
+import React from "react";
+
+export function Widget({ label = "widget" }: { label?: string }) {
+  return <span data-testid="widget">{label}</span>;
+}
+`
+  );
+
+  // Server page imports the directive-only client components.
   await writeFile(
     resolve(testDir, "src/page/page.tsx"),
     `import React from "react";
 import { Counter } from "../components/Counter.js";
+import { Widget } from "../components/Widget.fancy.js";
 
 export function Page(props: any) {
   return (
     <div>
       <h1>Directive Client Test</h1>
       <Counter start={props.start ?? 0} />
+      <Widget label="fancy" />
     </div>
   );
 }

--- a/test/unit/directive-client-hosting.test.ts
+++ b/test/unit/directive-client-hosting.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasFileLevelClientDirective,
+  sourceHasTopLevelClientDirective,
+} from "vite-plugin-react-server/directives";
+import { augmentClientReferenceError } from "vite-plugin-react-server/error";
+
+describe("directive-detected client modules", () => {
+  describe("hasFileLevelClientDirective (acorn-parseable sources)", () => {
+    it("detects a top-of-file 'use client' directive", () => {
+      expect(
+        hasFileLevelClientDirective(`"use client";\nexport const x = 1;`)
+      ).toBe(true);
+    });
+
+    it("tolerates a leading 'use strict' prologue", () => {
+      expect(
+        hasFileLevelClientDirective(
+          `"use strict";\n"use client";\nexport const x = 1;`
+        )
+      ).toBe(true);
+    });
+
+    it("does not flag a plain server module", () => {
+      expect(
+        hasFileLevelClientDirective(
+          `import React from "react";\nexport function Page(){ return null; }`
+        )
+      ).toBe(false);
+    });
+
+    it("does NOT flag the substring 'client' in an import path (robust, not naive)", () => {
+      expect(
+        hasFileLevelClientDirective(
+          `import { createClient } from "./client/foo.js";\nexport const x = 1;`
+        )
+      ).toBe(false);
+    });
+
+    it("does not flag a mid-file / function-level directive as file-level", () => {
+      expect(
+        hasFileLevelClientDirective(
+          `const a = 1;\n"use client";\nexport const x = 1;`
+        )
+      ).toBe(false);
+    });
+
+    it("returns false for empty/undefined input", () => {
+      expect(hasFileLevelClientDirective(undefined)).toBe(false);
+      expect(hasFileLevelClientDirective("")).toBe(false);
+    });
+  });
+
+  describe("sourceHasTopLevelClientDirective (raw TSX, no parser)", () => {
+    const tsx = `"use client";
+import React from "react";
+export function Counter({ start = 0 }: { start?: number }) {
+  return <button onClick={() => {}}>Count {start}</button>;
+}`;
+
+    it("detects the directive in raw, untranspiled TSX", () => {
+      expect(sourceHasTopLevelClientDirective(tsx)).toBe(true);
+    });
+
+    it("skips leading comments above the directive", () => {
+      expect(
+        sourceHasTopLevelClientDirective(
+          `// a comment\n/* block */\n"use client";\nexport const x = 1;`
+        )
+      ).toBe(true);
+    });
+
+    it("tolerates 'use strict' above 'use client'", () => {
+      expect(
+        sourceHasTopLevelClientDirective(`"use strict";\n"use client";`)
+      ).toBe(true);
+    });
+
+    it("is not fooled by the word 'client' in code or comments", () => {
+      expect(
+        sourceHasTopLevelClientDirective(
+          `import { createClient } from "./client";\nexport const x = 1;`
+        )
+      ).toBe(false);
+      expect(
+        sourceHasTopLevelClientDirective(`// use client comment only? no`)
+      ).toBe(false);
+    });
+
+    it("requires the directive to be the first statement", () => {
+      expect(
+        sourceHasTopLevelClientDirective(`const a = 1;\n"use client";`)
+      ).toBe(false);
+    });
+  });
+
+  describe("augmentClientReferenceError (clearer hosting errors)", () => {
+    it("explains 'outside the hosted root' failures", () => {
+      const original = new Error(
+        "Attempted to load a Client Module outside the hosted root."
+      );
+      const augmented = augmentClientReferenceError(original) as Error;
+      expect(augmented).toBeInstanceOf(Error);
+      expect(augmented.message).toContain("not hosted");
+      expect(augmented.message).toContain("vite-plugin-react-server");
+      // Preserves the original message + chains the cause.
+      expect(augmented.message).toContain("outside the hosted root");
+      expect((augmented as { cause?: unknown }).cause).toBe(original);
+    });
+
+    it("explains missing client-output module failures", () => {
+      const original = new Error(
+        "Cannot find module '/proj/dist/client/components/Counter-abc123.js'"
+      );
+      const augmented = augmentClientReferenceError(original) as Error;
+      expect(augmented.message).toContain("not emitted to the client build output");
+    });
+
+    it("passes unrelated errors through unchanged", () => {
+      const original = new Error("some unrelated failure");
+      expect(augmentClientReferenceError(original)).toBe(original);
+    });
+
+    it("does not double-augment", () => {
+      const original = new Error("Client Module outside the hosted root");
+      const once = augmentClientReferenceError(original) as Error;
+      const twice = augmentClientReferenceError(once);
+      expect(twice).toBe(once);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Makes vprs host first-party modules that declare a top-of-file `"use client"` **directive** but don't use the `.client.` filename suffix, so they work as client references in the static `--app` build (they already worked in dev). This is the long-standing gap behind directive-only client modules and node_modules client libraries (e.g. Chakra v3) failing under the `react-server` condition.

## What changed

- **Directive detection wired into hosting.** `createModuleID` now treats a module as a client component when it has a file-level `"use client"` directive, not just a `.client.` filename. Detection uses AST analysis (`analyzeDirectives` via Rollup's JSX-aware `this.parse` in `createTransformerPlugin`), threaded as a new `isClientByDirective` flag — deliberately NOT the naive `isClientComponentByCode` substring matcher.
- **Emission gap fixed.** New `createDirectiveClientAutoDiscover` scans `src/` (via a parser-free, structural `sourceHasTopLevelClientDirective` detector) and adds directive-only modules as client/SSR build inputs, so they're actually emitted to `dist/client`.
- **Hosting generalized.** The `/`-prefix in `createTransformerPlugin` (previously node_modules-clientPackages only) now applies to any directive-detected client reference.
- **Clearer error.** `augmentClientReferenceError` wraps the rsd-esm "outside the hosted root" / missing-client-module throws with an actionable cause.
- Docs: `getting-started.md` notes the `.client.` filename is now optional; README note.

## Tests

- New `test/unit/directive-client-hosting.test.ts` (15 tests, incl. substring/misplaced-directive false-positive guards + error augmentation) and `test/examples/directive-client-build.test.ts` (cross-env build regression).
- `npm run test:unit` -> 306/306. Build/error-boundary/hash-consistency example tests pass. Two pre-existing dev-server test failures confirmed unrelated (fail identically on baseline).

## Downstream validation (mission-control dashboard)

Verified end-to-end: installed this branch into the dashboard and ran its static build, which previously died with "Attempted to load a Client Module outside the hosted root." That error is gone — directive-only first-party modules (`useRoute`, `useChatCompose`, `AppFrame.client`, ...) and node_modules `ChakraProvider` now host, emit, and render.

## Compound filenames (also fixed)

Compound client filenames like `View.generated.tsx` / `View.default.tsx` initially still failed the static build: the chunk-naming path (`entryFile` -> `normalizer`) strips one trailing `.segment` (`View.generated` -> `View`), while `createModuleID` kept it — so the client reference pointed at `View.generated-<hash>.js` while the emitted chunk was `View-<hash>.js` (same hash, different basename) -> `ERR_MODULE_NOT_FOUND`. Fixed by mirroring the normalizer's single trailing-segment strip in `createModuleID` for directive-detected modules (guarded to preserve `.client`/`.server`, which the normalizer special-cases). Added a compound-filename (`Widget.fancy.tsx`) case to the regression test.

The mission-control dashboard's full static build (which uses `View.generated.tsx` + `View.default.tsx`) now **completes and renders** end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
