### PR TITLE
docs: index storybook.md in the User Guide section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,21 +7,22 @@
 3. [Configuration](./configuration.md) — all plugin options
 4. [CSS Handling](./css-handling.md) — inline/linked CSS, CSS modules
 5. [Server Actions](./server-actions.md) — `"use server"` directives, form actions
-6. [Examples](./examples.md) — static site, dynamic server, custom routing
-7. [Troubleshooting](./troubleshooting.md) — common errors and fixes
-8. [API Reference](./api-reference.md) — exported functions, types, components
+6. [Storybook](./storybook.md) — the `vite-plugin-react-server/storybook` preset for rendering your RSC components in stories
+7. [Examples](./examples.md) — static site, dynamic server, custom routing
+8. [Troubleshooting](./troubleshooting.md) — common errors and fixes
+9. [API Reference](./api-reference.md) — exported functions, types, components
 
 ## Internals (contributors)
 
-9. [Architecture](./internals/architecture.md) — condition system, module structure, plugin composition
-10. [Transformer](./internals/transformer.md) — directive handling and code transforms
-11. [Workers](./internals/workers.md) — RSC and HTML worker threads
-12. [Module-resolution escape hatches](./internals/module-resolution-escape-hatches.md) — when to reach for `external`, `noExternal`, `optimizeDeps`, virtual stubs, vendor aliases (and how to pick the right one)
+10. [Architecture](./internals/architecture.md) — condition system, module structure, plugin composition
+11. [Transformer](./internals/transformer.md) — directive handling and code transforms
+12. [Workers](./internals/workers.md) — RSC and HTML worker threads
+13. [Module-resolution escape hatches](./internals/module-resolution-escape-hatches.md) — when to reach for `external`, `noExternal`, `optimizeDeps`, virtual stubs, vendor aliases (and how to pick the right one)
 
 ## Maintenance
 
-13. [Releasing](./releasing.md) — version bumps, publishing, demo updates
-14. [React Compatibility](./react-type-compatibility.md) — vendored ESM transport, type system
+14. [Releasing](./releasing.md) — version bumps, publishing, demo updates
+15. [React Compatibility](./react-type-compatibility.md) — vendored ESM transport, type system
 
 ## Links
 


### PR DESCRIPTION
## Summary

`docs/storybook.md` exists but isn't linked from `docs/README.md`. Anyone navigating the docs from the index never finds it. Add it under **User Guide** as entry 6 (between *Server Actions* and *Examples* — feature/integration topic), shift the following entries down (6→7, 7→8, …) and renumber the Internals and Maintenance sections accordingly.

One-file change: `docs/README.md` only.

## Not in this PR

The eight other orphans under `docs/internals/*` (`COMMON_ISSUES.md`, `DEBUGGING.md`, `DEV_CACHING_ISSUE.md`, `ERROR_HANDLING.md`, `MESSAGE_PORTS_ANALYSIS.md`, `PLUGIN_ARCHITECTURE.md`, `TESTING.md`, `advanced-topics.md`) need a real keep/delete content review per file — some may be stale, `PLUGIN_ARCHITECTURE.md` likely overlaps with the already-indexed `architecture.md`, etc. That belongs in its own PR.