### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Patch release for the dev Fast Refresh fix (#87, bd-572).

Since 2.0.2:
- **#87** — dev Fast Refresh works under RSC: client-ref ids keep their real `.tsx` path in dev (extension mapping is build-only), so HMR no longer fetches a phantom `.client.js.tsx` (which 404'd after the first edit). Client-component edits now hot-update with state preserved, repeatedly, in both dev:rsc and dev:ssr — verified by the `dev-fast-refresh` e2e matrix (10/10) and full `test-all`.

Just the version bump (package.json + package-lock.json); `prepublishOnly` builds dist on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)