### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
## Summary

Bumps the package version `1.10.0` → `1.11.0` so the five merges that landed since `1.10.0` can be published.

### What's in 1.11.0

- **fix(storybook):** `storybook build` no longer breaks for vprs consumers. The preset's `virtual:react-server/hmr` handling switched from `rollupOptions.external` (which left a dangling browser-fetched URL in the static bundle) to a `resolveId`+`load` stub. `storybook dev` was unaffected; the bug only manifested under `storybook build` / Chromatic / hosted Storybook. PR #57.
- **refactor: unified client-module detection.** The eleven places across the plugin that each answered "is this a client module?" with their own implementation now route through a single `detectClientModule` helper in `plugin/loader/directives/`. **Default behaviour change:** the three `loader.isClientComponent*` defaults used to apply the loose substring matcher `/(\.|\/)?client(\.|\/)?/` to source and moduleId; they now apply the strict form (`.client.[cm]?[jt]sx?$` filename OR a top-of-file `"use client"` directive). The user-overridable signatures on `loader.*` are unchanged — restore the loose behaviour with a one-line override if you were relying on it. PR #60.
- **refactor(config):** the duplicated `createRollupLikeHash` (defined identically in two files) is extracted to a single shared module. Internal cleanup, no API change. PR #58.
- **docs:** new `docs/internals/module-resolution-escape-hatches.md` covering the seven different ways vprs reaches for `external` / `noExternal` / `optimizeDeps` / virtual stubs / vendor aliases, with the worked example of why externalising a `virtual:*` URL produced PR #57's bug. PR #59.
- **fix(test-harness):** addresses the cascade-failure flake pattern in the shared-build test harness. PR #61.

### Semver note

Treating this as a minor (`1.11.0`) rather than a major. The headline behaviour change in PR #60 — the default tightening on `loader.isClientComponent*` — leaves the public hook signatures unchanged; consumers relying on the loose substring default were depending on accidental behaviour, not documented contract. In practice every consumer uses the canonical `.client.tsx` filename or the `"use client"` directive, both of which the strict default recognises. A conservative semver read could justify `2.0.0`; we're going pragmatic minor.

## Test plan

- [x] `npm version minor --no-git-tag-version` → `1.11.0` (package.json + package-lock.json)
- [ ] Merge, then `npm publish` from main releases `1.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)