### PR TITLE
fix(dev): dev:ssr full-reload react-server condition error (bd-u7v)

### DIFF
--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -11,6 +11,7 @@ import { handleServerAction } from "./handleServerAction.client.js";
 import type { ConfigureWorkerRequestHandlerFn } from "../react-client/types.js";
 import { handleError } from "../error/handleError.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
+import { isReactServerCondition } from "../config/getCondition.js";
 import { setupGlobalErrorHandler, cleanupGlobalErrorHandler } from "../error/setupGlobalErrorHandler.js";
 import { pipeToResponse } from "../helpers/pipeToResponse.js";
 
@@ -179,35 +180,45 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
       const rootPath = routeFiles.root;
       // Note: htmlPath not used for RSC requests (always "" for headless mode)
       
-      // Pre-load props on main thread to apply Vite transforms (server actions need this)
-      // Use the server environment runner if available (Vite 6+), otherwise fall back to ssrLoadModule
-      // NOTE: In dev:ssr mode, this will fail because main thread lacks react-server condition.
-      // That's expected - the worker will load props instead.
+      // Pre-load props on main thread to apply Vite transforms (server actions need this).
+      // Only when the main process actually runs the react-server condition (dev:rsc):
+      // a props module pulls the server graph (and any client component it reaches loads
+      // its registerClientReference form, which imports react-server-dom-esm-server and
+      // hard-requires react-server). In dev:ssr the main thread is NOT react-server, so we
+      // must NOT attempt this — the worker loads props instead. Attempting it there made
+      // Vite's ModuleRunner log a "react-server condition must be enabled" error during
+      // full reloads even though we caught the rejection (bd-u7v). Gate on the condition
+      // so the doomed import never runs in dev:ssr.
       let resolvedPageProps: Record<string, unknown> | undefined;
       if (propsPath) {
         try {
           const fullPropsPath = `${handlerOptions.projectRoot}/${propsPath}`;
           const serverEnv = server.environments?.['server'];
           let propsModule: any;
-          
+
           if (handlerOptions.verbose) {
             logger.info(`[configureRequestHandler] Pre-loading props from: ${fullPropsPath}`);
           }
-          
-          if (serverEnv && 'runner' in serverEnv && serverEnv.runner) {
-            // Vite 6+ server environment with react-server conditions
+
+          if (
+            isReactServerCondition() &&
+            serverEnv &&
+            'runner' in serverEnv &&
+            serverEnv.runner
+          ) {
+            // dev:rsc — main thread has the react-server condition, so the server
+            // environment runner can evaluate the props (and the server graph) directly.
             try {
               propsModule = await (serverEnv.runner as any).import(fullPropsPath);
             } catch (runnerError: any) {
-              // Expected in dev:ssr mode - main thread lacks react-server condition
-              // Worker will load props instead (this is the normal path for dev:ssr)
               if (handlerOptions.verbose) {
-                logger.info(`[configureRequestHandler] Props will be loaded by worker (expected in dev:ssr mode)`);
+                logger.info(`[configureRequestHandler] Main-thread props import failed; worker will load props`);
               }
               propsModule = null;
             }
           } else {
-            // No server environment - let the worker handle it
+            // dev:ssr (no react-server on the main thread) or no server env:
+            // the worker loads props in its react-server context.
             propsModule = null;
           }
           const propsExportName = handlerOptions.propsExportName || "props";

--- a/test/e2e/dev-fast-refresh.spec.ts
+++ b/test/e2e/dev-fast-refresh.spec.ts
@@ -70,6 +70,10 @@ function defineSuite(mode: Mode, port: number) {
     let server: ChildProcess | undefined;
     let origCounter = "";
     let origPage = "";
+    // Accumulate the dev server's stdout+stderr so a test can assert the node
+    // console stays clean — the "react-server condition must be enabled" error
+    // on dev:ssr full reloads (bd-u7v) only shows here, not in the browser.
+    let serverLog = "";
     const baseURL = `http://localhost:${port}`;
 
     test.beforeAll(async () => {
@@ -96,8 +100,14 @@ function defineSuite(mode: Mode, port: number) {
         },
         stdio: ["ignore", "pipe", "pipe"],
       });
-      server.stdout?.on("data", (d) => process.stdout.write(`[dev:${mode}] ${d}`));
-      server.stderr?.on("data", (d) => process.stderr.write(`[dev:${mode}] ${d}`));
+      server.stdout?.on("data", (d) => {
+        serverLog += d;
+        process.stdout.write(`[dev:${mode}] ${d}`);
+      });
+      server.stderr?.on("data", (d) => {
+        serverLog += d;
+        process.stderr.write(`[dev:${mode}] ${d}`);
+      });
       await waitForServer(baseURL, 60_000);
     }, 90_000);
 
@@ -218,6 +228,16 @@ function defineSuite(mode: Mode, port: number) {
         page.getByRole("heading", { name: /vite-plugin-react-server demo/i })
       ).toBeVisible();
       expect(issues, issues.join("\n")).toEqual([]);
+    });
+
+    // Runs last (serial): the prior edits would, on dev:ssr, have triggered the
+    // node-console "react-server condition must be enabled" error during Vite's
+    // full reload (bd-u7v) if the props pre-load weren't gated to dev:rsc.
+    test("node console has no react-server condition error", () => {
+      expect(
+        serverLog,
+        serverLog.slice(-800)
+      ).not.toMatch(/condition must be enabled|error happened during full reload/i);
     });
   });
 }


### PR DESCRIPTION
## Problem
On **dev:ssr**, editing a client component logged a scary node-console error on Vite's full reload:
```
[vite] An error happened during full reload
The "react" package … the "react-server" condition must be enabled …
```
Client Fast Refresh itself worked (that was #87); this was separate. The SSR request handler pre-loads route props via the **server environment runner on the main thread**, but in dev:ssr the main process isn't `--conditions react-server`. The props chain reaches a client component whose `registerClientReference` form imports `react-server-dom-esm-server` (which hard-requires react-server) → throws. vprs *caught* it (the worker loads props instead, page works), but Vite's ModuleRunner logged the eval failure first — so dev:ssr looked broken while dev:rsc was clean.

## Fix
Gate the main-thread props pre-load on `isReactServerCondition()`. Only dev:rsc (where the main thread is react-server) attempts it; dev:ssr goes straight to the worker — the existing, working path — so the doomed import never runs and there's nothing for Vite to log. **No behavior change**: props still load via the worker in dev:ssr; the dev:rsc fast path is unchanged.

## Coverage
Extended `dev-fast-refresh.spec.ts` to buffer the dev server's stdout/stderr and assert the node console has no `react-server condition` / full-reload error — the matrix was browser-only and missed this. Now **12/12** (FR/HMR ×5 + node-console ×1, per mode).

Verified: full `test-all` green (503/163/341/20); matrix 12/12; mmc dev:ssr edit no longer logs the error, page still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)