### PR TITLE
refactor(config): route resolved isClientComponent* through the single detector

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -96,7 +96,9 @@ export const config = {
 | `allowedDirectives` | `string[]` | List of allowed directive names | `["use server", "use client"]` |
 | `mode` | `"development" \| "production" \| "test"` | Loader mode | `"development"` |
 | `isServerFunctionCode` | `(code: string, moduleId?: string) => boolean` | Custom server function detection | - |
-| `isClientComponentCode` | `(code: string, moduleId?: string) => boolean` | Custom client component detection | - |
+| `isClientComponentCode` | `(code: string, moduleId?: string) => boolean` | Custom client-module detection (source + filename) | `detectClientModule` (filename `.client.*` or top-of-file `"use client"`) |
+| `isClientComponentByCode` | `(code: string) => boolean` | Custom client-module detection (source only) | `detectClientModule` |
+| `isClientComponentByName` | `(moduleId: string) => boolean` | Custom client-module detection (filename only) | `detectClientModule`; a custom `autoDiscover.clientPattern` takes precedence |
 | `getDirectiveType` | `(directive: string, moduleId?: string) => "client" \| "server" \| undefined` | Custom directive type detection | - |
 
 ### Auto-Discovery Options

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -1,7 +1,9 @@
 import { Root } from "../components/root.js";
 import { Html } from "../components/html.js";
-import { parse } from "react-server-loader/transformer";
-import { detectClientModule } from "react-server-loader/directives";
+import {
+  parse,
+  DEFAULT_LOADER_CONFIG as RSL_LOADER_DEFAULTS,
+} from "react-server-loader/transformer";
 import { pluginRoot } from "../root.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { getCondition } from "./getCondition.js";
@@ -23,24 +25,6 @@ const IS_SERVER_ACTION_CODE = (code: string, moduleId?: string) =>
   (moduleId && SERVER_ACTION_FILE.test(moduleId.toLowerCase())) ||
   false;
 
-// Defaults for the user-overridable `loader.isClientComponent*` hooks. All
-// three delegate to the single detector at
-// `loader/directives/detectClientModule`, which recognises a module as
-// client when its filename matches `.client.[cm]?[jt]sx?$` OR its source
-// declares a top-of-file `"use client"` directive (AST-validated when a
-// parser is available, char-scanner otherwise). A path with "client" as a
-// substring of an identifier, comment, or directory name (e.g.
-// `src/lib/clientId.ts`) is NOT a client module.
-const IS_CLIENT_COMPONENT_CODE = (code: string, moduleId?: string) =>
-  detectClientModule({ source: code, moduleId });
-
-const IS_CLIENT_COMPONENT_BY_CODE = (code: string) =>
-  detectClientModule({ source: code });
-
-const IS_CLIENT_COMPONENT_BY_NAME = (
-  moduleId: string,
-  _transformedModuleId?: string,
-) => detectClientModule({ moduleId });
 // Directive configurations
 export const DIRECTIVE_CONFIGS = {
   client: {
@@ -102,9 +86,14 @@ export const DEFAULT_LOADER_CONFIG = {
   clientDirective: DIRECTIVE_PATTERNS.CLIENT,
   directivePattern: DIRECTIVE_PATTERNS.ANY,
   isServerFunctionCode: IS_SERVER_ACTION_CODE,
-  isClientComponentCode: IS_CLIENT_COMPONENT_CODE,
-  isClientComponentByCode: IS_CLIENT_COMPONENT_BY_CODE,
-  isClientComponentByName: IS_CLIENT_COMPONENT_BY_NAME,
+  // The user-overridable `loader.isClientComponent*` hooks default to
+  // react-server-loader's own defaults, which all delegate to the single
+  // detector `detectClientModule` (filename `.client.[cm]?[jt]sx?$` OR a
+  // top-of-file `"use client"` directive; substrings like `clientId` never
+  // match). vprs deliberately defines no detector of its own.
+  isClientComponentCode: RSL_LOADER_DEFAULTS.isClientComponentCode,
+  isClientComponentByCode: RSL_LOADER_DEFAULTS.isClientComponentByCode,
+  isClientComponentByName: RSL_LOADER_DEFAULTS.isClientComponentByName,
   allowedDirectives: DIRECTIVE_CONFIGS,
   importServerPath: "react-server-dom-esm/server",
   importClientPath: "react-server-dom-esm/server",

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -320,10 +320,6 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     options.loader?.serverDirective,
     DEFAULT_LOADER_CONFIG.serverDirective
   );
-  const clientDirective = resolveRegExp(
-    options.loader?.clientDirective,
-    DEFAULT_LOADER_CONFIG.clientDirective
-  );
   const isServerFunctionCode = resolveDirectiveMatcher(
     serverDirective,
     (code: string, moduleId?: string) =>
@@ -332,21 +328,38 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
       false
   );
 
-  const isClientComponentCode = resolveDirectiveMatcher(
-    clientDirective,
-    (code: string, moduleId?: string) =>
-      code.match(clientDirective) != null ||
-      (typeof moduleId === "string" && clientPattern.test(moduleId)) ||
-      false
-  );
+  // Resolution order for the client-module detectors: an explicit user hook
+  // wins; otherwise a user-supplied `loader.clientDirective` /
+  // `autoDiscover.clientPattern` drives the matching; otherwise the single
+  // detector (`detectClientModule` behind DEFAULT_LOADER_CONFIG) decides.
+  // The pattern argument must be the RAW user option — passing the
+  // pre-resolved `clientDirective` (never undefined) made the anchored
+  // default regex shadow the detector: `.client.tsx` modules without a
+  // directive resolved to false here while the worker loader (which
+  // re-resolves defaults after serialization strips function hooks) said
+  // true, and user-supplied `loader.isClientComponent*` hooks were ignored
+  // entirely.
+  const isClientComponentCode =
+    options.loader?.isClientComponentCode ??
+    resolveDirectiveMatcher(
+      options.loader?.clientDirective,
+      DEFAULT_LOADER_CONFIG.isClientComponentCode
+    );
 
-  const isClientComponentByCode = resolveDirectiveMatcher(
-    clientDirective,
-    (code: string) => code.match(clientDirective) != null || false
-  );
+  const isClientComponentByCode =
+    options.loader?.isClientComponentByCode ??
+    resolveDirectiveMatcher(
+      options.loader?.clientDirective,
+      DEFAULT_LOADER_CONFIG.isClientComponentByCode
+    );
 
-  const isClientComponentByName = (moduleId: string, _transformedModuleId?: string) => 
-    (typeof moduleId === "string" && clientPattern.test(moduleId)) || false;
+  const isClientComponentByName =
+    options.loader?.isClientComponentByName ??
+    (options.autoDiscover?.clientPattern
+      ? (moduleId: string, _transformedModuleId?: string) =>
+          (typeof moduleId === "string" && clientPattern.test(moduleId)) ||
+          false
+      : DEFAULT_LOADER_CONFIG.isClientComponentByName);
 
   const hashOption = options.build?.hash ?? DEFAULT_CONFIG.BUILD.hash;
 

--- a/test/unit/resolvedClientDetector.test.ts
+++ b/test/unit/resolvedClientDetector.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { testUserOptions } from "../test-config.js";
+import { resolveOptions } from "vite-plugin-react-server/config";
+import { DEFAULT_LOADER_CONFIG } from "vite-plugin-react-server/config";
+
+/**
+ * Pins the resolution routing for the `loader.isClientComponent*` hooks in
+ * `resolveOptions`: an explicit user hook wins; otherwise a user-supplied
+ * `loader.clientDirective` / `autoDiscover.clientPattern` drives matching;
+ * otherwise the single detector (`detectClientModule` behind
+ * DEFAULT_LOADER_CONFIG) decides.
+ *
+ * Regression target: the resolver used to pass the PRE-RESOLVED
+ * clientDirective (never undefined) into resolveDirectiveMatcher, so the
+ * anchored default regex always shadowed the detector — `.client.tsx`
+ * modules without a directive resolved to false in-process while the worker
+ * loader (re-resolving defaults after serialization strips function hooks)
+ * said true, and user-supplied hooks were silently ignored.
+ */
+
+// The loader config is only resolved when `loader.mode` is set.
+const resolve = (
+  extra: { loader?: Record<string, unknown>; autoDiscover?: Record<string, unknown> } = {}
+) =>
+  resolveOptions({
+    ...testUserOptions,
+    ...extra,
+    loader: { mode: "test", ...(extra.loader ?? {}) },
+  } as Parameters<typeof resolveOptions>[0]).userOptions!;
+
+describe("resolveOptions isClientComponent* routing", () => {
+  it("defaults are the DEFAULT_LOADER_CONFIG detectors themselves (worker parity)", () => {
+    const { loader } = resolve();
+    expect(loader!.isClientComponentCode).toBe(
+      DEFAULT_LOADER_CONFIG.isClientComponentCode
+    );
+    expect(loader!.isClientComponentByCode).toBe(
+      DEFAULT_LOADER_CONFIG.isClientComponentByCode
+    );
+    expect(loader!.isClientComponentByName).toBe(
+      DEFAULT_LOADER_CONFIG.isClientComponentByName
+    );
+  });
+
+  it("default isClientComponentCode recognises filename-only client modules", () => {
+    const { loader } = resolve();
+    // No directive in source — the filename branch must decide. The shadowed
+    // regex matcher returned false here.
+    expect(
+      loader!.isClientComponentCode(
+        `export const x = 1;`,
+        "src/components/Counter.client.tsx"
+      )
+    ).toBe(true);
+    // Substring trap stays rejected.
+    expect(
+      loader!.isClientComponentCode(`export const x = 1;`, "src/lib/clientId.ts")
+    ).toBe(false);
+  });
+
+  it("default isClientComponentCode accepts a directive after 'use strict'", () => {
+    const { loader } = resolve();
+    expect(
+      loader!.isClientComponentCode(
+        `"use strict";\n"use client";\nexport const x = 1;`,
+        "node_modules/some-lib/dist/leaf.js"
+      )
+    ).toBe(true);
+  });
+
+  it("an explicit user hook wins over the default", () => {
+    const isClientComponentCode = (_code: string, _moduleId?: string) => true;
+    const isClientComponentByName = (_moduleId: string) => true;
+    const { loader } = resolve({
+      loader: { isClientComponentCode, isClientComponentByName },
+    });
+    expect(loader!.isClientComponentCode).toBe(isClientComponentCode);
+    expect(loader!.isClientComponentByName).toBe(isClientComponentByName);
+  });
+
+  it("a user clientDirective drives source matching when no hook is given", () => {
+    const { loader } = resolve({
+      loader: { clientDirective: /^\/\/ my-client-marker/ },
+    });
+    expect(
+      loader!.isClientComponentCode(`// my-client-marker\nexport const x = 1;`)
+    ).toBe(true);
+    expect(
+      loader!.isClientComponentCode(`"use client";\nexport const x = 1;`)
+    ).toBe(false);
+  });
+
+  it("a user autoDiscover.clientPattern drives byName matching when no hook is given", () => {
+    const { loader } = resolve({
+      autoDiscover: { clientPattern: /\.browser\.tsx$/ },
+    });
+    expect(loader!.isClientComponentByName("src/App.browser.tsx")).toBe(true);
+    expect(loader!.isClientComponentByName("src/App.client.tsx")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Fixes the last detector divergence in the client-module detection consolidation: the matchers `resolveOptions` hands to the loader config were regex-based and disagreed with the `detectClientModule` detector used everywhere else.

## Why

`resolveOptions` passed the **pre-resolved** `clientDirective` (never `undefined`) into `resolveDirectiveMatcher`, so the anchored default regex always shadowed the real detector. Consequences:

- a `.client.tsx` module without a `"use client"` directive resolved to **false** in-process, while the worker loader (which re-resolves defaults after serialization strips function hooks) said **true** — the exact cross-layer disagreement class behind earlier detection bugs
- `"use strict";"use client"` node_modules leaves misclassified (anchored regex)
- user-supplied `loader.isClientComponent*` hooks were **silently ignored** (nothing ever consulted `options.loader?.isClientComponentCode`), despite being documented

## How

Resolution order is now: explicit user hook → user `clientDirective` / `autoDiscover.clientPattern` → `DEFAULT_LOADER_CONFIG` (delegating to `detectClientModule`).

vprs's local `IS_CLIENT_COMPONENT_*` wrappers are deleted in favour of `react-server-loader`'s identical exported defaults — vprs no longer defines any client detector of its own.

## Test

- New `test/unit/resolvedClientDetector.test.ts` pins the routing: default-identity with the rsl detectors (worker parity), filename-only client modules, `"use strict"` prologue, user-hook precedence, custom directive/pattern precedence.
- Full gates green: `test:server` 518 passed, `test:unit` 350 passed, `test:typecheck` 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)