### PR TITLE
refactor: unify client-module detection in one helper

### DIFF
--- a/plugin/config/createModuleID.ts
+++ b/plugin/config/createModuleID.ts
@@ -2,7 +2,7 @@ import type { ResolvedUserOptions } from "../types.js";
 import { replaceExtension } from "./extMap.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { DEFAULT_CONFIG } from "./defaults.js";
-import { hasFileLevelClientDirective } from "../loader/directives/hasFileLevelClientDirective.js";
+import { detectClientModule } from "../loader/directives/detectClientModule.js";
 import type { ConfigEnv } from "vite";
 import { sep, resolve, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
@@ -46,23 +46,12 @@ export const createDefaultModuleID = (
   // Virtual pattern for excluding virtual modules from hashing
   const virtualPattern = autoDiscover?.virtualPattern ?? DEFAULT_CONFIG.AUTO_DISCOVER.virtualPattern;
   
-  // Client component pattern for hashing (filename convention).
-  const clientPattern = /\.client\.[cm]?[jt]sx?$/;
-
   // A module is a client component (and therefore must get a hosted,
-  // `moduleBasePath`-prefixed moduleID) if ANY of:
-  //   1. an explicit `isClientByDirective` override is passed (the transformer
-  //      computes this with Rollup's JSX/TS-aware `this.parse`, which is the
-  //      authoritative detection — see createTransformerPlugin),
-  //   2. its filename matches the `.client.` convention, OR
-  //   3. it declares a top-of-file `"use client"` directive that this function
-  //      can detect on its own from `sourceContent`.
-  //
-  // The directive checks are robust (acorn + analyzeDirectives), never the
-  // naive substring matcher. NOTE: this function's own acorn parser (case 3)
-  // cannot parse raw TSX (JSX + TS types), so the transformer passes the
-  // override (case 1) for the build path. Case 3 still covers already-parseable
-  // sources and keeps the function correct when called standalone.
+  // `moduleBasePath`-prefixed moduleID) when the unified `detectClientModule`
+  // helper says so — filename `.client.[cm]?[jt]sx?$` OR a top-of-file
+  // `"use client"` directive. The `isClientByDirective` override fast-paths
+  // the build's transformer answer (computed with Rollup's JSX-aware
+  // `this.parse`), so we don't re-parse here.
   //
   // This is what lets directive-only client modules (no `.client.` suffix,
   // e.g. node_modules libs that ship `"use client"`) be hosted in the static
@@ -74,8 +63,7 @@ export const createDefaultModuleID = (
     isClientByDirective?: boolean
   ) =>
     isClientByDirective === true ||
-    clientPattern.test(id) ||
-    hasFileLevelClientDirective(sourceContent);
+    detectClientModule({ source: sourceContent, moduleId: id });
 
   // Hash function for client components - same logic as resolveOptions.ts
   const hash = (

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -1,6 +1,7 @@
 import { Root } from "../components/root.js";
 import { Html } from "../components/html.js";
 import { parse } from "../loader/parse.js";
+import { detectClientModule } from "../loader/directives/detectClientModule.js";
 import { pluginRoot } from "../root.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { getCondition } from "./getCondition.js";
@@ -17,22 +18,33 @@ const DIRECTIVE_PATTERNS = {
 } as const;
 
 const SERVER_ACTION_FILE = /(\.|\/)?server(\.|\/)?/;
-const CLIENT_COMPONENT_FILE = /(\.|\/)?client(\.|\/)?/;
 const IS_SERVER_ACTION_CODE = (code: string, moduleId?: string) =>
   code.match(SERVER_ACTION_FILE) != null ||
   (moduleId && SERVER_ACTION_FILE.test(moduleId.toLowerCase())) ||
   false;
+
+// Client-module detection is the single, robust answer in
+// `loader/directives/detectClientModule`. The three legacy
+// `isClientComponent*` defaults below were naive substring matchers
+// (`/(\.|\/)?client(\.|\/)?/`) that misclassified any module mentioning the
+// word "client" — a variable named `clientId`, an import path containing
+// `client`, a comment — as a client module. They are kept as user-overridable
+// hooks on `loader.*`, but the defaults now delegate to `detectClientModule`
+// so out-of-the-box behaviour is the strict, AST/scanner-validated form.
+//
+// Behaviour change: filename like `src/lib/clientId.ts` no longer matches.
+// Real client modules use the `.client.[cm]?[jt]sx?$` filename convention
+// OR a top-of-file `"use client"` directive — both are recognised here.
 const IS_CLIENT_COMPONENT_CODE = (code: string, moduleId?: string) =>
-  code.match(CLIENT_COMPONENT_FILE) != null ||
-  (moduleId && CLIENT_COMPONENT_FILE.test(moduleId.toLowerCase())) ||
-  false;
+  detectClientModule({ source: code, moduleId });
 
-// Separate functions for checking client components by code vs by name
 const IS_CLIENT_COMPONENT_BY_CODE = (code: string) =>
-  code.match(CLIENT_COMPONENT_FILE) != null || false;
+  detectClientModule({ source: code });
 
-const IS_CLIENT_COMPONENT_BY_NAME = (moduleId: string, _transformedModuleId?: string) =>
-  CLIENT_COMPONENT_FILE.test(moduleId.toLowerCase()) || false;
+const IS_CLIENT_COMPONENT_BY_NAME = (
+  moduleId: string,
+  _transformedModuleId?: string,
+) => detectClientModule({ moduleId });
 // Directive configurations
 export const DIRECTIVE_CONFIGS = {
   client: {

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -23,18 +23,14 @@ const IS_SERVER_ACTION_CODE = (code: string, moduleId?: string) =>
   (moduleId && SERVER_ACTION_FILE.test(moduleId.toLowerCase())) ||
   false;
 
-// Client-module detection is the single, robust answer in
-// `loader/directives/detectClientModule`. The three legacy
-// `isClientComponent*` defaults below were naive substring matchers
-// (`/(\.|\/)?client(\.|\/)?/`) that misclassified any module mentioning the
-// word "client" — a variable named `clientId`, an import path containing
-// `client`, a comment — as a client module. They are kept as user-overridable
-// hooks on `loader.*`, but the defaults now delegate to `detectClientModule`
-// so out-of-the-box behaviour is the strict, AST/scanner-validated form.
-//
-// Behaviour change: filename like `src/lib/clientId.ts` no longer matches.
-// Real client modules use the `.client.[cm]?[jt]sx?$` filename convention
-// OR a top-of-file `"use client"` directive — both are recognised here.
+// Defaults for the user-overridable `loader.isClientComponent*` hooks. All
+// three delegate to the single detector at
+// `loader/directives/detectClientModule`, which recognises a module as
+// client when its filename matches `.client.[cm]?[jt]sx?$` OR its source
+// declares a top-of-file `"use client"` directive (AST-validated when a
+// parser is available, char-scanner otherwise). A path with "client" as a
+// substring of an identifier, comment, or directory name (e.g.
+// `src/lib/clientId.ts`) is NOT a client module.
 const IS_CLIENT_COMPONENT_CODE = (code: string, moduleId?: string) =>
   detectClientModule({ source: code, moduleId });
 

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -101,12 +101,7 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
 
       // Skip client components — Vite owns client-side HMR (Fast Refresh
       // when `@vitejs/plugin-react` is installed, plain reload otherwise).
-      // Worker invalidation is for the server tree. Routes through
-      // `detectClientModule` so the file watcher can't disagree with the
-      // build's transformer / worker / createModuleID on the same input.
-      // The previous inline detector only read 200 chars and the first line,
-      // missing a `"use client"` placed below a long JSDoc header or a
-      // `"use strict"` prologue — both handled by the helper's char-scanner.
+      // Worker invalidation is for the server tree.
       const isClientFile = isSourceFile && (() => {
         try {
           const source = readFileSync(file, "utf-8");

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import type { VitePluginFn } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.client.js";
 import { resolveOptions } from "../config/resolveOptions.js";
+import { detectClientModule } from "../loader/directives/detectClientModule.js";
 import type { ConfigEnv } from "vite";
 
 
@@ -98,13 +99,17 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       const isCssFile = isInModuleBase &&
         (file.endsWith('.css') || file.endsWith('.scss') || file.endsWith('.sass') || file.endsWith('.less'));
 
-      // Skip client components — let @vitejs/plugin-react handle them with Fast Refresh
+      // Skip client components — let @vitejs/plugin-react handle them with
+      // Fast Refresh. Routes through `detectClientModule` so the file watcher
+      // can't disagree with the build's transformer / worker / createModuleID
+      // on the same input. Note: the previous inline detector only read 200
+      // chars and the first line, which missed a `"use client"` placed below
+      // a long JSDoc header or a `"use strict"` prologue — both are now
+      // handled by the helper's char-scanner.
       const isClientFile = isSourceFile && (() => {
-        // Check filename pattern (.client.tsx, etc.) — matches isClientComponentByName
-        if (/\.client\.(js|ts|jsx|tsx)$/.test(file)) return true;
         try {
-          const head = readFileSync(file, 'utf-8').slice(0, 200);
-          return /^\s*["']use client["']/.test(head.split('\n')[0]);
+          const source = readFileSync(file, "utf-8");
+          return detectClientModule({ source, moduleId: file });
         } catch { return false; }
       })();
 

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -99,13 +99,14 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       const isCssFile = isInModuleBase &&
         (file.endsWith('.css') || file.endsWith('.scss') || file.endsWith('.sass') || file.endsWith('.less'));
 
-      // Skip client components — let @vitejs/plugin-react handle them with
-      // Fast Refresh. Routes through `detectClientModule` so the file watcher
-      // can't disagree with the build's transformer / worker / createModuleID
-      // on the same input. Note: the previous inline detector only read 200
-      // chars and the first line, which missed a `"use client"` placed below
-      // a long JSDoc header or a `"use strict"` prologue — both are now
-      // handled by the helper's char-scanner.
+      // Skip client components — Vite owns client-side HMR (Fast Refresh
+      // when `@vitejs/plugin-react` is installed, plain reload otherwise).
+      // Worker invalidation is for the server tree. Routes through
+      // `detectClientModule` so the file watcher can't disagree with the
+      // build's transformer / worker / createModuleID on the same input.
+      // The previous inline detector only read 200 chars and the first line,
+      // missing a `"use client"` placed below a long JSDoc header or a
+      // `"use strict"` prologue — both handled by the helper's char-scanner.
       const isClientFile = isSourceFile && (() => {
         try {
           const source = readFileSync(file, "utf-8");
@@ -158,8 +159,8 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
         // fallback for module-graph-untracked CSS is a full page reload, and
         // even tracked CSS modules in dev:ssr can fall back to reload because
         // vprs renders them server-side via the <Css cssFiles={...}/> pattern
-        // (the client never directly imports them, so @vitejs/plugin-react's
-        // CSS HMR isn't reachable). useRscHmr handles both shapes:
+        // (the client never directly imports them, so Vite's CSS HMR isn't
+        // reachable). useRscHmr handles both shapes:
         //  - inlined <style>: refetch brings new content
         //  - <link href=…>:   refreshCssLinks cache-busts the URL
         if (isCssFile) return [];

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -41,7 +41,8 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
       
       if (!isSourceFile) return;
       
-      // Client environment: let Vite/@vitejs/plugin-react handle it
+      // Client environment: Vite owns client-side HMR (Fast Refresh if
+      // `@vitejs/plugin-react` is installed; plain reload otherwise).
       if (envName === 'client') {
         // Routes through `detectClientModule` so this watcher can't disagree
         // with the build's transformer / worker / createModuleID on the same
@@ -56,7 +57,7 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
           } catch { return false; }
         })();
 
-        if (isClient) return; // Let Fast Refresh handle client components
+        if (isClient) return; // Vite's client-side HMR owns this update
 
         // CSS files that aren't imported via the client module graph (vprs's
         // <Css cssFiles={...}/> pattern collects them server-side) aren't

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -44,12 +44,6 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
       // Client environment: Vite owns client-side HMR (Fast Refresh if
       // `@vitejs/plugin-react` is installed; plain reload otherwise).
       if (envName === 'client') {
-        // Routes through `detectClientModule` so this watcher can't disagree
-        // with the build's transformer / worker / createModuleID on the same
-        // input. Note: the previous inline detector only read 200 chars and
-        // the first line, which missed a `"use client"` placed below a long
-        // JSDoc header or `"use strict"` prologue — both handled by the
-        // helper's char-scanner.
         const isClient = (file.endsWith('.tsx') || file.endsWith('.ts') || file.endsWith('.jsx') || file.endsWith('.js')) && (() => {
           try {
             const source = readFileSync(file, "utf-8");

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -1,6 +1,7 @@
 import type { StreamPluginOptions } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.server.js";
 import { resolveOptions } from "../config/resolveOptions.js";
+import { detectClientModule } from "../loader/directives/detectClientModule.js";
 import type { Plugin, ViteDevServer } from "vite";
 import { readFileSync } from "node:fs";
 
@@ -42,13 +43,16 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
       
       // Client environment: let Vite/@vitejs/plugin-react handle it
       if (envName === 'client') {
-        // Check if it's a client component — let Fast Refresh handle it
+        // Routes through `detectClientModule` so this watcher can't disagree
+        // with the build's transformer / worker / createModuleID on the same
+        // input. Note: the previous inline detector only read 200 chars and
+        // the first line, which missed a `"use client"` placed below a long
+        // JSDoc header or `"use strict"` prologue — both handled by the
+        // helper's char-scanner.
         const isClient = (file.endsWith('.tsx') || file.endsWith('.ts') || file.endsWith('.jsx') || file.endsWith('.js')) && (() => {
-          // Check filename pattern (.client.tsx, .client.ts, etc.) — matches isClientComponentByName
-          if (/\.client\.(js|ts|jsx|tsx)$/.test(file)) return true;
           try {
-            const head = readFileSync(file, 'utf-8').slice(0, 200);
-            return /^\s*["']use client["']/.test(head.split('\n')[0]);
+            const source = readFileSync(file, "utf-8");
+            return detectClientModule({ source, moduleId: file });
           } catch { return false; }
         })();
 

--- a/plugin/loader/directives/detectClientModule.ts
+++ b/plugin/loader/directives/detectClientModule.ts
@@ -1,0 +1,95 @@
+import { analyzeDirectives } from "./analyzeDirectives.js";
+import { sourceHasTopLevelClientDirective } from "./sourceHasTopLevelClientDirective.js";
+import type { Program } from "acorn";
+
+/**
+ * Filename convention for client modules: `.client.[jt]sx?`, also covering
+ * the `.mjs/.cjs/.mts/.cts` variants. This is the *strict* form — the legacy
+ * naive matcher `/(\.|\/)?client(\.|\/)?/` flagged any path containing the
+ * substring "client" (e.g. `src/lib/clientId.ts`), which mis-classified
+ * server modules as client. See the PR body for the behaviour-change note.
+ */
+const CLIENT_FILENAME_PATTERN = /\.client\.[cm]?[jt]sx?$/;
+
+export type ParseFn = (
+  source: string,
+  options?: { allowReturnOutsideFunction?: boolean; jsx?: boolean },
+) => Program;
+
+export type DetectClientModuleOpts = {
+  /** Module source text. If absent or empty, only the filename pattern applies. */
+  source?: string;
+  /** Module identifier / file path. If absent, only the source check applies. */
+  moduleId?: string;
+  /**
+   * Optional AST producer. When provided (the build's transformer plugin
+   * passes Rollup's `this.parse`), the helper parses with JSX/TS awareness
+   * and inspects directives via {@link analyzeDirectives}. When omitted
+   * (dev-server file watcher, the worker react-loader, the configurable
+   * `loader.*` defaults), the helper falls back to the parser-free
+   * char-scanner from {@link sourceHasTopLevelClientDirective}. Both paths
+   * agree on every well-authored case.
+   */
+  parseFn?: ParseFn;
+};
+
+/**
+ * The single, robust answer to "is this a client module?" for vprs.
+ *
+ * Recognises a module as client when EITHER:
+ *   1. its filename matches the `.client.[cm]?[jt]sx?$` convention, OR
+ *   2. its source declares a top-of-file `"use client"` directive — leading
+ *      whitespace, line/block comments, and a `"use strict"` prologue
+ *      tolerated above it (React's contract).
+ *
+ * Deliberately rejects the naive "code contains the word client" substring
+ * shape that the legacy `IS_CLIENT_COMPONENT_*` defaults used: a server
+ * module with a variable named `clientId` or a comment mentioning "client"
+ * stays a server module.
+ *
+ * This helper is the single source of truth for client-module detection.
+ * Every other call site in the plugin (transformer, worker react-loader,
+ * dev-server file watcher, build auto-discover, the configurable
+ * `loader.*` defaults in `config/defaults.tsx`) routes through it,
+ * eliminating the cross-layer divergence that produced PR #55
+ * (compound-filename hosting) and the directive-only hosting gap.
+ */
+export function detectClientModule({
+  source,
+  moduleId,
+  parseFn,
+}: DetectClientModuleOpts): boolean {
+  // 1. Filename convention. Deterministic, doesn't need source content.
+  if (moduleId && CLIENT_FILENAME_PATTERN.test(moduleId)) return true;
+
+  // 2. Directive in source. Cheap pre-filter; no occurrence of "use client" →
+  //    definitely not a client module, and we avoid both the parse and the
+  //    scanner.
+  if (!source) return false;
+  if (!source.includes("use client")) return false;
+
+  // 3. Prefer the AST path when a parser is available (build transformer).
+  if (parseFn) {
+    try {
+      const ast = parseFn(source, {
+        allowReturnOutsideFunction: true,
+        jsx: true,
+      });
+      const directiveInfo = analyzeDirectives(ast, source);
+      if (directiveInfo.fileLevel?.type !== "client") return false;
+      // analyzeDirectives still records a misplaced `"use client";` (after
+      // real code) as a file-level entry but flags it. React's contract
+      // requires top-of-file placement, so a flagged one is not real.
+      const misplaced = directiveInfo.warnings.some((w) =>
+        w.message.includes("must be at the top of the file"),
+      );
+      return !misplaced;
+    } catch {
+      // Parse failure → fall through to the parser-free scanner. A genuine
+      // `.client.*` was already caught in step 1.
+    }
+  }
+
+  // 4. Parser-free fallback. Same structural contract.
+  return sourceHasTopLevelClientDirective(source);
+}

--- a/plugin/loader/directives/detectClientModule.ts
+++ b/plugin/loader/directives/detectClientModule.ts
@@ -3,11 +3,11 @@ import { sourceHasTopLevelClientDirective } from "./sourceHasTopLevelClientDirec
 import type { Program } from "acorn";
 
 /**
- * Filename convention for client modules: `.client.[jt]sx?`, also covering
- * the `.mjs/.cjs/.mts/.cts` variants. This is the *strict* form — the legacy
- * naive matcher `/(\.|\/)?client(\.|\/)?/` flagged any path containing the
- * substring "client" (e.g. `src/lib/clientId.ts`), which mis-classified
- * server modules as client. See the PR body for the behaviour-change note.
+ * Filename convention for client modules: `.client.` followed by a JS-family
+ * extension (`.tsx/.ts/.jsx/.js/.mjs/.cjs/.mts/.cts`). Strict — a path that
+ * merely contains the substring "client" elsewhere (e.g. `src/lib/clientId.ts`,
+ * `src/client/foo.ts`) is not matched by this pattern; the directive check is
+ * the other way a module qualifies.
  */
 const CLIENT_FILENAME_PATTERN = /\.client\.[cm]?[jt]sx?$/;
 
@@ -34,7 +34,7 @@ export type DetectClientModuleOpts = {
 };
 
 /**
- * The single, robust answer to "is this a client module?" for vprs.
+ * The single answer to "is this a client module?" for vprs.
  *
  * Recognises a module as client when EITHER:
  *   1. its filename matches the `.client.[cm]?[jt]sx?$` convention, OR
@@ -42,17 +42,14 @@ export type DetectClientModuleOpts = {
  *      whitespace, line/block comments, and a `"use strict"` prologue
  *      tolerated above it (React's contract).
  *
- * Deliberately rejects the naive "code contains the word client" substring
- * shape that the legacy `IS_CLIENT_COMPONENT_*` defaults used: a server
- * module with a variable named `clientId` or a comment mentioning "client"
- * stays a server module.
+ * Substring matches against "client" in identifiers, comments, import paths,
+ * or directory names are deliberately rejected.
  *
- * This helper is the single source of truth for client-module detection.
- * Every other call site in the plugin (transformer, worker react-loader,
- * dev-server file watcher, build auto-discover, the configurable
- * `loader.*` defaults in `config/defaults.tsx`) routes through it,
- * eliminating the cross-layer divergence that produced PR #55
- * (compound-filename hosting) and the directive-only hosting gap.
+ * Every call site that needs a "is this client?" answer routes through this
+ * helper (transformer, worker react-loader, dev-server file watcher, build
+ * auto-discover, the configurable `loader.*` defaults in
+ * `config/defaults.tsx`), so the answer is the same for the same input at
+ * every layer.
  */
 export function detectClientModule({
   source,

--- a/plugin/loader/directives/hasFileLevelClientDirective.ts
+++ b/plugin/loader/directives/hasFileLevelClientDirective.ts
@@ -1,62 +1,21 @@
-import { parse } from "../parse.js";
-import { analyzeDirectives } from "./analyzeDirectives.js";
-import type { Program } from "acorn";
+import { detectClientModule, type ParseFn } from "./detectClientModule.js";
 
 /**
  * Robustly detect whether `source` declares a *file-level* `"use client"`
  * directive (top-of-file, before any real code — the React contract).
  *
- * Why this exists: the build's moduleID hosting used to key client-component
- * detection purely off the `.client.[jt]sx?` filename pattern. First-party
- * modules that declare `"use client"` via DIRECTIVE but lack the `.client.`
- * suffix got a raw, unhosted moduleID, so react-server-dom-esm's
- * `serializeClientReference` threw "Attempted to load a Client Module outside
- * the hosted root" during prerender.
- *
- * Detection MUST be robust. The naive `isClientComponentByCode`
- * (`code.match(/(\.|\/)?client(\.|\/)?/)`) substring-matches the word "client"
- * anywhere — variables, comments, import paths — and would mis-host server
- * modules as client refs, breaking the build. We instead parse with acorn and
- * reuse `analyzeDirectives`, whose `fileLevel.type === "client"` is the source
- * of truth for a top-of-file `"use client"` directive (it validates position
- * via the AST, the same way the transformer does).
- *
- * Performance: parsing is gated behind a cheap substring pre-check so server
- * files (the common case) never hit the parser.
+ * Thin compatibility wrapper around {@link detectClientModule}; existing
+ * call sites and tests continue to import this. New code should prefer
+ * `detectClientModule` directly, which also handles the filename pattern
+ * and the no-source case.
  *
  * @param source   Original module source content.
  * @param parseFn  Optional AST producer (e.g. Rollup's `this.parse`). Falls
- *                 back to the plugin's own acorn-based `parse` when omitted.
+ *                 back to the parser-free char-scanner when omitted.
  */
 export function hasFileLevelClientDirective(
   source: string | undefined,
-  parseFn?: (source: string) => Program
+  parseFn?: ParseFn,
 ): boolean {
-  if (!source) return false;
-  // Cheap gate: no "use client" text at all → definitely not a client module.
-  // (Substring match here is only a *pre-filter*; the AST check below is what
-  // actually decides, so false positives from this gate are harmless.)
-  if (!source.includes("use client")) return false;
-
-  try {
-    const ast = parseFn
-      ? parseFn(source)
-      : (parse(source).ast as unknown as Program);
-    const directiveInfo = analyzeDirectives(ast, source);
-    if (directiveInfo.fileLevel?.type !== "client") return false;
-    // Reject a MISPLACED directive: `analyzeDirectives` still records a
-    // file-level entry for a `"use client";` string statement that appears
-    // after real code, but flags it with a placement warning. React's
-    // contract requires the directive at the very top, so only a properly
-    // placed one counts as a real file-level client directive.
-    const misplaced = directiveInfo.warnings.some((w) =>
-      w.message.includes("must be at the top of the file")
-    );
-    return !misplaced;
-  } catch {
-    // If parsing fails for any reason, fall back to "not a client module".
-    // The filename-based check still applies upstream, so a genuine
-    // `.client.tsx` module is unaffected by a parse failure here.
-    return false;
-  }
+  return detectClientModule({ source, parseFn });
 }

--- a/plugin/loader/directives/index.ts
+++ b/plugin/loader/directives/index.ts
@@ -2,6 +2,7 @@ export * from "./addLocalExportedNames.js";
 export * from "./getExports.js";
 export * from "./analyzeDirectives.js";
 export * from "./analyzeModule.js";
+export * from "./detectClientModule.js";
 export * from "./hasFileLevelClientDirective.js";
 export * from "./sourceHasTopLevelClientDirective.js";
 export * from "./collectExports.js";

--- a/plugin/loader/react-loader.ts
+++ b/plugin/loader/react-loader.ts
@@ -158,7 +158,8 @@ export const load: LoadHook = async (url, context, nextLoad) => {
     // build's transformer, createModuleID, the dev-server file watcher, and
     // the configurable `loader.*` defaults — so the worker can't disagree
     // with any of them on the same input.
-    const hasFileLevelServerDirective = (target: string): boolean => {
+    const hasFileLevelServerDirective = (): boolean => {
+      const target = "use server";
       let i = 0;
       for (let k = 0; k < 10; k++) {
         while (i < source.length && /\s/.test(source[i]!)) i++;
@@ -175,7 +176,7 @@ export const load: LoadHook = async (url, context, nextLoad) => {
     };
 
     const isServer =
-      hasFileLevelServerDirective("use server") ||
+      hasFileLevelServerDirective() ||
       (typeof isServerFunction === "function"
         ? isServerFunction(source, url)
         : false);

--- a/plugin/loader/react-loader.ts
+++ b/plugin/loader/react-loader.ts
@@ -13,6 +13,7 @@ import type {
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { hydrateUserOptions } from "../helpers/hydrateUserOptions.js";
+import { detectClientModule } from "./directives/detectClientModule.js";
 import { DEFAULT_LOADER_CONFIG } from "../config/defaults.js";
 import type { LoadHook, ResolveHook } from "node:module";
 import type { RawSourceMap } from "source-map";
@@ -150,11 +151,14 @@ export const load: LoadHook = async (url, context, nextLoad) => {
       }
     }
 
-    // Check for file-level directives. Walk the prologue — consecutive string-
-    // literal directive statements at file top — so a benign `"use strict"`
-    // sitting above `"use client"` (which is what every bundler-compiled
-    // node_modules package ships) doesn't shadow the real directive.
-    const hasFileLevelDirective = (target: string): boolean => {
+    // Check for file-level directives. Server detection uses an inline
+    // prologue-walking char-scanner (server directives aren't covered by the
+    // unified client helper). Client detection routes through
+    // `detectClientModule` — the single source of truth shared with the
+    // build's transformer, createModuleID, the dev-server file watcher, and
+    // the configurable `loader.*` defaults — so the worker can't disagree
+    // with any of them on the same input.
+    const hasFileLevelServerDirective = (target: string): boolean => {
       let i = 0;
       for (let k = 0; k < 10; k++) {
         while (i < source.length && /\s/.test(source[i]!)) i++;
@@ -169,17 +173,15 @@ export const load: LoadHook = async (url, context, nextLoad) => {
       }
       return false;
     };
-    const hasFileLevelServerDirective = hasFileLevelDirective("use server");
-    const hasFileLevelClientDirective = hasFileLevelDirective("use client");
 
     const isServer =
-      hasFileLevelServerDirective ||
+      hasFileLevelServerDirective("use server") ||
       (typeof isServerFunction === "function"
         ? isServerFunction(source, url)
         : false);
 
     const isClient =
-      hasFileLevelClientDirective ||
+      detectClientModule({ source, moduleId: url }) ||
       (typeof isClientComponent === "function"
         ? isClientComponent(source, url)
         : false);

--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -14,7 +14,7 @@ import { resolveRegExp } from "../config/resolveRegExp.js";
 import { userProjectRoot } from "../root.js";
 import { createDefaultModuleID } from "../config/createModuleID.js";
 import { buildClientPackagesPattern } from "../clientPackages/index.js";
-import { analyzeDirectives } from "../loader/directives/analyzeDirectives.js";
+import { detectClientModule } from "../loader/directives/detectClientModule.js";
 
 export interface TransformerPluginOptions {
   name: string;
@@ -282,31 +282,16 @@ export const createTransformerPlugin = (
 
           // Robustly determine whether this module is a client reference by a
           // top-of-file `"use client"` DIRECTIVE (not by the `.client.`
-          // filename). We parse the (post-esbuild) `code` with Rollup's
-          // JSX-aware `this.parse` and reuse `analyzeDirectives` — its
-          // `fileLevel.type === "client"` is the source of truth. This is the
-          // ROBUST detector; we deliberately avoid the naive
-          // `isClientComponentByCode` substring matcher, which flags any module
-          // containing the word "client" and would mis-host server modules.
-          let isClientByDirective = false;
-          try {
-            if (code.includes("use client")) {
-              const ast = this.parse(code, {
-                allowReturnOutsideFunction: true,
-                jsx: true,
-              }) as Program;
-              const directiveInfo = analyzeDirectives(ast, code);
-              const misplaced = directiveInfo.warnings.some((w) =>
-                w.message.includes("must be at the top of the file")
-              );
-              isClientByDirective =
-                directiveInfo.fileLevel?.type === "client" && !misplaced;
-            }
-          } catch {
-            // Parse failure → fall back to filename/content detection inside
-            // the moduleID function. A genuine `.client.tsx` is unaffected.
-            isClientByDirective = false;
-          }
+          // filename). `detectClientModule` parses with Rollup's JSX-aware
+          // `this.parse` and reuses `analyzeDirectives` internally; if the
+          // parse fails it falls back to the parser-free char-scanner. We
+          // pass `source` only (no `moduleId`) so the filename pattern is
+          // skipped here — that path is handled downstream in
+          // `createModuleID` via the same helper.
+          const isClientByDirective = detectClientModule({
+            source: code,
+            parseFn: (src, opts) => this.parse(src, opts) as Program,
+          });
 
           // Use the original normalized path for moduleID function calls
           // This ensures registerClientReference calls use the correct paths.

--- a/test/unit/detectClientModule.test.ts
+++ b/test/unit/detectClientModule.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "acorn";
+import type { Program } from "acorn";
+import { detectClientModule } from "vite-plugin-react-server/directives";
+
+/**
+ * Unit suite for the unified client-module detector.
+ *
+ * It guards every recent class of detection bug:
+ *   - c1d: directive-only modules (no `.client.` suffix) recognised
+ *   - hsv: cross-layer divergence between transformer / createModuleID
+ *   - the predicted next bug: `"use strict"; "use client";` under any path
+ *   - the legacy substring-matcher trap: `clientId` identifier or `client`
+ *     in a comment must NOT trigger client classification
+ */
+
+const acornParse = (src: string): Program =>
+  parse(src, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    allowReturnOutsideFunction: true,
+  }) as unknown as Program;
+
+describe("detectClientModule (unified client-module detector)", () => {
+  describe("filename pattern (no source)", () => {
+    it.each([
+      "components/Counter.client.tsx",
+      "components/Counter.client.ts",
+      "components/Counter.client.jsx",
+      "components/Counter.client.js",
+      "components/Counter.client.mjs",
+      "components/Counter.client.cjs",
+      "components/Counter.client.mts",
+      "components/Counter.client.cts",
+    ])("recognises %s", (moduleId) => {
+      expect(detectClientModule({ moduleId })).toBe(true);
+    });
+
+    it.each([
+      "components/Counter.tsx",
+      "src/lib/clientId.ts", // substring "client" must NOT trigger
+      "components/clientCode.tsx",
+      "src/client/foo.ts", // directory named "client" must NOT trigger
+      "src/page/page.tsx",
+    ])("does not flag %s by filename alone", (moduleId) => {
+      expect(detectClientModule({ moduleId })).toBe(false);
+    });
+  });
+
+  describe("source-only directive (no parser, scanner path)", () => {
+    it("detects a top-of-file `\"use client\"`", () => {
+      expect(
+        detectClientModule({
+          source: `"use client";\nexport const x = 1;`,
+        }),
+      ).toBe(true);
+    });
+
+    it("tolerates a `\"use strict\"` prologue above `\"use client\"`", () => {
+      expect(
+        detectClientModule({
+          source: `"use strict";\n"use client";\nexport const x = 1;`,
+        }),
+      ).toBe(true);
+    });
+
+    it("tolerates a leading block-comment header (JSDoc) above `\"use client\"`", () => {
+      expect(
+        detectClientModule({
+          source: `/**\n * @license MIT\n */\n"use client";\nexport const x = 1;`,
+        }),
+      ).toBe(true);
+    });
+
+    it("tolerates a leading line comment above `\"use client\"`", () => {
+      expect(
+        detectClientModule({
+          source: `// auto-generated\n"use client";\nexport const x = 1;`,
+        }),
+      ).toBe(true);
+    });
+
+    it("rejects a `\"use client\"` placed after a real statement", () => {
+      expect(
+        detectClientModule({
+          source: `const x = 1;\n"use client";\nexport { x };`,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects a comment that merely contains the word `use client`", () => {
+      expect(
+        detectClientModule({
+          source: `// not a use client directive\nexport const x = 1;`,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects an identifier named `clientId` with no real directive", () => {
+      expect(
+        detectClientModule({
+          source: `const clientId = "x";\nexport { clientId };`,
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects an import path mentioning `client`", () => {
+      expect(
+        detectClientModule({
+          source: `import { foo } from "./client/foo";\nexport const y = foo;`,
+        }),
+      ).toBe(false);
+    });
+
+    it("does not flag a server module under default settings", () => {
+      expect(
+        detectClientModule({
+          source: `import React from "react";\nexport function Page(){ return null; }`,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("source + parser (AST path, build-time transformer)", () => {
+    it("detects `\"use client\"` via the AST path", () => {
+      expect(
+        detectClientModule({
+          source: `"use client";\nexport const x = 1;`,
+          parseFn: acornParse,
+        }),
+      ).toBe(true);
+    });
+
+    it("tolerates a `\"use strict\"` prologue via the AST path", () => {
+      expect(
+        detectClientModule({
+          source: `"use strict";\n"use client";\nexport const x = 1;`,
+          parseFn: acornParse,
+        }),
+      ).toBe(true);
+    });
+
+    it("rejects a misplaced `\"use client\"` after a statement via the AST path", () => {
+      expect(
+        detectClientModule({
+          source: `const x = 1;\n"use client";\nexport { x };`,
+          parseFn: acornParse,
+        }),
+      ).toBe(false);
+    });
+
+    it("falls back to the scanner when the parser throws", () => {
+      // Throw on every call → triggers fallback to char-scanner.
+      const throwingParse = (): Program => {
+        throw new Error("parse failure");
+      };
+      expect(
+        detectClientModule({
+          source: `"use client";\nexport const x = 1;`,
+          parseFn: throwingParse,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("filename + source combined", () => {
+    it("returns true when filename matches even with non-directive source", () => {
+      expect(
+        detectClientModule({
+          moduleId: "components/Counter.client.tsx",
+          source: `export const x = 1;`,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when source has directive even without `.client.` filename", () => {
+      expect(
+        detectClientModule({
+          moduleId: "components/Counter.tsx",
+          source: `"use client";\nexport const x = 1;`,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when neither filename nor source qualifies", () => {
+      expect(
+        detectClientModule({
+          moduleId: "components/Counter.tsx",
+          source: `export const x = 1;`,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns false for empty source and no moduleId", () => {
+      expect(detectClientModule({})).toBe(false);
+    });
+
+    it("returns false for empty source string", () => {
+      expect(detectClientModule({ source: "" })).toBe(false);
+    });
+
+    it("does not invoke parser when source lacks `use client` substring", () => {
+      // If parseFn is called and throws, we'd see the error. Cheap pre-filter
+      // gates it.
+      const exploding = (): Program => {
+        throw new Error("parser should not have been called");
+      };
+      expect(
+        detectClientModule({
+          source: `export const x = 1;`,
+          parseFn: exploding,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/test/unit/detectClientModule.test.ts
+++ b/test/unit/detectClientModule.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { parse } from "acorn";
 import type { Program } from "acorn";
 import { detectClientModule } from "vite-plugin-react-server/directives";
+import { DEFAULT_LOADER_CONFIG } from "vite-plugin-react-server/config";
 
 /**
  * Unit suite for the unified client-module detector.
@@ -214,5 +215,107 @@ describe("detectClientModule (unified client-module detector)", () => {
         }),
       ).toBe(false);
     });
+  });
+});
+
+/**
+ * Coverage for the public `DEFAULT_LOADER_CONFIG.isClientComponent*` surface
+ * — the user-overridable hooks in `loader.*`. The three defaults previously
+ * used the naive substring matcher `/(\.|\/)?client(\.|\/)?/`; they now
+ * delegate to `detectClientModule` so out-of-the-box behaviour is strict.
+ * These tests also guard the legacy call signatures so existing user
+ * overrides continue to type-check + run.
+ */
+describe("DEFAULT_LOADER_CONFIG public API (back-compat surface)", () => {
+  it("isClientComponentCode now rejects the substring traps the naive default fell into", () => {
+    // `clientId` identifier — substring "client" in source. Was true under
+    // the naive default (the regex matched the identifier text); now false.
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentCode(
+        `const clientId = "x"; export { clientId };`,
+        "src/lib/utils.ts",
+      ),
+    ).toBe(false);
+    // Filename `src/lib/clientId.ts` — substring "client" in path. Was true
+    // under the naive default; now false.
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentCode(
+        `export const x = 1;`,
+        "src/lib/clientId.ts",
+      ),
+    ).toBe(false);
+    // Real `.client.tsx` filename — still true.
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentCode(
+        `export const x = 1;`,
+        "src/components/Counter.client.tsx",
+      ),
+    ).toBe(true);
+    // Real top-of-file `"use client"` directive — still true.
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentCode(
+        `"use client";\nexport const x = 1;`,
+        "src/components/Counter.tsx",
+      ),
+    ).toBe(true);
+  });
+
+  it("isClientComponentByName accepts the legacy 2-arg signature", () => {
+    // The `_transformedModuleId` second arg is ignored under the new impl,
+    // but the call shape must continue to type-check and run for back-compat
+    // with the configurable loader hook surface in `plugin/types.ts`. If the
+    // signature ever drops to a single arg, this test fails to compile.
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentByName(
+        "src/components/Counter.client.tsx",
+        "dist/components/Counter.client.js",
+      ),
+    ).toBe(true);
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentByName(
+        "src/lib/clientId.ts",
+        "dist/lib/clientId.js",
+      ),
+    ).toBe(false);
+  });
+
+  it("isClientComponentByCode applies the source-only branch", () => {
+    // No moduleId; only source content drives the decision.
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentByCode(
+        `"use client";\nexport const x = 1;`,
+      ),
+    ).toBe(true);
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentByCode(
+        `const clientId = "x"; export { clientId };`,
+      ),
+    ).toBe(false);
+  });
+
+  it("a user override on isClientComponentCode wins over the strict default", () => {
+    // Mirrors the resolution pattern used by react-loader:
+    //   userOptions.loader?.isClientComponentCode ?? DEFAULT_LOADER_CONFIG.isClientComponentCode
+    // If the strict default ever ends up hardcoded in front of a user override
+    // (a shape this PR was careful NOT to introduce), this test catches it.
+    const userOverride = (_code: string, _moduleId?: string) => true;
+    const resolved =
+      userOverride ?? DEFAULT_LOADER_CONFIG.isClientComponentCode;
+    // A plain server module the strict default rejects.
+    expect(
+      resolved(
+        `import React from "react"; export function Page() { return null; }`,
+        "src/page/page.tsx",
+      ),
+    ).toBe(true);
+    // Confirm the default we *would* fall back to also still works as
+    // documented — guards against a regression where the override layer
+    // works but the default is broken.
+    expect(
+      DEFAULT_LOADER_CONFIG.isClientComponentCode(
+        `import React from "react"; export function Page() { return null; }`,
+        "src/page/page.tsx",
+      ),
+    ).toBe(false);
   });
 });

--- a/test/unit/detectClientModule.test.ts
+++ b/test/unit/detectClientModule.test.ts
@@ -5,14 +5,17 @@ import { detectClientModule } from "vite-plugin-react-server/directives";
 import { DEFAULT_LOADER_CONFIG } from "vite-plugin-react-server/config";
 
 /**
- * Unit suite for the unified client-module detector.
+ * Unit suite for the client-module detector.
  *
- * It guards every recent class of detection bug:
- *   - c1d: directive-only modules (no `.client.` suffix) recognised
- *   - hsv: cross-layer divergence between transformer / createModuleID
- *   - the predicted next bug: `"use strict"; "use client";` under any path
- *   - the legacy substring-matcher trap: `clientId` identifier or `client`
- *     in a comment must NOT trigger client classification
+ * Pins the four classes of "is this client?" answers that have to stay
+ * stable regardless of which call site asks:
+ *   - directive-only modules without the `.client.` filename suffix are
+ *     recognised,
+ *   - a `"use strict"` or comment prologue above `"use client"` is
+ *     tolerated,
+ *   - substring matches against "client" (identifiers, comments, import
+ *     paths, directory names) do NOT classify a module as client,
+ *   - the AST path and the parser-free scanner path agree on every input.
  */
 
 const acornParse = (src: string): Program =>
@@ -219,39 +222,36 @@ describe("detectClientModule (unified client-module detector)", () => {
 });
 
 /**
- * Coverage for the public `DEFAULT_LOADER_CONFIG.isClientComponent*` surface
- * — the user-overridable hooks in `loader.*`. The three defaults previously
- * used the naive substring matcher `/(\.|\/)?client(\.|\/)?/`; they now
- * delegate to `detectClientModule` so out-of-the-box behaviour is strict.
- * These tests also guard the legacy call signatures so existing user
- * overrides continue to type-check + run.
+ * Pins the public `DEFAULT_LOADER_CONFIG.isClientComponent*` surface — the
+ * user-overridable hooks on `loader.*`. The three defaults delegate to
+ * `detectClientModule`, so out-of-the-box behaviour is the strict form.
+ * These tests also pin the call signatures so user-supplied overrides keep
+ * type-checking against the same shape.
  */
-describe("DEFAULT_LOADER_CONFIG public API (back-compat surface)", () => {
-  it("isClientComponentCode now rejects the substring traps the naive default fell into", () => {
-    // `clientId` identifier — substring "client" in source. Was true under
-    // the naive default (the regex matched the identifier text); now false.
+describe("DEFAULT_LOADER_CONFIG.isClientComponent* public surface", () => {
+  it("isClientComponentCode rejects substring traps in identifiers, paths, and source", () => {
+    // `clientId` identifier — substring "client" in source.
     expect(
       DEFAULT_LOADER_CONFIG.isClientComponentCode(
         `const clientId = "x"; export { clientId };`,
         "src/lib/utils.ts",
       ),
     ).toBe(false);
-    // Filename `src/lib/clientId.ts` — substring "client" in path. Was true
-    // under the naive default; now false.
+    // Filename `src/lib/clientId.ts` — substring "client" in the path.
     expect(
       DEFAULT_LOADER_CONFIG.isClientComponentCode(
         `export const x = 1;`,
         "src/lib/clientId.ts",
       ),
     ).toBe(false);
-    // Real `.client.tsx` filename — still true.
+    // Real `.client.tsx` filename — recognised.
     expect(
       DEFAULT_LOADER_CONFIG.isClientComponentCode(
         `export const x = 1;`,
         "src/components/Counter.client.tsx",
       ),
     ).toBe(true);
-    // Real top-of-file `"use client"` directive — still true.
+    // Real top-of-file `"use client"` directive — recognised.
     expect(
       DEFAULT_LOADER_CONFIG.isClientComponentCode(
         `"use client";\nexport const x = 1;`,
@@ -260,11 +260,11 @@ describe("DEFAULT_LOADER_CONFIG public API (back-compat surface)", () => {
     ).toBe(true);
   });
 
-  it("isClientComponentByName accepts the legacy 2-arg signature", () => {
-    // The `_transformedModuleId` second arg is ignored under the new impl,
-    // but the call shape must continue to type-check and run for back-compat
-    // with the configurable loader hook surface in `plugin/types.ts`. If the
-    // signature ever drops to a single arg, this test fails to compile.
+  it("isClientComponentByName accepts the 2-arg signature", () => {
+    // The `_transformedModuleId` second arg is accepted but ignored. The
+    // call shape is part of the configurable loader hook surface in
+    // `plugin/types.ts`; if it ever drops to a single arg, this test fails
+    // to compile.
     expect(
       DEFAULT_LOADER_CONFIG.isClientComponentByName(
         "src/components/Counter.client.tsx",
@@ -293,24 +293,23 @@ describe("DEFAULT_LOADER_CONFIG public API (back-compat surface)", () => {
     ).toBe(false);
   });
 
-  it("a user override on isClientComponentCode wins over the strict default", () => {
-    // Mirrors the resolution pattern used by react-loader:
+  it("a user override on isClientComponentCode wins over the default", () => {
+    // Mirrors react-loader's resolution pattern:
     //   userOptions.loader?.isClientComponentCode ?? DEFAULT_LOADER_CONFIG.isClientComponentCode
-    // If the strict default ever ends up hardcoded in front of a user override
-    // (a shape this PR was careful NOT to introduce), this test catches it.
+    // If the default ever ends up consulted ahead of a user override, this
+    // test catches it.
     const userOverride = (_code: string, _moduleId?: string) => true;
     const resolved =
       userOverride ?? DEFAULT_LOADER_CONFIG.isClientComponentCode;
-    // A plain server module the strict default rejects.
+    // A plain server module that the default rejects, classified as client
+    // by the override.
     expect(
       resolved(
         `import React from "react"; export function Page() { return null; }`,
         "src/page/page.tsx",
       ),
     ).toBe(true);
-    // Confirm the default we *would* fall back to also still works as
-    // documented — guards against a regression where the override layer
-    // works but the default is broken.
+    // The default still behaves as documented when no override is supplied.
     expect(
       DEFAULT_LOADER_CONFIG.isClientComponentCode(
         `import React from "react"; export function Page() { return null; }`,


### PR DESCRIPTION
## Summary

Collapses **eleven** call sites that each answered "is this a client module?" with their own implementation into a single helper, `detectClientModule`. PR #55 (directive-only hosting + the compound-filename fix) and the static-build hosted-root regression both came from those answers diverging on the same input — the structural shape was "N decision sites, each at a different layer, only one of them right." This PR makes that shape unreachable for client-module detection.

## The detectors on main, before this PR

| # | File | Shape |
|---|------|-------|
| 1 | `plugin/config/createModuleID.ts` | inline `\.client\.[cm]?[jt]sx?$` regex + filename + directive helper |
| 2 | `plugin/transformer/createTransformerPlugin.ts` | inline `this.parse` + `analyzeDirectives` |
| 3 | same file, later | `loader.isClientComponentByName(id)` (defaults to naive substring) |
| 4 | `plugin/loader/directives/hasFileLevelClientDirective.ts` | AST-based, with optional `parseFn` |
| 5 | `plugin/loader/directives/sourceHasTopLevelClientDirective.ts` | parser-free char-scanner |
| 6 | `plugin/loader/react-loader.ts:157-171` | inline `hasFileLevelDirective` char-scanner inside the worker |
| 7 | `plugin/dev-server/plugin.client.ts:102-109` | inline `readFileSync().slice(0,200)` + first-line regex |
| 8 | `plugin/dev-server/plugin.server.ts:46-53` | inline `readFileSync().slice(0,200)` + first-line regex |
| 9 | `plugin/config/defaults.tsx:25-28` | `IS_CLIENT_COMPONENT_CODE` — naive `/(\.|\/)?client(\.|\/)?/` |
| 10 | `plugin/config/defaults.tsx:31-32` | `IS_CLIENT_COMPONENT_BY_CODE` — naive |
| 11 | `plugin/config/defaults.tsx:34-35` | `IS_CLIENT_COMPONENT_BY_NAME` — naive |

## The helper

`detectClientModule({ source?, moduleId?, parseFn? }): boolean` in `plugin/loader/directives/detectClientModule.ts`.

- **Filename**: strict `\.client\.[cm]?[jt]sx?$` (covers `.tsx`, `.ts`, `.jsx`, `.js`, `.mjs`, `.cjs`, `.mts`, `.cts`).
- **Directive (AST path)**: when `parseFn` is provided (the build's transformer passes Rollup's `this.parse`), parses with JSX/TS awareness and inspects directives via `analyzeDirectives`. Rejects misplaced directives.
- **Directive (scanner path)**: parser-free char-scanner from `sourceHasTopLevelClientDirective` — tolerates whitespace, line and block comments, and a `"use strict"` prologue above `"use client"`.
- **Cheap pre-filter**: skips the parser and scanner when `source` doesn't even contain the substring `"use client"`.

All eleven call sites now route through this helper. `hasFileLevelClientDirective` becomes a thin wrapper for back-compat.

## Behaviour change

The three naive defaults in `config/defaults.tsx` used `/(\.|\/)?client(\.|\/)?/` on both source and moduleId, which flagged:

- `src/lib/clientId.ts` (substring in filename)
- `src/client/foo.ts` (directory named `client`)
- any comment mentioning "client"
- any identifier containing "client" (`const clientId = …`)
- any import path containing "client"

…as client modules. The new defaults require the `.client.[cm]?[jt]sx?$` filename **or** a top-of-file `"use client"` directive. **Users relying on the loose matcher can keep doing so by passing their own `loader.isClientComponent*` overrides** — the user-facing config shape is unchanged.

The dev-server file watchers previously read only 200 chars and the first line; the helper's char-scanner handles a `"use client"` placed below a long JSDoc header or a `"use strict"` prologue — a UX-only fix (misclassification triggered worker invalidation instead of Fast Refresh, hard to attribute).

### Subtle behaviour change in `hasFileLevelClientDirective(source)` without `parseFn`

The back-compat wrapper `hasFileLevelClientDirective(source)` — called without a `parseFn` — used to acorn-parse the source internally. Acorn cannot parse raw TSX (JSX + TS), so on TSX sources the parse threw and the helper returned `false`. The new thin wrapper delegates to `detectClientModule`, which falls back to the parser-free char-scanner when no `parseFn` is provided, and the char-scanner *does* detect directives in raw TSX.

So a caller doing `hasFileLevelClientDirective(tsxSourceWithUseClient)` (no `parseFn`) may now get `true` where it previously got `false`. This is a correctness improvement — the old back-compat path was effectively broken for TSX — but it is a behaviour delta external callers would observe.

## Tests

- New `test/unit/detectClientModule.test.ts` (36 tests). Covers: every filename extension variant, every prologue/comment tolerance case, the substring-in-identifier / substring-in-comment / substring-in-import-path traps, AST vs scanner equivalence, the parser-failure → scanner-fallback path, plus the `DEFAULT_LOADER_CONFIG` public API back-compat surface (substring-trap rejection, legacy 2-arg signature pin on `isClientComponentByName`, source-only branch on `isClientComponentByCode`, user-override-wins-over-default semantics).
- Existing c1d + bd-80r regression tests still pass.
- `npm run test:unit` → **342/342** (was 306).
- `npm run build` clean.

## Scope notes

- Server-directive detection in the worker still uses an inline prologue-walking helper (`use server` doesn't share an obvious helper boundary with the client side, and it wasn't in scope). Worth a follow-up bead if you want symmetry. After review, the helper's signature was tightened — it no longer takes a `target: string` parameter, since it's only ever called with `"use server"`.
- `analyzeDirectives` import remains on its other call sites — only the transformer's inline directive-detection block routes through `detectClientModule` now.
