### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.0.8",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Minor release covering everything since 2.0.8 (#100). Highlights:

**Features**
- AbortSignal support in `createReactFetcher` (#108)
- Clear diagnostic when client-only React APIs are reached in the server graph (#110)
- Dogfooded docs site: vprs statically generates its own docs (#111), with mobile nav (#114)

**Fixes**
- `useRscHmr` subscribes once regardless of callback identity (#101)
- Vendor RSC renderer pairs with the process's React variant and survives NODE_ENV flips (#107)
- Test-infra hardening: atomic cross-process fixture lock (#115), fixture cache + teardown drain (#105), timeout headroom (#117)

**Compatibility**
- Node engines widened from `^23.7.0` to `>=22` — both current LTS lines are now accepted (#112). Widening, so not a breaking change.

Full test gate (server + client modes, 573 tests) ran green on this tree today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)