### PR TITLE
chore: bump version to 1.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
## Summary

Bumps the package version `1.11.0` → `1.11.1` so the regression fix from PR #68 can be published.

## What's in 1.11.1

- **fix(detector):** widened `CLIENT_FILENAME_PATTERN` from `/\.client\.[cm]?[jt]sx?$/` to `/(^|[\/.])client\.[cm]?[jt]sx?$/`. The 1.11.0 tightening correctly rejected substring traps like `clientId.ts` but accidentally stopped matching the common app-entry filename `client.tsx` (no dot before "client"). That broke any vprs consumer using `src/client.tsx` as their client entry — concretely, **mmc's deployed site shipped without its `@font-face` declarations** because `client.tsx`'s `import "./globalStyles.css"` no longer reached the client bundle. PR #68.

Substring-trap protection is fully preserved (`clientId.ts`, `clientUtils.ts`, `clients.tsx`, `src/client/foo.ts` all still don't match).

## Test plan

- [x] `npm version patch --no-git-tag-version` → `1.11.1` (package.json + package-lock.json)
- [ ] Merge, then `npm publish` from main releases `1.11.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)