### PR TITLE
chore: drop top-level console.log from entrypoint

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,6 @@ const condition = getCondition("");
 // no trailing slash
 const dir = new URL("./", import.meta.url).pathname.replace(/\/$/, "");
 
-console.log(`[index.ts] Condition: ${condition}, importing: ${dir}/plugin/plugin.${condition}.js`);
-
 export const { vitePluginReactServer, vitePluginReactClient } = (await import(
   `${dir}/plugin/plugin.${condition}.js`
 )) as {


### PR DESCRIPTION
The startup log at `index.ts:11` fires on every consumer's Vite startup. Removing.