### PR TITLE
chore: bump version to 1.11.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "1.11.3",
+      "version": "1.11.4",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Picks up PR #78 (per-environment resolve.conditions — closes bd-dc0 client interop regression, keeps bd-2dd server-side fix).