### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
## Summary

Bumps the package version `1.9.0` → `1.10.0` so the directive-`"use client"` hosting feature merged in #55 can be published.

#55 added the feature code to `main` but its version bump didn't make it into the squash merge, leaving `main` at `1.9.0` (npm latest is also `1.9.0`). This minor bump (new feature, non-breaking) makes `main` publishable as `1.10.0`.

## Test plan

- [x] `npm version minor --no-git-tag-version` → `1.10.0` (package.json + package-lock.json)
- [ ] Merge, then `npm publish` releases `1.10.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)