### PR TITLE
fix: keep quoted NODE_OPTIONS segments attached to their flag

### DIFF
--- a/plugin/config/getCondition.ts
+++ b/plugin/config/getCondition.ts
@@ -2,8 +2,11 @@
 // This file is consumed in both server and client plugin contexts.
 
 /**
- * Tokenizes NODE_OPTIONS string into individual arguments
- * Handles quoted strings, spaces, and special characters
+ * Tokenizes NODE_OPTIONS string into individual arguments.
+ * Tokens split on unquoted whitespace only; a quoted segment stays attached
+ * to the token it appears in (Node semantics: quotes protect spaces, so
+ * `--conditions="react-server"` is ONE token, `--require "./my path/x.js"`
+ * is two).
  */
 const tokenizeNodeOptions = (): string[] => {
   const nodeOptions = process.env["NODE_OPTIONS"] || "";
@@ -24,19 +27,11 @@ const tokenizeNodeOptions = (): string[] => {
       if (char === quoteChar) {
         inQuotes = false;
         quoteChar = "";
-        if (current.trim()) {
-          tokens.push(current.trim());
-          current = "";
-        }
       } else {
         current += char;
       }
     } else {
       if (char === '"' || char === "'") {
-        if (current.trim()) {
-          tokens.push(current.trim());
-          current = "";
-        }
         inQuotes = true;
         quoteChar = char;
       } else if (char === " " || char === "\t" || char === "\n") {

--- a/test/unit/getCondition.test.ts
+++ b/test/unit/getCondition.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// Import the SOURCE (not the built package entry) so this test guards the
+// tokenizer fix in `plugin/config/getCondition.ts` directly — reverting it
+// must make the regression assertions below fail without a rebuild.
+import { getNodeOptionsConditions } from "../../plugin/config/getCondition.js";
+
+// getNodeOptionsConditions reads process.env.NODE_OPTIONS at call time and
+// ignores execArgv, so it isolates the tokenizer from the conditions vitest
+// itself runs under.
+describe("getNodeOptionsConditions (NODE_OPTIONS tokenizer)", () => {
+  const saved = process.env["NODE_OPTIONS"];
+
+  beforeEach(() => {
+    delete process.env["NODE_OPTIONS"];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env["NODE_OPTIONS"];
+    else process.env["NODE_OPTIONS"] = saved;
+  });
+
+  it("returns [] when NODE_OPTIONS is unset or blank", () => {
+    expect(getNodeOptionsConditions()).toEqual([]);
+    process.env["NODE_OPTIONS"] = "   ";
+    expect(getNodeOptionsConditions()).toEqual([]);
+  });
+
+  it("parses the space form: --conditions react-server", () => {
+    process.env["NODE_OPTIONS"] = "--conditions react-server";
+    expect(getNodeOptionsConditions()).toEqual(["react-server"]);
+  });
+
+  it("parses the equals form: --conditions=react-server", () => {
+    process.env["NODE_OPTIONS"] = "--conditions=react-server";
+    expect(getNodeOptionsConditions()).toEqual(["react-server"]);
+  });
+
+  it('parses the quoted equals form: --conditions="react-server" (regression, bug: quote split the flag from its value)', () => {
+    process.env["NODE_OPTIONS"] = '--conditions="react-server"';
+    expect(getNodeOptionsConditions()).toEqual(["react-server"]);
+  });
+
+  it("parses the single-quoted equals form: --conditions='react-server'", () => {
+    process.env["NODE_OPTIONS"] = "--conditions='react-server'";
+    expect(getNodeOptionsConditions()).toEqual(["react-server"]);
+  });
+
+  it("parses a quoted value after a space: --conditions \"react-server\"", () => {
+    process.env["NODE_OPTIONS"] = '--conditions "react-server"';
+    expect(getNodeOptionsConditions()).toEqual(["react-server"]);
+  });
+
+  it("splits comma lists, quoted or not", () => {
+    process.env["NODE_OPTIONS"] = '--conditions="react-server, custom"';
+    expect(getNodeOptionsConditions()).toEqual(["react-server", "custom"]);
+  });
+
+  it("keeps unrelated quoted flags separate from conditions", () => {
+    process.env["NODE_OPTIONS"] =
+      '--require "./my path/file.js" --conditions=react-server --no-addons';
+    expect(getNodeOptionsConditions()).toEqual(["react-server"]);
+  });
+
+  it("parses the short flag: -C react-server", () => {
+    process.env["NODE_OPTIONS"] = "-C react-server";
+    expect(getNodeOptionsConditions()).toEqual(["react-server"]);
+  });
+});


### PR DESCRIPTION
## Problem

`tokenizeNodeOptions` flushed the current token whenever it encountered a quote character. `NODE_OPTIONS='--conditions="react-server"'` therefore tokenized as `--conditions=` plus a separate `react-server`, and `parseNodeArgs` extracted no condition — while Node's own resolver honors that form. The false negative made `hasReactServerCondition()` / `getCondition()` consumers (worker spawning, wrong-side vendor probes) misjudge a process that actually runs under `react-server`.

## Fix

Quotes now only toggle quoting state; their content stays in the current token. Tokens split on unquoted whitespace alone, which matches Node's NODE_OPTIONS semantics (quotes exist to protect spaces): `--conditions="react-server"` is one token, `--require "./my path/file.js"` is two.

## Tests

New `test/unit/getCondition.test.ts` covers the space, equals, quoted-equals (double and single), quoted-after-space, comma-list and `-C` forms, plus quoted unrelated flags. It imports the source module directly, so reverting the tokenizer fails the suite without a rebuild (verified: 3 tests fail on the previous tokenizer). Full `test:server` (582 passed) and `test:client` (175 passed) gates are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)