### PR TITLE
docs: clarify client module discovery + optional clientEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ dist/
 
 ## Client components
 
-Mark a client component with a top-of-file `"use client"` directive. The
-`.client.` filename suffix is **optional** — a first-party module that starts
-with `"use client"` is detected, hosted, and emitted as a client chunk in the
-static (`--app`) build, so you can import it directly into a server component:
+vprs recognises a file as a client module when **either** of these is true:
+
+- the filename matches `(^|[\/.])client\.[cm]?[jt]sx?$` — i.e. `Button.client.tsx`, `bar.client.mjs`, or the standalone basename `src/client.tsx` / `client.tsx`, or
+- the file starts with a top-of-file `"use client"` directive (leading whitespace, line/block comments, and an optional `"use strict"` prologue are tolerated above it).
+
+Either is sufficient. Substrings like `clientUtils.tsx`, `clientId.ts`, or `clients.tsx` are **not** treated as client modules, and a `"use client"` directive placed after real code does not count.
 
 ```tsx
 // src/components/Counter.tsx  ← no `.client.` suffix needed
@@ -67,9 +69,7 @@ export function Counter() {
 }
 ```
 
-Detection is by directive position (top of file, the same rule React enforces),
-not by a substring match. The `.client.` convention still works as a visual
-marker. See [Getting Started](./docs/getting-started.md#the-client-filename-is-optional).
+See [Getting Started](./docs/getting-started.md#the-client-filename-is-optional).
 
 ## Third-party client-component packages
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,6 +27,7 @@ export const config = {
 | `Html` | `React.ComponentType<HtmlProps>` | Wrapper component for production pages | - |
 | `pageExportName` | `string` | Name of the page export | `"Page"` |
 | `propsExportName` | `string` | Name of the props export | `"props"` |
+| `clientEntry` | `string` | Optional explicit client entry. Not needed when `index.html` has a `<script type="module" src>` for the entry — Vite discovers it itself. See [Configuration](./configuration.md#client-entry). | - |
 | `htmlWorkerPath` | `string` | Path to custom HTML worker | - |
 | `rscWorkerPath` | `string` | Path to custom RSC worker | - |
 | `CssCollector` | `React.ComponentType<CssCollectorProps>` | Component for collecting CSS (handles both inline and non-inline modes) | - |
@@ -104,7 +105,7 @@ export const config = {
 |--------|------|-------------|---------|
 | `cssPattern` | `RegExp \| string` | Pattern to match CSS files | `/\.css$/` |
 | `cssModulePattern` | `RegExp \| string` | Pattern to match CSS module files | `/\.css\.js$/` |
-| `clientPattern` | `RegExp \| string` | Pattern to match client component files | `/\.client\.(js\|ts\|jsx\|tsx)$/` |
+| `clientPattern` | `RegExp \| string` | Pattern to match client-module filenames. Anchored so substrings like `clientUtils.tsx` are not matched; the standalone basename `client.tsx` matches alongside the dotted-suffix form `Foo.client.tsx`. A top-of-file `"use client"` directive is recognised independently. | `/(^\|[\/.])client\.[cm]?[jt]sx?$/` |
 | `serverPattern` | `RegExp \| string` | Pattern to match server function files | `/\.server\.(js\|ts\|jsx\|tsx)$/` |
 | `htmlPattern` | `RegExp \| string` | Pattern to match HTML files | `/\.html$/` |
 | `jsonPattern` | `RegExp \| string` | Pattern to match JSON files | `/\.json$/` |
@@ -377,7 +378,7 @@ const DIRECTIVE_CONFIGS = {
 const AUTO_DISCOVER = {
   modulePattern: /\.(m|c)?(j|t)sx?$/,
   serverPattern: /(?:\.\/)?server(?:\.(m|c)?(j|t)sx?)?$/,
-  clientPattern: /(?:\.\/)?client(?:\.(m|c)?(j|t)sx?)?$/,
+  clientPattern: /(^|[\/.])client\.[cm]?[jt]sx?$/,
   pagePattern: /(?:\.\/)?page(?:\.(m|c)?(j|t)sx?)?$/,
   propsPattern: /(?:\.\/)?props(?:\.(m|c)?(j|t)sx?)?$/,
   cssPattern: /\.css$/,
@@ -386,6 +387,8 @@ const AUTO_DISCOVER = {
   rscPattern: /\.rsc$/,
 };
 ```
+
+A file is treated as a client module when **either** the filename matches `clientPattern` **or** the source starts with a top-of-file `"use client"` directive. Both mechanisms are first-class — neither is a fallback to the other.
 
 ### Extension Mapping
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ export default defineConfig({
     Root: "src/Root.tsx",              // string — root wrapper component
     pageExportName: "Page",            // named export to use from Page file
     propsExportName: "props",          // named export to use from props file
+    clientEntry: "src/client.tsx",     // optional — see "Client entry" below
 
     // Optional — direct component references (react-server condition only)
     components: {
@@ -101,6 +102,12 @@ import { MyHtml } from "./src/Html.js";
 
 components: { Html: MyHtml },
 ```
+
+## Client entry
+
+For the conventional setup — an `index.html` with `<script type="module" src="/src/client.tsx">` (or similar) — you do **not** need to set `clientEntry`. vprs leaves that file to Vite's own entry-point discovery and won't add it as a duplicate input, even if the file carries a `"use client"` directive.
+
+Set `clientEntry` only when the client entry isn't referenced from `index.html` and needs to be picked up another way.
 
 ## Dev Modes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -172,10 +172,12 @@ export const Page = () => (
 
 ### The `.client.` filename is optional
 
-A top-of-file `"use client"` directive is enough — the `.client.` filename
-suffix is **not** required. A first-party module that starts with
-`"use client"` is detected, hosted, and emitted as a client chunk in the
-static (`--app`) build exactly like a `.client.tsx` file:
+vprs recognises a file as a client module when **either** of these is true:
+
+- the filename matches `(^|[\/.])client\.[cm]?[jt]sx?$` — i.e. `Button.client.tsx`, `bar.client.mjs`, or the standalone basename `src/client.tsx` / `client.tsx`, or
+- the file starts with a top-of-file `"use client"` directive (leading whitespace, line/block comments, and an optional `"use strict"` prologue are tolerated above it).
+
+Either is sufficient. Substrings like `clientUtils.tsx`, `clientId.ts`, or `clients.tsx` are **not** treated as client modules, and a `"use client"` directive placed after real code does not count.
 
 ```tsx
 // src/components/Counter.tsx  ← no `.client.` suffix
@@ -194,10 +196,15 @@ import { Counter } from "./components/Counter.js";
 // ...renders <Counter /> as a client reference
 ```
 
-Detection is by directive position (the directive must be at the very top of
-the file, the same rule React enforces), not by a substring match — a module
-that merely mentions the word "client" is not treated as a client component.
-The `.client.` convention still works and is handy as a visual marker.
+### Client entry
+
+Most projects have an `index.html` with something like:
+
+```html
+<script type="module" src="/src/client.tsx"></script>
+```
+
+vprs leaves that file to Vite's normal entry-point discovery — you do **not** need to set `clientEntry`, even though the file may carry a `"use client"` directive. The `clientEntry` option still exists for advanced cases that don't go through `index.html`.
 
 ## Add an HTML Shell
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,9 +29,22 @@ node --import vite-plugin-react-server/register ./your-script.mjs
 
 ## `"use client"` Not Working
 
-- Must be the **first line** of the file
-- Use `.client.` suffix for auto-discovery: `Counter.client.tsx`
-- Import with `.js` extension: `import { Counter } from "./Counter.client.js"`
+vprs treats a file as a client module when either of these is true:
+
+- the filename matches `(^|[\/.])client\.[cm]?[jt]sx?$` (e.g. `Counter.client.tsx`, or the standalone basename `src/client.tsx`), or
+- the file starts with a top-of-file `"use client"` directive — leading whitespace, comments, and an optional `"use strict"` prologue are tolerated above it, but the directive must come before any real code.
+
+Substrings like `clientUtils.tsx` or `clientId.ts` are **not** matched. Import with `.js` extension regardless: `import { Counter } from "./Counter.js"`.
+
+## Global CSS / Fonts Not Loading
+
+If your client-entry's CSS imports (global stylesheet, font CSS) aren't reaching the page, check that `index.html` has a `<script type="module" src="...">` for the entry, e.g.:
+
+```html
+<script type="module" src="/src/client.tsx"></script>
+```
+
+You do **not** need to set `clientEntry` for the conventional case — vprs leaves index.html-referenced entries to Vite's own discovery so it can pick up their CSS through the normal Vite manifest.
 
 ## `"use server"` Not Working
 


### PR DESCRIPTION
## Summary

Two user-facing changes between 1.10.x and 1.11.x weren't reflected in the docs:

- **Client-module recognition** is now two first-class mechanisms — the filename convention (`(^|[\/.])client\.[cm]?[jt]sx?$`, which also covers the standalone basename `client.tsx` since 1.11.1) and a top-of-file `"use client"` directive. Either is sufficient; neither is a fallback.
- **`clientEntry` is optional** for the conventional setup. When `index.html` has `<script type="module" src="/src/client.tsx">`, vprs leaves the file to Vite's own discovery (since 1.11.2).

Entry points to read: `README.md` "Client components" and `docs/getting-started.md` "The `.client.` filename is optional" / new "Client entry" subsection.

## Test plan

- [x] `npm run test:unit` (357 passing)