### PR TITLE
fix(static): rewrite invalid as="stylesheet" CSS preload hint in SSG output

### DIFF
--- a/plugin/react-static/fileWriter.ts
+++ b/plugin/react-static/fileWriter.ts
@@ -15,6 +15,7 @@ import { Transform, PassThrough } from "node:stream";
 import type { FileWriterFn } from "./types.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
 import { handleError } from "../error/handleError.js";
+import { createCssPreloadFixStream } from "./fixCssPreloadHint.js";
 
 /**
  * A robust content collecting transform stream that handles race conditions
@@ -193,11 +194,18 @@ export const fileWriter: FileWriterFn = function _fileWriter(
     }
   }
 
+  // For HTML, splice in a transform that rewrites stable React's invalid
+  // `as="stylesheet"` CSS preload hint to the valid `as="style"` on the way to
+  // disk (see fixCssPreloadHint.ts). RSC output is left untouched.
+  const cssPreloadFix =
+    fileType === "html" ? createCssPreloadFixStream() : undefined;
+
   return new Promise<void>((resolve, reject) => {
     // Handle abort signal
     const abortHandler = () => {
       writeStream.destroy();
       contentCollector.destroy();
+      cssPreloadFix?.destroy();
       sourceStream.destroy?.();
       const abortReason = signal?.reason || new Error("File write aborted");
       reject(abortReason);
@@ -207,8 +215,12 @@ export const fileWriter: FileWriterFn = function _fileWriter(
       signal.addEventListener("abort", abortHandler);
     }
 
-    // Set up the stream pipeline manually for better control
-    sourceStream.pipe(contentCollector).pipe(writeStream);
+    // Set up the stream pipeline manually for better control.
+    if (cssPreloadFix) {
+      sourceStream.pipe(cssPreloadFix).pipe(contentCollector).pipe(writeStream);
+    } else {
+      sourceStream.pipe(contentCollector).pipe(writeStream);
+    }
 
     // Handle errors from any part of the pipeline
     const handleError = (error: Error) => {
@@ -224,6 +236,7 @@ export const fileWriter: FileWriterFn = function _fileWriter(
     };
 
     sourceStream.on('error', handleError);
+    cssPreloadFix?.on('error', handleError);
     contentCollector.on('error', handleError);
     writeStream.on('error', handleError);
 

--- a/plugin/react-static/fixCssPreloadHint.ts
+++ b/plugin/react-static/fixCssPreloadHint.ts
@@ -1,0 +1,69 @@
+/**
+ * fixCssPreloadHint.ts
+ *
+ * PURPOSE: Neutralize the invalid CSS preload hint that stable React's Flight
+ * server emits, so apps on stable React stop flooding the console with
+ * "Preload ... was ignored / invalid `as` value" warnings — without forking,
+ * vendoring, or patching React.
+ *
+ * Root cause (bead geitje-bot-mission-control-1wz, discovered-from d9x):
+ * React 19.2.x stable's `ReactFlightServerConfigDOM.processLink()` calls
+ * `preload(href, 'stylesheet')`, but `stylesheet` is NOT a valid preload `as`
+ * value (the valid token is `style`). The Flight client replays the hint
+ * verbatim, so the static HTML ends up with:
+ *     <link rel="preload" href="..." as="stylesheet"/>
+ * Browsers reject the hint and warn. The real, valid stylesheet link
+ * (`<link rel="stylesheet" ... data-precedence>`) is emitted separately, so the
+ * preload is redundant — we simply rewrite the token to the valid `style` to
+ * silence the warning while preserving React's preload intent.
+ *
+ * We can't change what React's Flight server serializes, but vprs owns the SSG
+ * HTML writer (fileWriter), so we fix it there on the way to disk. Scope is the
+ * exact token `as="stylesheet"`, which only ever appears in this invalid
+ * preload hint — a real stylesheet uses `rel="stylesheet"` (never `as=`), and
+ * other preloads use `as="image"`, `as="script"`, etc. — so the rewrite cannot
+ * touch anything legitimate.
+ */
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+const INVALID = 'as="stylesheet"';
+const VALID = 'as="style"';
+
+/** Replace every invalid CSS preload token in a complete string. */
+export function fixCssPreloadHint(html: string): string {
+  return html.split(INVALID).join(VALID);
+}
+
+/**
+ * A streaming Transform that rewrites `as="stylesheet"` -> `as="style"` as HTML
+ * flows to disk. Safe across chunk boundaries: a `StringDecoder` keeps partial
+ * multibyte sequences intact, and we hold back the last `INVALID.length - 1`
+ * characters of each emitted chunk so a token split across two chunks is still
+ * matched once the rest arrives.
+ */
+export function createCssPreloadFixStream(): Transform {
+  const decoder = new StringDecoder("utf8");
+  // The longest tail that could be the start of a token split across chunks.
+  const hold = INVALID.length - 1;
+  let carry = "";
+
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      const buf = carry + decoder.write(chunk as Buffer);
+      const replaced = fixCssPreloadHint(buf);
+      if (replaced.length <= hold) {
+        // Not enough yet to safely emit anything without risking a split token.
+        carry = replaced;
+        callback();
+        return;
+      }
+      carry = replaced.slice(replaced.length - hold);
+      callback(null, replaced.slice(0, replaced.length - hold));
+    },
+    flush(callback) {
+      const buf = carry + decoder.end();
+      callback(null, fixCssPreloadHint(buf));
+    },
+  });
+}

--- a/plugin/react-static/index.server.ts
+++ b/plugin/react-static/index.server.ts
@@ -6,6 +6,10 @@ export { createRscToHtmlStream } from "./rscToHtmlStream.server.js";
 export { collectHtmlContent } from "./collectHtmlContent.js";
 // Shared exports
 export { fileWriter } from "./fileWriter.js";
+export {
+  fixCssPreloadHint,
+  createCssPreloadFixStream,
+} from "./fixCssPreloadHint.js";
 export { renderPages } from "./renderPages.js";
 export { configurePreviewServer } from "./configurePreviewServer.js";
 export { collectRscContent } from "./collectRscContent.js";

--- a/static.ts
+++ b/static.ts
@@ -4,6 +4,8 @@ export {
     temporaryReferences,
     createBuildLoader,
     fileWriter,
+    fixCssPreloadHint,
+    createCssPreloadFixStream,
     renderPages,
     configurePreviewServer,
     collectRscContent,

--- a/test/unit/fixCssPreloadHint.test.ts
+++ b/test/unit/fixCssPreloadHint.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { Readable } from "node:stream";
+import {
+  fixCssPreloadHint,
+  createCssPreloadFixStream,
+} from "vite-plugin-react-server/static";
+
+// Regression: stable React 19.2.x's Flight server emits CSS preload hints with
+// the invalid token `as="stylesheet"` (the valid preload value is `style`), and
+// the Flight client replays it verbatim into the SSG HTML, flooding the browser
+// console with "preload ignored / invalid as" warnings. vprs rewrites the token
+// to the valid `as="style"` in its HTML writer, without forking React.
+// See bead geitje-bot-mission-control-1wz (discovered-from d9x).
+
+// Real bytes captured from an mmc GitHub Pages build (dist/static/index.html).
+const REAL_SAMPLE =
+  '<link rel="preload" as="image" imageSrcSet="/10mmc/illustration-220.webp 220w"/>' +
+  '<link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.5.0/css/flag-icon.min.css" as="stylesheet"/>' +
+  '<link rel="preload" href="/assets/globalStyles-rszm1l.css" as="stylesheet"/>' +
+  '<link rel="stylesheet" href="/assets/globalStyles-rszm1l.css" data-precedence="high"/>';
+
+async function runStream(chunks: string[]): Promise<string> {
+  const fix = createCssPreloadFixStream();
+  const out: Buffer[] = [];
+  Readable.from(chunks.map((c) => Buffer.from(c, "utf8"))).pipe(fix);
+  for await (const chunk of fix) out.push(Buffer.from(chunk));
+  return Buffer.concat(out).toString("utf8");
+}
+
+describe("fixCssPreloadHint (pure)", () => {
+  it("rewrites the invalid token to the valid one", () => {
+    expect(fixCssPreloadHint('<link as="stylesheet"/>')).toBe(
+      '<link as="style"/>'
+    );
+  });
+
+  it("rewrites every occurrence", () => {
+    const out = fixCssPreloadHint(REAL_SAMPLE);
+    expect(out).not.toContain('as="stylesheet"');
+    expect(out.match(/as="style"/g)).toHaveLength(2);
+  });
+
+  it("leaves real stylesheet links and other preloads untouched", () => {
+    const out = fixCssPreloadHint(REAL_SAMPLE);
+    // The real, valid stylesheet link must be preserved verbatim.
+    expect(out).toContain(
+      '<link rel="stylesheet" href="/assets/globalStyles-rszm1l.css" data-precedence="high"/>'
+    );
+    // `as="image"` and other preloads are not CSS hints and stay as-is.
+    expect(out).toContain('as="image"');
+  });
+
+  it("is a no-op when there is nothing to fix", () => {
+    const clean = '<link rel="stylesheet" href="/a.css"/>';
+    expect(fixCssPreloadHint(clean)).toBe(clean);
+  });
+});
+
+describe("createCssPreloadFixStream (streaming)", () => {
+  it("rewrites the token within a single chunk", async () => {
+    expect(await runStream([REAL_SAMPLE])).toBe(fixCssPreloadHint(REAL_SAMPLE));
+  });
+
+  it("rewrites a token split across chunk boundaries", async () => {
+    // Split right in the middle of the `as="stylesheet"` token.
+    const left = '<link rel="preload" href="/a.css" as="sty';
+    const right = 'lesheet"/>';
+    const out = await runStream([left, right]);
+    expect(out).toBe('<link rel="preload" href="/a.css" as="style"/>');
+    expect(out).not.toContain('as="stylesheet"');
+  });
+
+  it("rewrites tokens split byte-by-byte (worst case)", async () => {
+    const input = REAL_SAMPLE;
+    const out = await runStream(input.split(""));
+    expect(out).toBe(fixCssPreloadHint(input));
+  });
+
+  it("preserves multibyte UTF-8 split across chunk boundaries", async () => {
+    // A 3-byte char (€) split across two chunks must round-trip intact.
+    const euro = Buffer.from("€", "utf8");
+    const fix = createCssPreloadFixStream();
+    const out: Buffer[] = [];
+    Readable.from([
+      Buffer.concat([Buffer.from('<p>', "utf8"), euro.subarray(0, 1)]),
+      Buffer.concat([euro.subarray(1), Buffer.from('</p>', "utf8")]),
+    ]).pipe(fix);
+    for await (const chunk of fix) out.push(Buffer.from(chunk));
+    expect(Buffer.concat(out).toString("utf8")).toBe("<p>€</p>");
+  });
+});


### PR DESCRIPTION
## Problem

Apps on **stable React 19.2.x** get their browser console flooded with `A preload for '…' is found, but is not used … invalid \`as\` value` warnings for every linked CSS file in the static build.

Root cause is upstream React, not vprs: `ReactFlightServerConfigDOM.processLink()` calls `preload(href, 'stylesheet')`, but `stylesheet` is **not** a valid preload `as` value (the valid token is `style`). The Flight client replays the hint verbatim, so the SSG HTML ends up with:

```html
<link rel="preload" href="/assets/globalStyles.css" as="stylesheet"/>
```

The real, valid `<link rel="stylesheet" … data-precedence>` is emitted separately, so the preload is purely redundant — the styling works, it's just console noise (plus a wasted, ignored hint).

## Why fix it here

We deliberately target **stable** React to avoid chasing experimental/patched builds, so the fix lives in vprs, not in a React fork. vprs owns the SSG HTML writer, so `fileWriter` now splices a small streaming transform into the **HTML** pipeline that rewrites `as="stylesheet"` → `as="style"` on the way to disk. RSC output is untouched.

The token is unambiguous and safe to rewrite globally: a real stylesheet uses `rel="stylesheet"` (never `as=`), and other preloads use `as="image"` / `as="script"` / etc. — so the rewrite can only ever hit the invalid CSS hint. Styling is unchanged because the separate `rel="stylesheet"` links are never modified.

## Implementation

- **`plugin/react-static/fixCssPreloadHint.ts`** — `fixCssPreloadHint(html)` (pure) + `createCssPreloadFixStream()` (Transform). Chunk-boundary safe: `StringDecoder` keeps multibyte UTF-8 intact, and a held-back tail catches a token split across two chunks.
- **`plugin/react-static/fileWriter.ts`** — splice the transform into the pipeline for `fileType === "html"` only; wired into error + abort handling.
- Exported from the `./static` barrel.

## Verification

- New unit test `test/unit/fixCssPreloadHint.test.ts` (8 cases): single chunk, every occurrence, real-stylesheet/`as="image"` left untouched, no-op, token split mid-chunk, byte-by-byte worst case, multibyte split. **8/8 green.**
- End-to-end through the **real** `fileWriter` against captured mmc build bytes: HTML rewritten to `as="style"`, RSC stream untouched, `rel="stylesheet"` + `as="image"` intact.
- Full unit suite **352/352 green**, `tsc --build` clean.

Final confirmation against a published build: run an mmc/linked-CSS SSG build after this ships and check the console is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)