### PR TITLE
refactor(config): extract createRollupLikeHash into a shared module

### DIFF
--- a/plugin/config/createModuleID.ts
+++ b/plugin/config/createModuleID.ts
@@ -6,7 +6,7 @@ import { hasFileLevelClientDirective } from "../loader/directives/hasFileLevelCl
 import type { ConfigEnv } from "vite";
 import { sep, resolve, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
-import { createHash } from "node:crypto";
+import { createRollupLikeHash } from "./createRollupLikeHash.js";
 
 export type ModuleIDKey =
   | "modulePattern"
@@ -76,30 +76,6 @@ export const createDefaultModuleID = (
     isClientByDirective === true ||
     clientPattern.test(id) ||
     hasFileLevelClientDirective(sourceContent);
-
-  // Clean hash API that mimics Rollup's behavior
-  const createRollupLikeHash = (content: string, hashCharacters: 'base36' | 'base64' | 'hex' = 'base36') => {
-    const hash = createHash('sha1');
-    hash.update(content);
-    const fullHash = hash.digest('hex');
-    
-    // Apply the same character set logic as Rollup
-    switch (hashCharacters) {
-      case 'base36':
-        // Convert hex to base36 (0-9, a-z)
-        return parseInt(fullHash.substring(0, 8), 16).toString(36);
-      case 'base64':
-        // Convert to base64-like format (A-Z, a-z, 0-9, -, _)
-        return Buffer.from(fullHash.substring(0, 8), 'hex').toString('base64')
-          .replace(/\+/g, '-')
-          .replace(/\//g, '_')
-          .replace(/=/g, '');
-      case 'hex':
-      default:
-        // Return hex format
-        return fullHash.substring(0, 8);
-    }
-  };
 
   // Hash function for client components - same logic as resolveOptions.ts
   const hash = (

--- a/plugin/config/createRollupLikeHash.ts
+++ b/plugin/config/createRollupLikeHash.ts
@@ -1,0 +1,47 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Content-addressed hash for client-component module IDs that mimics Rollup's
+ * `hashCharacters` semantics. Used to give every hosted client module a stable,
+ * source-content-derived suffix so the build's emitted chunk and the registered
+ * client reference agree on the same filename across runs and across the
+ * transformer / build / SSG pipelines.
+ *
+ * Hashes the input with sha1, then truncates the first 8 hex characters and
+ * re-encodes them into one of three character sets:
+ *   - `base36` (default): hex parsed as int then `.toString(36)` — Rollup's
+ *     default; short, filename-safe, no special characters.
+ *   - `base64`: first 8 hex chars decoded to bytes and base64-encoded with
+ *     URL-safe substitutions (`+`→`-`, `/`→`_`, `=` stripped).
+ *   - `hex`: raw first 8 hex characters.
+ *
+ * `base36` is the default because it matches Rollup's own default and produces
+ * the shortest hash for the same input space, which keeps generated module IDs
+ * compact in source maps and import graphs.
+ */
+export const createRollupLikeHash = (
+  content: string,
+  hashCharacters: "base36" | "base64" | "hex" = "base36",
+) => {
+  const hash = createHash("sha1");
+  hash.update(content);
+  const fullHash = hash.digest("hex");
+
+  // Apply the same character set logic as Rollup
+  switch (hashCharacters) {
+    case "base36":
+      // Convert hex to base36 (0-9, a-z)
+      return parseInt(fullHash.substring(0, 8), 16).toString(36);
+    case "base64":
+      // Convert to base64-like format (A-Z, a-z, 0-9, -, _)
+      return Buffer.from(fullHash.substring(0, 8), "hex")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+    case "hex":
+    default:
+      // Return hex format
+      return fullHash.substring(0, 8);
+  }
+};

--- a/plugin/config/index.client.ts
+++ b/plugin/config/index.client.ts
@@ -13,6 +13,7 @@ export * from './interpolatePattern.js';
 export * from './resolvePages.js';
 export * from './resolveUserConfig.js';
 export * from './createModuleID.js';
+export * from './createRollupLikeHash.js';
 export * from './getCondition.js';
 export * from './mimeTypes.js';
 export * from './resolveDirectiveMatcher.js';

--- a/plugin/config/index.server.ts
+++ b/plugin/config/index.server.ts
@@ -13,6 +13,7 @@ export * from './interpolatePattern.js';
 export * from './resolvePages.js';
 export * from './resolveUserConfig.js';
 export * from './createModuleID.js';
+export * from './createRollupLikeHash.js';
 export * from './getCondition.js';
 export * from './mimeTypes.js';
 export * from './resolveDirectiveMatcher.js';

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -24,8 +24,8 @@ import { createLogger, type Logger } from "vite";
 import { getCondition } from "./getCondition.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { stashUserOptions, getStashedUserOptions, getEnvironmentId } from "./stashedOptionsState.js";
-import { createHash } from "node:crypto";
 import { readFileSync, existsSync } from "node:fs";
+import { createRollupLikeHash } from "./createRollupLikeHash.js";
 
 export type ResolveOptionsReturn =
   | {
@@ -349,30 +349,6 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     (typeof moduleId === "string" && clientPattern.test(moduleId)) || false;
 
   const hashOption = options.build?.hash ?? DEFAULT_CONFIG.BUILD.hash;
-
-  // Clean hash API that mimics Rollup's behavior but allows control over input
-  const createRollupLikeHash = (content: string, hashCharacters: 'base36' | 'base64' | 'hex' = 'base36') => {
-    const hash = createHash('sha1');
-    hash.update(content);
-    const fullHash = hash.digest('hex');
-    
-    // Apply the same character set logic as Rollup
-    switch (hashCharacters) {
-      case 'base36':
-        // Convert hex to base36 (0-9, a-z)
-        return parseInt(fullHash.substring(0, 8), 16).toString(36);
-      case 'base64':
-        // Convert to base64-like format (A-Z, a-z, 0-9, -, _)
-        return Buffer.from(fullHash.substring(0, 8), 'hex').toString('base64')
-          .replace(/\+/g, '-')
-          .replace(/\//g, '_')
-          .replace(/=/g, '');
-      case 'hex':
-      default:
-        // Return hex format
-        return fullHash.substring(0, 8);
-    }
-  };
 
   // User-facing hash function that can take source content or filename
   const hash = (input: string | null, _ssr: boolean, sourceContent?: string) => {

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -14,7 +14,7 @@ import {
   mergeClientPackagesNoExternal,
   mergeClientPackagesOptimizeDepsExclude,
 } from "../clientPackages/index.js";
-import { createHash } from "node:crypto";
+import { createRollupLikeHash } from "./createRollupLikeHash.js";
 
 const stashedUserConfig: Record<string, ResolvedUserConfig | null> = {};
 let originalConfig: UserConfig | null = null;
@@ -724,10 +724,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
                       if (existsSync(sourcePath)) {
                         const sourceContent = readFileSync(sourcePath, "utf-8");
                         // Use a short hash of the source content as salt
-                        return createHash("sha1")
-                          .update(sourceContent)
-                          .digest("hex")
-                          .substring(0, 8);
+                        return createRollupLikeHash(sourceContent, "hex");
                       }
                     } catch (error) {
                       // Fallback: use the module ID as salt

--- a/test/unit/createRollupLikeHash.test.ts
+++ b/test/unit/createRollupLikeHash.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { createRollupLikeHash } from "vite-plugin-react-server/config";
+
+// Guards against silent drift in the Rollup-like content hash used for
+// client-component module IDs. Both `createModuleID` and `resolveOptions`
+// route through this single implementation; if the hash output ever changes,
+// hosted client modules will get new filenames and previously-built bundles
+// will mismatch. These literal snapshots make any such change loud.
+describe("createRollupLikeHash", () => {
+  // A representative source roughly mirroring a "use client" module body.
+  const sample =
+    'export default function MyClient() { return null; }';
+
+  describe("hashCharacters: base36 (default)", () => {
+    it("hashes a representative source to a stable base36 value", () => {
+      expect(createRollupLikeHash(sample, "base36")).toBe("p4aj8u");
+    });
+
+    it("defaults to base36 when no hashCharacters is provided", () => {
+      expect(createRollupLikeHash(sample)).toBe(
+        createRollupLikeHash(sample, "base36"),
+      );
+    });
+
+    it("hashes empty input deterministically", () => {
+      expect(createRollupLikeHash("", "base36")).toBe("1ojsg6m");
+    });
+  });
+
+  describe("hashCharacters: base64", () => {
+    it("hashes a representative source to a stable url-safe base64 value", () => {
+      expect(createRollupLikeHash(sample, "base64")).toBe("WogH7g");
+    });
+
+    it("hashes empty input deterministically", () => {
+      expect(createRollupLikeHash("", "base64")).toBe("2jmj7g");
+    });
+  });
+
+  describe("hashCharacters: hex", () => {
+    it("hashes a representative source to a stable 8-char hex prefix", () => {
+      expect(createRollupLikeHash(sample, "hex")).toBe("5a8807ee");
+    });
+
+    it("hashes empty input to the canonical sha1-empty prefix", () => {
+      // First 8 chars of sha1("") = "da39a3ee...".
+      expect(createRollupLikeHash("", "hex")).toBe("da39a3ee");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`createRollupLikeHash` was defined **twice** on `main` with byte-identical bodies:

- `plugin/config/createModuleID.ts` (inside `createDefaultModuleID`)
- `plugin/config/resolveOptions.ts` (inside `resolveOptions`)

Same sha1, same 8-char truncation, same `base36` / `base64` / `hex` switch, same default. The two copies were kept in sync by hand, which is exactly the kind of duplication that drifts silently. #55 already demonstrated the risk: it threaded a `sourceContent` argument into the `createModuleID` hash call site, but nothing forced the parallel update on the `resolveOptions` side — the only thing saving us was that the *function* signature didn't change, just the call site.

## What changed

- New file `plugin/config/createRollupLikeHash.ts` exporting a single implementation with the same signature both call sites use today.
- Both inline definitions removed. Both files now `import { createRollupLikeHash } from "./createRollupLikeHash.js"`.
- `createHash` imports dropped from both `createModuleID.ts` and `resolveOptions.ts` (no longer used after the extraction).
- Re-exported from `./config/index.{server,client}.ts` for parity with the other config utilities and so it's reachable from tests via the `vite-plugin-react-server/config` subpath.
- New unit test `test/unit/createRollupLikeHash.test.ts` pins literal expected hashes for a representative source under each of the three `hashCharacters` modes plus the empty-input edge case. If the hash output ever changes, hosted client module IDs would change with it — this test makes any such change loud.

## Why

Pure structural move. Behaviour is preserved — the two original definitions are byte-identical (`diff <(sed -n '81,102p' createModuleID.ts) <(sed -n '354,375p' resolveOptions.ts)` returns nothing). The point is to make sure the *next* PR that needs to evolve the hashing — different hash algorithm, different truncation, additional input normalization — can't accidentally fork the two paths again.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run test:unit` — 313/313 pass (was 306/306; +7 new tests in `createRollupLikeHash.test.ts`)
- [x] Verified the two original definitions are byte-identical (zero-byte diff)