### PR TITLE
chore: bump version to 2.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Releases the static-build browser-client RSC fixes from #93:
- the vendored `react-server-dom-esm` browser client resolves its dev/prod variant from the mirrored mode (no more dev/prod RSC payload mismatch in dev-mode builds)
- the headless per-route `.rsc` no longer carries the full `<html>` document, so the browser client mounts page content into `#root` instead of nesting `<html>` in a `<div>` (fixes the freeze on static / no-backend hosts)

No code changes beyond the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)