### PR TITLE
feat(utils): AbortSignal support in createReactFetcher

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -479,6 +479,32 @@ For consumers who want to import only the pure helpers (urls, env, routeToURL) w
 import { createReactFetcher, setupRscHmr, useRscHmr, callServer } from "vite-plugin-react-server/utils/rsc-client";
 ```
 
+#### Cancelling a superseded RSC fetch
+
+`createReactFetcher` accepts an `AbortSignal`. Without one, a flight fetch
+that gets superseded — a fast double-navigation, a refetch racing an earlier
+fetch — aborts mid-body and the decoder's `TypeError: Error in input stream`
+lands in the nearest error boundary, briefly flashing an error card for a
+stream nobody is waiting on anymore.
+
+Have each navigation/refetch own an `AbortController`, and abort the previous
+one before starting the next. A stream cancelled through its signal never
+rejects — the stale thenable stays pending (React keeps the current UI) until
+the replacing fetch resolves:
+
+```tsx
+let controller: AbortController | undefined;
+
+function navigate(url: string) {
+  controller?.abort();          // cancel the in-flight stream, silently
+  controller = new AbortController();
+  setContent(createReactFetcher({ url, signal: controller.signal }));
+}
+```
+
+Genuine flight failures (network errors, decode failures on a stream that was
+NOT aborted) still reject and reach the error boundary as before.
+
 ### Storybook preset
 
 A Storybook preset that makes a vprs app build and render in Storybook. Referenced as an addon, not imported directly. See [Storybook](./storybook.md).

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -12,27 +12,60 @@ export function createReactFetcher({
   headers = {
     Accept: "text/x-component",
   },
+  signal,
 }: {
   url?: string;
   moduleBaseURL?: string;
   publicOrigin?: string;
   indexRSC?: string;
   headers?: HeadersInit;
+  /**
+   * Abort the underlying flight fetch. Pass an AbortController's signal and
+   * abort it when the stream is superseded (e.g. a navigation starts a new
+   * fetch before this one lands) — see the consumer pattern in the docs.
+   * A stream cancelled through this signal never surfaces as a render
+   * error: the returned thenable stays pending instead of rejecting, since
+   * the consumer is about to replace it anyway.
+   */
+  signal?: AbortSignal;
 } = {}): PromiseLike<React.ReactNode> {
   const parsedURL = createPageURL(
     moduleBaseURL,
     publicOrigin,
     env.DEV
   )(url, indexRSC);
-  return createFromFetch(
+  const content = createFromFetch(
     fetch(parsedURL.indexRSC, {
       headers: headers,
+      signal,
     }),
     {
       callServer: createCallServer(parsedURL.moduleBaseURL),
       moduleBaseURL: parsedURL.moduleBaseURL,
     }
   );
+  if (!signal) {
+    return content;
+  }
+  // A superseded stream rejects with AbortError (pre-flush) or the decoder's
+  // "Error in input stream" TypeError (aborted mid-body). Neither is a real
+  // flight failure when the caller cancelled on purpose — swallow them by
+  // staying pending, so React keeps showing the previous/suspended UI until
+  // the replacing fetch resolves. Genuine decode failures (signal not
+  // aborted) still reject.
+  return {
+    then: (onfulfilled, onrejected) =>
+      Promise.resolve(content).then(
+        onfulfilled,
+        (error: unknown) => {
+          if (signal.aborted) {
+            return new Promise<never>(() => {}) as never;
+          }
+          if (onrejected) return onrejected(error);
+          throw error;
+        }
+      ),
+  };
 }
 
 /** HMR event name used by the plugin */

--- a/test/unit/createReactFetcher.test.ts
+++ b/test/unit/createReactFetcher.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 /**
- * createReactFetcher AbortSignal support (bd: stale in-flight RSC streams
- * can't be cancelled).
+ * createReactFetcher AbortSignal support.
  *
  * The fetcher must (a) forward the signal to fetch, and (b) keep a
  * deliberately-cancelled stream from surfacing as a render error — the

--- a/test/unit/createReactFetcher.test.ts
+++ b/test/unit/createReactFetcher.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * createReactFetcher AbortSignal support (bd: stale in-flight RSC streams
+ * can't be cancelled).
+ *
+ * The fetcher must (a) forward the signal to fetch, and (b) keep a
+ * deliberately-cancelled stream from surfacing as a render error — the
+ * superseded thenable stays pending instead of rejecting, while genuine
+ * flight failures still reject.
+ */
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function flightResponse(body = '0:"ok"\n'): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/x-component" },
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("window", { location: { pathname: "/" } });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+async function importFetcher() {
+  const mod = await import("../../plugin/utils/createReactFetcher.js");
+  return mod.createReactFetcher;
+}
+
+describe("createReactFetcher signal forwarding", () => {
+  it("passes the AbortSignal through to fetch", async () => {
+    const createReactFetcher = await importFetcher();
+    const controller = new AbortController();
+    const seen: RequestInit[] = [];
+    globalThis.fetch = vi.fn(async (_url: any, init?: RequestInit) => {
+      seen.push(init ?? {});
+      return flightResponse();
+    }) as any;
+
+    createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost",
+      signal: controller.signal,
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].signal).toBe(controller.signal);
+  });
+
+  it("works without a signal (back-compat)", async () => {
+    const createReactFetcher = await importFetcher();
+    globalThis.fetch = vi.fn(async () => flightResponse()) as any;
+
+    const content = createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost",
+    });
+    await expect(Promise.resolve(content)).resolves.toBeDefined();
+  });
+});
+
+describe("createReactFetcher cancellation semantics", () => {
+  it("an aborted fetch never rejects the returned thenable (stays pending)", async () => {
+    const createReactFetcher = await importFetcher();
+    const controller = new AbortController();
+    globalThis.fetch = vi.fn(
+      (_url: any, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(
+              new DOMException("The operation was aborted.", "AbortError")
+            )
+          );
+        })
+    ) as any;
+
+    const content = createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost",
+      signal: controller.signal,
+    });
+
+    let settled: string | null = null;
+    Promise.resolve(content).then(
+      () => (settled = "resolved"),
+      () => (settled = "rejected")
+    );
+
+    controller.abort();
+    // give microtasks + a macrotask a chance to deliver any rejection
+    await new Promise((r) => setTimeout(r, 20));
+    expect(settled).toBe(null);
+  });
+
+  it("a genuine flight failure (signal not aborted) still rejects", async () => {
+    const createReactFetcher = await importFetcher();
+    const controller = new AbortController();
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("network down");
+    }) as any;
+
+    const content = createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost",
+      signal: controller.signal,
+    });
+
+    await expect(Promise.resolve(content)).rejects.toThrow("network down");
+  });
+});


### PR DESCRIPTION
## Why

A superseded in-flight RSC fetch (fast double-navigation, refetch racing an earlier one) has no cancellation path: `createReactFetcher` calls `fetch()` without a signal, so the stale stream aborts mid-body and the flight decoder's `TypeError: Error in input stream` re-throws into the nearest error boundary — briefly flashing an error card for a stream nobody is waiting on. Surfaced in a consumer app's navigation flow; the app-side page-lifecycle guard only covers the hard-reload case, not in-app double-nav.

## What

- `createReactFetcher` accepts an optional `signal?: AbortSignal`, forwarded to the underlying `fetch`.
- A stream cancelled through its signal never surfaces as a render error: the returned thenable stays pending (React keeps showing the current UI) until the replacing fetch resolves. Genuine flight failures — network errors, decode failures with the signal NOT aborted — still reject and reach the error boundary exactly as before.
- The consumer pattern (each navigation/refetch owns an `AbortController`, aborts the previous one before starting the next) is documented in `docs/api-reference.md`.
- No signal passed → byte-for-byte previous behavior.

## Verification

- New `test/unit/createReactFetcher.test.ts`: signal forwarded to fetch, no-signal back-compat, aborted fetch stays pending (never rejects), genuine failure still rejects.
- Full `test-all` gate green: test:server 526, test:client 173, test:unit 354, typecheck 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)