### PR TITLE
fix(detector): widen CLIENT_FILENAME_PATTERN to also match standalone client.[jt]sx?

### DIFF
--- a/plugin/loader/directives/detectClientModule.ts
+++ b/plugin/loader/directives/detectClientModule.ts
@@ -3,13 +3,24 @@ import { sourceHasTopLevelClientDirective } from "./sourceHasTopLevelClientDirec
 import type { Program } from "acorn";
 
 /**
- * Filename convention for client modules: `.client.` followed by a JS-family
- * extension (`.tsx/.ts/.jsx/.js/.mjs/.cjs/.mts/.cts`). Strict — a path that
- * merely contains the substring "client" elsewhere (e.g. `src/lib/clientId.ts`,
- * `src/client/foo.ts`) is not matched by this pattern; the directive check is
- * the other way a module qualifies.
+ * Filename convention for client modules. Matches a JS-family extension
+ * (`.tsx/.ts/.jsx/.js/.mjs/.cjs/.mts/.cts`) on either:
+ *   - the dotted suffix convention (`Foo.client.tsx`, `bar.client.mjs`), or
+ *   - the standalone basename `client.tsx`/`.ts`/etc. when it sits at the
+ *     start of a path or directly after a directory separator
+ *     (`src/client.tsx`, `client.tsx`).
+ *
+ * The leading-`(^|[\/.])` anchor is what keeps this strict — substrings like
+ * `clientId.ts`, `clientUtils.tsx`, or `src/lib/clientHelpers.ts` are NOT
+ * matched, because the character before "client" must be start-of-string,
+ * a path separator, or a dot, not a letter.
+ *
+ * The standalone-basename branch covers the common app-entry convention of
+ * naming the client bundle entry `client.tsx`; without it, a project using
+ * that name would not be classified as client by filename and any CSS or
+ * asset imports from that entry would silently not reach the client bundle.
  */
-const CLIENT_FILENAME_PATTERN = /\.client\.[cm]?[jt]sx?$/;
+const CLIENT_FILENAME_PATTERN = /(^|[\/.])client\.[cm]?[jt]sx?$/;
 
 export type ParseFn = (
   source: string,

--- a/test/unit/detectClientModule.test.ts
+++ b/test/unit/detectClientModule.test.ts
@@ -28,6 +28,7 @@ const acornParse = (src: string): Program =>
 describe("detectClientModule (unified client-module detector)", () => {
   describe("filename pattern (no source)", () => {
     it.each([
+      // Dotted suffix convention.
       "components/Counter.client.tsx",
       "components/Counter.client.ts",
       "components/Counter.client.jsx",
@@ -36,6 +37,13 @@ describe("detectClientModule (unified client-module detector)", () => {
       "components/Counter.client.cjs",
       "components/Counter.client.mts",
       "components/Counter.client.cts",
+      // Standalone-basename convention — common app-entry filename.
+      "client.tsx",
+      "src/client.tsx",
+      "src/client.ts",
+      "src/client.jsx",
+      "src/client.js",
+      "src/client.mjs",
     ])("recognises %s", (moduleId) => {
       expect(detectClientModule({ moduleId })).toBe(true);
     });
@@ -44,7 +52,9 @@ describe("detectClientModule (unified client-module detector)", () => {
       "components/Counter.tsx",
       "src/lib/clientId.ts", // substring "client" must NOT trigger
       "components/clientCode.tsx",
+      "src/lib/clientUtils.ts", // substring with letter prefix must NOT trigger
       "src/client/foo.ts", // directory named "client" must NOT trigger
+      "src/clients.tsx", // "client" followed by other letters must NOT trigger
       "src/page/page.tsx",
     ])("does not flag %s by filename alone", (moduleId) => {
       expect(detectClientModule({ moduleId })).toBe(false);


### PR DESCRIPTION
## Real regression in 1.11.0

PR #60's detector unification tightened the client-filename regex to `/\.client\.[cm]?[jt]sx?$/`. That correctly rejected substring traps like `clientId.ts` and `src/lib/clientUtils.ts`, but it **also stopped matching the common app-entry filename `client.tsx`**, because that filename has no dot before "client".

### Concrete impact

**[mmc](https://nicobrinkkemper.github.io/mmc/8mmc/) shipped without its custom fonts on 1.11.0.** mmc's `src/client.tsx` does `import "./globalStyles.css"`, and `globalStyles.css` contains all the `@font-face` declarations. Pre-1.11.0, the loose substring default classified `client.tsx` as client → its CSS reached the client bundle. Post-1.11.0, the strict pattern didn't match `client.tsx` → it was treated server-side → `@font-face` never reached the bundle.

Any vprs consumer using the common `client.tsx` app-entry convention is broken the same way. This is a clear footgun.

## Fix

Widen the pattern to `/(^|[\/.])client\.[cm]?[jt]sx?$/`. The leading `(^|[\/.])` anchor requires the character before "client" to be **start-of-string, a path separator, or a dot** — never a letter. So:

| filename | matches? |
|---|---|
| `client.tsx` (mmc's case) | ✅ matches |
| `src/client.tsx` | ✅ matches |
| `Foo.client.tsx` (existing dotted convention) | ✅ still matches |
| `clientId.ts` (substring trap from PR #60) | ❌ still doesn't match |
| `src/lib/clientUtils.ts` | ❌ still doesn't match |
| `src/clients.tsx` (`client` followed by letter) | ❌ still doesn't match |
| `src/client/foo.ts` (directory named "client") | ❌ still doesn't match |

The substring-trap protection PR #60 added is fully preserved; this PR just adds the standalone-basename branch the original tightening missed.

## Tests

- `test/unit/detectClientModule.test.ts` — added six positive cases (the standalone-basename variants across extensions) and two more negative cases (`clientUtils.ts`, `clients.tsx`) to pin the trap-rejection invariant.
- `npm run test:unit` → **357/357** (was 349).
- `npm run build` clean.

## Release plan

Once this merges, bump to **1.11.1** and publish. Then re-bump mmc/bidoof/dashboard to `^1.11.1`. The fix is small enough that a patch release is appropriate; the behavioural change is purely "stop breaking a case 1.11.0 shouldn't have broken".

🤖 Generated with [Claude Code](https://claude.com/claude-code)