### PR TITLE
docs: pitch the dual-condition architecture; stop implying react-server is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # vite-plugin-react-server
 
-A Vite plugin that transforms React components into native ESM modules with React Server Components support. Build static sites, dynamic servers, or anything in between — your components become portable ESM that works with any HTTP server.
+React Server Components for plain Vite on **stable React** — no framework, no
+experimental builds. One `vite build --app` prerenders your pages to static
+HTML + RSC payloads and emits your components as portable ESM that runs under
+any HTTP server: static hosting, Express/Hono, or anything in between.
+
+It works in BOTH Node module conditions, by design: the dev server and the
+build run with or without `--conditions react-server`, and whichever side your
+main thread is on, a worker thread mirrors the other half (server components
+need a react-server context, client hydration needs a react-client one — you
+always have both). Running the main thread under react-server is an optional
+optimization — slightly faster, better stack traces — never a requirement.
 
 ## Install
 
@@ -39,7 +49,10 @@ export const Page = ({ url }: { url: string }) => <div>Hello from {url}</div>;
 # Dev server
 npx vite
 
-# Build
+# Build (static site + server/client ESM)
+npx vite build --app
+
+# Same build, react-server main thread — optional: a bit faster, better stack traces
 NODE_OPTIONS='--conditions react-server' vite build --app
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,13 +72,20 @@ export default defineConfig({
   "scripts": {
     "dev": "vite",
     "dev:rsc": "NODE_OPTIONS='--conditions react-server' vite",
-    "build": "NODE_OPTIONS='--conditions react-server' vite build --app",
+    "build": "vite build --app",
+    "build:rsc": "NODE_OPTIONS='--conditions react-server' vite build --app",
     "preview": "vite preview"
   }
 }
 ```
 
-Both `dev` and `dev:rsc` serve the same app. The difference is internal — see [Architecture](./internals/architecture.md) if you're curious.
+The plain and `:rsc` variants serve and build the same app — neither mode is
+required. Whichever condition the main thread runs, the plugin spawns a worker
+for the mirrored half, so server components and client hydration both always
+have their proper React context. The `:rsc` variants put the react-server side
+on the main thread: an optional optimization (slightly faster, better stack
+traces). See [Architecture](./internals/architecture.md) for how the mirroring
+works.
 
 ```bash
 npm run dev


### PR DESCRIPTION
## Why

The README opens with a generic transform description and shows `NODE_OPTIONS='--conditions react-server' vite build --app` as **the** build command. Readers — humans and AI agents alike — conclude the react-server condition is required for builds. It isn't, and the actual architecture is the pitch: dev and build run in either Node condition, with a worker mirroring the other half (server components always get a react-server context, client hydration always gets a react-client one). The react-server main thread is an optional optimization — slightly faster, better stack traces — never a requirement.

## What

- README opens with the stable-React + dual-condition pitch; build snippets show the plain `vite build --app` first, the `:rsc` variant as the optional faster path.
- getting-started's scripts split `build` / `build:rsc` and explain the mirroring (with the Architecture pointer for depth).

## Verification

Conditionless build verified end-to-end: the docs site itself prerenders all 27 pages with no `NODE_OPTIONS` set (the `test:client` suite has always covered this mode too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)