### PR TITLE
fix(clientPackages): root optimizeDeps.exclude wiring (dev-server side of bd-2dd)

### DIFF
--- a/plugin/clientPackages/plugin.ts
+++ b/plugin/clientPackages/plugin.ts
@@ -24,6 +24,19 @@ interface ClientPackagesUserOptions {
  * `createEnvironmentPlugin`'s, so by the time `resolveUserConfig` reads
  * `userOptions.clientPackages` for the noExternal merge, the auto-detected
  * packages are already in the list.
+ *
+ * Returns a partial Vite config that adds the merged list to the **root**
+ * `optimizeDeps.exclude`. The per-environment SSR-side exclude in
+ * `resolveUserConfig` covers `srrConfig.optimizeDeps.exclude` only — that
+ * never reaches Vite's dev pre-bundler, which reads from the root config.
+ * Without this, esbuild concatenates every `"use client"` directive out of
+ * each clientPackage submodule into `node_modules/.vite/deps/<pkg>.js`, the
+ * server-env module runner consults the same cache when resolving the
+ * package, and vprs's transformer never sees the directives to convert
+ * them into `registerClientReference` — a server component importing
+ * `@chakra-ui/react` (or any other auto-detected client package) then
+ * crashes the dev server with `react does not provide an export named
+ * createContext` under the `react-server` condition.
  */
 export const clientPackagesDiscoveryPlugin = (
   userOptions: ClientPackagesUserOptions & Record<string, unknown>
@@ -39,7 +52,12 @@ export const clientPackagesDiscoveryPlugin = (
         logger: userOptions.verbose ? createLogger("warn") : undefined,
       });
       userOptions.clientPackages = merged;
-      return undefined;
+      if (merged.length === 0) return undefined;
+      return {
+        optimizeDeps: {
+          exclude: [...merged],
+        },
+      };
     },
   };
 };

--- a/test/unit/clientPackages.test.ts
+++ b/test/unit/clientPackages.test.ts
@@ -5,6 +5,8 @@ import {
   mergeClientPackagesOptimizeDepsExclude,
   discoverClientPackages,
 } from "../../plugin/clientPackages/index.js";
+import { clientPackagesDiscoveryPlugin } from "../../plugin/clientPackages/plugin.js";
+import type { Plugin } from "vite";
 
 describe("clientPackages/buildClientPackagesPattern", () => {
   it("returns null for empty list (so caller can short-circuit, not match every id)", () => {
@@ -118,5 +120,62 @@ describe("clientPackages/discoverClientPackages", () => {
       exclude: ["b"],
     });
     expect(result).toEqual(["a"]);
+  });
+});
+
+describe("clientPackages/clientPackagesDiscoveryPlugin", () => {
+  // Reason these tests exist: the per-environment SSR-side exclude in
+  // `resolveUserConfig` (`srrConfig.optimizeDeps.exclude`) does NOT reach
+  // Vite's dev pre-bundler, which reads from the root `optimizeDeps.exclude`.
+  // Without this plugin returning a root-level exclude, esbuild concatenates
+  // every `"use client"` directive out of each clientPackage submodule into
+  // `node_modules/.vite/deps/<pkg>.js`, the server-env module runner
+  // consults the same cache, and a server component importing the package
+  // throws `react does not provide an export named createContext` under
+  // the `react-server` condition.
+  it("returns a root optimizeDeps.exclude entry for every discovered package", async () => {
+    const userOptions = {
+      // Manual list bypasses crawl; the plugin still has to wire it through
+      // to root-level optimizeDeps.exclude.
+      clientPackages: ["@my-org/internal-ui", "@another/lib"],
+    };
+    const plugin = clientPackagesDiscoveryPlugin(userOptions) as Plugin & {
+      config: (config: unknown, env: { command: string }) => Promise<unknown>;
+    };
+    const result = (await plugin.config({}, { command: "serve" })) as {
+      optimizeDeps: { exclude: string[] };
+    };
+    expect(result).toBeDefined();
+    expect(result.optimizeDeps.exclude).toEqual(
+      expect.arrayContaining(["@my-org/internal-ui", "@another/lib"])
+    );
+  });
+
+  it("returns undefined when no packages are detected (so Vite doesn't merge an empty array)", async () => {
+    const userOptions = {};
+    const plugin = clientPackagesDiscoveryPlugin(userOptions) as Plugin & {
+      config: (config: unknown, env: { command: string }) => Promise<unknown>;
+    };
+    const result = await plugin.config({}, { command: "serve" });
+    // With no manual entries and (likely) no crawl results for the cwd,
+    // the plugin should not pollute the Vite root config.
+    if (result !== undefined) {
+      const exclude = (result as { optimizeDeps?: { exclude?: string[] } })
+        .optimizeDeps?.exclude;
+      expect(exclude == null || exclude.length > 0).toBe(true);
+    }
+  });
+
+  it("mutates userOptions.clientPackages so downstream consumers see the merged list", async () => {
+    const userOptions: { clientPackages?: readonly string[] } = {
+      clientPackages: ["@user/pkg"],
+    };
+    const plugin = clientPackagesDiscoveryPlugin(userOptions) as Plugin & {
+      config: (config: unknown, env: { command: string }) => Promise<unknown>;
+    };
+    await plugin.config({}, { command: "serve" });
+    expect(userOptions.clientPackages).toEqual(
+      expect.arrayContaining(["@user/pkg"])
+    );
   });
 });


### PR DESCRIPTION
## What

`clientPackagesDiscoveryPlugin.config` now returns a partial Vite config that adds the discovered/manual client packages to **root-level** `optimizeDeps.exclude`, alongside the existing SSR-side merge in `resolveUserConfig`.

## Why

The per-environment SSR-side exclude (`srrConfig.optimizeDeps.exclude` in `resolveUserConfig.ts`) never reaches Vite's dev pre-bundler, which reads from the root config. Result: esbuild concatenates every `"use client"` directive out of each client-package submodule into `node_modules/.vite/deps/<pkg>.js`. The server-env module runner consults the same cache, vprs's `enforce: "post"` transform sees a directive-stripped blob, no `registerClientReference` calls get emitted, and a server component importing `@chakra-ui/react` (or any other auto-detected client package) throws `react does not provide an export named createContext` under the `react-server` condition.

This is the dev-server side of `bd-2dd` — `c1d` (PR #55, 1.10.0) closed the static-build path, but the dev path was still broken.

## Verified

- 360/360 unit tests pass (3 new ones added).
- Packed + installed into mission-control dashboard, ran `npm run dev` for ~12s. Before: `node_modules/.vite/deps/@chakra-ui_react.js` existed (2.9 MB, zero `"use client"` directives). After: no `@chakra-ui*` entries in `.vite/deps/` at all.

## Not in scope

This unblocks `bd-3fn` (dashboard server-component migration) but doesn't perform the migration itself.