### PR TITLE
fix(dev): Fast Refresh under RSC — keep client-ref ids .tsx in dev (bd-572) + e2e matrix

### DIFF
--- a/plugin/config/createModuleID.ts
+++ b/plugin/config/createModuleID.ts
@@ -260,16 +260,19 @@ export const createDefaultModuleID = (
       id = moduleBasePath + id;
     }
     
-    // Step 6: Apply extension mapping
-    // ALWAYS replace extensions for client components (browser can't import .tsx)
-    // For other files, only replace in build mode.
-    // Directive-detected client modules count as client components too.
+    // Step 6: Apply extension mapping — BUILD ONLY.
+    // In a build the browser can't import .tsx, so client components are mapped
+    // to .js. In DEV, Vite transpiles .tsx on the fly, so mapping there gives
+    // the client-reference id a phantom .js the dev module graph never has —
+    // the import resolves to "<name>.client.js.tsx", which 404s on the second
+    // HMR fetch and kills Fast Refresh after the first edit (bd-572). Keep the
+    // real .tsx id in dev.
     const isClientComponent = isClientComponentId(
       id,
       sourceContent,
       isClientByDirective
     );
-    if (isBuild || isClientComponent) {
+    if (isBuild) {
       id = replaceExtension(id, {
         build: { extensionMap: build.extensionMap },
       });

--- a/test/dev/rsc-stream-format.test.ts
+++ b/test/dev/rsc-stream-format.test.ts
@@ -140,12 +140,15 @@ describe("RSC Stream Format", () => {
     await rm(testDir, { recursive: true, force: true });
   });
 
-  it("should include client component references with .js extension", () => {
-    // Client references should be .js, not .tsx
-    // The transformer should convert the extension for browser compatibility
-    // Note: filenames may include hashes like Link.client-14k4vk9.js
-    expect(response.result).toMatch(/I\[.*Link\.client.*\.js.*Link/);
-    expect(response.result).not.toMatch(/I\[.*\.client\.tsx.*Link/);
+  it("should include client component references with the dev .tsx extension", () => {
+    // In DEV the browser imports client modules through Vite, which transpiles
+    // .tsx on the fly — so the client-reference id keeps its real .tsx path.
+    // Extension mapping to .js happens only in a BUILD (where the browser loads
+    // the compiled .js). Forcing .js in dev produced a phantom
+    // "<name>.client.js.tsx" import that 404'd on the second HMR fetch and broke
+    // Fast Refresh after the first edit (bd-572).
+    expect(response.result).toMatch(/I\[.*Link\.client.*\.tsx.*Link/);
+    expect(response.result).not.toMatch(/I\[.*\.client\.js[^.].*Link/);
   });
 
   it("should include Root component in the stream", () => {

--- a/test/e2e/dev-fast-refresh.spec.ts
+++ b/test/e2e/dev-fast-refresh.spec.ts
@@ -13,9 +13,10 @@
  * Every case also asserts that vprs's condition guard
  * ("Condition mismatch …" / "react … under the wrong condition") never fires.
  *
- * Cases that don't yet hold under vprs's RSC conditions are marked with
- * `test.fail()` and a note — they pin the Fast-Refresh-vs-RSC bugs, and the FR
- * ticket is "delete those markers". Flip one off only when it genuinely passes.
+ * All cases pass as of the dev-only extension fix (bd-572): vprs no longer maps
+ * client-ref ids to `.js` in dev, so Fast Refresh's incremental fetch hits the
+ * real `.tsx` module instead of a phantom `.client.js.tsx` (404). This matrix
+ * now guards against Fast-Refresh / HMR regressions under RSC.
  *
  * Requires the bidoof-template fixture to have `@vitejs/plugin-react` wired
  * (`react()` before `vitePluginReactServer()`); without it the FR cases just
@@ -148,11 +149,6 @@ function defineSuite(mode: Mode, port: number) {
     test("client edit → Fast Refresh preserves state, no full reload", async ({
       page,
     }) => {
-      // KNOWN-BROKEN: Fast Refresh doesn't yet hot-update client components
-      // under vprs's RSC conditions — the edit fails to propagate (and on
-      // dev:rsc the first update can break subsequent HMR). Remove this marker
-      // when the FR-vs-RSC integration is fixed; an unexpected pass flags it.
-      test.fail();
       const issues = watchIssues(page);
       await page.goto(baseURL, { waitUntil: "networkidle" });
       const counter = page.getByRole("button", { name: /Click count/i });
@@ -180,9 +176,6 @@ function defineSuite(mode: Mode, port: number) {
     });
 
     test("repeated client edits keep hot-updating", async ({ page }) => {
-      // KNOWN-BROKEN: see the note above — once client-edit HMR is unreliable,
-      // repeated edits don't propagate either. Remove this marker when fixed.
-      test.fail();
       const issues = watchIssues(page);
       await page.goto(baseURL, { waitUntil: "networkidle" });
       await page.evaluate(() => ((window as Window & { __fr2?: string }).__fr2 = "alive"));

--- a/test/e2e/dev-fast-refresh.spec.ts
+++ b/test/e2e/dev-fast-refresh.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * Fast Refresh + HMR matrix across dev:rsc and dev:ssr.
+ *
+ * Codifies the dev cases that were being reproduced by hand:
+ *   - first paint renders cleanly,
+ *   - editing a CLIENT component hot-updates AND preserves state (Fast
+ *     Refresh) without a full reload,
+ *   - REPEATED client edits keep working (the "works once, then breaks" report
+ *     under dev:rsc),
+ *   - editing a SERVER component updates the view (RSC HMR refetch),
+ *   - a hard refresh renders without tripping the condition guard.
+ *
+ * Every case also asserts that vprs's condition guard
+ * ("Condition mismatch …" / "react … under the wrong condition") never fires.
+ *
+ * Cases that don't yet hold under vprs's RSC conditions are marked with
+ * `test.fail()` and a note — they pin the Fast-Refresh-vs-RSC bugs, and the FR
+ * ticket is "delete those markers". Flip one off only when it genuinely passes.
+ *
+ * Requires the bidoof-template fixture to have `@vitejs/plugin-react` wired
+ * (`react()` before `vitePluginReactServer()`); without it the FR cases just
+ * full-reload and the state-preservation assertions fail.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bidoofDir = join(__dirname, "../../../bidoof-template");
+const counterFile = join(bidoofDir, "src/components/Counter.client.tsx");
+const pageFile = join(bidoofDir, "src/page/page.tsx");
+
+const CONDITION_RE = /Condition mismatch|wrong condition|under the wrong|loaded under/i;
+
+async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
+}
+
+/** Collect condition-guard warnings + uncaught page errors for an assertion. */
+function watchIssues(page: Page): string[] {
+  const issues: string[] = [];
+  page.on("console", (m) => {
+    if (CONDITION_RE.test(m.text())) issues.push(`console: ${m.text()}`);
+  });
+  page.on("pageerror", (e) => issues.push(`pageerror: ${e.message}`));
+  return issues;
+}
+
+type Mode = "rsc" | "ssr";
+
+function defineSuite(mode: Mode, port: number) {
+  test.describe(`Fast Refresh + HMR — dev:${mode}`, () => {
+    // Serial (single worker) so beforeAll spawns exactly one server for this
+    // mode — under the default parallelism each worker would re-run beforeAll
+    // and collide on the port. No retries for the same reason.
+    test.describe.configure({ mode: "serial", retries: 0 });
+    let server: ChildProcess | undefined;
+    let origCounter = "";
+    let origPage = "";
+    const baseURL = `http://localhost:${port}`;
+
+    test.beforeAll(async () => {
+      origCounter = await readFile(counterFile, "utf-8");
+      origPage = await readFile(pageFile, "utf-8");
+      server = spawn("npx", ["vite", "--port", String(port), "--strictPort"], {
+        cwd: bidoofDir,
+        shell: true,
+        // Own process group so afterAll can kill the whole tree (shell -> npx
+        // -> vite -> esbuild); killing just the parent orphans vite and leaks
+        // the port to the next run.
+        detached: true,
+        env: {
+          ...process.env,
+          // dev:rsc carries the global react-server condition; dev:ssr does not.
+          NODE_OPTIONS: mode === "rsc" ? "--conditions react-server" : "",
+          NODE_ENV: "development",
+          BASE_URL: "/",
+          PUBLIC_ORIGIN: baseURL,
+          FORCE_COLOR: "1",
+          // WSL2 inotify on /mnt is unreliable; poll so edits are noticed.
+          CHOKIDAR_USEPOLLING: "true",
+          CHOKIDAR_INTERVAL: "500",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      server.stdout?.on("data", (d) => process.stdout.write(`[dev:${mode}] ${d}`));
+      server.stderr?.on("data", (d) => process.stderr.write(`[dev:${mode}] ${d}`));
+      await waitForServer(baseURL, 60_000);
+    }, 90_000);
+
+    test.afterEach(async () => {
+      // Restore both fixture files between tests so each starts from a clean
+      // source (tests edit the same files), then let the watcher settle.
+      await writeFile(counterFile, origCounter).catch(() => {});
+      await writeFile(pageFile, origPage).catch(() => {});
+      await new Promise((r) => setTimeout(r, 400));
+    });
+
+    test.afterAll(async () => {
+      await writeFile(counterFile, origCounter).catch(() => {});
+      await writeFile(pageFile, origPage).catch(() => {});
+      // Kill the whole process group (negative pid), wait for the real exit,
+      // escalate to SIGKILL — so vite/esbuild children don't orphan + hold the
+      // port for the next run.
+      const pid = server?.pid;
+      if (pid && server && server.exitCode === null && server.signalCode === null) {
+        await new Promise<void>((resolve) => {
+          server!.once("exit", () => resolve());
+          try {
+            process.kill(-pid, "SIGTERM");
+          } catch {
+            server!.kill("SIGTERM");
+          }
+          setTimeout(() => {
+            if (server && server.exitCode === null && server.signalCode === null) {
+              try {
+                process.kill(-pid, "SIGKILL");
+              } catch {
+                server.kill("SIGKILL");
+              }
+            }
+          }, 2000);
+        });
+      }
+    });
+
+    test("first paint renders without condition errors", async ({ page }) => {
+      const issues = watchIssues(page);
+      await page.goto(baseURL, { waitUntil: "networkidle" });
+      await expect(
+        page.getByRole("heading", { name: /vite-plugin-react-server demo/i })
+      ).toBeVisible();
+      expect(issues, issues.join("\n")).toEqual([]);
+    });
+
+    test("client edit → Fast Refresh preserves state, no full reload", async ({
+      page,
+    }) => {
+      // KNOWN-BROKEN: Fast Refresh doesn't yet hot-update client components
+      // under vprs's RSC conditions — the edit fails to propagate (and on
+      // dev:rsc the first update can break subsequent HMR). Remove this marker
+      // when the FR-vs-RSC integration is fixed; an unexpected pass flags it.
+      test.fail();
+      const issues = watchIssues(page);
+      await page.goto(baseURL, { waitUntil: "networkidle" });
+      const counter = page.getByRole("button", { name: /Click count/i });
+      await counter.click();
+      await counter.click();
+      await expect(counter).toHaveText(/Click count: 2/);
+      // Marker that a full page reload would wipe; Fast Refresh preserves it.
+      await page.evaluate(() => ((window as Window & { __fr?: string }).__fr = "alive"));
+
+      await writeFile(counterFile, origCounter.replace("Click count", "Clicks logged"));
+
+      // Hot-update applied…
+      await expect(
+        page.getByRole("button", { name: /Clicks logged/i })
+      ).toBeVisible({ timeout: 8000 });
+      // …state preserved (count still 2, not reset to 0)…
+      await expect(
+        page.getByRole("button", { name: /Clicks logged: 2/i })
+      ).toBeVisible();
+      // …and it was Fast Refresh, not a full reload.
+      expect(
+        await page.evaluate(() => (window as Window & { __fr?: string }).__fr)
+      ).toBe("alive");
+      expect(issues, issues.join("\n")).toEqual([]);
+    });
+
+    test("repeated client edits keep hot-updating", async ({ page }) => {
+      // KNOWN-BROKEN: see the note above — once client-edit HMR is unreliable,
+      // repeated edits don't propagate either. Remove this marker when fixed.
+      test.fail();
+      const issues = watchIssues(page);
+      await page.goto(baseURL, { waitUntil: "networkidle" });
+      await page.evaluate(() => ((window as Window & { __fr2?: string }).__fr2 = "alive"));
+
+      await writeFile(counterFile, origCounter.replace("Click count", "Tally one"));
+      await expect(page.getByRole("button", { name: /Tally one/i })).toBeVisible({
+        timeout: 8000,
+      });
+
+      await writeFile(counterFile, origCounter.replace("Click count", "Tally two"));
+      await expect(page.getByRole("button", { name: /Tally two/i })).toBeVisible({
+        timeout: 8000,
+      });
+
+      expect(
+        await page.evaluate(() => (window as Window & { __fr2?: string }).__fr2)
+      ).toBe("alive");
+      expect(issues, issues.join("\n")).toEqual([]);
+    });
+
+    test("server-component edit → view updates via HMR", async ({ page }) => {
+      const issues = watchIssues(page);
+      await page.goto(baseURL, { waitUntil: "networkidle" });
+
+      await writeFile(
+        pageFile,
+        origPage.replace("vite-plugin-react-server demo", "RSC demo updated")
+      );
+      await expect(
+        page.getByRole("heading", { name: /RSC demo updated/i })
+      ).toBeVisible({ timeout: 10000 });
+      expect(issues, issues.join("\n")).toEqual([]);
+    });
+
+    test("hard refresh renders without condition errors", async ({ page }) => {
+      const issues = watchIssues(page);
+      await page.goto(baseURL, { waitUntil: "networkidle" });
+      await page.reload({ waitUntil: "networkidle" });
+      await expect(
+        page.getByRole("heading", { name: /vite-plugin-react-server demo/i })
+      ).toBeVisible();
+      expect(issues, issues.join("\n")).toEqual([]);
+    });
+  });
+}
+
+// Two suites in one file run serially in a single worker, so they don't race
+// on the shared fixture files or fight for a port.
+defineSuite("rsc", 33700);
+defineSuite("ssr", 33701);


### PR DESCRIPTION
Fixes the Fast-Refresh-vs-RSC breakage (bd-572) and adds an e2e matrix that guards it.

## Root cause
`createModuleID` mapped client-component extensions `.tsx → .js` **even in dev**. The browser imported `<name>.client.js`, which resolved to a phantom `<name>.client.js.tsx`. Fast Refresh's first edit applied, but the next HMR fetch of that bogus path 404'd and broke all subsequent HMR (the "works once, then breaks" report; the dev:ssr refresh condition error was the same breakage).

## Fix
Gate the extension map on `isBuild` (was `isBuild || isClientComponent`). In dev Vite transpiles `.tsx` on the fly, so the client-ref id keeps its real `.tsx` path and FR's incremental fetch hits a real module. **Build refs are unchanged (`.js`).**

## Matrix (each × dev:rsc and dev:ssr) — all green
| scenario | status |
|---|---|
| first paint, no condition errors | ✅ |
| client edit → Fast Refresh (hot-update + state preserved, no full reload) | ✅ (was the bug) |
| repeated client edits keep hot-updating | ✅ (was the bug) |
| server-component edit → HMR refetch | ✅ |
| hard refresh, no condition mismatch | ✅ |

**10/10 pass — no `test.fail()` markers remain.** Repeated edits verified to hot-update with state preserved across all of them.

## Validation
- Full `test-all` green: server 503 / client 163 / unit 341 / typecheck 20.
- `rsc-stream-format.test.ts` updated: dev client refs are now `.tsx` — its old `.js`-in-dev assertion *was* the bug (build refs still `.js`).
- e2e matrix `dev-fast-refresh.spec.ts`: 10/10.
- Serial per mode + process-group kill in `afterAll` so vite children don't orphan/leak the port.

e2e-only suite (not in `test-all`); requires the bidoof fixture to have `react()` wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)