### PR TITLE
fix(vendor): pair the RSC renderer with the process's React variant; survive NODE_ENV flips

### DIFF
--- a/plugin/react-static/renderPagesBatched.ts
+++ b/plugin/react-static/renderPagesBatched.ts
@@ -12,6 +12,7 @@ import { fileWriter } from "./fileWriter.js";
 import type { Manifest } from "vite";
 import { createRenderMetrics } from "../metrics/createRenderMetrics.js";
 import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
+import { lockReactFamily } from "../vendor/lazyVendorModule.js";
 
 const DEFAULT_BATCH_SIZE = 8;
 
@@ -250,6 +251,12 @@ export const renderPagesBatched: RenderPagesFn = (
   handlerOptions,
   renderPage
 ) => {
+  // Pin react + jsx-runtime to ONE dev/prod variant before any page module
+  // loads in-process — a page's jsx-runtime import otherwise samples
+  // NODE_ENV at load time and can disagree with the cached react/renderer
+  // when tooling flipped NODE_ENV after plugin import.
+  lockReactFamily();
+
   const {
     autoDiscoveredFiles,
     manifest = {},

--- a/plugin/react-static/temporaryReferences.server.ts
+++ b/plugin/react-static/temporaryReferences.server.ts
@@ -1,5 +1,24 @@
 import { ReactDOMServer } from "../vendor/vendor.server.js";
 
-const { createTemporaryReferenceSet } = ReactDOMServer;
+type TemporaryReferenceSet = ReturnType<
+  typeof ReactDOMServer.createTemporaryReferenceSet
+>;
 
-export const temporaryReferences = createTemporaryReferenceSet();
+// LAZY: this module is reached at plugin-import time (orchestrator chain).
+// Creating the reference set there would touch the vendored renderer and lock
+// its dev/prod variant to NODE_ENV-at-import — the exact mismatch the lazy
+// vendor modules exist to prevent (see vendor/lazyVendorModule.ts). Defer the
+// createTemporaryReferenceSet() call to first use (build/render time).
+let lazySet: TemporaryReferenceSet | null = null;
+const ensure = (): TemporaryReferenceSet =>
+  (lazySet ??= ReactDOMServer.createTemporaryReferenceSet());
+
+export const temporaryReferences = new Proxy({} as TemporaryReferenceSet, {
+  get(_target, prop) {
+    const target = ensure() as any;
+    const value = target[prop];
+    // Map-like methods need the real set as `this`
+    return typeof value === "function" ? value.bind(target) : value;
+  },
+  has: (_target, prop) => prop in (ensure() as any),
+});

--- a/plugin/react-static/temporaryReferences.server.ts
+++ b/plugin/react-static/temporaryReferences.server.ts
@@ -4,21 +4,50 @@ type TemporaryReferenceSet = ReturnType<
   typeof ReactDOMServer.createTemporaryReferenceSet
 >;
 
-// LAZY: this module is reached at plugin-import time (orchestrator chain).
-// Creating the reference set there would touch the vendored renderer and lock
-// its dev/prod variant to NODE_ENV-at-import — the exact mismatch the lazy
-// vendor modules exist to prevent (see vendor/lazyVendorModule.ts). Defer the
-// createTemporaryReferenceSet() call to first use (build/render time).
-let lazySet: TemporaryReferenceSet | null = null;
-const ensure = (): TemporaryReferenceSet =>
-  (lazySet ??= ReactDOMServer.createTemporaryReferenceSet());
+/**
+ * LAZY temporary-reference sets.
+ *
+ * Calling createTemporaryReferenceSet() at module scope would touch the
+ * vendored renderer at plugin-import time and lock its dev/prod variant to
+ * NODE_ENV-at-import — the exact mismatch the lazy vendor modules exist to
+ * prevent (see vendor/lazyVendorModule.ts). The proxy defers the call to
+ * first use (build/render time).
+ *
+ * Proxy semantics: method lookups return BOUND methods, cached per property
+ * so identity is stable and hot build paths don't allocate per call. Writes
+ * and deletes forward to the real set. This is NOT a real WeakMap instance
+ * (`instanceof` is false, internal-slot calls like
+ * `WeakMap.prototype.has.call(proxy, k)` throw) — never hand it to APIs
+ * that brand-check; in-repo consumers only call .has/.get/.set/.delete.
+ */
+export function createLazyTemporaryReferenceSet(): TemporaryReferenceSet {
+  let lazySet: TemporaryReferenceSet | null = null;
+  const bound = new Map<PropertyKey, unknown>();
+  const ensure = (): TemporaryReferenceSet =>
+    (lazySet ??= ReactDOMServer.createTemporaryReferenceSet());
 
-export const temporaryReferences = new Proxy({} as TemporaryReferenceSet, {
-  get(_target, prop) {
-    const target = ensure() as any;
-    const value = target[prop];
-    // Map-like methods need the real set as `this`
-    return typeof value === "function" ? value.bind(target) : value;
-  },
-  has: (_target, prop) => prop in (ensure() as any),
-});
+  return new Proxy({} as TemporaryReferenceSet, {
+    get(_target, prop) {
+      const target = ensure() as any;
+      const value = target[prop];
+      if (typeof value !== "function") return value;
+      let fn = bound.get(prop);
+      if (fn === undefined) {
+        fn = value.bind(target);
+        bound.set(prop, fn);
+      }
+      return fn;
+    },
+    has: (_target, prop) => prop in (ensure() as any),
+    set(_target, prop, value) {
+      (ensure() as any)[prop] = value;
+      return true;
+    },
+    deleteProperty(_target, prop) {
+      delete (ensure() as any)[prop];
+      return true;
+    },
+  });
+}
+
+export const temporaryReferences = createLazyTemporaryReferenceSet();

--- a/plugin/stream/createRenderToPipeableStreamHandler.server.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.server.ts
@@ -1,5 +1,6 @@
 import { createElementWithReact } from "../helpers/createElementWithReact.js";
-import { React, ReactDOMServer } from "../vendor/vendor.server.js";
+import { React, ReactDOMServer, getVendoredRendererMode } from "../vendor/vendor.server.js";
+import { assertRendererElementParity } from "../utils/assertRendererElementParity.js";
 import { assertReactServer } from "../config/getCondition.js";
 import { handleError } from "../error/handleError.js";
 import { augmentClientReferenceError } from "../error/augmentClientReferenceError.js";
@@ -250,7 +251,17 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
           );
         }
 
-        result = ReactDOMServer.renderToPipeableStream(
+        // Touch the renderer BEFORE the parity check: the vendored module
+        // loads lazily on first property access, and the check needs its
+        // resolved dev/prod mode.
+        const renderToPipeableStream = ReactDOMServer.renderToPipeableStream;
+        assertRendererElementParity(
+          element,
+          getVendoredRendererMode(),
+          `createRscStream:${route}`
+        );
+
+        result = renderToPipeableStream(
           element,
           handlerOptions.moduleBasePath || "",
           pipeableStreamOptions

--- a/plugin/stream/renderRscStream.server.ts
+++ b/plugin/stream/renderRscStream.server.ts
@@ -4,7 +4,8 @@ import type { RscRenderResult } from "./renderRscStream.types.js";
 import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
 import { createReactElement } from "../helpers/createRscRenderHelpers.server.js";
 import { checkReactVersion } from "../utils/checkReactVersion.js";
-import { ReactDOMServer } from "../vendor/vendor.server.js";
+import { assertRendererElementParity } from "../utils/assertRendererElementParity.js";
+import { ReactDOMServer, getVendoredRendererMode } from "../vendor/vendor.server.js";
 import type { StreamHandlers } from "../worker/types.js";
 
 
@@ -81,8 +82,18 @@ export function renderRscStream(
     
     checkReactVersion();
 
+    // Touch the renderer BEFORE the parity check: the vendored module loads
+    // lazily on first property access, and the check needs its resolved
+    // dev/prod mode.
+    const renderToPipeableStream = ReactDOMServer.renderToPipeableStream;
+    assertRendererElementParity(
+      reactElement,
+      getVendoredRendererMode(),
+      `renderRscStream:${route}`
+    );
+
     // Render React to stream - let it flow naturally like the RSC worker
-    const reactStream = ReactDOMServer.renderToPipeableStream(
+    const reactStream = renderToPipeableStream(
       reactElement,
       options.moduleBasePath || "",
       {

--- a/plugin/utils/assertRendererElementParity.ts
+++ b/plugin/utils/assertRendererElementParity.ts
@@ -1,38 +1,80 @@
 import type { RendererMode } from "../vendor/lazyVendorModule.js";
 
 /**
- * Guard against the dev-renderer/prod-element mismatch.
+ * Guard against dev/prod renderer-vs-element mismatches.
  *
  * The vendored RSC renderer and the page's react/jsx-runtime each pick a
  * dev or prod variant from NODE_ENV at their own require time. When NODE_ENV
- * flips between the two (tooling that mutates it mid-process), a DEVELOPMENT
- * renderer can be handed PRODUCTION-shaped elements (no `_store`) and dies
- * deep inside React with "Cannot set properties of undefined (setting
- * 'validated')" — nothing in that stack names the actual cause.
+ * flips between the two (tooling that mutates it mid-process):
  *
- * The lazy vendored require (lazyVendorModule.ts) makes this near-impossible
- * to hit; this check is the belt-and-braces diagnostic for the residual
- * cases (e.g. NODE_ENV flipped again after the first render).
+ * - a DEVELOPMENT renderer handed PRODUCTION elements (no `_store`) dies
+ *   deep inside React with "Cannot set properties of undefined (setting
+ *   'validated')";
+ * - a PRODUCTION renderer handed DEVELOPMENT elements crashes through the
+ *   shared dispatcher with "dispatcher.getOwner is not a function".
+ *
+ * Neither stack names the actual cause. The lazy vendored require + react
+ * pairing (lazyVendorModule.ts) makes both near-impossible to hit; this
+ * check is the belt-and-braces diagnostic for the residual cases.
+ *
+ * Only PLAIN elements are checked: wrapper nodes (React.memo / lazy /
+ * portal / context) legitimately carry no `_store` in development, so their
+ * `$$typeof` values are excluded to avoid false positives on custom roots.
  */
+
+const PLAIN_ELEMENT_TYPES = new Set<symbol>([
+  Symbol.for("react.transitional.element"), // React 19
+  Symbol.for("react.element"), // pre-19 naming, kept for safety
+]);
+
+function mismatchDirection(
+  element: unknown,
+  rendererMode: RendererMode | null
+): "dev-renderer-prod-elements" | "prod-renderer-dev-elements" | null {
+  if (rendererMode === null) return null;
+  if (typeof element !== "object" || element === null) return null;
+  const tag = (element as { $$typeof?: unknown }).$$typeof;
+  if (typeof tag !== "symbol" || !PLAIN_ELEMENT_TYPES.has(tag)) return null;
+
+  const hasStore = (element as { _store?: unknown })._store !== undefined;
+  if (rendererMode === "development" && !hasStore) {
+    return "dev-renderer-prod-elements";
+  }
+  if (rendererMode === "production" && hasStore) {
+    return "prod-renderer-dev-elements";
+  }
+  return null;
+}
+
 export function assertRendererElementParity(
   element: unknown,
   rendererMode: RendererMode | null,
   context: string
 ): void {
-  if (rendererMode !== "development") return;
-  if (typeof element !== "object" || element === null) return;
-  if (!("$$typeof" in element)) return;
-  if ((element as { _store?: unknown })._store !== undefined) return;
+  const direction = mismatchDirection(element, rendererMode);
+  if (direction === null) return;
+
+  const [rendererVariant, elementVariant, crash] =
+    direction === "dev-renderer-prod-elements"
+      ? [
+          "DEVELOPMENT",
+          "PRODUCTION",
+          `"Cannot set properties of undefined (setting 'validated')"`,
+        ]
+      : [
+          "PRODUCTION",
+          "DEVELOPMENT",
+          `"dispatcher.getOwner is not a function"`,
+        ];
 
   throw new Error(
     `[vite-plugin-react-server] ${context}: the vendored RSC renderer was ` +
-      `loaded as a DEVELOPMENT build, but this React element was created by a ` +
-      `PRODUCTION react/jsx-runtime (no _store). NODE_ENV changed between the ` +
-      `renderer's first load and element creation (current NODE_ENV=` +
-      `${process.env["NODE_ENV"] ?? "<unset>"}). Pin NODE_ENV before importing ` +
-      `vite-plugin-react-server or before the first build/render in this ` +
-      `process, and avoid flipping it mid-process. Without this check the ` +
-      `render dies inside React with "Cannot set properties of undefined ` +
-      `(setting 'validated')".`
+      `loaded as a ${rendererVariant} build, but this React element was ` +
+      `created by a ${elementVariant} react/jsx-runtime. NODE_ENV changed ` +
+      `between the renderer's first load and element creation (current ` +
+      `NODE_ENV=${process.env["NODE_ENV"] ?? "<unset>"}). Pin NODE_ENV ` +
+      `before importing vite-plugin-react-server or before the first ` +
+      `build/render in this process, and avoid flipping it mid-process. ` +
+      `Without this check the render dies inside React with ${crash}.`
   );
 }

--- a/plugin/utils/assertRendererElementParity.ts
+++ b/plugin/utils/assertRendererElementParity.ts
@@ -1,0 +1,38 @@
+import type { RendererMode } from "../vendor/lazyVendorModule.js";
+
+/**
+ * Guard against the dev-renderer/prod-element mismatch.
+ *
+ * The vendored RSC renderer and the page's react/jsx-runtime each pick a
+ * dev or prod variant from NODE_ENV at their own require time. When NODE_ENV
+ * flips between the two (tooling that mutates it mid-process), a DEVELOPMENT
+ * renderer can be handed PRODUCTION-shaped elements (no `_store`) and dies
+ * deep inside React with "Cannot set properties of undefined (setting
+ * 'validated')" — nothing in that stack names the actual cause.
+ *
+ * The lazy vendored require (lazyVendorModule.ts) makes this near-impossible
+ * to hit; this check is the belt-and-braces diagnostic for the residual
+ * cases (e.g. NODE_ENV flipped again after the first render).
+ */
+export function assertRendererElementParity(
+  element: unknown,
+  rendererMode: RendererMode | null,
+  context: string
+): void {
+  if (rendererMode !== "development") return;
+  if (typeof element !== "object" || element === null) return;
+  if (!("$$typeof" in element)) return;
+  if ((element as { _store?: unknown })._store !== undefined) return;
+
+  throw new Error(
+    `[vite-plugin-react-server] ${context}: the vendored RSC renderer was ` +
+      `loaded as a DEVELOPMENT build, but this React element was created by a ` +
+      `PRODUCTION react/jsx-runtime (no _store). NODE_ENV changed between the ` +
+      `renderer's first load and element creation (current NODE_ENV=` +
+      `${process.env["NODE_ENV"] ?? "<unset>"}). Pin NODE_ENV before importing ` +
+      `vite-plugin-react-server or before the first build/render in this ` +
+      `process, and avoid flipping it mid-process. Without this check the ` +
+      `render dies inside React with "Cannot set properties of undefined ` +
+      `(setting 'validated')".`
+  );
+}

--- a/plugin/vendor/lazyVendorModule.ts
+++ b/plugin/vendor/lazyVendorModule.ts
@@ -22,9 +22,10 @@ import { createRequire } from "node:module";
  *    driving a cached DEVELOPMENT react crashes with "dispatcher.getOwner
  *    is not a function".
  *
- * So the loader (a) defers the require to FIRST USE, and (b) resolves the
+ * So the loader (a) defers the require to FIRST USE, (b) resolves the
  * dev/prod variant from the React copy already in the require cache when
- * there is one, falling back to NODE_ENV only when react hasn't loaded yet.
+ * there is one (falling back to NODE_ENV), and (c) pins the rest of the
+ * react family (jsx-runtime) to the same variant before anything renders.
  */
 
 export type RendererMode = "development" | "production";
@@ -34,24 +35,32 @@ const nodeRequire = createRequire(import.meta.url);
 export const nodeEnvMode = (): RendererMode =>
   process.env["NODE_ENV"] === "production" ? "production" : "development";
 
+let cachedReactMode: RendererMode | null = null;
+
 /**
  * The dev/prod variant of the React copy this process is locked into
  * (Node's CJS cache is per-process: the first require wins for everyone),
- * or null when react hasn't been required yet.
+ * or null when react hasn't been required yet. Memoized once non-null —
+ * an evaluated CJS module never unloads, so the answer can't change.
+ *
+ * Caveat (rare): with two physical react copies in the process the scan
+ * reports whichever evaluated first; the lockReactFamily warning gives
+ * visibility when the result disagrees with the build's NODE_ENV.
  */
 export function reactModeFromCache(): RendererMode | null {
+  if (cachedReactMode !== null) return cachedReactMode;
   const cache = nodeRequire.cache ?? {};
-  for (const [key, entry] of Object.entries(cache)) {
+  for (const key in cache) {
     // Node's ESM-CJS bridge (cjs-module-lexer) statically analyzes BOTH
     // branches of react's NODE_ENV wrapper and leaves UNEVALUATED entries in
     // the cache (loaded=false, empty exports). Only a fully evaluated module
     // tells us which variant the process actually runs.
-    if (!entry?.loaded) continue;
+    if (!cache[key]?.loaded) continue;
     if (/[\\/]react[\\/]cjs[\\/]react\.[^\\/]*development\.js$/.test(key)) {
-      return "development";
+      return (cachedReactMode = "development");
     }
     if (/[\\/]react[\\/]cjs[\\/]react\.[^\\/]*production\.js$/.test(key)) {
-      return "production";
+      return (cachedReactMode = "production");
     }
   }
   return null;
@@ -87,6 +96,7 @@ export function withNodeEnv<T>(mode: RendererMode, fn: () => T): T {
 }
 
 let lockedFamilyMode: RendererMode | null = null;
+let warnedModeMismatch = false;
 
 /**
  * Pin the consumer React family (react, react/jsx-runtime,
@@ -94,34 +104,73 @@ let lockedFamilyMode: RendererMode | null = null;
  * variant — the variant React is already locked to if it has loaded, else
  * the current NODE_ENV.
  *
- * Call before loading user page modules for an in-process render: a page
- * bundle's `react/jsx-runtime` import evaluates whenever the module loads,
- * and without this pre-warm it can resolve a DIFFERENT variant than the
+ * Runs automatically on the first load of any lazy vendor module (so every
+ * render path — SSG, dev server, workers — is covered without per-call-site
+ * wiring) and explicitly before in-process page loads in renderPagesBatched.
+ *
+ * A page bundle's `react/jsx-runtime` import evaluates whenever the module
+ * loads; without this pre-warm it can resolve a DIFFERENT variant than the
  * already-cached react (NODE_ENV flipped in between), producing elements
  * the paired renderer can't process.
  */
 export function lockReactFamily(): RendererMode {
   if (lockedFamilyMode !== null) return lockedFamilyMode;
   const mode = reactPairedMode();
-  const projectRoot =
-    process.env["npm_config_local_prefix"] || process.cwd();
-  const projectRequire = createRequire(
-    `${projectRoot.replace(/\/$/, "")}/package.json`
+
+  // The locked variant can legitimately differ from the build's NODE_ENV —
+  // a bare `vite build` imports the plugin (caching react) BEFORE Vite sets
+  // NODE_ENV=production. Pairing keeps that build working instead of
+  // crashing, but the output is then rendered with the development React —
+  // say so loudly, once.
+  if (mode !== nodeEnvMode() && !warnedModeMismatch) {
+    warnedModeMismatch = true;
+    console.warn(
+      `[vite-plugin-react-server] React family locked to ${mode.toUpperCase()} ` +
+        `but NODE_ENV is ${process.env["NODE_ENV"] ?? "<unset>"}: react was ` +
+        `loaded before NODE_ENV settled (typically at plugin import during ` +
+        `config load). Rendering proceeds with the ${mode} React to stay ` +
+        `consistent. To get ${nodeEnvMode()} output, pin NODE_ENV before ` +
+        `importing vite-plugin-react-server (e.g. NODE_ENV=${nodeEnvMode()} ` +
+        `vite build).`
+    );
+  }
+
+  // Resolve the consumer's react: prefer the consumer project, fall back to
+  // the plugin's own resolution (monorepos where cwd isn't the app root).
+  const bases = [process.env["npm_config_local_prefix"], process.cwd()].filter(
+    (b): b is string => typeof b === "string" && b.length > 0
   );
+  let pinned = false;
   withNodeEnv(mode, () => {
-    try {
-      projectRequire("react");
-      projectRequire("react/jsx-runtime");
-    } catch {
-      // no consumer react resolvable from here — nothing to pin
-    }
-    try {
-      projectRequire("react/jsx-dev-runtime");
-    } catch {
-      // optional entry; fine if absent
+    const requires = [
+      ...bases.map((b) =>
+        createRequire(`${b.replace(/\/$/, "")}/package.json`)
+      ),
+      nodeRequire,
+    ];
+    for (const req of requires) {
+      try {
+        req("react");
+        req("react/jsx-runtime");
+        pinned = true;
+      } catch {
+        continue; // not resolvable from this base — try the next
+      }
+      try {
+        req("react/jsx-dev-runtime");
+      } catch {
+        // optional entry; fine if absent
+      }
+      break;
     }
   });
-  lockedFamilyMode = mode;
+
+  // Only memoize when something is actually pinned (or react was already
+  // evaluated) — otherwise a later call, after react becomes resolvable,
+  // should re-derive instead of trusting a lock that pinned nothing.
+  if (pinned || reactModeFromCache() !== null) {
+    lockedFamilyMode = mode;
+  }
   return mode;
 }
 
@@ -134,16 +183,28 @@ export interface LazyVendorModule<T extends object> {
 
 export function createLazyVendorModule<T extends object>(
   load: (mode: RendererMode) => T,
-  resolveMode: () => RendererMode = nodeEnvMode
+  resolveMode: () => RendererMode = nodeEnvMode,
+  /**
+   * Optional ground truth: inspect what the require ACTUALLY returned
+   * (e.g. scan require.cache for the evaluated variant file). Guards
+   * against the CJS cache already holding the other variant — `load()`
+   * returns that cached module no matter what `resolveMode()` asked for,
+   * and the parity diagnostics must reason from reality, not intent.
+   */
+  detectLoadedMode?: () => RendererMode | null
 ): LazyVendorModule<T> {
   let loaded: T | null = null;
   let loadedMode: RendererMode | null = null;
 
   const ensure = (): T => {
     if (loaded === null) {
+      // Pin the react family before the transport loads — every render
+      // path reaches a vendor proxy first, so the dev server and workers
+      // are covered without per-call-site wiring.
+      lockReactFamily();
       const mode = resolveMode();
       loaded = withNodeEnv(mode, () => load(mode));
-      loadedMode = mode;
+      loadedMode = detectLoadedMode?.() ?? mode;
     }
     return loaded;
   };
@@ -160,4 +221,22 @@ export function createLazyVendorModule<T extends object>(
   });
 
   return { proxy, getLoadedMode: () => loadedMode };
+}
+
+/**
+ * Ground-truth detector for the vendored transport: which variant file is
+ * ACTUALLY evaluated in the CJS cache for the given cjs basename prefix
+ * (e.g. "react-server-dom-esm-server.node").
+ */
+export function vendoredTransportModeFromCache(
+  cjsFilePrefix: string
+): RendererMode | null {
+  const cache = nodeRequire.cache ?? {};
+  for (const key in cache) {
+    if (!cache[key]?.loaded) continue;
+    if (!key.includes(cjsFilePrefix)) continue;
+    if (key.endsWith(".development.js")) return "development";
+    if (key.endsWith(".production.js")) return "production";
+  }
+  return null;
 }

--- a/plugin/vendor/lazyVendorModule.ts
+++ b/plugin/vendor/lazyVendorModule.ts
@@ -117,13 +117,13 @@ export function lockReactFamily(): RendererMode {
   if (lockedFamilyMode !== null) return lockedFamilyMode;
   const mode = reactPairedMode();
 
-  // The locked variant can legitimately differ from the build's NODE_ENV —
-  // PROGRAMMATIC builds (createBuilder/build() from a script that imported
+  // The locked variant can legitimately differ from the build's NODE_ENV:
+  // programmatic builds (createBuilder/build() from a script that imports
   // the plugin first) and harnesses that mutate NODE_ENV mid-process cache
-  // react before NODE_ENV settles. (The vite CLI is fine: verified v6.3.5
-  // sets NODE_ENV=production before evaluating the config.) Pairing keeps
-  // such builds working instead of crashing, but the output is rendered
-  // with the development React — say so loudly, once.
+  // react before NODE_ENV settles. The vite CLI itself sets NODE_ENV before
+  // evaluating the config, so it never hits this. Pairing keeps such builds
+  // working instead of crashing, but the output is rendered with the
+  // development React — say so loudly, once.
   if (mode !== nodeEnvMode() && !warnedModeMismatch) {
     warnedModeMismatch = true;
     console.warn(

--- a/plugin/vendor/lazyVendorModule.ts
+++ b/plugin/vendor/lazyVendorModule.ts
@@ -1,0 +1,163 @@
+import { createRequire } from "node:module";
+
+/**
+ * Lazy, React-paired CJS loading for the vendored react-server-dom-esm
+ * transport.
+ *
+ * Two failure modes this prevents (both: NODE_ENV flipping mid-process):
+ *
+ * 1. The vendored CJS wrappers branch on process.env.NODE_ENV at require
+ *    time. Requiring them eagerly at plugin-import time locks the dev/prod
+ *    renderer to NODE_ENV-at-import, which can disagree with the variant of
+ *    the React elements created later — `vite build` (and any harness
+ *    driving it) sets NODE_ENV AFTER the plugin is imported. A development
+ *    renderer fed production elements dies inside React with "Cannot set
+ *    properties of undefined (setting 'validated')".
+ *
+ * 2. Even loaded lazily, sampling NODE_ENV independently can disagree with
+ *    the React copy the process is ALREADY locked into: any top-level
+ *    `import React from "react"` in the plugin graph (e.g. the default
+ *    components) caches react's dev/prod pick at plugin-import time, and
+ *    every later require returns that cached copy. A production renderer
+ *    driving a cached DEVELOPMENT react crashes with "dispatcher.getOwner
+ *    is not a function".
+ *
+ * So the loader (a) defers the require to FIRST USE, and (b) resolves the
+ * dev/prod variant from the React copy already in the require cache when
+ * there is one, falling back to NODE_ENV only when react hasn't loaded yet.
+ */
+
+export type RendererMode = "development" | "production";
+
+const nodeRequire = createRequire(import.meta.url);
+
+export const nodeEnvMode = (): RendererMode =>
+  process.env["NODE_ENV"] === "production" ? "production" : "development";
+
+/**
+ * The dev/prod variant of the React copy this process is locked into
+ * (Node's CJS cache is per-process: the first require wins for everyone),
+ * or null when react hasn't been required yet.
+ */
+export function reactModeFromCache(): RendererMode | null {
+  const cache = nodeRequire.cache ?? {};
+  for (const [key, entry] of Object.entries(cache)) {
+    // Node's ESM-CJS bridge (cjs-module-lexer) statically analyzes BOTH
+    // branches of react's NODE_ENV wrapper and leaves UNEVALUATED entries in
+    // the cache (loaded=false, empty exports). Only a fully evaluated module
+    // tells us which variant the process actually runs.
+    if (!entry?.loaded) continue;
+    if (/[\\/]react[\\/]cjs[\\/]react\.[^\\/]*development\.js$/.test(key)) {
+      return "development";
+    }
+    if (/[\\/]react[\\/]cjs[\\/]react\.[^\\/]*production\.js$/.test(key)) {
+      return "production";
+    }
+  }
+  return null;
+}
+
+/** Variant the vendored transport must pair with: cached react, else NODE_ENV. */
+export const reactPairedMode = (): RendererMode =>
+  reactModeFromCache() ?? nodeEnvMode();
+
+/**
+ * Run `fn` with NODE_ENV swapped to `mode` for its (synchronous) duration.
+ * The React-family CJS entries pick their variant from NODE_ENV at require
+ * time, and the variant files themselves are NODE_ENV-gated (the development
+ * build is wrapped in `"production" !== NODE_ENV &&` and evaluates to EMPTY
+ * exports under production) — so loading a paired variant when NODE_ENV
+ * disagrees requires the swap.
+ */
+export function withNodeEnv<T>(mode: RendererMode, fn: () => T): T {
+  const previous = process.env["NODE_ENV"];
+  const needSwap = (previous === "production") !== (mode === "production");
+  if (needSwap) process.env["NODE_ENV"] = mode;
+  try {
+    return fn();
+  } finally {
+    if (needSwap) {
+      if (previous === undefined) {
+        delete (process.env as Record<string, string | undefined>)["NODE_ENV"];
+      } else {
+        process.env["NODE_ENV"] = previous;
+      }
+    }
+  }
+}
+
+let lockedFamilyMode: RendererMode | null = null;
+
+/**
+ * Pin the consumer React family (react, react/jsx-runtime,
+ * react/jsx-dev-runtime) into the CJS cache as ONE consistent dev/prod
+ * variant — the variant React is already locked to if it has loaded, else
+ * the current NODE_ENV.
+ *
+ * Call before loading user page modules for an in-process render: a page
+ * bundle's `react/jsx-runtime` import evaluates whenever the module loads,
+ * and without this pre-warm it can resolve a DIFFERENT variant than the
+ * already-cached react (NODE_ENV flipped in between), producing elements
+ * the paired renderer can't process.
+ */
+export function lockReactFamily(): RendererMode {
+  if (lockedFamilyMode !== null) return lockedFamilyMode;
+  const mode = reactPairedMode();
+  const projectRoot =
+    process.env["npm_config_local_prefix"] || process.cwd();
+  const projectRequire = createRequire(
+    `${projectRoot.replace(/\/$/, "")}/package.json`
+  );
+  withNodeEnv(mode, () => {
+    try {
+      projectRequire("react");
+      projectRequire("react/jsx-runtime");
+    } catch {
+      // no consumer react resolvable from here — nothing to pin
+    }
+    try {
+      projectRequire("react/jsx-dev-runtime");
+    } catch {
+      // optional entry; fine if absent
+    }
+  });
+  lockedFamilyMode = mode;
+  return mode;
+}
+
+export interface LazyVendorModule<T extends object> {
+  /** The module, loaded on first property access. */
+  proxy: T;
+  /** dev/prod variant the module resolved to, or null before first use. */
+  getLoadedMode: () => RendererMode | null;
+}
+
+export function createLazyVendorModule<T extends object>(
+  load: (mode: RendererMode) => T,
+  resolveMode: () => RendererMode = nodeEnvMode
+): LazyVendorModule<T> {
+  let loaded: T | null = null;
+  let loadedMode: RendererMode | null = null;
+
+  const ensure = (): T => {
+    if (loaded === null) {
+      const mode = resolveMode();
+      loaded = withNodeEnv(mode, () => load(mode));
+      loadedMode = mode;
+    }
+    return loaded;
+  };
+
+  const proxy = new Proxy({} as T, {
+    get: (_target, prop) => (ensure() as any)[prop],
+    has: (_target, prop) => prop in (ensure() as any),
+    ownKeys: () => Reflect.ownKeys(ensure() as any),
+    getOwnPropertyDescriptor: (_target, prop) => {
+      const desc = Reflect.getOwnPropertyDescriptor(ensure() as any, prop);
+      if (desc) return { ...desc, configurable: true };
+      return undefined;
+    },
+  });
+
+  return { proxy, getLoadedMode: () => loadedMode };
+}

--- a/plugin/vendor/lazyVendorModule.ts
+++ b/plugin/vendor/lazyVendorModule.ts
@@ -118,10 +118,12 @@ export function lockReactFamily(): RendererMode {
   const mode = reactPairedMode();
 
   // The locked variant can legitimately differ from the build's NODE_ENV —
-  // a bare `vite build` imports the plugin (caching react) BEFORE Vite sets
-  // NODE_ENV=production. Pairing keeps that build working instead of
-  // crashing, but the output is then rendered with the development React —
-  // say so loudly, once.
+  // PROGRAMMATIC builds (createBuilder/build() from a script that imported
+  // the plugin first) and harnesses that mutate NODE_ENV mid-process cache
+  // react before NODE_ENV settles. (The vite CLI is fine: verified v6.3.5
+  // sets NODE_ENV=production before evaluating the config.) Pairing keeps
+  // such builds working instead of crashing, but the output is rendered
+  // with the development React — say so loudly, once.
   if (mode !== nodeEnvMode() && !warnedModeMismatch) {
     warnedModeMismatch = true;
     console.warn(

--- a/plugin/vendor/vendor.server.ts
+++ b/plugin/vendor/vendor.server.ts
@@ -1,7 +1,11 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { transportPkgDir } from "./transportDir.js";
-import { createLazyVendorModule, reactPairedMode } from "./lazyVendorModule.js";
+import {
+  createLazyVendorModule,
+  reactPairedMode,
+  vendoredTransportModeFromCache,
+} from "./lazyVendorModule.js";
 import { hasReactServerCondition } from "../config/getCondition.js";
 
 // Load react-server-dom-esm/server from the vendored copy that ships inside
@@ -14,22 +18,28 @@ import { hasReactServerCondition } from "../config/getCondition.js";
 // plugin-import time. See lazyVendorModule.ts.
 const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
 
-// Wrong-side imports must stay LOUD: evaluating this module in a process
-// WITHOUT the react-server condition throws at module init, exactly like the
-// old eager require did (the vendored server demands a react-server react).
-// The lazy path below only applies where this module legitimately runs.
-if (!hasReactServerCondition()) {
-  vendorRequire("react-server-dom-esm/server");
-}
-
 const lazyServer = createLazyVendorModule(
   () =>
     vendorRequire(
       "react-server-dom-esm/server"
     ) as typeof import("react-server-dom-esm/server.node"),
-  reactPairedMode
+  reactPairedMode,
+  // ground truth: which variant file actually evaluated (the CJS cache may
+  // already hold the other one — getLoadedMode must report reality)
+  () => vendoredTransportModeFromCache("react-server-dom-esm-server.node")
 );
 const ReactDOMServer = lazyServer.proxy;
+
+// Wrong-side imports must stay LOUD: evaluating this module in a process
+// WITHOUT the react-server condition throws at module init, exactly like the
+// old eager require did (the vendored server demands a react-server react).
+// The eager probe goes THROUGH the lazy module so its mode bookkeeping stays
+// truthful even when the condition heuristic is wrong and the require
+// unexpectedly succeeds.
+if (!hasReactServerCondition()) {
+  void (ReactDOMServer as { renderToPipeableStream?: unknown })
+    .renderToPipeableStream;
+}
 
 /** dev/prod variant the vendored RSC renderer resolved to (null until first use). */
 export const getVendoredRendererMode = lazyServer.getLoadedMode;

--- a/plugin/vendor/vendor.server.ts
+++ b/plugin/vendor/vendor.server.ts
@@ -1,17 +1,52 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { transportPkgDir } from "./transportDir.js";
+import { createLazyVendorModule, reactPairedMode } from "./lazyVendorModule.js";
+import { hasReactServerCondition } from "../config/getCondition.js";
 
 // Load react-server-dom-esm/server from the vendored copy that ships inside
 // the react-server-loader dependency. The vendored package.json exports map
 // defaults to server.node.js.
+//
+// LAZY: the vendored CJS picks its dev/prod renderer from NODE_ENV at require
+// time, so the require is deferred to first use — NODE_ENV must be sampled
+// after build tooling (vite build, test harnesses) has settled it, not at
+// plugin-import time. See lazyVendorModule.ts.
 const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
-const ReactDOMServer = vendorRequire("react-server-dom-esm/server") as typeof import("react-server-dom-esm/server.node");
 
-// React still comes from the consumer's project
+// Wrong-side imports must stay LOUD: evaluating this module in a process
+// WITHOUT the react-server condition throws at module init, exactly like the
+// old eager require did (the vendored server demands a react-server react).
+// The lazy path below only applies where this module legitimately runs.
+if (!hasReactServerCondition()) {
+  vendorRequire("react-server-dom-esm/server");
+}
+
+const lazyServer = createLazyVendorModule(
+  () =>
+    vendorRequire(
+      "react-server-dom-esm/server"
+    ) as typeof import("react-server-dom-esm/server.node"),
+  reactPairedMode
+);
+const ReactDOMServer = lazyServer.proxy;
+
+/** dev/prod variant the vendored RSC renderer resolved to (null until first use). */
+export const getVendoredRendererMode = lazyServer.getLoadedMode;
+
+// React still comes from the consumer's project. ALSO LAZY: under
+// --conditions react-server the consumer react's CJS entry branches on
+// NODE_ENV too, and its dev createElement consults the dispatcher installed
+// by the renderer — a dev react paired with a prod renderer dies with
+// "dispatcher.getOwner is not a function". Deferring both keeps the pair
+// resolving from the same settled NODE_ENV.
 const projectRoot = process.env["npm_config_local_prefix"] || process.cwd();
 const projectRequire = createRequire(join(projectRoot, "package.json"));
-const React = projectRequire("react") as typeof import("react");
+const lazyReact = createLazyVendorModule(
+  () => projectRequire("react") as typeof import("react"),
+  reactPairedMode
+);
+const React = lazyReact.proxy;
 
 export { ReactDOMServer, React };
 export type * from "react-server-dom-esm/server.node";

--- a/plugin/vendor/vendor.static.ts
+++ b/plugin/vendor/vendor.static.ts
@@ -1,16 +1,43 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { transportPkgDir } from "./transportDir.js";
+import { createLazyVendorModule, reactPairedMode } from "./lazyVendorModule.js";
+import { hasReactServerCondition } from "../config/getCondition.js";
 
 // Load react-server-dom-esm/static from the vendored copy that ships inside
 // the react-server-loader dependency. The vendored package.json exports map
 // defaults to static.node.js.
+//
+// LAZY: deferred to first use so the dev/prod variant is picked from the
+// settled NODE_ENV, not NODE_ENV-at-plugin-import. See lazyVendorModule.ts.
 const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
-const ReactDOMServer = vendorRequire("react-server-dom-esm/static") as typeof import("react-server-dom-esm/static.node");
 
-// React still comes from the consumer's project
+// Wrong-side imports must stay LOUD — see vendor.server.ts.
+if (!hasReactServerCondition()) {
+  vendorRequire("react-server-dom-esm/static");
+}
+
+const lazyStatic = createLazyVendorModule(
+  () =>
+    vendorRequire(
+      "react-server-dom-esm/static"
+    ) as typeof import("react-server-dom-esm/static.node"),
+  reactPairedMode
+);
+const ReactDOMServer = lazyStatic.proxy;
+
+/** dev/prod variant the vendored static renderer resolved to (null until first use). */
+export const getVendoredRendererMode = lazyStatic.getLoadedMode;
+
+// React still comes from the consumer's project. ALSO LAZY — its CJS entry
+// branches on NODE_ENV like the renderer; the pair must resolve together
+// (see vendor.server.ts).
 const projectRoot = process.env["npm_config_local_prefix"] || process.cwd();
 const projectRequire = createRequire(join(projectRoot, "package.json"));
-const React = projectRequire("react") as typeof import("react");
+const lazyReact = createLazyVendorModule(
+  () => projectRequire("react") as typeof import("react"),
+  reactPairedMode
+);
+const React = lazyReact.proxy;
 
 export { ReactDOMServer, React };

--- a/plugin/vendor/vendor.static.ts
+++ b/plugin/vendor/vendor.static.ts
@@ -1,7 +1,11 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { transportPkgDir } from "./transportDir.js";
-import { createLazyVendorModule, reactPairedMode } from "./lazyVendorModule.js";
+import {
+  createLazyVendorModule,
+  reactPairedMode,
+  vendoredTransportModeFromCache,
+} from "./lazyVendorModule.js";
 import { hasReactServerCondition } from "../config/getCondition.js";
 
 // Load react-server-dom-esm/static from the vendored copy that ships inside
@@ -12,19 +16,23 @@ import { hasReactServerCondition } from "../config/getCondition.js";
 // settled NODE_ENV, not NODE_ENV-at-plugin-import. See lazyVendorModule.ts.
 const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
 
-// Wrong-side imports must stay LOUD — see vendor.server.ts.
-if (!hasReactServerCondition()) {
-  vendorRequire("react-server-dom-esm/static");
-}
-
 const lazyStatic = createLazyVendorModule(
   () =>
     vendorRequire(
       "react-server-dom-esm/static"
     ) as typeof import("react-server-dom-esm/static.node"),
-  reactPairedMode
+  reactPairedMode,
+  // static.node.js wraps the same server.node cjs files as server.node.js
+  () => vendoredTransportModeFromCache("react-server-dom-esm-server.node")
 );
 const ReactDOMServer = lazyStatic.proxy;
+
+// Wrong-side imports must stay LOUD — see vendor.server.ts (the probe goes
+// through the lazy module so mode bookkeeping stays truthful).
+if (!hasReactServerCondition()) {
+  void (ReactDOMServer as { prerenderToNodeStream?: unknown })
+    .prerenderToNodeStream;
+}
 
 /** dev/prod variant the vendored static renderer resolved to (null until first use). */
 export const getVendoredRendererMode = lazyStatic.getLoadedMode;

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { pluginRoot } from "../root.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { lockReactFamily } from "../vendor/lazyVendorModule.js";
 import { createLogger, type Logger } from "vite";
 import type { HtmlWorkerOutputMessage } from "./html/types.js";
 import type { RscWorkerOutputMessage } from "./rsc/types.js";
@@ -290,7 +291,11 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
       [envPrefix + "SSR"]: "true",
       [envPrefix + "BASE_URL"]: workerData.userOptions?.moduleBaseURL ?? "",
       [envPrefix + "PUBLIC_ORIGIN"]: workerData.userOptions?.publicOrigin ?? "",
-      NODE_ENV: process.env["NODE_ENV"] ?? "production",
+      // Workers must run the SAME React dev/prod variant the parent locked
+      // into its CJS cache — a parent rendering with dev React feeding an
+      // html worker that resolved prod React can't consume the stream
+      // (NODE_ENV may have flipped between plugin import and worker spawn).
+      NODE_ENV: lockReactFamily(),
       NODE_PATH: nodePath,
 
       // Ensure NODE_OPTIONS has the correct condition
@@ -378,13 +383,17 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
             clearTimeout(timeout);
             worker.removeListener("message", messageHandler);
             worker.removeListener("exit", exitHandler);
-            if (msg.env !== mode) {
+            // Compare against the NODE_ENV we spawned the worker with (the
+            // locked React-family variant), not the vite mode — the two
+            // legitimately differ when NODE_ENV flipped after plugin import
+            // and the process is locked to the React it already loaded.
+            if (msg.env !== env.NODE_ENV) {
               if (verbose)
                 logger.info(`[create:${id}] Worker environment mismatch.`);
               reject({
                 type: "error",
                 error: new Error(
-                  `Worker environment mismatch: ${msg.env} !== ${mode}`
+                  `Worker environment mismatch: ${msg.env} !== ${env.NODE_ENV}`
                 ),
                 workerPath: workerPathWithDefault,
               } satisfies CreateWorkerError);

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -12,6 +12,15 @@ import { existsSync } from "node:fs";
 import { pluginRoot } from "../root.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { lockReactFamily } from "../vendor/lazyVendorModule.js";
+
+function workerNodeEnv(): string {
+  const locked = lockReactFamily();
+  const parentEnv = process.env["NODE_ENV"];
+  const parentCompatible =
+    parentEnv != null &&
+    (parentEnv === "production") === (locked === "production");
+  return parentCompatible ? parentEnv : locked;
+}
 import { createLogger, type Logger } from "vite";
 import type { HtmlWorkerOutputMessage } from "./html/types.js";
 import type { RscWorkerOutputMessage } from "./rsc/types.js";
@@ -295,7 +304,11 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
       // into its CJS cache — a parent rendering with dev React feeding an
       // html worker that resolved prod React can't consume the stream
       // (NODE_ENV may have flipped between plugin import and worker spawn).
-      NODE_ENV: lockReactFamily(),
+      // The parent's NODE_ENV passes through VERBATIM when it already maps
+      // to the locked variant (preserving values like "test" that user code
+      // branches on); the locked mode only overrides on a genuine variant
+      // conflict or when NODE_ENV is unset.
+      NODE_ENV: workerNodeEnv(),
       NODE_PATH: nodePath,
 
       // Ensure NODE_OPTIONS has the correct condition

--- a/plugin/worker/rsc/state.server.ts
+++ b/plugin/worker/rsc/state.server.ts
@@ -3,7 +3,7 @@ import { createCssProps } from "../../helpers/createCssProps.js";
 import type { CssContent, ResolvedUserOptions, HmrState } from "../../types.js";
 import type { PassThrough } from "node:stream";
 import { relative } from "node:path";
-import { ReactDOMServer } from "../../vendor/vendor.server.js";
+import { createLazyTemporaryReferenceSet } from "../../react-static/temporaryReferences.server.js";
 import { getModuleRef } from "../../helpers/moduleRefs.js";
 
 // Track active RSC streams
@@ -15,8 +15,12 @@ export const cssFiles = new Map<string, CssContent>();
 // Track module IDs
 export const moduleIds = new Map<string, string>();
 
-// Track resolved components cache using WeakMap for better memory management
-export const temporaryReferences = ReactDOMServer.createTemporaryReferenceSet();
+// Track resolved components cache using WeakMap for better memory management.
+// Lazy: a module-scope createTemporaryReferenceSet() would force the vendored
+// renderer to load during worker bootstrap with whatever NODE_ENV is set at
+// that instant — the lazy set defers it to first render, where the paired
+// variant logic applies (see vendor/lazyVendorModule.ts).
+export const temporaryReferences = createLazyTemporaryReferenceSet();
 
 // Track all cached component IDs so we can clear them on HMR
 // This is necessary because temporaryReferences doesn't support iteration

--- a/test/examples/node-env-flip-build.test.ts
+++ b/test/examples/node-env-flip-build.test.ts
@@ -5,8 +5,8 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
- * Regression test for the NODE_ENV-flip build panic (bd: dev RSC renderer +
- * prod elements mismatch).
+ * Regression test for the NODE_ENV-flip build panic (dev RSC renderer fed
+ * prod elements).
  *
  * The trigger: vite-plugin-react-server is imported while NODE_ENV is UNSET,
  * then tooling sets NODE_ENV=production BEFORE the build runs — exactly what

--- a/test/examples/node-env-flip-build.test.ts
+++ b/test/examples/node-env-flip-build.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdir, writeFile, rm, readFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression test for the NODE_ENV-flip build panic (bd: dev RSC renderer +
+ * prod elements mismatch).
+ *
+ * The trigger: vite-plugin-react-server is imported while NODE_ENV is UNSET,
+ * then tooling sets NODE_ENV=production BEFORE the build runs — exactly what
+ * `vite build` wrappers and test harnesses do. With the vendored RSC renderer
+ * require()d eagerly at plugin-import time, the renderer locked to its
+ * DEVELOPMENT variant (NODE_ENV-at-import) while the page's react/jsx-runtime
+ * loaded later as PRODUCTION; the SSG prerender then died inside React with
+ * `Cannot set properties of undefined (setting 'validated')`
+ * (dev renderer writes element._store, prod elements don't have one).
+ *
+ * The fix defers the vendored require to FIRST USE, so the renderer samples
+ * the settled NODE_ENV. This test runs the exact trigger in a dedicated child
+ * process (import plugin → flip NODE_ENV → build+SSG in ONE process) and
+ * asserts the build completes and emits the prerendered page.
+ *
+ * Complements dev-prod-error-visibility.test.ts, which pins NODE_ENV from
+ * process start per mode — this test is specifically about the flip.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = resolve(__dirname, "../fixtures/node-env-flip-build");
+
+async function setupFixture(dir: string) {
+  await rm(dir, { recursive: true, force: true });
+  await mkdir(resolve(dir, "src/page"), { recursive: true });
+  await mkdir(resolve(dir, "src/components"), { recursive: true });
+  await writeFile(
+    resolve(dir, "index.html"),
+    `<!DOCTYPE html><html><head><title>T</title></head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    resolve(dir, "src/client.tsx"),
+    `import React from "react";\nimport { createRoot } from "react-dom/client";\ncreateRoot(document.getElementById("root")!).render(<div>Client App</div>);\n`
+  );
+  await writeFile(
+    resolve(dir, "src/components/Counter.client.tsx"),
+    `"use client";\nimport React from "react";\nconst { useState } = React;\nexport function Counter({ start = 0 }: { start?: number }) {\n  const [count, setCount] = useState(start);\n  return <button onClick={() => setCount((c) => c + 1)}>Count: {count}</button>;\n}\n`
+  );
+  await writeFile(
+    resolve(dir, "src/page/page.tsx"),
+    `import React from "react";\nimport { Counter } from "../components/Counter.client.js";\nexport function Page(props: any) {\n  return (\n    <div>\n      <h1>Env Flip</h1>\n      <Counter start={props.start ?? 0} />\n    </div>\n  );\n}\n`
+  );
+  await writeFile(
+    resolve(dir, "src/page/props.ts"),
+    `export const props = (url: string) => ({ start: 5, url });`
+  );
+  // The driver reproduces the trigger ordering INSIDE one process:
+  //   1. import the plugin while NODE_ENV is unset (vendored renderer must
+  //      NOT lock its dev/prod variant here),
+  //   2. flip NODE_ENV to production (what build tooling does),
+  //   3. run the full build + SSG prerender.
+  await writeFile(
+    resolve(dir, "build-flip.mjs"),
+    `// 1. plugin import with NODE_ENV unset\n` +
+      `const { vitePluginReactServer } = await import("vite-plugin-react-server");\n` +
+      `if (process.env.NODE_ENV) throw new Error("precondition: NODE_ENV must be unset at import, got " + process.env.NODE_ENV);\n` +
+      `// 2. tooling flips NODE_ENV after the plugin is already imported\n` +
+      `process.env.NODE_ENV = "production";\n` +
+      `// 3. build + SSG prerender in the SAME process\n` +
+      `const { createBuilder } = await import("vite");\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: "src/page/page.tsx",\n` +
+      `    props: "src/page/props.ts",\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    verbose: false,\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `    build: { pages: ["/"], assetsDir: "assets", client: "client", server: "server", static: "static", outDir: "dist" },\n` +
+      `    css: { inlineCss: false },\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("FLIP_BUILD_OK");\n`
+  );
+}
+
+describe("NODE_ENV flip between plugin import and build (SSG prerender)", () => {
+  let status: number | null;
+  let stdout: string;
+  let stderr: string;
+
+  beforeAll(async () => {
+    await setupFixture(FIXTURE_ROOT);
+
+    const env = { ...process.env };
+    delete env["NODE_ENV"]; // unset at process start — part of the trigger
+    env["NODE_OPTIONS"] = "--conditions react-server";
+
+    const proc = spawnSync("node", ["build-flip.mjs"], {
+      cwd: FIXTURE_ROOT,
+      encoding: "utf8",
+      timeout: 120000,
+      env,
+    });
+    status = proc.status;
+    stdout = proc.stdout ?? "";
+    stderr = proc.stderr ?? "";
+  }, 180000);
+
+  afterAll(async () => {
+    await rm(FIXTURE_ROOT, { recursive: true, force: true });
+  });
+
+  it("the build completes (no 'validated' panic from the dev-renderer/prod-element mismatch)", () => {
+    expect(stderr).not.toContain("setting 'validated'");
+    expect(status, `flip build failed:\n${stderr}`).toBe(0);
+    expect(stdout).toContain("FLIP_BUILD_OK");
+  });
+
+  it("the SSG prerender emitted the page", async () => {
+    const html = await readFile(
+      resolve(FIXTURE_ROOT, "dist/static/index.html"),
+      "utf8"
+    );
+    expect(html).toContain("Env Flip");
+  });
+});

--- a/test/unit/lazyVendoredRenderer.test.ts
+++ b/test/unit/lazyVendoredRenderer.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  createLazyVendorModule,
+  reactModeFromCache,
+  reactPairedMode,
+} from "../../plugin/vendor/lazyVendorModule.js";
+import { assertRendererElementParity } from "../../plugin/utils/assertRendererElementParity.js";
+
+const ORIGINAL_NODE_ENV = process.env["NODE_ENV"];
+
+afterEach(() => {
+  if (ORIGINAL_NODE_ENV === undefined) {
+    delete process.env["NODE_ENV"];
+  } else {
+    process.env["NODE_ENV"] = ORIGINAL_NODE_ENV;
+  }
+});
+
+describe("createLazyVendorModule", () => {
+  it("does not load at creation time", () => {
+    let loads = 0;
+    const lazy = createLazyVendorModule(() => {
+      loads++;
+      return { render: () => "ok" };
+    });
+    expect(loads).toBe(0);
+    expect(lazy.getLoadedMode()).toBe(null);
+  });
+
+  it("samples NODE_ENV at FIRST USE, not at import — the bd-hhe ordering", () => {
+    // The crash scenario: plugin imported while NODE_ENV is unset/development,
+    // tooling (vite build / test harness) sets NODE_ENV=production AFTERWARDS,
+    // then the first render happens. An eager require would have locked the
+    // DEVELOPMENT renderer; lazy loading must resolve PRODUCTION.
+    process.env["NODE_ENV"] = "development";
+    const lazy = createLazyVendorModule(() => ({ render: () => "ok" }));
+
+    process.env["NODE_ENV"] = "production";
+    void lazy.proxy.render; // first property access triggers the load
+
+    expect(lazy.getLoadedMode()).toBe("production");
+  });
+
+  it("loads once and keeps the first-resolved mode", () => {
+    let loads = 0;
+    process.env["NODE_ENV"] = "production";
+    const lazy = createLazyVendorModule(() => {
+      loads++;
+      return { a: 1, b: 2 };
+    });
+
+    void lazy.proxy.a;
+    process.env["NODE_ENV"] = "development";
+    void lazy.proxy.b;
+
+    expect(loads).toBe(1);
+    expect(lazy.getLoadedMode()).toBe("production");
+  });
+
+  it("proxy forwards property access, `in`, and key enumeration", () => {
+    const lazy = createLazyVendorModule(() => ({ render: () => "rendered" }));
+    expect(lazy.proxy.render()).toBe("rendered");
+    expect("render" in lazy.proxy).toBe(true);
+    expect(Object.keys(lazy.proxy)).toContain("render");
+  });
+
+  it("passes the resolved mode to the loader (explicit-variant requires)", () => {
+    let seenMode: string | null = null;
+    process.env["NODE_ENV"] = "production";
+    const lazy = createLazyVendorModule((mode) => {
+      seenMode = mode;
+      return { ok: true };
+    });
+    void lazy.proxy.ok;
+    expect(seenMode).toBe("production");
+  });
+});
+
+describe("reactPairedMode", () => {
+  it("pairs with the React copy already in the require cache, over NODE_ENV", () => {
+    // The test process itself has react loaded (vitest setup / other suites),
+    // so reactModeFromCache() reflects the process's locked-in variant; a
+    // conflicting NODE_ENV must NOT override it. (This is the
+    // "dispatcher.getOwner is not a function" pairing rule.)
+    const cached = reactModeFromCache();
+    if (cached === null) {
+      // react genuinely not loaded in this worker — fallback is NODE_ENV
+      process.env["NODE_ENV"] = "production";
+      expect(reactPairedMode()).toBe("production");
+      return;
+    }
+    process.env["NODE_ENV"] =
+      cached === "production" ? "development" : "production";
+    expect(reactPairedMode()).toBe(cached);
+  });
+});
+
+describe("assertRendererElementParity", () => {
+  const devElement = { $$typeof: Symbol.for("react.element"), _store: {} };
+  const prodElement = { $$typeof: Symbol.for("react.element") };
+
+  it("throws a clear diagnostic for dev renderer + prod element", () => {
+    expect(() =>
+      assertRendererElementParity(prodElement, "development", "test")
+    ).toThrow(/DEVELOPMENT build.*PRODUCTION react\/jsx-runtime/s);
+  });
+
+  it("passes for dev renderer + dev element", () => {
+    expect(() =>
+      assertRendererElementParity(devElement, "development", "test")
+    ).not.toThrow();
+  });
+
+  it("passes for prod renderer regardless of element shape", () => {
+    expect(() =>
+      assertRendererElementParity(prodElement, "production", "test")
+    ).not.toThrow();
+    expect(() =>
+      assertRendererElementParity(devElement, "production", "test")
+    ).not.toThrow();
+  });
+
+  it("skips non-element values and unloaded renderers", () => {
+    expect(() =>
+      assertRendererElementParity("a string child", "development", "test")
+    ).not.toThrow();
+    expect(() =>
+      assertRendererElementParity(null, "development", "test")
+    ).not.toThrow();
+    expect(() =>
+      assertRendererElementParity(prodElement, null, "test")
+    ).not.toThrow();
+  });
+});

--- a/test/unit/lazyVendoredRenderer.test.ts
+++ b/test/unit/lazyVendoredRenderer.test.ts
@@ -27,11 +27,11 @@ describe("createLazyVendorModule", () => {
     expect(lazy.getLoadedMode()).toBe(null);
   });
 
-  it("samples NODE_ENV at FIRST USE, not at import — the bd-hhe ordering", () => {
+  it("samples NODE_ENV at FIRST USE, not at import — the flip ordering", () => {
     // The crash scenario: plugin imported while NODE_ENV is unset/development,
-    // tooling (vite build / test harness) sets NODE_ENV=production AFTERWARDS,
-    // then the first render happens. An eager require would have locked the
-    // DEVELOPMENT renderer; lazy loading must resolve PRODUCTION.
+    // tooling sets NODE_ENV=production AFTERWARDS, then the first render
+    // happens. An eager require locks the DEVELOPMENT renderer; lazy loading
+    // must resolve PRODUCTION.
     process.env["NODE_ENV"] = "development";
     const lazy = createLazyVendorModule(() => ({ render: () => "ok" }));
 

--- a/test/unit/lazyVendoredRenderer.test.ts
+++ b/test/unit/lazyVendoredRenderer.test.ts
@@ -74,6 +74,20 @@ describe("createLazyVendorModule", () => {
     void lazy.proxy.ok;
     expect(seenMode).toBe("production");
   });
+
+  it("prefers the ground-truth detector over the requested mode", () => {
+    // The CJS cache may already hold the OTHER variant — load() returns it
+    // regardless of what resolveMode asked for, and getLoadedMode must
+    // report what actually evaluated, not what was intended.
+    process.env["NODE_ENV"] = "production";
+    const lazy = createLazyVendorModule(
+      () => ({ ok: true }),
+      () => "production",
+      () => "development" // ground truth disagrees
+    );
+    void lazy.proxy.ok;
+    expect(lazy.getLoadedMode()).toBe("development");
+  });
 });
 
 describe("reactPairedMode", () => {
@@ -105,18 +119,31 @@ describe("assertRendererElementParity", () => {
     ).toThrow(/DEVELOPMENT build.*PRODUCTION react\/jsx-runtime/s);
   });
 
-  it("passes for dev renderer + dev element", () => {
+  it("throws a clear diagnostic for prod renderer + dev element (getOwner crash class)", () => {
+    expect(() =>
+      assertRendererElementParity(devElement, "production", "test")
+    ).toThrow(/PRODUCTION build.*DEVELOPMENT react\/jsx-runtime/s);
+  });
+
+  it("passes for matched pairs in both modes", () => {
     expect(() =>
       assertRendererElementParity(devElement, "development", "test")
     ).not.toThrow();
-  });
-
-  it("passes for prod renderer regardless of element shape", () => {
     expect(() =>
       assertRendererElementParity(prodElement, "production", "test")
     ).not.toThrow();
+  });
+
+  it("ignores wrapper node types that legitimately carry no _store", () => {
+    // React.memo / lazy / portal roots have different $$typeof values and no
+    // _store even in development — they must not trip the heuristic.
+    const memoNode = { $$typeof: Symbol.for("react.memo") };
+    const lazyNode = { $$typeof: Symbol.for("react.lazy") };
     expect(() =>
-      assertRendererElementParity(devElement, "production", "test")
+      assertRendererElementParity(memoNode, "development", "test")
+    ).not.toThrow();
+    expect(() =>
+      assertRendererElementParity(lazyNode, "development", "test")
     ).not.toThrow();
   });
 


### PR DESCRIPTION
## Why

A single production SSG build panics with `Cannot set properties of undefined (setting 'validated')` whenever NODE_ENV is set **after** the plugin is imported. That ordering occurs in programmatic builds (`createBuilder`/`build()` from a script that imports the plugin first), embedders, and test harnesses that mutate NODE_ENV mid-process. (The `vite` CLI is unaffected: it sets NODE_ENV before evaluating the config.) Root cause: two independent NODE_ENV samplings diverge in one process. The vendored RSC renderer was `require()`d eagerly at plugin-import time (locking dev/prod to NODE_ENV-at-import; the orchestrator chain reached `createTemporaryReferenceSet()` at import), while the page's `react`/`react/jsx-runtime` loaded later under the settled NODE_ENV. A development renderer fed production elements (no `_store`) dies deep inside React.

## What

Layered fix:

1. **Lazy vendored requires** (`vendor.server`/`vendor.static`, via `lazyVendorModule.ts` Proxy) — first property access loads the module, after tooling settles NODE_ENV. `temporaryReferences.server` defers its `createTemporaryReferenceSet()` call the same way. Wrong-side imports stay loud: without the react-server condition the old eager (throwing) require still runs at module init (pinned by `imports.test`).
2. **React-paired variant selection** (`reactPairedMode`) — the renderer resolves to the variant of the React copy the process has *already evaluated* (require.cache scan, `loaded`-only entries: Node's cjs-module-lexer leaves unevaluated cache entries for both wrapper branches), falling back to NODE_ENV. An independently-sampled prod renderer driving a cached dev react crashes with `dispatcher.getOwner is not a function` — pairing fixes both directions. The variant files are NODE_ENV-gated (the dev build evaluates to *empty exports* under production), so the one synchronous require runs under a scoped NODE_ENV swap.
3. **`lockReactFamily()`** at `renderPagesBatched` start pins `react` + `jsx-runtime`(+dev) into the cache as one variant before any page module loads in-process.
4. **Workers spawn with the locked NODE_ENV** (an html worker that resolved prod React can't consume a dev-rendered RSC stream), and the READY-handshake env check compares against the spawned env, not vite's mode.
5. **`assertRendererElementParity()`** at both `renderToPipeableStream` call sites — if a dev renderer ever meets prod elements again, the error names the cause and fix instead of dying inside React.

## Verification

- New `test/examples/node-env-flip-build.test.ts` runs the exact trigger in a dedicated child process (import plugin with NODE_ENV unset → flip to production → build+SSG in one process). It reproduces the `validated` panic against the previous code and passes with this PR.
- New `test/unit/lazyVendoredRenderer.test.ts` covers the lazy module, the pairing rule, and the diagnostic.
- `dev-prod-error-visibility.test.ts` (NODE_ENV pinned per process) passes unchanged — pinned-env behavior is identical.
- Full `test-all` gate green: test:server 534, test:client 175, test:unit 360, typecheck 20.

## Follow-up worth tracking

The plugin-import graph still evaluates `react` eagerly via the default components chain (`config/defaults` → `components/root|html|css` → top-level `import React from "react"`). That's what locks the process's React variant at import in the flip scenario (the pairing logic now handles it gracefully, rendering SSG with the locked variant). Removing react from the import graph would let a flipped process render fully in the settled mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
