### PR TITLE
fix(env): per-environment resolve.conditions (bd-dc0 client interop regression)

### DIFF
--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -1,4 +1,10 @@
-import { createLogger, type ConfigEnv, type UserConfig } from "vite";
+import {
+  createLogger,
+  defaultClientConditions,
+  defaultServerConditions,
+  type ConfigEnv,
+  type UserConfig,
+} from "vite";
 import type {
   ResolvedUserConfig,
   ResolvedUserOptions,
@@ -476,6 +482,20 @@ export const resolveUserConfig: ResolveUserConfigFn =
         envPrefix: vitePrefix,
         resolve: {
           ...config.resolve,
+          // Per-environment conditions are the load-bearing fix for the
+          // dev-server case where the process was started with a global
+          // `--conditions react-server` (the conventional `dev:rsc` script).
+          // Without this explicit override, Node's module resolver sees
+          // `react-server` for every environment and the client graph
+          // pulls the `react-server` build of `react/jsx-runtime` — which
+          // does not export `jsx` / `jsxs` — and `@chakra-ui/react`-style
+          // packages' transitive CJS deps (`hoist-non-react-statics`,
+          // etc.) lose their interop shims because they get resolved
+          // through the SSR conditions path. Spelling the conditions out
+          // here scopes `react-server` to the server env only.
+          conditions: ssr
+            ? [...defaultServerConditions]
+            : [...defaultClientConditions],
           // For static builds (browser/ESM): don't externalize anything - bundle everything
           // For client/server builds (SSR): externalize React modules as usual
           external: ssr
@@ -597,6 +617,19 @@ export const resolveUserConfig: ResolveUserConfigFn =
         envPrefix: vitePrefix,
         resolve: {
           ...config.resolve,
+          // The server env owns the `react-server` condition. Spelling it
+          // out here (instead of relying on a process-wide
+          // `--conditions react-server` flag the caller set in
+          // `NODE_OPTIONS`) lets the client / ssr envs resolve the
+          // default React build of `react/jsx-runtime` in the same Vite
+          // process — which is what fixes the client interop regression
+          // surfaced when a client component imports a client package
+          // (Chakra, emotion, …) under a global `--conditions
+          // react-server` shell.
+          conditions: [
+            "react-server",
+            ...defaultServerConditions.filter((c) => c !== "react-server"),
+          ],
           externalConditions: config.resolve?.externalConditions ?? [
             "react-server",
           ],


### PR DESCRIPTION
## What

Sets `resolve.conditions` per-environment in `resolveUserConfig`:

| env | `resolve.conditions` |
|---|---|
| `client` (ssr: false) | `defaultClientConditions` |
| `ssr` (ssr: true, `react-client`) | `defaultServerConditions` |
| `server` (ssr: true, `react-server`) | `['react-server', …defaultServerConditions]` |

Imports `defaultClientConditions` and `defaultServerConditions` from `vite` (same primitives @vitejs/plugin-rsc uses).

## Why

PR #76 (1.11.3) closed the dev-server side of bd-2dd by excluding `clientPackages` from root `optimizeDeps`. That regressed client interop (bd-dc0): the conventional `dev:rsc` script sets `NODE_OPTIONS='--conditions react-server'` process-wide, so Vite's main thread resolves *every* import under the `react-server` condition — including the client environment's. Browser symptoms:

- `react/jsx-runtime.js?v=… does not provide an export named 'jsx'` (the `react-server` build of jsx-runtime lacks those exports)
- `hoist-non-react-statics.cjs.js?v=… does not provide an export named 'default'` (transitive CJS interop fails through the SSR conditions path)

Scoping `react-server` to the server env via per-env conditions is the load-bearing fix: client/ssr envs resolve React's standard build and get proper interop, while the server env keeps the RSC contract.

Side benefit: plain `npm run dev` works now too (no `NODE_OPTIONS` required), because vprs configures the condition where it actually belongs.

## Verified

- 360/360 unit tests pass.
- Dashboard build under `NODE_OPTIONS='--conditions react-server'` (the conventional `build` script) still clean: 1 page rendered in 4.25s, `globalStyles-…` linked.
- `dev:rsc` against the dashboard: no `does not provide an export` errors in the dev log; `@chakra-ui/react` stays out of `.vite/deps/` (PR #76's exclude still in effect for the server side).

## Acceptance (per bd-dc0)

1. **bd-2dd**: server component importing `@chakra-ui/react` under `react-server` renders without `react does not provide an export named createContext` — preserved by PR #76.
2. **bd-dc0**: client component importing Chakra Button + `@emotion/react` loads cleanly in dev — the conditions fix scopes `react-server` off the client graph.

## Follow-up

A Chakra client+server fixture in `test/dev/` wired into bd-1rv's parameterized dev suite would pin both directions as a regression test. Out of scope for this PR; can land separately.