### PR TITLE
fix(test): make build-abort-handling self-sufficient

### DIFF
--- a/test/examples/build-abort-handling.test.ts
+++ b/test/examples/build-abort-handling.test.ts
@@ -25,10 +25,7 @@ describe("Build Abort Handling (Cross-Environment)", () => {
       
       await expect(
         getSharedBuild('build-abort-test-project', `build-abort-${testEvent}`, {
-          setupProject: async (dir: string) => {
-            // Use the already set up testDir
-            return;
-          },
+          setupProject: async (dir: string) => { await setupTestProject(dir); },
           build: {
             pages: ["/"],
           },
@@ -48,10 +45,7 @@ describe("Build Abort Handling (Cross-Environment)", () => {
     
     await expect(
       getSharedBuild('build-abort-test-project', 'build-abort-start', {
-        setupProject: async (dir: string) => {
-          // Use the already set up testDir
-          return;
-        },
+        setupProject: async (dir: string) => { await setupTestProject(dir); },
         build: {
           pages: ["/"],
         },
@@ -72,10 +66,7 @@ describe("Build Abort Handling (Cross-Environment)", () => {
       
       await expect(
         getSharedBuild('build-abort-test-project', `build-abort-file-${testEvent}`, {
-          setupProject: async (dir: string) => {
-            // Use the already set up testDir
-            return;
-          },
+          setupProject: async (dir: string) => { await setupTestProject(dir); },
           build: {
             pages: ["/"],
           },
@@ -99,10 +90,7 @@ describe("Build Abort Handling (Cross-Environment)", () => {
     // This should work for both client and server workflows
     await expect(
       getSharedBuild('build-abort-test-project', 'build-abort-consistency', {
-        setupProject: async (dir: string) => {
-          // Use the already set up testDir
-          return;
-        },
+        setupProject: async (dir: string) => { await setupTestProject(dir); },
         build: {
           pages: ["/"],
         },
@@ -122,10 +110,7 @@ describe("Build Abort Handling (Cross-Environment)", () => {
     
     await expect(
       getSharedBuild('build-abort-test-project', 'build-abort-panic', {
-        setupProject: async (dir: string) => {
-          // Use the already set up testDir
-          return;
-        },
+        setupProject: async (dir: string) => { await setupTestProject(dir); },
         build: {
           pages: ["/"],
         },


### PR DESCRIPTION
## Summary

`main` is currently broken (post-merge CI for PR #61 went red) because `test/examples/build-abort-handling.test.ts` was relying on fixture state smuggled in via an outer `beforeAll`, which PR #61's wipe-on-cache-miss legitimately removed. This PR makes the five callsites self-sufficient.

## What happened

Each of the five `getSharedBuild('build-abort-test-project', …)` calls in this file passed `setupProject: async (dir) => { return; }` — a deliberate no-op. The pattern relied on `getSharedBuild`'s prior "dir exists → skip setup" branch silently reusing the directory the `beforeAll` had populated.

PR #61 dropped that short-circuit (it was the root cause of the cascade-failure flake) and now wipes + re-runs setup on cache miss. The empty `setupProject` therefore runs against a freshly-wiped directory, leaving no source files, and the build fails with:

> `Could not resolve entry module "index.html".`

That's an actual test bug PR #61 *exposed*, not a regression PR #61 introduced. But it's blocking `main`, so it needs to be fixed-forward before #62 can publish.

## Fix

Replace each empty `setupProject` with an inline lambda:

```ts
setupProject: async (dir: string) => { await setupTestProject(dir); }
```

The lambda wrapper (not the bare `setupTestProject` reference) is deliberate. Passing `setupTestProject` directly would flip `getSharedBuild`'s `isDefaultSetup` check to `true` and move the `testDir` from `fixtures/shared/build-abort-test-project` to the shared `fixtures/shared/shared` directory, crossing it with every other default-setup test. The lambda keeps `isDefaultSetup = false` so the dedicated `build-abort-test-project` dir is preserved and each callsite runs a real fresh setup.

The outer `beforeAll`'s `mkdir + setupTestProject` is now redundant (every `getSharedBuild` call does both), but harmless. Left untouched to keep this PR's diff minimal.

## Test plan

- [x] `test/examples/build-abort-handling.test.ts` — 5/5 pass locally
- [x] Full unit suite still green
- [ ] CI verifies main is unblocked once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)