### PR TITLE
fix(hmr): subscribe useRscHmr once, regardless of callback identity

### DIFF
--- a/plugin/dev-server/virtualRscHmrPlugin.ts
+++ b/plugin/dev-server/virtualRscHmrPlugin.ts
@@ -9,7 +9,7 @@ const RESOLVED_VIRTUAL_RSC_HMR = '\0' + VIRTUAL_RSC_HMR;
  * HMR code is dead-code eliminated in production builds (import.meta.hot is undefined).
  */
 const VIRTUAL_RSC_HMR_SOURCE = /* js */`
-import { useEffect, useCallback } from "react";
+import { useEffect, useRef } from "react";
 
 const RSC_HMR_EVENT = 'vite-plugin-react-server:server-component-update';
 
@@ -53,10 +53,20 @@ function refreshCssLinks(data) {
 }
 
 export function useRscHmr(refetch, options = {}) {
-  const { verbose = true, filter } = options;
+  // Keep the latest callback + options in a ref so the subscribe effect can run
+  // exactly once on mount. Keying the effect on the handler identity instead
+  // would tear down and re-add the import.meta.hot listener on every render —
+  // and since client-side RSC navigation re-renders the shell, an unmemoized
+  // (inline) refetch callback would churn the listener (and re-log "Listening…")
+  // on every navigation. The ref pattern makes inline callbacks safe.
+  const ref = useRef(null);
+  ref.current = { refetch, options };
 
-  const handler = useCallback(
-    (data) => {
+  useEffect(() => {
+    if (typeof import.meta.hot === 'undefined') return;
+    const handler = (data) => {
+      const { refetch, options } = ref.current;
+      const { verbose = true, filter } = options;
       if (filter && !filter(data)) return;
       if (verbose) {
         console.log('[RSC HMR] Server component updated:', data.file, data.kind ? '(' + data.kind + ')' : '');
@@ -65,20 +75,15 @@ export function useRscHmr(refetch, options = {}) {
         refreshCssLinks(data);
       }
       refetch(window.location.pathname);
-    },
-    [refetch, verbose, filter]
-  );
-
-  useEffect(() => {
-    if (typeof import.meta.hot === 'undefined') return;
+    };
     import.meta.hot.on(RSC_HMR_EVENT, handler);
-    if (verbose) {
+    if (ref.current.options.verbose !== false) {
       console.log('[RSC HMR] Listening for server component updates');
     }
     return () => {
       import.meta.hot.off(RSC_HMR_EVENT, handler);
     };
-  }, [handler, verbose]);
+  }, []);
 }
 
 export function setupRscHmr(options = {}) {

--- a/plugin/utils/useRscHmr.ts
+++ b/plugin/utils/useRscHmr.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useRef } from "react";
 import { RSC_HMR_EVENT } from "./createReactFetcher.js";
 import type { RscHmrData } from "./createReactFetcher.js";
 import { env } from "./env.js";
@@ -79,8 +79,24 @@ export function useRscHmr(
 ) {
   const { verbose = env.DEV, filter } = options;
 
-  const handler = useCallback(
-    (data: RscHmrData) => {
+  // Keep the latest callback + options in a ref so the subscribe effect can run
+  // exactly once on mount. Keying the effect on the handler identity instead
+  // would tear down and re-add the import.meta.hot listener on every render —
+  // and since client-side RSC navigation re-renders the shell, an unmemoized
+  // (inline) refetch callback would churn the listener (and re-log "Listening…")
+  // on every navigation. The ref pattern makes inline callbacks safe.
+  const ref = useRef<{
+    refetch: (url: string) => void;
+    verbose: boolean;
+    filter?: (data: RscHmrData) => boolean;
+  }>({ refetch, verbose, filter });
+  ref.current = { refetch, verbose, filter };
+
+  useEffect(() => {
+    if (typeof import.meta.hot === 'undefined') return;
+
+    const handler = (data: RscHmrData) => {
+      const { refetch, verbose, filter } = ref.current;
       if (filter && !filter(data)) return;
       const kind = (data as { kind?: string }).kind;
       if (verbose) {
@@ -90,21 +106,16 @@ export function useRscHmr(
         refreshCssLinks(data);
       }
       refetch(window.location.pathname);
-    },
-    [refetch, verbose, filter]
-  );
-
-  useEffect(() => {
-    if (typeof import.meta.hot === 'undefined') return;
+    };
 
     import.meta.hot.on(RSC_HMR_EVENT, handler);
-    
-    if (verbose) {
+
+    if (ref.current.verbose) {
       console.log('[RSC HMR] Listening for server component updates');
     }
 
     return () => {
       import.meta.hot!.off(RSC_HMR_EVENT, handler);
     };
-  }, [handler, verbose]);
+  }, []);
 }


### PR DESCRIPTION
## Problem

`useRscHmr` keyed its `import.meta.hot` subscribe effect on the **handler identity** — deps `[handler, verbose]`, where `handler = useCallback(…, [refetch, verbose, filter])`. When a consumer passes an **inline / unmemoized** callback, the handler changes every render, so the effect tears down and re-adds the HMR listener on every render.

Client-side RSC navigation re-renders the shell, so this churns the listener — and re-logs `[RSC HMR] Listening for server component updates` — on **every navigation**. It's harmless (the cleanup calls `import.meta.hot.off`, so no listener leak), but it's wasteful, noisy, and a footgun: it silently pushes a memoization requirement onto callers. The bundled bidoof demo (`src/client.tsx`, mirrored by downstream starters) passes exactly such an inline arrow.

## Fix

Latest-ref pattern: stash the current callback + options in a `useRef`, and subscribe **once on mount** (empty-deps effect), reading the live callback from the ref inside the handler. The listener attaches once and `Listening…` logs once for the component's lifetime — whether or not the caller memoizes.

Applied to both implementations:
- the virtual `virtual:react-server/hmr` module (`plugin/dev-server/virtualRscHmrPlugin.ts`)
- the `vite-plugin-react-server/utils` export (`plugin/utils/useRscHmr.ts`)

## Verification

- `tsc --noEmit` clean; `npm run build` clean.
- Existing dev HMR unit tests (`test/dev/hmr.test.ts`, `test/dev/css-hmr.test.ts`) stay green (5/5).
- End-to-end against the bidoof demo (which uses an inline arrow), pointing it at this build: `[RSC HMR] Listening…` went from **7 logs across 3 navigations → 1**, with HMR refetch still working.

Downstream apps that already memoized their callback to work around this (e.g. the mission-control dashboard) can drop that workaround once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)