### PR TITLE
chore: bump version to 2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Releases the dev-mode static build fixes from #91:
- client-component references match emitted chunks in `vite build --mode development` (no more `ERR_MODULE_NOT_FOUND` at SSG)
- the production JSX transform is forced for the ESM server bundle (fixes `module is not defined`)
- vite `mode` mirrors `NODE_ENV` as a single source of truth (honors an explicit `--mode`/config `mode`, otherwise mirrors)

No code changes beyond the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)