### PR TITLE
feat(storybook): keep the plugin by default so RSC works in Storybook

### DIFF
--- a/plugin/storybook/preset.ts
+++ b/plugin/storybook/preset.ts
@@ -87,8 +87,79 @@ function stubVirtualRscHmr(): Plugin {
   };
 }
 
-/** Storybook `viteFinal` preset hook. */
-export const viteFinal = async (config: UserConfig): Promise<UserConfig> => {
+/** Options for the Storybook preset, passed via the addon entry:
+ * `addons: [{ name: "vite-plugin-react-server/storybook", options: { rsc: true } }]`.
+ */
+export interface StorybookPresetOptions {
+  /**
+   * Whether the vprs plugin stays active in Storybook (default `true`).
+   *
+   * When kept, the RSC dev server runs inside Storybook and Server Components
+   * stream for real — the `.rsc` / `_rsc` routes are served, so a story's
+   * `createReactFetcher` can render the live app. No launch flag is needed: the
+   * plugin sets the `react-server` condition per-environment and the RSC worker
+   * sets it for itself, so plain `storybook dev` is enough.
+   *
+   * Set `rsc: false` to opt OUT — strip the plugin and bundle client components
+   * only. That's the lighter, no-RSC-worker build for projects that only want
+   * to story client UI; the preset then re-adds the few resolver/HMR shims the
+   * stripped plugin would otherwise have provided.
+   */
+  rsc?: boolean;
+}
+
+/** Silences the MODULE_LEVEL_DIRECTIVE warning Rollup emits for every
+ * "use client"/"use server" file when bundling UI libraries (Chakra, Ark,
+ * MUI, …). Meaningless in Storybook; preserves a consumer's existing onwarn. */
+const silenceDirectiveWarnings = (
+  prev: NonNullable<
+    NonNullable<UserConfig["build"]>["rollupOptions"]
+  >["onwarn"],
+): NonNullable<
+  NonNullable<UserConfig["build"]>["rollupOptions"]
+>["onwarn"] => {
+  return (warning, defaultHandler) => {
+    if (
+      warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+      typeof warning.message === "string" &&
+      /use (client|server)/.test(warning.message)
+    ) {
+      return;
+    }
+    if (typeof prev === "function") {
+      prev(warning, defaultHandler);
+      return;
+    }
+    defaultHandler(warning);
+  };
+};
+
+/** Storybook `viteFinal` preset hook. Storybook merges the addon's registered
+ * `options` into the options object, so `options.rsc` is the flag set via
+ * `addons: [{ name: "…/storybook", options: { rsc: true } }]`. */
+export const viteFinal = async (
+  config: UserConfig,
+  options?: StorybookPresetOptions,
+): Promise<UserConfig> => {
+  const onwarn = silenceDirectiveWarnings(config.build?.rollupOptions?.onwarn);
+
+  // DEFAULT: keep the vprs plugin so the RSC dev server runs inside Storybook.
+  // The plugin resolves `react-server-dom-esm/*` and provides
+  // `virtual:react-server/hmr` itself, so the strip-compensation shims are NOT
+  // added here (they would shadow the real providers). Server Components stream
+  // from the `.rsc` route for stories that fetch them.
+  if (options?.rsc !== false) {
+    return {
+      ...config,
+      build: {
+        ...config.build,
+        rollupOptions: { ...config.build?.rollupOptions, onwarn },
+      },
+    };
+  }
+
+  // Opt-out (`rsc: false`) — client-only: strip the vprs plugin and re-add only
+  // the helpers a client story needs.
   const plugins = (config.plugins ?? []).filter((p) => {
     if (!p || typeof p !== "object" || Array.isArray(p)) return true;
     const name = (p as { name?: string }).name ?? "";
@@ -104,8 +175,6 @@ export const viteFinal = async (config: UserConfig): Promise<UserConfig> => {
   // why externalizing a virtual specifier was the wrong shape.
   const external = Array.isArray(existingExternal) ? existingExternal : [];
 
-  const prevOnwarn = config.build?.rollupOptions?.onwarn;
-
   return {
     ...config,
     plugins: [resolveReactServerDomEsm(), stubVirtualRscHmr(), ...plugins],
@@ -115,24 +184,7 @@ export const viteFinal = async (config: UserConfig): Promise<UserConfig> => {
       rollupOptions: {
         ...config.build?.rollupOptions,
         external,
-        // Any library shipping "use client"/"use server" directives (Chakra,
-        // Ark, MUI, …) triggers a MODULE_LEVEL_DIRECTIVE warning per file when
-        // bundled — meaningless in Storybook, which has no RSC runtime. Silence
-        // just those; preserve a consumer's existing onwarn. UI-lib-agnostic.
-        onwarn(warning, defaultHandler) {
-          if (
-            warning.code === "MODULE_LEVEL_DIRECTIVE" &&
-            typeof warning.message === "string" &&
-            /use (client|server)/.test(warning.message)
-          ) {
-            return;
-          }
-          if (typeof prevOnwarn === "function") {
-            prevOnwarn(warning, defaultHandler);
-            return;
-          }
-          defaultHandler(warning);
-        },
+        onwarn,
       },
     },
   };


### PR DESCRIPTION
## What

Makes the Storybook preset **keep the vprs plugin by default**, so React Server Components render and the RSC dev server runs inside Storybook out of the box. Opt out with `{ rsc: false }` for the previous client-only strip.

```ts
// default — RSC on, nothing to configure:
addons: ["vite-plugin-react-server/storybook"]

// opt out to the lighter client-only build:
addons: [{ name: "vite-plugin-react-server/storybook", options: { rsc: false } }]
```

## Why

The preset used to **always strip** the plugin (its doc said RSC wasn't supported in Storybook). But that was over-conservative — verified by experiment:

- Storybook **boots fine** with the plugin kept; client stories still render with zero errors.
- The dev-server middleware **self-gates** (`if (!isRscRequest) return next()` on `text/x-component` / `.rsc` / `_rsc`), so it never shadows Storybook's manager/iframe — it only answers RSC requests.
- Real RSC flight streams are served at the `.rsc` route inside Storybook: `GET /page.rsc` → `200 text/x-component` with a valid payload (`"$Sreact.fragment"`, client refs). So a story's `createReactFetcher` can render the **live app**.
- **No launch flag needed** — the plugin applies the `react-server` condition per-environment (PR #78) and the RSC worker sets it for itself, so plain `storybook dev` works (confirmed: `/page.rsc` streams without any `NODE_OPTIONS`).

So inventing an opt-*in* flag would just be backward-compat for a default we'd already concluded was wrong. The default now does the right thing.

## Details

- `rsc !== false` (default): keep the plugin; add only the `onwarn` directive-silencer. The plugin resolves `react-server-dom-esm/*` and provides `virtual:react-server/hmr` itself, so the strip-compensation shims are **not** added (they'd shadow the real providers).
- `rsc === false`: the original behavior — strip the plugin and re-add `resolveReactServerDomEsm` + the `virtual:react-server/hmr` stub + the directive-silencer.
- Addon options reach the preset via `viteFinal(config, options)` → `options.rsc` (verified empirically in SB 10.4).

## ⚠️ Behavior change

The `vite-plugin-react-server/storybook` preset now defaults to RSC-on (plugin kept) instead of client-only (stripped). Projects relying on the strip pass `{ rsc: false }`.

## Verification

- `storybook dev`: boots; `/page.rsc` → `200 text/x-component`; client + server-component stories render with 0 console errors (Playwright).
- `tsc --build` clean; `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)