### PR TITLE
fix: static-build browser-client RSC — dev rsdom variant mismatch + headless .rsc <html> leak

### DIFF
--- a/plugin/helpers/createRscRenderHelpers.server.ts
+++ b/plugin/helpers/createRscRenderHelpers.server.ts
@@ -38,7 +38,13 @@ export function createReactElement(
 
   return createElementWithReact(React, {
     ...finalOptions,
-    Html: isHeadless ? React.Fragment : finalOptions.HtmlComponent,
+    // NOTE: createElementWithReact reads `HtmlComponent`, not `Html`. For a
+    // headless (page-level) stream the Html wrapper must be replaced with a
+    // Fragment so the emitted .rsc has no <html>/<head>/<body> wrapper — this
+    // is what the browser client mounts into #root. Setting `Html` here was a
+    // no-op, leaking the full document into the headless .rsc (matches the
+    // dev server, which already sets HtmlComponent: React.Fragment).
+    HtmlComponent: isHeadless ? React.Fragment : finalOptions.HtmlComponent,
     as: isHeadless ? React.Fragment : "div",
   });
 }

--- a/plugin/helpers/createRscRenderHelpers.server.ts
+++ b/plugin/helpers/createRscRenderHelpers.server.ts
@@ -38,12 +38,13 @@ export function createReactElement(
 
   return createElementWithReact(React, {
     ...finalOptions,
-    // NOTE: createElementWithReact reads `HtmlComponent`, not `Html`. For a
-    // headless (page-level) stream the Html wrapper must be replaced with a
-    // Fragment so the emitted .rsc has no <html>/<head>/<body> wrapper — this
-    // is what the browser client mounts into #root. Setting `Html` here was a
-    // no-op, leaking the full document into the headless .rsc (matches the
-    // dev server, which already sets HtmlComponent: React.Fragment).
+    // A headless (page-level) stream must drop the Html wrapper so its .rsc has
+    // no <html>/<head>/<body> — that's what the browser client mounts into
+    // #root (a full document there nests <html> inside a <div> and wedges it).
+    // createElementWithReact reads `HtmlComponent`, NOT `Html`, so the previous
+    // `Html: Fragment` was silently ignored: the Fragment override never took
+    // effect and the headless stream kept emitting the full document. Set the
+    // key the helper actually reads. (The dev server already does this.)
     HtmlComponent: isHeadless ? React.Fragment : finalOptions.HtmlComponent,
     as: isHeadless ? React.Fragment : "div",
   });

--- a/plugin/vendor/vendor-alias.ts
+++ b/plugin/vendor/vendor-alias.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "vite";
 import { join } from "node:path";
 import { lstatSync, readlinkSync, symlinkSync, unlinkSync } from "node:fs";
 import { transportPkgDir, transportRoot } from "./transportDir.js";
+import { getNodeEnv } from "../config/getNodeEnv.js";
 
 /**
  * Vite plugin that aliases `react-server-dom-esm/*` imports to the vendored
@@ -20,9 +21,32 @@ export function vitePluginVendorAlias(): Plugin {
     name: "vite-plugin-react-server:vendor-alias",
     enforce: "pre",
 
-    config(_config, env) {
+    config(config, _env) {
       const pkg = transportPkgDir;
-      const isProd = env.mode === "production";
+      // Pick the dev/prod variant of the browser client from the SAME unified
+      // `mode` that `resolveUserConfig` uses for the React build define — never
+      // from `env.mode` alone.
+      //
+      // `env.mode` (configEnv.mode) is pre-populated with the command default
+      // ("production" for `vite build`, "development" for serve), so it cannot
+      // distinguish explicit user intent. Under `NODE_ENV=development vite
+      // build` it would be "production" and this alias would pull the
+      // PRODUCTION rsdom browser client even though React itself and the dev
+      // `.rsc` are development — yielding the runtime error "Failed to read a
+      // RSC payload created by a development version of React on the server
+      // while using a production version on the client."
+      //
+      // Mirror resolveUserConfig's rule: an explicit `config.mode` (set only
+      // when the user passes `--mode <m>` or authors `mode` in their config)
+      // wins; otherwise mirror NODE_ENV (normalized by getNodeEnv). This keeps
+      // the rsdom browser client's dev/prod choice locked to the same mode that
+      // selects the dev-vs-prod React build.
+      const explicitMode =
+        typeof config.mode === "string" && config.mode !== ""
+          ? config.mode
+          : undefined;
+      const mode = explicitMode ?? getNodeEnv();
+      const isProd = mode === "production";
 
       return {
         resolve: {

--- a/plugin/worker/rsc/handleRscRender.server.ts
+++ b/plugin/worker/rsc/handleRscRender.server.ts
@@ -132,10 +132,13 @@ export const handleRscRender: HandleRscRenderFn = function _handleRscRender(
 
     // Use ReactDOMServer directly in the worker
     // For headless streams, use Fragment; for full streams, use the actual Html component
+    // NOTE: createElementWithReact reads `HtmlComponent`, not `Html`; setting
+    // `Html` here was a no-op that leaked the full <html> document into the
+    // headless stream. Override the key the helper actually consumes.
     const isHeadless = id.includes("headless");
     const element = createElementWithReact(React, {
       ...finalOptions,
-      Html: isHeadless ? React.Fragment : finalOptions.HtmlComponent,
+      HtmlComponent: isHeadless ? React.Fragment : finalOptions.HtmlComponent,
       as: isHeadless ? React.Fragment : "div",
     });
     if (verbose) {

--- a/plugin/worker/rsc/handleRscRender.server.ts
+++ b/plugin/worker/rsc/handleRscRender.server.ts
@@ -130,11 +130,11 @@ export const handleRscRender: HandleRscRenderFn = function _handleRscRender(
       }
     }
 
-    // Use ReactDOMServer directly in the worker
-    // For headless streams, use Fragment; for full streams, use the actual Html component
-    // NOTE: createElementWithReact reads `HtmlComponent`, not `Html`; setting
-    // `Html` here was a no-op that leaked the full <html> document into the
-    // headless stream. Override the key the helper actually consumes.
+    // Headless streams use a Fragment instead of the Html wrapper; full streams
+    // keep the real Html component. createElementWithReact reads `HtmlComponent`,
+    // NOT `Html` — so the previous `Html: Fragment` was silently ignored, the
+    // override never applied, and the headless stream emitted the full <html>
+    // document. Set the key the helper actually reads.
     const isHeadless = id.includes("headless");
     const element = createElementWithReact(React, {
       ...finalOptions,


### PR DESCRIPTION
This PR ships two related fixes for the static-build / browser-client RSC path. Both surface on the same repro route (`/static-no-backend`) served from a static host with no backend.

---

## Fix 1 — dev-mode build pulls the production rsdom browser client (RSC payload mismatch)

### Problem

A dev-mode app build —

```
NODE_ENV=development NODE_OPTIONS='--conditions react-server' vite build --app
```

— produced a **development** client bundle (non-minified React) that nonetheless imported the **production** `react-server-dom-esm` browser client. The static build's `.rsc` is emitted by the **development** rsdom server. At runtime the browser threw, before the app rendered:

```
Failed to read a RSC payload created by a development version of React
on the server while using a production version on the client.
```

### Root cause

`plugin/vendor/vendor-alias.ts` aliases `react-server-dom-esm/client.browser` directly to the ESM dev/prod build, choosing the variant from `const isProd = env.mode === "production"`. `env.mode` (`configEnv.mode`) is pre-populated with the **command default** — `"production"` for `vite build` — regardless of `--mode` or `NODE_ENV` (the exact pitfall already documented in `resolveUserConfig.ts`). So a `NODE_ENV=development` build set `isProd = true`, aliasing the browser client to the production rsdom file while React and the dev `.rsc` went development → payload-version mismatch.

### Fix

Resolve the variant from the **same unified `mode`** that `resolveUserConfig` already uses for the React build define: an explicit `config.mode` wins, otherwise mirror `NODE_ENV` via `getNodeEnv()`. This locks the rsdom browser client's dev/prod choice to the mode that selects the dev-vs-prod React build.

### Verification

- **Production safety:** `vite build --app` static chunks are **byte-identical** before/after (`md5sum` match); prod still imports `client.browser.production.js` and minified React.
- **Dev build fixed:** dev build now imports `client.browser.development.js`; the `Failed to read a RSC payload…` error is gone. (This is what made Fix 2's bug observable in a dev build — see below.)

---

## Fix 2 — headless `.rsc` leaks the full `<html>` document into the per-route stream

### Problem

The static build wrote a per-route `.rsc` whose **root element was the full `<html>` document** (the user's `Html` component), even though the headless code path intends a page-level stream. The browser client does:

```js
createRoot(document.getElementById("root")).render(<Shell data={createReactFetcher(/* the route's .rsc */)} />)
```

and `React.use()`s that stream — so React rendered `<html>` **into** `<div id="root">`. On load: console error `In HTML, <html> cannot be a child of <div>`, a malformed fiber tree, and a **frozen tab on the first click/keystroke** (React-DOM's event walk wedges). The prerendered `index.html` was fine (single `<html>`, page inside `#root`) — only the client-fetched `.rsc` wrongly carried the document wrapper.

### Root cause

`createReactElement` (`plugin/helpers/createRscRenderHelpers.server.ts`) and the RSC worker (`plugin/worker/rsc/handleRscRender.server.ts`) tried to drop the `Html` wrapper for headless streams by passing `Html: React.Fragment` — but `createElementWithReact` reads **`HtmlComponent`**, not `Html`. The override was a **no-op**: the real `Html` component stayed in place and the full document leaked into the headless `.rsc`. The dev server already had this right (`HtmlComponent: React.Fragment` in `configureReactServer.server.ts`, with a comment noting it "prevents hydration errors where `<html>` would be rendered inside #root div"), which is why dev streamed page-level and worked.

### Fix

Override **`HtmlComponent`** (the key the helper actually consumes) in both headless paths. The per-route `.rsc` is now genuinely page-level (no `html`/`head`/`body`), matching what the client mounts into `#root` and what the dev server streams. The full/`Html`-wrapped stream that prerenders `index.html` is untouched — `index.html` still emits a single `<html>` with the page inside `#root`.

### Verification (consumer app, `/static-no-backend?v=control`, headless Chromium)

Both **dev** (`NODE_ENV=development … vite build --app`) and **prod** (`vite build --app`) builds:

- (a) built `.rsc` has **0** `html`/`head`/`body` element refs (page-level root);
- (b) the `In HTML, <html> cannot be a child of <div>` console error is **gone** (0 console errors total);
- (c) the form renders, typing a character updates the input value, and the main thread stays responsive — **no freeze**;
- (d) `index.html` still has exactly one `<html>` with the page inside `#root`.

The prod freeze is fixed too, since the same `.rsc` fix applies.

---

## Tests

`test:unit` (344 passed) and `test:typecheck` (20 passed) green. No example/build test asserted on the `.rsc` carrying the document wrapper, so none needed updating (the `.rsc` assertions check generic ref-marker structure; the `<html>` assertions are scoped to `.html` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
