### PR TITLE
fix: hot-update client-graph CSS modules under dev:rsc

### DIFF
--- a/plugin/dev-server/collectRunnerCss.ts
+++ b/plugin/dev-server/collectRunnerCss.ts
@@ -6,7 +6,7 @@ import type {
   Logger,
 } from "vite";
 
-const CSS_EXT = /\.(css|scss|sass|less|styl|stylus|pcss|postcss)(\?|$)/;
+export const CSS_EXT = /\.(css|scss|sass|less|styl|stylus|pcss|postcss)(\?|$)/;
 
 export type CollectedCss = { id: string; code: string };
 

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import type { VitePluginFn } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.client.js";
 import { resolveOptions } from "../config/resolveOptions.js";
+import { CSS_EXT } from "./collectRunnerCss.js";
 import { detectClientModule } from "react-server-loader/directives";
 import type { ConfigEnv } from "vite";
 
@@ -96,8 +97,7 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       // CSS edits route through the same worker-invalidation path so the
       // ModuleRunner cache drops every reachable CSS module before the
       // next render asks for class-name hashes.
-      const isCssFile = isInModuleBase &&
-        (file.endsWith('.css') || file.endsWith('.scss') || file.endsWith('.sass') || file.endsWith('.less'));
+      const isCssFile = isInModuleBase && CSS_EXT.test(file);
 
       // Skip client components — Vite owns client-side HMR (Fast Refresh
       // when `@vitejs/plugin-react` is installed, plain reload otherwise).

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -1,6 +1,7 @@
 import type { StreamPluginOptions } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.server.js";
 import { resolveOptions } from "../config/resolveOptions.js";
+import { CSS_EXT } from "./collectRunnerCss.js";
 import { detectClientModule } from "react-server-loader/directives";
 import type { Plugin, ViteDevServer } from "vite";
 import { readFileSync } from "node:fs";
@@ -53,9 +54,7 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
 
         if (isClient) return; // Vite's client-side HMR owns this update
 
-        const isCssFile =
-          file.endsWith('.css') || file.endsWith('.scss') ||
-          file.endsWith('.sass') || file.endsWith('.less');
+        const isCssFile = CSS_EXT.test(file);
 
         // A CSS module imported transitively by a "use client" component lives
         // in the CLIENT module graph (the browser fetches it directly and Vite

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -33,7 +33,7 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
     hotUpdate(ctx: any) {
       const { file, server } = ctx;
       const envName = ctx.environment?.name ?? 'unknown';
-      
+
       const moduleBase = userOptions.moduleBase || "src";
       const projectRoot = userOptions.projectRoot || server?.config?.root || '';
       const normalizedFile = file.replace(projectRoot, '').replace(/^\/+/, '');
@@ -53,16 +53,28 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
 
         if (isClient) return; // Vite's client-side HMR owns this update
 
+        const isCssFile =
+          file.endsWith('.css') || file.endsWith('.scss') ||
+          file.endsWith('.sass') || file.endsWith('.less');
+
+        // A CSS module imported transitively by a "use client" component lives
+        // in the CLIENT module graph (the browser fetches it directly and Vite
+        // injects it as a <style>), so Vite's native CSS HMR already updates it
+        // in place — no reload, no <link> cache-bust. Detect that case by the
+        // presence of client-environment modules for this file and hand the
+        // update back to Vite. Suppressing it here (the `return []` below) is
+        // what previously left client-graph CSS edits stuck until a manual
+        // refresh: the RSC <link> cache-bust never matches a Vite <style>.
+        if (isCssFile && (ctx.modules?.length ?? 0) > 0) {
+          return; // let Vite's native client CSS HMR apply the update
+        }
+
         // CSS files that aren't imported via the client module graph (vprs's
         // <Css cssFiles={...}/> pattern collects them server-side) aren't
         // tracked by Vite's CSS HMR, so a content edit leaves the <link>
         // tag's href unchanged. Tag the event so useRscHmr knows to refresh
         // matching link tags by cache-busting their href.
-        const kind: 'css' | 'component' =
-          file.endsWith('.css') || file.endsWith('.scss') ||
-          file.endsWith('.sass') || file.endsWith('.less')
-            ? 'css'
-            : 'component';
+        const kind: 'css' | 'component' = isCssFile ? 'css' : 'component';
 
         // Server component changed — send RSC refetch event to client
         // Only do this once (from client env) to avoid duplicate events


### PR DESCRIPTION
## Problem

Under dev:rsc (`NODE_OPTIONS='--conditions react-server'` + vite), editing a `*.module.css` reachable only through a `"use client"` component did **not** hot-update the styles in the browser. No HMR update reached the page and no full reload fired either — only a manual refresh applied the new rules. CSS modules used by **server** components hot-update fine, so the bug was isolated to the client module graph.

The merged regression guard `test/e2e/dev-rsc-client-css-hmr.spec.ts` pinned this: the server-component CSS control passed, the client-component CSS case was red.

## Root cause

The dev:rsc `hotUpdate` hook (`plugin/dev-server/plugin.server.ts`) ran for all environments. In the `client` environment it treated **every** CSS file as server-collected CSS (vprs's `<Css cssFiles={...}/>` pattern): it sent the `vite-plugin-react-server:server-component-update` RSC event and `return []` to suppress Vite's update.

A CSS module imported transitively by a `"use client"` component is actually in the **client** module graph — the browser fetches it directly and Vite injects it as a `<style>`. Vite's native CSS HMR handles it perfectly. But the blanket `return []` suppressed that, and the RSC handler's fallback (`refreshCssLinks` cache-busting a `<link href>`) never matches a Vite-injected `<style>` — so the edit stayed stuck until a manual refresh.

A probe confirmed the asymmetry on the `client` environment's `hotUpdate`:
- server-graph `home.module.css` → `ctx.modules` empty (not in client graph)
- client-graph `counterStyles.module.css` → `ctx.modules` = `[/src/css/counterStyles.module.css]` (in client graph)

## Fix

Detect client-graph CSS by the presence of client-environment modules for the changed file (`ctx.modules`). When present, return `undefined` so Vite's native client CSS HMR applies the update in place (no reload). Server-collected CSS (no client-graph module) keeps the existing RSC-event + `<link>` cache-bust path unchanged, so the server-component CSS control stays green.

This is implemented at the same layer that already discriminates client vs server modules in this hook — no full-page-reload workaround.

## Verification

- `test/e2e/dev-rsc-client-css-hmr.spec.ts` — both tests pass (control + previously-red client-CSS).
- `test/e2e/dev-fast-refresh.spec.ts` — 12/12 pass (no regression).
- `test/e2e/dev-ssr-css-hmr.spec.ts` — 2/2 pass.
- `test/e2e/hmr.spec.ts` (dev:rsc on :3200) — 10/10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)