### PR TITLE
docs: lower Node floor in README from 23.7.0 to 22.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ noise. See [Storybook](./docs/storybook.md) for details. (Requires vprs ≥ 1.9.
 
 ## Requirements
 
-- Node.js 23.7.0+
+- Node.js 22.0.0+ (the build uses `node:fs/promises#glob`, which landed in 22)
 - React experimental channel (`react@experimental` / `react-dom@experimental`). Stable React 19.x is **not yet supported** — the vendored `react-server-dom-esm` reads `TaintRegistryPendingRequests` from React's server internals, and the taint registry is only exposed on the experimental channel today. See [React Compatibility](./docs/react-type-compatibility.md) for the full story; stable support is tracked separately and is gated on upstream React landing the taint API in the stable build.
 - Vite 6+
 


### PR DESCRIPTION
The README's `Node.js 23.7.0+` was overstated. Verified by running mmc's full build (300 pages) under Node 22.22.3 — builds clean, fonts linked. Same build fails under Node 20.20.2 because `node:fs/promises#glob` isn't exported until 22.0.0.

`.nvmrc` unchanged — that's the dev recommendation, not the floor.