### PR TITLE
chore: bump version to 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Release **2.0.7** (patch). Unreleased since 2.0.6:
- **fix:** CSS modules reached through a `"use client"` component now hot-update under dev:rsc instead of requiring a manual refresh (#96) — the dev hotUpdate hook was blanket-suppressing Vite's native CSS HMR for the client env; now it hands client-graph CSS back to Vite. Also unified CSS detection on the canonical `CSS_EXT` regex.
- **test:** e2e regression guard for the above (#95), green on main.

Publish build (`prepublishOnly → npm run build`) verified clean. Merge, then `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)