### PR TITLE
test: timeout headroom for the two slowest build tests

### DIFF
--- a/test/examples/build-abort-handling.test.ts
+++ b/test/examples/build-abort-handling.test.ts
@@ -27,7 +27,7 @@ describe("Build Abort Handling (Cross-Environment)", () => {
         })
       ).rejects.toThrow(errString);
     }
-  }, 10000); // Increase timeout to 10 seconds for this test
+  }); // two real builds in a loop — the global 30s testTimeout applies
 
   it("should abort build when abort condition is triggered in onEvent during build.start", async () => {
     const testEvent = "build.start";

--- a/test/examples/error-boundaries-build.test.ts
+++ b/test/examples/error-boundaries-build.test.ts
@@ -7,7 +7,9 @@ import {
 import { setupErrorBoundaryTestProject } from "../setup.js";
 
 describe("Error Boundaries Build (Cross-Environment)", () => {
-  test("should generate error boundary components in static output", async () => {
+  // runs several full builds (one per panic-threshold variant) — needs
+  // headroom beyond the global 30s on slow machines
+  test("should generate error boundary components in static output", { timeout: 90_000 }, async () => {
     await expect(
       getSharedBuild(
         "error-boundaries-test-project",


### PR DESCRIPTION
## Why

Pushed to #115's branch minutes after it merged, so these two commits never reached main. On hardware slow enough to have reproduced the fixture cascade, the only remaining failures were two plain build-timeout misses — verified there: the tests pass in isolation (~2.8s) and only exceed their ceilings under full-suite parallelism.

## What

- `build-abort-handling`: removes a stale hand-written 10s per-test override (predates the global default moving 5s → 30s); the test runs two real builds in a loop and now inherits the 30s global.
- `error-boundaries-build` static-output test: 90s — it runs a full build per panic-threshold variant, and suite-level contention (not solo speed) is what the ceiling has to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)