### PR TITLE
fix(clientPackages): scope optimizeDeps exclude to the server env (client interop just works)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/plugin/clientPackages/plugin.ts
+++ b/plugin/clientPackages/plugin.ts
@@ -53,9 +53,23 @@ export const clientPackagesDiscoveryPlugin = (
       });
       userOptions.clientPackages = merged;
       if (merged.length === 0) return undefined;
+      // Exclude client packages from optimizeDeps ONLY in the server
+      // (react-server) environment: there, pre-bundling would concatenate the
+      // package into one chunk and strip its per-file `"use client"` directives
+      // before vprs's transform can convert them to client references.
+      //
+      // We deliberately do NOT exclude them from the client (browser)
+      // environment — there, letting esbuild pre-bundle them normally is what we
+      // want: it resolves their transitive CJS deps (hoist-non-react-statics,
+      // the React runtime, …) and synthesizes the named/default exports the
+      // browser bundle needs. A blanket root-level exclude is what used to break
+      // the client (those deps served raw → "does not provide an export named…"
+      // errors); scoping the exclude per-environment fixes both sides without
+      // hand-collecting transitive deps.
+      const exclude = [...merged];
       return {
-        optimizeDeps: {
-          exclude: [...merged],
+        environments: {
+          server: { optimizeDeps: { exclude } },
         },
       };
     },

--- a/test/unit/clientPackages.test.ts
+++ b/test/unit/clientPackages.test.ts
@@ -124,44 +124,49 @@ describe("clientPackages/discoverClientPackages", () => {
 });
 
 describe("clientPackages/clientPackagesDiscoveryPlugin", () => {
-  // Reason these tests exist: the per-environment SSR-side exclude in
-  // `resolveUserConfig` (`srrConfig.optimizeDeps.exclude`) does NOT reach
-  // Vite's dev pre-bundler, which reads from the root `optimizeDeps.exclude`.
-  // Without this plugin returning a root-level exclude, esbuild concatenates
-  // every `"use client"` directive out of each clientPackage submodule into
-  // `node_modules/.vite/deps/<pkg>.js`, the server-env module runner
-  // consults the same cache, and a server component importing the package
-  // throws `react does not provide an export named createContext` under
-  // the `react-server` condition.
-  it("returns a root optimizeDeps.exclude entry for every discovered package", async () => {
+  // Reason these tests exist: client packages must be excluded from the SERVER
+  // (react-server) environment's optimizeDeps so esbuild doesn't pre-bundle
+  // them and strip the per-file `"use client"` directives the RSC transform
+  // needs. The exclude is scoped per-environment (NOT root) so the CLIENT
+  // environment still pre-bundles them normally — that's what handles their
+  // transitive CJS interop for the browser. A root-level exclude used to break
+  // the client (those deps served raw → missing-export errors).
+  it("excludes every discovered package from the SERVER env optimizeDeps (not root, not client)", async () => {
     const userOptions = {
-      // Manual list bypasses crawl; the plugin still has to wire it through
-      // to root-level optimizeDeps.exclude.
+      // Manual list bypasses crawl; the plugin still has to wire it through.
       clientPackages: ["@my-org/internal-ui", "@another/lib"],
     };
     const plugin = clientPackagesDiscoveryPlugin(userOptions) as Plugin & {
       config: (config: unknown, env: { command: string }) => Promise<unknown>;
     };
     const result = (await plugin.config({}, { command: "serve" })) as {
-      optimizeDeps: { exclude: string[] };
+      optimizeDeps?: { exclude?: string[] };
+      environments?: { server?: { optimizeDeps?: { exclude?: string[] } } };
     };
     expect(result).toBeDefined();
-    expect(result.optimizeDeps.exclude).toEqual(
+    // Scoped to the server env...
+    expect(result.environments?.server?.optimizeDeps?.exclude).toEqual(
       expect.arrayContaining(["@my-org/internal-ui", "@another/lib"])
     );
+    // ...and NOT applied at the root (which would also strip them from the
+    // client/browser bundle and break CJS interop).
+    expect(result.optimizeDeps?.exclude).toBeUndefined();
   });
 
-  it("returns undefined when no packages are detected (so Vite doesn't merge an empty array)", async () => {
+  it("returns undefined when no packages are detected (so Vite doesn't merge empty config)", async () => {
     const userOptions = {};
     const plugin = clientPackagesDiscoveryPlugin(userOptions) as Plugin & {
       config: (config: unknown, env: { command: string }) => Promise<unknown>;
     };
     const result = await plugin.config({}, { command: "serve" });
     // With no manual entries and (likely) no crawl results for the cwd,
-    // the plugin should not pollute the Vite root config.
+    // the plugin should not pollute the Vite config.
     if (result !== undefined) {
-      const exclude = (result as { optimizeDeps?: { exclude?: string[] } })
-        .optimizeDeps?.exclude;
+      const exclude = (
+        result as {
+          environments?: { server?: { optimizeDeps?: { exclude?: string[] } } };
+        }
+      ).environments?.server?.optimizeDeps?.exclude;
       expect(exclude == null || exclude.length > 0).toBe(true);
     }
   });


### PR DESCRIPTION
## Problem

When a project uses a third-party client package shipping per-file `"use client"` directives (Chakra v3, Emotion, Ark, MUI, …), vprs excludes it from `optimizeDeps` so esbuild can't pre-bundle it and strip the directives the RSC transform needs.

That exclude was applied at the **root** `optimizeDeps`, so it also hit the **browser** bundle — the packages' transitive CJS deps (`hoist-non-react-statics`, the React runtime entries) were served raw, and the client's ESM import of their named/default exports failed:

```
does not provide an export named 'default'  (hoist-non-react-statics)
does not provide an export named 'jsx'      (react/jsx-runtime)
```

Blank screen. Consumers worked around it with a manual `optimizeDeps.include` list.

## Fix

Scope the exclude to the **server (react-server) environment only** — `environments.server.optimizeDeps.exclude` — instead of root. The **client** environment is left to pre-bundle those packages normally, which is exactly what resolves their transitive CJS interop for the browser.

- Server side: directives survive (the package isn't pre-bundled there) → the transform converts them to client references.
- Client side: esbuild pre-bundles the package and synthesizes the interop the browser needs.

No hand-collecting of transitive deps, no `package.json` / `require.resolve` crawling.

> _Supersedes the first version of this PR_, which kept the root exclude and re-included each package's transitive deps via a `collectDeps` helper. That worked but was a patch on the over-broad root exclude and **broke in monorepos** (it resolved deps from the project root). Per-env scoping removes the root exclude entirely, so the smell is gone. (The original comment claimed per-env `optimizeDeps` doesn't reach the dev pre-bundler — re-verified on Vite 6.4: it does.)

## Verification

- With **no** app-side `optimizeDeps` workaround, a client component using Chakra renders in dev (`/`) in a real browser with **zero console errors** (Playwright).
- Server-side directive conversion still works (the page's client references resolve).
- `test/unit/clientPackages.test.ts`: 17 passing (the discovery-plugin tests now assert the per-env shape). `tsc --build` + `vite build` clean.

Targets **2.0.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)