### PR TITLE
feat!: react-server-loader becomes a peer dependency admitting both React trains

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ npm install -D vite-plugin-react-server react react-dom
 
 vprs 2.0 runs on **stable React 19.2+**. The `react-server-dom-esm` transport
 ships inside the [`react-server-loader`](https://www.npmjs.com/package/react-server-loader)
-dependency (installed automatically), so you no longer install a transport or an
-experimental React build yourself. Upgrading from 1.x? See the
+peer dependency — npm and pnpm install the stable train automatically (yarn
+users add it explicitly). To run the experimental React train, install
+`react-server-loader@experimental` alongside `react@experimental`; see
+[React Compatibility](./docs/react-type-compatibility.md). Upgrading from 1.x? See the
 [migration notes](./docs/getting-started.md#upgrading-from-1x).
 
 ## Minimal Example
@@ -146,7 +148,7 @@ It strips the vprs plugin from Storybook's builder, resolves the
   server APIs vprs relies on (`prerenderToNodeStream`, the `react-server`
   transport exports) are part of stable React, so no experimental build is
   required. The matching `react-server-dom-esm` transport is provided by the
-  `react-server-loader` dependency; experimental React still works if you want
+  `react-server-loader` peer; experimental React still works if you want
   the newest RSC features. See [React Compatibility](./docs/react-type-compatibility.md).
 - Vite 6+
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ A Vite plugin that transforms React components into native ESM modules with Reac
 npm install -D vite-plugin-react-server react react-dom
 ```
 
-vprs 2.0 runs on **stable React 19.2+**. The `react-server-dom-esm` transport
-ships inside the [`react-server-loader`](https://www.npmjs.com/package/react-server-loader)
-peer dependency — npm and pnpm install the stable train automatically (yarn
-users add it explicitly). To run the experimental React train, install
-`react-server-loader@experimental` alongside `react@experimental`; see
+vprs 2.0 runs on **stable React 19.2+**. Everything React-version-locked —
+the `react-server-dom-esm` transport (server side AND the flight client your
+browser bundle ships), the directive engine, the Node loader — lives in the
+[`react-server-loader`](https://www.npmjs.com/package/react-server-loader)
+peer dependency, which version-mirrors React. npm and pnpm install the stable
+train automatically (yarn users add it explicitly); to run the experimental
+React train, install `react-server-loader@experimental` alongside
+`react@experimental`. See
 [React Compatibility](./docs/react-type-compatibility.md). Upgrading from 1.x? See the
 [migration notes](./docs/getting-started.md#upgrading-from-1x).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,9 +9,10 @@ npm install -D vite-plugin-react-server react react-dom
 vprs 2.0 runs on **stable React 19.2+** (`react` / `react-dom` at `^19.2.7`).
 The `react-server-dom-esm` ESM transport is provided by the
 [`react-server-loader`](https://www.npmjs.com/package/react-server-loader)
-dependency (installed automatically) — you don't install a transport or an
-experimental React build yourself. If you want the newest RSC features you can
-still run on experimental React; see
+peer dependency. npm and pnpm install the stable train automatically; yarn
+users add it explicitly. Switching to the experimental React train is a
+direct install — `react-server-loader@experimental` next to
+`react@experimental` — see
 [React Compatibility](./react-type-compatibility.md).
 
 ## Upgrading from 1.x

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -29,22 +29,19 @@ npm view react-server-loader@experimental peerDependencies
 npm install react@<that-exact-version> react-dom@<that-exact-version>
 ```
 
-`react-server-loader` is a regular dependency of this plugin, so installing
-`react-server-loader@experimental` alongside it leaves TWO copies in the
-tree — the plugin keeps resolving its own nested stable one. Route the
-plugin's copy to the experimental build with your package manager's
-override (use the exact version the dist-tag currently points at):
+`react-server-loader` is a **peer dependency** whose range admits both
+trains (`^19.2.8 || >=0.0.0-0 <0.0.1`). npm ≥7 and pnpm ≥8 auto-install
+the stable train by default — installing the plugin needs no extra step.
+To run the experimental train, install the loader (and its matching React)
+directly; a direct dependency satisfies the peer and there is exactly one
+copy in the tree:
 
-```jsonc
-// npm — package.json
-"overrides": { "react-server-loader": "0.0.0-experimental-<hash>-<date>" }
-
-// yarn — package.json
-"resolutions": { "react-server-loader": "0.0.0-experimental-<hash>-<date>" }
-
-// pnpm — package.json
-"pnpm": { "overrides": { "react-server-loader": "0.0.0-experimental-<hash>-<date>" } }
+```bash
+npm install react-server-loader@experimental react@experimental react-dom@experimental
 ```
+
+Yarn does not auto-install peers — install `react-server-loader` explicitly
+there even for the stable train.
 
 One practical reason to run experimental today: stable React 19.2.x emits
 the cosmetic `as="stylesheet"` preload warning

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.8",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -30,6 +29,7 @@
         "playwright": "^1.58.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "react-server-loader": "^19.2.8",
         "source-map": "^0.7.4",
         "supports-color": "^10.0.0",
         "ts-node": "^10.9.2",
@@ -41,11 +41,12 @@
         "webpack-sources": "^3.2.3"
       },
       "engines": {
-        "node": "^23.7.0"
+        "node": ">=22"
       },
       "peerDependencies": {
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
         "vite": "*"
       },
       "peerDependenciesMeta": {
@@ -4639,6 +4640,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4648,6 +4650,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -4667,6 +4670,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.8.tgz",
       "integrity": "sha512-4xYQ2QkP24Jw49hkrVXCjn97Jg1RpNS20n+kqINhABvgNgD8SKYWBNfaXiPGZg2ZfGvqgPTSZm2bHulD1eACDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -4896,6 +4900,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -5083,6 +5088,7 @@
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -382,7 +382,8 @@
   "peerDependencies": {
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "vite": "*"
+    "vite": "*",
+    "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -418,12 +419,12 @@
     "typescript-eslint": "^8.33.1",
     "vite": "^6.3.5",
     "vitest": "^3.0.4",
-    "webpack-sources": "^3.2.3"
+    "webpack-sources": "^3.2.3",
+    "react-server-loader": "^19.2.8"
   },
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
-    "react-server-loader": "^19.2.8",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }

--- a/plugin/vendor/transportDir.ts
+++ b/plugin/vendor/transportDir.ts
@@ -11,7 +11,29 @@ import { dirname, join } from "node:path";
  * in its exports map, so this resolves under any resolution condition.
  */
 const require = createRequire(import.meta.url);
-const rslRoot = dirname(require.resolve("react-server-loader/package.json"));
+
+function resolveRslRoot(): string {
+  try {
+    return dirname(require.resolve("react-server-loader/package.json"));
+  } catch (error) {
+    // react-server-loader is a PEER dependency: npm>=7/pnpm>=8 install it
+    // automatically, but yarn (and npm with legacy-peer-deps/omit=peer)
+    // doesn't — without this, those users get a bare ERR_MODULE_NOT_FOUND
+    // pointing nowhere useful.
+    throw new Error(
+      "[vite-plugin-react-server] react-server-loader is not installed. " +
+        "It is a peer dependency that npm and pnpm install automatically, " +
+        "but your package manager configuration does not. Install it next " +
+        "to the plugin:\n\n" +
+        "  yarn add react-server-loader        # stable React train\n" +
+        "  yarn add react-server-loader@experimental   # experimental train\n\n" +
+        "See docs/react-type-compatibility.md for the train pairing.",
+      { cause: error }
+    );
+  }
+}
+
+const rslRoot = resolveRslRoot();
 
 /** Absolute path to the `react-server-loader` package root (for Vite fs.allow). */
 export const transportRoot = rslRoot;


### PR DESCRIPTION
## Why

`react-server-loader` was a regular dependency pinned to `^19.2.8`, which made the experimental React train effectively unreachable: installing `react-server-loader@experimental` alongside the plugin leaves two copies in the tree (the plugin resolves its own nested stable one), and the only working route was the package-manager override recipe #116 documented. Inconvenient — and the stable `as="stylesheet"` preload warning gives ordinary users a real reason to want the experimental channel today.

(Re-spun from #116's branch — the original PR merged carrying only the docs commit while this change was still landing on its branch.)

## What

- `react-server-loader` moves to **peerDependencies** with the range `"^19.2.8 || >=0.0.0-0 <0.0.1"` — verified against npm's semver to admit stable 19.2.x AND any `0.0.0-experimental-*` build while rejecting everything else.
- npm ≥7 / pnpm ≥8 auto-install peers → default installs unchanged: zero extra steps, stable train.
- Experimental becomes a plain direct install, one copy in the tree, no overrides:
  ```bash
  npm i react-server-loader@experimental react@experimental react-dom@experimental
  ```
- Yarn doesn't auto-install peers — yarn users add `react-server-loader` explicitly (documented).
- The pinned copy stays in `devDependencies` for this repo's own build/tests.
- Docs: README, getting-started, and react-type-compatibility now describe the peer flow (replacing the override recipe as the primary path).

**BREAKING** for yarn consumers and npm installs configured to omit peers — release as a major or a clearly-noted minor.

## Verification

Full `test-all` gate green on this change (81/45/36/4 files) — the devDependency keeps local resolution identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)