### PR TITLE
chore: bump version to 2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Bumps `package.json` + `package-lock.json` to **2.0.8**.

**2.0.8** = the dev:ssr client-graph CSS HMR fix + its e2e guard (#98) — the dev:ssr counterpart to #96's dev:rsc fix. Under `dev:ssr`, client-graph CSS modules now hot-update without a manual refresh.

Verified the publish build (`prepublishOnly` → `npm run build`) runs clean, so the publish won't choke.

**To publish:** merge this, then from `main` run `npm publish` (it builds dist via `prepublishOnly` and ships 2.0.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)