### PR TITLE
fix(defaults): MODULE_BASE_PATH default to "/" — fixes dev double-slash URL footgun

### DIFF
--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -144,7 +144,19 @@ export const DEFAULT_CONFIG = {
   CLIENT_ASSETS_DIR: "assets",
   RSC_DIR: "rsc",
   MODULE_BASE: "src",
-  MODULE_BASE_PATH: "",
+  // Both default to "/" so emitted client-reference moduleIDs ("/foo.client.js")
+  // concatenate cleanly with the consumer's moduleBaseURL ("/") in
+  // `react-server-dom-esm`'s client (literal string concat at
+  // `react-server-dom-esm-client.*.development.js`). When MODULE_BASE_PATH was
+  // "", `createModuleID`'s Step-5 prepend was skipped, the transformer's
+  // hosting step added the leading "/" on its own, and the resulting
+  // moduleID + moduleBaseURL combination produced "//foo.client.js" in dev —
+  // browsers ESM-import that literally, Vite's dev catch-all returns its
+  // index.html, and the module loader rejects on MIME mismatch
+  // (`NS_ERROR_CORRUPTED_CONTENT`). Consumers that explicitly set
+  // moduleBasePath (mmc historically did, bidoof always has) sidestepped it;
+  // consumers leaning on the default tripped over it.
+  MODULE_BASE_PATH: "/",
   MODULE_BASE_URL: "/",
   PUBLIC_ORIGIN: "",
   PAGE: "page.tsx",


### PR DESCRIPTION
## What

`DEFAULT_CONFIG.MODULE_BASE_PATH` flips from `""` to `"/"`. One-line change in `plugin/config/defaults.tsx:147`.

## Why

`MODULE_BASE_URL` already defaults to `"/"`. With `MODULE_BASE_PATH = ""`, consumers leaning on the default hit a URL-construction footgun in dev:

1. `createModuleID` Step 5 (`if (moduleBasePath && !id.startsWith(moduleBasePath)) { id = moduleBasePath + id; }`) short-circuits on the empty string — no prepend.
2. `createTransformerPlugin` (`transformer/createTransformerPlugin.ts:329-331`) adds a leading `"/"` for hosted-path correctness when `needsHosting`.
3. The emitted moduleID is `/foo.client.js`.
4. The browser concatenates `moduleBaseURL + mod` (literal string concat at `react-server-dom-esm-client.*.development.js:81`).
5. `"/" + "/foo.client.js"` → `"//foo.client.js"`.
6. Vite's dev catch-all serves `index.html` for the double-slash URL → MIME mismatch in the module loader → `NS_ERROR_CORRUPTED_CONTENT`.

Consumers that explicitly set `moduleBasePath: "/"` (bidoof always; mmc historically until commit `cc4273d`) sidestepped this. The geitje dashboard's `app/vite.config.ts` doesn't set it; mmc post-`cc4273d` doesn't either — both broke in dev as soon as my earlier fixes (PR #76, PR #78) closed the chakra/createContext and react-server-condition-bleed crashes that previously prevented the pipeline from progressing far enough to hit this.

Production never surfaced it: GitHub Pages / S3 / CloudFront / nginx all normalize `//` → `/` at the host layer.

## Verified

- 360/360 unit tests pass.
- mmc dev:rsc with the explicit `moduleBasePath: "/"` line removed (relying on the new default) — emitted RSC stream contains `I["src/components/Clickable.client.js","ClientClickable"]` (no leading `/`). Concatenated with `moduleBaseURL = "/"` → `/src/components/Clickable.client.js` — single-slash, correctly resolved by Vite's dev server.
- bidoof's explicit `moduleBasePath: "/"` is unchanged behavior — no regression.

## Migration

None. Consumers explicitly setting `moduleBasePath` see no change. Consumers relying on the default get correct dev URLs without further config.

Refs: bd-2dd, bd-dc0.