### PR TITLE
fix(test): playwright e2e afterAll waits on real exit + escalates to SIGKILL

### DIFF
--- a/test/e2e/dev-ssr-css-hmr.spec.ts
+++ b/test/e2e/dev-ssr-css-hmr.spec.ts
@@ -94,14 +94,26 @@ test.afterAll(async () => {
   if (originalCss !== undefined) {
     await writeFile(cssFile, originalCss);
   }
-  if (server && !server.killed) {
-    server.kill("SIGTERM");
-    await new Promise<void>((r) => {
-      const t = setTimeout(() => r(), 2000);
-      server!.once("exit", () => {
-        clearTimeout(t);
-        r();
-      });
+  // `server.killed` only tracks "did kill() get called", not "did the
+  // process actually exit". A SIGTERM that lands while the vite child
+  // is mid-request, mid-restart, or stuck in worker spawn never reaches
+  // the handler; the 2s budget expires; the afterAll returns; and the
+  // vite child is now an orphan that survives the playwright run. On a
+  // single test pass that's one stray process; iterating builds up.
+  //
+  // Wait for the actual `exit` event before resolving. After the SIGTERM
+  // grace runs out, escalate to SIGKILL and wait again — the kernel
+  // can't ignore SIGKILL, so the second wait is guaranteed to land.
+  if (server && server.exitCode === null && server.signalCode === null) {
+    await new Promise<void>((resolve) => {
+      const onExit = () => resolve();
+      server!.once("exit", onExit);
+      server!.kill("SIGTERM");
+      setTimeout(() => {
+        if (server && server.exitCode === null && server.signalCode === null) {
+          server.kill("SIGKILL");
+        }
+      }, 2000);
     });
   }
 });

--- a/test/e2e/dev-ssr-server-actions.spec.ts
+++ b/test/e2e/dev-ssr-server-actions.spec.ts
@@ -106,14 +106,20 @@ test.beforeAll(async () => {
 }, 90_000);
 
 test.afterAll(async () => {
-  if (server && !server.killed) {
-    server.kill("SIGTERM");
-    await new Promise<void>((r) => {
-      const t = setTimeout(() => r(), 2000);
-      server!.once("exit", () => {
-        clearTimeout(t);
-        r();
-      });
+  // See dev-ssr-css-hmr.spec.ts for the rationale. `server.killed` only
+  // tracks "did kill() get called"; rely on the `exit` event with a
+  // SIGKILL escalation so a stuck vite child can't outlive the test
+  // suite and orphan into the agent session.
+  if (server && server.exitCode === null && server.signalCode === null) {
+    await new Promise<void>((resolve) => {
+      const onExit = () => resolve();
+      server!.once("exit", onExit);
+      server!.kill("SIGTERM");
+      setTimeout(() => {
+        if (server && server.exitCode === null && server.signalCode === null) {
+          server.kill("SIGKILL");
+        }
+      }, 2000);
     });
   }
 });


### PR DESCRIPTION
## What

The two self-contained-server e2e specs (\`dev-ssr-css-hmr\` and \`dev-ssr-server-actions\`) replace their SIGTERM-and-2s-grace cleanup with: subscribe to \`exit\`, send SIGTERM, escalate to SIGKILL after 2s if the process is still alive, await the \`exit\` event in either case.

## Why

\`ChildProcess.killed\` only tracks "did kill() get called", not "did the process actually exit". A SIGTERM that lands while the vite child is mid-request, mid-restart, or stuck in worker spawn doesn't reach the signal handler in 2s — the \`afterAll\` returns, and the vite process orphans into the parent shell session. bd-bzm reported >100 stray vite processes after a few hours of e2e iterations.

SIGKILL can't be ignored, so once the second wait subscribes to \`exit\` and the kernel fires the signal, the cleanup completes cleanly.

## Verified

- \`npm run build\` clean.
- The exit-then-SIGKILL pattern is mechanical; not running the playwright suite end-to-end in this environment (it requires the bidoof-template + a graphical browser stack) — local verification is to run \`npm run test:e2e\` and confirm \`ps aux | grep vite\` shows no leftover processes.

Closes bd-bzm.