### PR TITLE
fix(clientPackages): scope optimizeDeps exclude to dev only (fixes build double-slash)

### DIFF
--- a/plugin/clientPackages/plugin.ts
+++ b/plugin/clientPackages/plugin.ts
@@ -53,6 +53,12 @@ export const clientPackagesDiscoveryPlugin = (
       });
       userOptions.clientPackages = merged;
       if (merged.length === 0) return undefined;
+      // optimizeDeps (esbuild pre-bundling) is a DEV-server concern; a
+      // production build uses Rollup and ignores it. Returning a per-env
+      // `environments.server` config in build mode corrupts the build's
+      // environment resolution (client-reference paths come out with a
+      // double slash). Scope the exclude to dev only.
+      if (env.command !== "serve") return undefined;
       // Exclude client packages from optimizeDeps ONLY in the server
       // (react-server) environment: there, pre-bundling would concatenate the
       // package into one chunk and strip its per-file `"use client"` directives


### PR DESCRIPTION
## Problem

#84 (merged in `31687f1`) returns `environments.server.optimizeDeps.exclude` from the discovery plugin's `config` hook. `main`'s CI is now red because that per-env config, returned in **build** mode, corrupts the build's environment resolution: client-reference import specifiers come out with a double slash (`dist/client//components/Link.client-*.js`), which the loader can't resolve — failing the example build tests.

`optimizeDeps` is an esbuild **dev-prebundle** concern; Rollup ignores it in a production build. So the exclude only ever needs to apply on the dev server.

## Fix

One condition: return `undefined` from the `config` hook in build mode (`env.command !== "serve"`). The build's env config is left untouched (no double slash); the dev server keeps the exact behavior #84 introduced — client packages prebundle for the browser while the server (react-server) env excludes them so per-file `"use client"` directives survive.

## Validation

Full `test-all` green in **both** modes — server 503, client 163, unit 341, typecheck 20 — and the example suite shows **zero** double-slash. Verified the dev-browser benefit (the original #84 win) is unchanged since the exclude still applies in `serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)