### PR TITLE
refactor(config): one canonical trailing-segment rule for entry naming and moduleID

### DIFF
--- a/plugin/config/createModuleID.ts
+++ b/plugin/config/createModuleID.ts
@@ -3,6 +3,7 @@ import { replaceExtension } from "./extMap.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { DEFAULT_CONFIG } from "./defaults.js";
 import { detectClientModule } from "react-server-loader/directives";
+import { stripTrailingDotSegment } from "../helpers/inputNormalizer.js";
 import type { ConfigEnv } from "vite";
 import { sep, resolve, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
@@ -199,23 +200,18 @@ export const createDefaultModuleID = (
 
         // Step 1b: Match the build's entryFile name normalization for
         // DIRECTIVE-detected client modules. The emitted chunk name comes from
-        // `entryFile` → `normalizer(n.name)`, which strips one trailing
-        // ".segment" unless it's `.client`/`.server`. For a compound filename
-        // like `view/View.generated.tsx` that collapses to `view/View`, but
-        // this moduleID otherwise keeps `.generated` — so the registered client
-        // reference (`view/View.generated-<hash>.js`) wouldn't match the emitted
-        // chunk (`view/View-<hash>.js`) → ERR_MODULE_NOT_FOUND at SSG render.
-        // `.client.`-named modules are unaffected (the normalizer preserves
-        // that suffix, and so do we). Single-segment names have nothing to strip.
+        // `entryFile` → `normalizer(n.name)`, which collapses one trailing
+        // ".segment" (`view/View.generated` → `view/View`) — so the moduleID
+        // must collapse identically or the registered client reference points
+        // at a chunk that was never emitted (ERR_MODULE_NOT_FOUND at SSG
+        // render). Delegated to the normalizer's own rule instead of a local
+        // copy so the two paths can't drift again.
         if (isClientByDirective) {
-          const noExt = transformedId.replace(/\.[cm]?[jt]sx?$/, "");
-          if (!noExt.endsWith(".client") && !noExt.endsWith(".server")) {
-            const lastDot = noExt.lastIndexOf(".");
-            if (lastDot > noExt.lastIndexOf("/")) {
-              transformedId =
-                noExt.slice(0, lastDot) + transformedId.slice(noExt.length);
-            }
-          }
+          const ext = transformedId.match(/\.[cm]?[jt]sx?$/)?.[0] ?? "";
+          const noExt = ext
+            ? transformedId.slice(0, -ext.length)
+            : transformedId;
+          transformedId = stripTrailingDotSegment(noExt) + ext;
         }
 
         // Step 2: Apply extension mapping for build

--- a/plugin/helpers/inputNormalizer.ts
+++ b/plugin/helpers/inputNormalizer.ts
@@ -9,20 +9,36 @@ import { DEFAULT_CONFIG } from "../config/defaults.js";
 
 let stashedNormalizer: InputNormalizer | null = null;
 
+/**
+ * Strip ONE trailing ".segment" from an extension-less module path —
+ * `view/View.generated` → `view/View` — the normalization Rollup chunk names
+ * get for entry naming. `.client`/`.server` suffixes are load-bearing and
+ * preserved. A dot inside a directory name doesn't count (`view.v2/Widget`
+ * stays intact).
+ *
+ * This is THE canonical trailing-segment rule: the build's entry naming
+ * (via `removeExtension: true` here) and the transformer's client-reference
+ * moduleID (`createModuleID` Step 1b) must agree on it, or the registered
+ * client ref points at a chunk name that was never emitted
+ * (ERR_MODULE_NOT_FOUND at SSG render).
+ */
+export function stripTrailingDotSegment(path: string): string {
+  if (path.endsWith(".client") || path.endsWith(".server")) {
+    return path;
+  }
+  const lastDot = path.lastIndexOf(".");
+  if (lastDot === -1 || lastDot <= path.lastIndexOf("/")) {
+    return path;
+  }
+  return path.slice(0, lastDot);
+}
+
 const resolveExtensionOptions = (
   removeExtension: CreateInputNormalizerProps["removeExtension"]
 ) => {
   if (typeof removeExtension === "boolean") {
     if (removeExtension) {
-      return (path: string) => {
-        // if extension is client or server, don't remove it
-        if (path.endsWith(".client") || path.endsWith(".server")) {
-          return path;
-        }
-        const extensionIndex = path.lastIndexOf(".");
-
-        return extensionIndex !== -1 ? path.slice(0, extensionIndex) : path;
-      };
+      return stripTrailingDotSegment;
     }
     return (path: string) => path;
   }

--- a/test/unit/createModuleID.test.ts
+++ b/test/unit/createModuleID.test.ts
@@ -76,4 +76,62 @@ describe("createDefaultModuleID — dev-mode build ref/emit parity", () => {
     expect(id).toContain("src/components/Widget.client");
     expect(id).not.toMatch(/-[A-Za-z0-9]+\.js$/);
   });
+
+  /**
+   * Trailing-segment normalization for DIRECTIVE-detected client modules
+   * (Step 1b) must match the build's entryFile normalizer
+   * (stripTrailingDotSegment) for every naming convention — the two used to
+   * be independent copies that agreed only by inspection (the compound-
+   * filename bug fixed in PR #55 was exactly such a drift).
+   */
+  describe("directive-detected client moduleID — trailing-segment parity", () => {
+    const buildId = (id: string) =>
+      createDefaultModuleID(options, buildProd, "production")(
+        id,
+        undefined,
+        /* isClientByDirective */ true
+      );
+
+    it("compound filename collapses one trailing segment (bd-80r regression)", () => {
+      expect(buildId("src/view/View.generated.tsx")).toMatch(
+        /^\/view\/View-[A-Za-z0-9]+\.js$/
+      );
+    });
+
+    it("multi-dot filename collapses exactly ONE trailing segment", () => {
+      expect(buildId("src/components/A.B.C.tsx")).toMatch(
+        /^\/components\/A\.B-[A-Za-z0-9]+\.js$/
+      );
+    });
+
+    it("hyphenated-with-dots filename collapses the dot segment only", () => {
+      expect(buildId("src/components/a-b.c.tsx")).toMatch(
+        /^\/components\/a-b-[A-Za-z0-9]+\.js$/
+      );
+    });
+
+    it("`.client.` suffix is preserved, not collapsed", () => {
+      expect(buildId("src/components/Widget.client.tsx")).toMatch(
+        /^\/components\/Widget\.client-[A-Za-z0-9]+\.js$/
+      );
+    });
+
+    it("`.server.` suffix is preserved, not collapsed", () => {
+      expect(buildId("src/components/Widget.server.tsx")).toMatch(
+        /^\/components\/Widget\.server-[A-Za-z0-9]+\.js$/
+      );
+    });
+
+    it("a dot in a DIRECTORY name is not a trailing segment", () => {
+      expect(buildId("src/view.v2/Widget.tsx")).toMatch(
+        /^\/view\.v2\/Widget-[A-Za-z0-9]+\.js$/
+      );
+    });
+
+    it("single-segment filename has nothing to strip", () => {
+      expect(buildId("src/components/Widget.tsx")).toMatch(
+        /^\/components\/Widget-[A-Za-z0-9]+\.js$/
+      );
+    });
+  });
 });

--- a/test/unit/createModuleID.test.ts
+++ b/test/unit/createModuleID.test.ts
@@ -92,7 +92,7 @@ describe("createDefaultModuleID — dev-mode build ref/emit parity", () => {
         /* isClientByDirective */ true
       );
 
-    it("compound filename collapses one trailing segment (bd-80r regression)", () => {
+    it("compound filename collapses one trailing segment (compound-filename regression, PR #55)", () => {
       expect(buildId("src/view/View.generated.tsx")).toMatch(
         /^\/view\/View-[A-Za-z0-9]+\.js$/
       );

--- a/test/unit/stripTrailingDotSegment.test.ts
+++ b/test/unit/stripTrailingDotSegment.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+// Import the SOURCE so this guards plugin/helpers/inputNormalizer.ts directly.
+import { stripTrailingDotSegment } from "../../plugin/helpers/inputNormalizer.js";
+
+/**
+ * The canonical trailing-segment rule shared by the build's entryFile
+ * normalizer (`removeExtension: true`) and the transformer's client-reference
+ * moduleID (createModuleID Step 1b). One implementation, one truth — these
+ * cases pin its behavior for every naming convention either side sees.
+ */
+describe("stripTrailingDotSegment", () => {
+  it("collapses one trailing segment from a compound name", () => {
+    expect(stripTrailingDotSegment("view/View.generated")).toBe("view/View");
+  });
+
+  it("collapses exactly ONE segment from a multi-dot name", () => {
+    expect(stripTrailingDotSegment("components/A.B.C")).toBe("components/A.B");
+  });
+
+  it("handles hyphenated names with dots", () => {
+    expect(stripTrailingDotSegment("components/a-b.c")).toBe("components/a-b");
+  });
+
+  it("preserves the `.client` suffix", () => {
+    expect(stripTrailingDotSegment("components/Link.client")).toBe(
+      "components/Link.client"
+    );
+  });
+
+  it("preserves the `.server` suffix", () => {
+    expect(stripTrailingDotSegment("actions/save.server")).toBe(
+      "actions/save.server"
+    );
+  });
+
+  it("ignores dots in directory names (no basename dot → no strip)", () => {
+    // The old inline copy in the normalizer truncated this to "view" —
+    // the dot must be in the BASENAME to count as a trailing segment.
+    expect(stripTrailingDotSegment("view.v2/Widget")).toBe("view.v2/Widget");
+  });
+
+  it("strips only the basename segment when both dir and basename have dots", () => {
+    expect(stripTrailingDotSegment("view.v2/Widget.generated")).toBe(
+      "view.v2/Widget"
+    );
+  });
+
+  it("leaves dot-less paths untouched", () => {
+    expect(stripTrailingDotSegment("components/Widget")).toBe(
+      "components/Widget"
+    );
+  });
+});


### PR DESCRIPTION
## Why

The compound-filename bug (#55) was a copy-paste drift of the entry-name normalizer's trailing-segment-strip logic, manually inlined as Step 1b in `createModuleID`. That PR fixed the drift but left two implementations that agree only by inspection — every new naming convention is a fresh chance for the registered client reference and the emitted chunk name to disagree, which surfaces as `ERR_MODULE_NOT_FOUND` at SSG render.

## What

- The rule now lives once: `stripTrailingDotSegment` in `plugin/helpers/inputNormalizer.ts` — collapse ONE trailing `.segment` of the **basename**, preserving the load-bearing `.client`/`.server` suffixes. The build's entryFile normalization (`removeExtension: true`) and `createModuleID` Step 1b both delegate to it, so they can't drift again.
- Unifying also fixes a latent normalizer bug the inline copy didn't have: a dot in a **directory** name (`view.v2/Widget`) was treated as a trailing segment and truncated the whole basename to `view`. The canonical rule only counts basename dots (the moduleID side already guarded this).
- New tests pin the rule for multi-dot (`A.B.C.tsx`), hyphenated-with-dots (`a-b.c.tsx`), `.client.`/`.server.` boundaries, dotted directories, and the `Widget.generated.tsx` regression — at both the helper level (`test/unit/stripTrailingDotSegment.test.ts`) and through the directive-detected moduleID path (`test/unit/createModuleID.test.ts`).

## Verification

Full `test-all` gate green: test:server 537, test:client 173, test:unit 365, typecheck 20. The existing #55 regression suite (`directive-client-build.test.ts`) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)