### PR TITLE
docs: scrub private beads (bd-*) references from public docs

### DIFF
--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-The plugin vendors a build of `react-server-dom-esm` whose internals (taint registries on `ReactSharedInternalsServer`, etc.) are tied to React's experimental release channel. Stable React 19.x doesn't expose the same internals — see bd-lr4.
+The plugin vendors a build of `react-server-dom-esm` whose internals (taint registries on `ReactSharedInternalsServer`, etc.) are tied to React's experimental release channel. Stable React 19.x doesn't expose the same internals — see PR #32.
 
 | React Version | Support | Notes |
 |---------------|---------|-------|
@@ -22,7 +22,7 @@ npm install react@0.0.0-experimental-f93b9fd4-20251217 react-dom@0.0.0-experimen
 
 **Peer dependency**: `react: ">=0.0.0-experimental-0 <1.0.0"`. The upper bound rejects stable React (19.x, 20.x) so npm warns instead of resolving silently to a broken pairing. Any 0.0.0 prerelease (experimental, canary, next) satisfies the lower bound.
 
-> Earlier 1.4.x docs claimed "React 19+ stable: Full Support." That was incorrect — local development with `file:` link masked the mismatch by hoisting the plugin's own experimental React into the consumer. npm-installed consumers crashed in the static build path. See bd-lr4.
+> Earlier 1.4.x docs claimed "React 19+ stable: Full Support." That was incorrect — local development with `file:` link masked the mismatch by hoisting the plugin's own experimental React into the consumer. npm-installed consumers crashed in the static build path. See PR #32.
 
 ## Vendored ESM Transport
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,7 +10,7 @@ Step-by-step guide for publishing a new version of `vite-plugin-react-server` an
 
 ## 1. Verify everything passes
 
-The unit/integration suite alone is not sufficient — the plugin can pass its own tests while breaking downstream consumers via cross-condition module leaks (see `bd-6pi` for a 2026-04 example). **You must also verify against the linked demo repos.**
+The unit/integration suite alone is not sufficient — the plugin can pass its own tests while breaking downstream consumers via cross-condition module leaks (PR #30 is one historical example). **You must also verify against the linked demo repos.**
 
 ```bash
 cd ~/code/vite-plugin-react-server
@@ -60,9 +60,9 @@ npx playwright test test/e2e/hmr.spec.ts
 # - todo toggle persists
 ```
 
-**If any of 1a–1d fails, do not publish.** File a `bd` issue and bisect to the introducing commit. A regression that is already on `main` but not yet released is still a release-blocker — it ships to consumers the moment you `npm publish`.
+**If any of 1a–1d fails, do not publish.** File an issue and bisect to the introducing commit. A regression that is already on `main` but not yet released is still a release-blocker — it ships to consumers the moment you `npm publish`.
 
-> ⚠️ **`file:` link masks React version mismatches.** Linked demos resolve `react`/`react-dom` against the plugin's own `node_modules`, which means whatever experimental React is installed inside `vite-plugin-react-server/` gets hoisted into the consumer for free. A demo that pins stable React 19 in its own `package.json` will *still* run against the plugin's experimental React under `file:` link, and never exercise the actual stable-React path. To verify a release works for npm consumers — not just `file:`-link consumers — also `npm pack` the tarball and install it into a clean fixture before publishing. Skipping this is what let v1.4.6 ship broken on stable React (bd-lr4).
+> ⚠️ **`file:` link masks React version mismatches.** Linked demos resolve `react`/`react-dom` against the plugin's own `node_modules`, which means whatever experimental React is installed inside `vite-plugin-react-server/` gets hoisted into the consumer for free. A demo that pins stable React 19 in its own `package.json` will *still* run against the plugin's experimental React under `file:` link, and never exercise the actual stable-React path. To verify a release works for npm consumers — not just `file:`-link consumers — also `npm pack` the tarball and install it into a clean fixture before publishing. Skipping this is what let v1.4.6 ship broken on stable React (fixed in PR #32).
 
 ## 2. Bump the version
 


### PR DESCRIPTION
## Summary

Public-facing docs referenced private mission-control beads (`bd-lr4`, `bd-6pi`) plus one generic mention of "file a `bd` issue". Those ids aren't resolvable to anyone reading the docs from outside the maintainer's tracker, so they read as broken references that hint at a private system. Replace each with the public GitHub PR number that actually fixed the underlying bug, or with neutral wording:

- `bd-lr4` → **PR #32** (`fix: pin peerDeps to experimental React channel`)
- `bd-6pi` → **PR #30** (`fix: cross-condition cleanup + hello-world example + RSC stream error surface`)
- "File a `bd` issue and bisect" → "File an issue and bisect"

## Files

- `docs/react-type-compatibility.md` — two `bd-lr4` mentions in the supported-versions narrative.
- `docs/releasing.md` — one `bd-6pi`, one `bd-lr4`, and the generic "file a `bd` issue" phrasing.

No code change, no new docs.

## Out of scope

The same `bd-*` ids also appear in some older commit messages on `main` (e.g. `fix(bd-lr4):` for PR #32, `fix(bd-6pi, bd-qvz):` for PR #30). Rewriting git history to scrub those is intentionally **not** done here — too invasive for a docs cleanup, and the SHAs are referenced from elsewhere. Future commits should use public PR numbers in subject lines, not bead ids.