### PR TITLE
refactor: drop React from the plugin-import graph (both entries)

### DIFF
--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -181,7 +181,7 @@ export const DEFAULT_CONFIG = {
   // NOTE: no default Html/Root components are held here. They import React at
   // module scope, and DEFAULT_CONFIG is in the eager plugin-import graph
   // (config eval), so referencing them here used to cache React's dev/prod
-  // variant before NODE_ENV settled (bd 0uy, the lockReactFamily warning case).
+  // variant before NODE_ENV settled (the lockReactFamily warning case).
   // The default components are loaded lazily at point-of-use instead — see
   // createHandlerOptions.server.ts (`await import("../components/root.js")`)
   // and resolveWithDefaultRootAndHtml.

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -178,13 +178,11 @@ export const DEFAULT_CONFIG = {
   RSC_WORKER_STARTUP_TIMEOUT: 3000, // 3 seconds default timeout for RSC worker startup
   FILE_WRITE_TIMEOUT: 10000, // 10 seconds default timeout for file write operations
   WORKER_SHUTDOWN_TIMEOUT: 1000, // Reduced to 1 second for faster test cleanup
-  // NOTE: no default Html/Root components are held here. They import React at
-  // module scope, and DEFAULT_CONFIG is in the eager plugin-import graph
-  // (config eval), so referencing them here used to cache React's dev/prod
-  // variant before NODE_ENV settled (the lockReactFamily warning case).
-  // The default components are loaded lazily at point-of-use instead — see
-  // createHandlerOptions.server.ts (`await import("../components/root.js")`)
-  // and resolveWithDefaultRootAndHtml.
+  // Default Html/Root components are intentionally NOT held here: they import
+  // React at module scope, and DEFAULT_CONFIG is evaluated during config load,
+  // so a reference here would pin React's dev/prod variant before NODE_ENV is
+  // final (the lockReactFamily warning). They are loaded lazily at point-of-use
+  // instead — see createHandlerOptions.server.ts and resolveWithDefaultRootAndHtml.
   BUILD: {
     pages: [],
     client: "client",

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -1,5 +1,3 @@
-import { Root } from "../components/root.js";
-import { Html } from "../components/html.js";
 import {
   parse,
   DEFAULT_LOADER_CONFIG as RSL_LOADER_DEFAULTS,
@@ -180,10 +178,13 @@ export const DEFAULT_CONFIG = {
   RSC_WORKER_STARTUP_TIMEOUT: 3000, // 3 seconds default timeout for RSC worker startup
   FILE_WRITE_TIMEOUT: 10000, // 10 seconds default timeout for file write operations
   WORKER_SHUTDOWN_TIMEOUT: 1000, // Reduced to 1 second for faster test cleanup
-  COMPONENTS: {
-    Html: Html,
-    Root: Root,
-  },
+  // NOTE: no default Html/Root components are held here. They import React at
+  // module scope, and DEFAULT_CONFIG is in the eager plugin-import graph
+  // (config eval), so referencing them here used to cache React's dev/prod
+  // variant before NODE_ENV settled (bd 0uy, the lockReactFamily warning case).
+  // The default components are loaded lazily at point-of-use instead — see
+  // createHandlerOptions.server.ts (`await import("../components/root.js")`)
+  // and resolveWithDefaultRootAndHtml.
   BUILD: {
     pages: [],
     client: "client",

--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -237,7 +237,7 @@ export const configureReactServer: ConfigureReactServerFn =
         // Load actual components first - this registers them in the module graph
         // which is required for CSS collection to work.
         // The default Root is imported lazily (point-of-use) so the static
-        // plugin-import graph never pulls React in at config eval (bd 0uy).
+        // plugin-import graph never pulls React in at config eval.
         const { Root: DefaultRoot } = await import("../components/root.js");
         let PageComponent: React.ComponentType<any> = React.Fragment;
         let RootComponent: React.ComponentType<any> = DefaultRoot;

--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -14,7 +14,6 @@ import { handleError } from "../error/handleError.js";
 import { cleanupWorker } from "../helpers/workerCleanup.js";
 import { mergeConfig, type ResolvedConfig } from "vite";
 import { resolvePageAndProps } from "../helpers/resolvePageAndProps.js";
-import { Root as DefaultRoot } from "../components/root.js";
 
 export const configureReactServer: ConfigureReactServerFn =
   function _configureReactServer({
@@ -236,7 +235,10 @@ export const configureReactServer: ConfigureReactServerFn =
         };
 
         // Load actual components first - this registers them in the module graph
-        // which is required for CSS collection to work
+        // which is required for CSS collection to work.
+        // The default Root is imported lazily (point-of-use) so the static
+        // plugin-import graph never pulls React in at config eval (bd 0uy).
+        const { Root: DefaultRoot } = await import("../components/root.js");
         let PageComponent: React.ComponentType<any> = React.Fragment;
         let RootComponent: React.ComponentType<any> = DefaultRoot;
         let pageProps: any = {};

--- a/plugin/helpers/resolveWithDefaultRootAndHtml.ts
+++ b/plugin/helpers/resolveWithDefaultRootAndHtml.ts
@@ -11,7 +11,7 @@ import type { React } from "../vendor/vendor.server.js";
  * The default Root/Html components import React at module scope, so they are
  * loaded lazily here (dynamic import at point-of-use) rather than statically:
  * a static import would root React in the graph of every `…/helpers` consumer
- * and at plugin import (bd 0uy). This makes the function async — callers must
+ * and at plugin import. This makes the function async — callers must
  * `await` it.
  *
  * @param RootComponent - The root component to use, or undefined to use default

--- a/plugin/helpers/resolveWithDefaultRootAndHtml.ts
+++ b/plugin/helpers/resolveWithDefaultRootAndHtml.ts
@@ -8,11 +8,10 @@ import type { React } from "../vendor/vendor.server.js";
  * that RootComponent and HtmlComponent are always defined, falling back to
  * default components when needed.
  *
- * The default Root/Html components import React at module scope, so they are
- * loaded lazily here (dynamic import at point-of-use) rather than statically:
- * a static import would root React in the graph of every `…/helpers` consumer
- * and at plugin import. This makes the function async — callers must
- * `await` it.
+ * Async because it dynamic-imports the default components only when a fallback
+ * is actually needed. The defaults import React at module scope; a static
+ * import of them would pull React into the graph of every `…/helpers` consumer
+ * (and into the plugin's import graph) at load time, so keep them dynamic.
  *
  * @param RootComponent - The root component to use, or undefined to use default
  * @param HtmlComponent - The HTML component to use, or undefined to use default

--- a/plugin/helpers/resolveWithDefaultRootAndHtml.ts
+++ b/plugin/helpers/resolveWithDefaultRootAndHtml.ts
@@ -1,23 +1,31 @@
 import type { HtmlComponentType, RootComponentType } from "../types.js";
 import type { React } from "../vendor/vendor.server.js";
-import { Html as DefaultHtml } from "../components/html.js";
-import { Root as DefaultRoot } from "../components/root.js";
 
 /**
  * Resolves components with appropriate fallbacks
- * 
+ *
  * This helper can be used in both client and server environments to ensure
  * that RootComponent and HtmlComponent are always defined, falling back to
  * default components when needed.
- * 
+ *
+ * The default Root/Html components import React at module scope, so they are
+ * loaded lazily here (dynamic import at point-of-use) rather than statically:
+ * a static import would root React in the graph of every `…/helpers` consumer
+ * and at plugin import (bd 0uy). This makes the function async — callers must
+ * `await` it.
+ *
  * @param RootComponent - The root component to use, or undefined to use default
  * @param HtmlComponent - The HTML component to use, or undefined to use default
- * @returns Object containing resolved RootComponent and HtmlComponent
+ * @returns Promise of an object containing resolved RootComponent and HtmlComponent
  */
-export function resolveWithDefaultRootAndHtml(
+export async function resolveWithDefaultRootAndHtml(
   RootComponent?: RootComponentType | typeof React.Fragment | undefined,
   HtmlComponent?: HtmlComponentType | typeof React.Fragment | undefined
 ) {
+  const [{ Root: DefaultRoot }, { Html: DefaultHtml }] = await Promise.all([
+    RootComponent ? Promise.resolve({ Root: undefined }) : import("../components/root.js"),
+    HtmlComponent ? Promise.resolve({ Html: undefined }) : import("../components/html.js"),
+  ]);
   return {
     RootComponent: RootComponent || DefaultRoot,
     HtmlComponent: HtmlComponent || DefaultHtml,

--- a/plugin/react-static/renderPage.server.ts
+++ b/plugin/react-static/renderPage.server.ts
@@ -31,8 +31,6 @@ import { createMainThreadHandlers } from "../stream/createMainThreadHandlers.js"
 import { createRscToHtmlStream } from "./rscToHtmlStream.server.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
 import { resolvePageAndProps } from "../helpers/resolvePageAndProps.js";
-import { Root as DefaultRoot } from "../components/root.js";
-import { Html as DefaultHtml } from "../components/html.js";
 import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
 import { join } from "node:path";
 import { createHeadlessStreamState, trackHeadlessStreamError, hasHeadlessStreamError } from "../helpers/headlessStreamState.js";
@@ -218,11 +216,15 @@ export const renderPage: RenderPageFn = async function* renderPage(
       }
     }
 
-    // Use defaults if components are still not loaded
+    // Use defaults if components are still not loaded. Imported lazily
+    // (point-of-use) so the static plugin-import graph never pulls React in at
+    // config eval (bd 0uy).
     if (!RootComponent) {
+      const { Root: DefaultRoot } = await import("../components/root.js");
       RootComponent = DefaultRoot as any;
     }
     if (!HtmlComponent) {
+      const { Html: DefaultHtml } = await import("../components/html.js");
       HtmlComponent = DefaultHtml as any;
     }
 

--- a/plugin/react-static/renderPage.server.ts
+++ b/plugin/react-static/renderPage.server.ts
@@ -218,7 +218,7 @@ export const renderPage: RenderPageFn = async function* renderPage(
 
     // Use defaults if components are still not loaded. Imported lazily
     // (point-of-use) so the static plugin-import graph never pulls React in at
-    // config eval (bd 0uy).
+    // config eval.
     if (!RootComponent) {
       const { Root: DefaultRoot } = await import("../components/root.js");
       RootComponent = DefaultRoot as any;

--- a/plugin/vendor/vendor.client.ts
+++ b/plugin/vendor/vendor.client.ts
@@ -5,13 +5,13 @@ import { createLazyVendorModule, reactPairedMode } from "./lazyVendorModule.js";
 import { hasReactServerCondition } from "../config/getCondition.js";
 
 // Vendored react-server-dom-esm/client.node + the consumer's react-dom/server
-// and react. All LAZY (mirrors vendor.server.ts): these CJS modules pick their
-// dev/prod variant from NODE_ENV at require time, so the require must be
-// deferred to first use — after build tooling (vite build, test harnesses) has
-// settled NODE_ENV, not at plugin-import time. A module-scope require here used
-// to load react-dom + react into the client plugin-import graph during config
-// eval, caching React's variant before NODE_ENV settled.
-// See lazyVendorModule.ts.
+// and react, exposed as LAZY proxies (mirrors vendor.server.ts). These CJS
+// modules pick their dev/prod variant from NODE_ENV at require time, so the
+// require is deferred to first property access — by then build tooling (vite
+// build, test harnesses) has settled NODE_ENV. A module-scope require would
+// instead load react-dom + react during config eval (this file is reachable
+// from the plugin's import graph), pinning React's variant before NODE_ENV is
+// final. See lazyVendorModule.ts.
 const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
 const lazyClient = createLazyVendorModule(
   () =>
@@ -37,14 +37,13 @@ const lazyReact = createLazyVendorModule(
 );
 const React = lazyReact.proxy;
 
-// Wrong-side imports must stay LOUD (mirrors vendor.server.ts): this is the
-// client/SSR renderer side, so evaluating it UNDER the react-server condition
-// must throw at module init exactly like the old eager require did —
-// react-dom/server is banned under react-server, and code paths
-// (createHtmlStream.client) plus the stream-imports test rely on that import
-// rejecting. The probe goes THROUGH the lazy proxy so the require still loads
-// lazily on the correct (client) side, keeping React out of the client
-// plugin-import graph.
+// Wrong-side guard (mirrors vendor.server.ts). This is the client/SSR renderer
+// side; react-dom/server is banned under the react-server condition, so
+// evaluating this module there must throw at module init. Consumers depend on
+// that: createHtmlStream.client and the stream-imports test expect importing a
+// client renderer under react-server to reject. Forcing the proxy here makes
+// the require run (and throw) only on the wrong side; on the correct side the
+// proxy stays untouched, so React still loads lazily.
 if (hasReactServerCondition()) {
   void (ReactDOMServer as { renderToPipeableStream?: unknown })
     .renderToPipeableStream;

--- a/plugin/vendor/vendor.client.ts
+++ b/plugin/vendor/vendor.client.ts
@@ -10,7 +10,7 @@ import { hasReactServerCondition } from "../config/getCondition.js";
 // deferred to first use — after build tooling (vite build, test harnesses) has
 // settled NODE_ENV, not at plugin-import time. A module-scope require here used
 // to load react-dom + react into the client plugin-import graph during config
-// eval, caching React's variant before NODE_ENV settled (bd 0uy / 15t).
+// eval, caching React's variant before NODE_ENV settled.
 // See lazyVendorModule.ts.
 const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
 const lazyClient = createLazyVendorModule(
@@ -44,7 +44,7 @@ const React = lazyReact.proxy;
 // (createHtmlStream.client) plus the stream-imports test rely on that import
 // rejecting. The probe goes THROUGH the lazy proxy so the require still loads
 // lazily on the correct (client) side, keeping React out of the client
-// plugin-import graph (bd 0uy / 15t).
+// plugin-import graph.
 if (hasReactServerCondition()) {
   void (ReactDOMServer as { renderToPipeableStream?: unknown })
     .renderToPipeableStream;

--- a/plugin/vendor/vendor.client.ts
+++ b/plugin/vendor/vendor.client.ts
@@ -1,16 +1,54 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { transportPkgDir } from "./transportDir.js";
+import { createLazyVendorModule, reactPairedMode } from "./lazyVendorModule.js";
+import { hasReactServerCondition } from "../config/getCondition.js";
 
-// Load react-server-dom-esm/client.node directly from the vendored copy that
-// ships inside the react-server-loader dependency.
+// Vendored react-server-dom-esm/client.node + the consumer's react-dom/server
+// and react. All LAZY (mirrors vendor.server.ts): these CJS modules pick their
+// dev/prod variant from NODE_ENV at require time, so the require must be
+// deferred to first use — after build tooling (vite build, test harnesses) has
+// settled NODE_ENV, not at plugin-import time. A module-scope require here used
+// to load react-dom + react into the client plugin-import graph during config
+// eval, caching React's variant before NODE_ENV settled (bd 0uy / 15t).
+// See lazyVendorModule.ts.
 const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
-const ReactDOMClient = vendorRequire(join(transportPkgDir, "client.node.js")) as typeof import("react-server-dom-esm/client.node");
+const lazyClient = createLazyVendorModule(
+  () =>
+    vendorRequire(
+      join(transportPkgDir, "client.node.js")
+    ) as typeof import("react-server-dom-esm/client.node"),
+  reactPairedMode
+);
+const ReactDOMClient = lazyClient.proxy;
 
-// React and react-dom still come from the consumer's project
+// React and react-dom still come from the consumer's project, also lazy so the
+// react/react-dom/renderer trio all resolve from one settled NODE_ENV.
 const projectRoot = process.env["npm_config_local_prefix"] || process.cwd();
 const projectRequire = createRequire(join(projectRoot, "package.json"));
-const ReactDOMServer = projectRequire("react-dom/server") as typeof import("react-dom/server");
-const React = projectRequire("react") as typeof import("react");
+const lazyReactDOMServer = createLazyVendorModule(
+  () => projectRequire("react-dom/server") as typeof import("react-dom/server"),
+  reactPairedMode
+);
+const ReactDOMServer = lazyReactDOMServer.proxy;
+const lazyReact = createLazyVendorModule(
+  () => projectRequire("react") as typeof import("react"),
+  reactPairedMode
+);
+const React = lazyReact.proxy;
+
+// Wrong-side imports must stay LOUD (mirrors vendor.server.ts): this is the
+// client/SSR renderer side, so evaluating it UNDER the react-server condition
+// must throw at module init exactly like the old eager require did —
+// react-dom/server is banned under react-server, and code paths
+// (createHtmlStream.client) plus the stream-imports test rely on that import
+// rejecting. The probe goes THROUGH the lazy proxy so the require still loads
+// lazily on the correct (client) side, keeping React out of the client
+// plugin-import graph (bd 0uy / 15t).
+if (hasReactServerCondition()) {
+  void (ReactDOMServer as { renderToPipeableStream?: unknown })
+    .renderToPipeableStream;
+}
 
 export { ReactDOMServer, React, ReactDOMClient };
+export type React = typeof import("react");

--- a/plugin/worker/rsc/hydrateRscRenderMessage.server.ts
+++ b/plugin/worker/rsc/hydrateRscRenderMessage.server.ts
@@ -42,7 +42,7 @@ function createLoader(
  * This function orchestrates the process of preparing a render message for execution
  * by validating, resolving URLs, merging defaults, and setting up components and loaders.
  */
-export function hydrateRscRenderMessage(
+export async function hydrateRscRenderMessage(
   {
     message,
     pageProps,
@@ -77,9 +77,10 @@ export function hydrateRscRenderMessage(
   // Step 4: Log render start if verbose
   logRenderStart(mergedValues.route, mergedValues.verbose, logger, "rsc-worker");
 
-  // Step 5: Resolve components with fallbacks
-  const { RootComponent: resolvedRootComponent, HtmlComponent: resolvedHtmlComponent } = 
-    resolveWithDefaultRootAndHtml(RootComponent, HtmlComponent);
+  // Step 5: Resolve components with fallbacks (async: defaults are loaded
+  // lazily so the helper doesn't statically root React — bd 0uy)
+  const { RootComponent: resolvedRootComponent, HtmlComponent: resolvedHtmlComponent } =
+    await resolveWithDefaultRootAndHtml(RootComponent, HtmlComponent);
 
   // Step 6: Create the loader
   const loader = createLoader(

--- a/plugin/worker/rsc/hydrateRscRenderMessage.server.ts
+++ b/plugin/worker/rsc/hydrateRscRenderMessage.server.ts
@@ -78,7 +78,7 @@ export async function hydrateRscRenderMessage(
   logRenderStart(mergedValues.route, mergedValues.verbose, logger, "rsc-worker");
 
   // Step 5: Resolve components with fallbacks (async: defaults are loaded
-  // lazily so the helper doesn't statically root React — bd 0uy)
+  // lazily so the helper doesn't statically root React)
   const { RootComponent: resolvedRootComponent, HtmlComponent: resolvedHtmlComponent } =
     await resolveWithDefaultRootAndHtml(RootComponent, HtmlComponent);
 

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -37,7 +37,6 @@ import { resolvePageAndProps } from "../../helpers/resolvePageAndProps.js";
 import { resolveComponent } from "../../helpers/resolveComponent.js";
 import { handleError } from "../../error/handleError.js";
 import type { PanicThreshold } from "../../types.js";
-import { Root as DefaultRoot } from "../../components/root.js";
 import { workerUserOptions } from "./workerUserOptions.js";
 import { hydrateUserOptions } from "../../helpers/hydrateUserOptions.js";
 import { React } from "../../vendor/vendor.server.js";
@@ -486,7 +485,10 @@ async function loadComponentsWithCache(options: {
       }
     }
   } else {
-    // No rootPath provided - use built-in default Root component
+    // No rootPath provided - use built-in default Root component. Imported
+    // lazily here (matching the Html path below) so the static import graph
+    // never roots React (bd 0uy).
+    const { Root: DefaultRoot } = await import("../../components/root.js");
     RootComponent = DefaultRoot;
     if (verbose) {
       logger?.info(`[rsc-worker] Using built-in default Root component`);

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -487,7 +487,7 @@ async function loadComponentsWithCache(options: {
   } else {
     // No rootPath provided - use built-in default Root component. Imported
     // lazily here (matching the Html path below) so the static import graph
-    // never roots React (bd 0uy).
+    // never roots React.
     const { Root: DefaultRoot } = await import("../../components/root.js");
     RootComponent = DefaultRoot;
     if (verbose) {

--- a/test/unit/plugin-import-no-react.test.ts
+++ b/test/unit/plugin-import-no-react.test.ts
@@ -1,0 +1,58 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for bd 0uy: the plugin's react-server entry must not pull
+ * React into the module graph at import time. React's CJS variant (dev/prod)
+ * locks to whatever loads first; if a static `import` chain rooted in the
+ * plugin's default Html/Root components evaluates React at plugin-import
+ * (config eval), a process that later settles NODE_ENV/condition is stuck with
+ * the wrong variant — the `lockReactFamily` warning case.
+ *
+ * This MUST run in a child process: vitest itself runs under react-server with
+ * React already loaded, so an in-process cache check would always see React.
+ * We import the BUILT entry (pretest:server builds dist) under the react-server
+ * condition with NODE_ENV unset, then scan the CJS require cache for a fully
+ * evaluated react variant. Only `module.loaded === true` entries count — Node's
+ * ESM->CJS bridge leaves unevaluated (loaded=false) stubs from static analysis.
+ */
+const SERVER_ENTRY = resolve(process.cwd(), "dist/plugin/index.server.js");
+
+const PROBE = `
+import { createRequire } from "node:module";
+const req = createRequire(${JSON.stringify(SERVER_ENTRY)});
+const loaded = () => {
+  const cache = req.cache ?? {};
+  const hits = [];
+  for (const key in cache) {
+    if (!cache[key]?.loaded) continue;
+    if (/[\\\\/]react[\\\\/]cjs[\\\\/]react\\.[^\\\\/]*\\.js$/.test(key)) hits.push(key);
+    else if (/[\\\\/]node_modules[\\\\/]react[\\\\/]index\\.js$/.test(key)) hits.push(key);
+  }
+  return hits;
+};
+await import(${JSON.stringify(SERVER_ENTRY)});
+process.stdout.write(JSON.stringify(loaded()));
+`;
+
+describe("plugin react-server entry does not import React at load (bd 0uy)", () => {
+  it("loads zero React modules when the server entry is imported", () => {
+    // Built dist is a pretest:server prerequisite; skip loudly if absent so a
+    // bare `vitest` run without a build doesn't report a false failure.
+    if (!existsSync(SERVER_ENTRY)) {
+      throw new Error(
+        `${SERVER_ENTRY} not built — run \`npm run build\` before this test (pretest:server does this).`,
+      );
+    }
+    const env = { ...process.env };
+    delete env.NODE_ENV;
+    const out = execFileSync(
+      process.execPath,
+      ["--conditions", "react-server", "--input-type=module", "-e", PROBE],
+      { env, encoding: "utf8" },
+    );
+    expect(JSON.parse(out)).toEqual([]);
+  });
+});

--- a/test/unit/plugin-import-no-react.test.ts
+++ b/test/unit/plugin-import-no-react.test.ts
@@ -4,55 +4,78 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * Regression guard for bd 0uy: the plugin's react-server entry must not pull
- * React into the module graph at import time. React's CJS variant (dev/prod)
- * locks to whatever loads first; if a static `import` chain rooted in the
- * plugin's default Html/Root components evaluates React at plugin-import
- * (config eval), a process that later settles NODE_ENV/condition is stuck with
- * the wrong variant — the `lockReactFamily` warning case.
+ * Regression guard for bd 0uy / 15t: neither plugin entry may pull React (or
+ * react-dom, or the vendored react-server-dom-esm transport) into the module
+ * graph at import time. React's CJS variant (dev/prod) locks to whatever loads
+ * first; if a static import chain — the default Html/Root components, or the
+ * vendor modules — evaluates React at plugin-import (config eval), a process
+ * that later settles NODE_ENV/condition is stuck with the wrong variant (the
+ * `lockReactFamily` warning case).
  *
  * This MUST run in a child process: vitest itself runs under react-server with
  * React already loaded, so an in-process cache check would always see React.
- * We import the BUILT entry (pretest:server builds dist) under the react-server
- * condition with NODE_ENV unset, then scan the CJS require cache for a fully
- * evaluated react variant. Only `module.loaded === true` entries count — Node's
- * ESM->CJS bridge leaves unevaluated (loaded=false) stubs from static analysis.
+ * We import the BUILT entry (pretest:server builds dist), then scan the CJS
+ * require cache for a fully evaluated react / react-dom / transport module.
+ * Only `module.loaded === true` entries count — Node's ESM->CJS bridge leaves
+ * unevaluated (loaded=false) stubs from static analysis.
  */
-const SERVER_ENTRY = resolve(process.cwd(), "dist/plugin/index.server.js");
-
-const PROBE = `
+const probe = (entryAbsPath: string) => `
 import { createRequire } from "node:module";
-const req = createRequire(${JSON.stringify(SERVER_ENTRY)});
+const req = createRequire(${JSON.stringify(entryAbsPath)});
 const loaded = () => {
   const cache = req.cache ?? {};
   const hits = [];
   for (const key in cache) {
     if (!cache[key]?.loaded) continue;
-    if (/[\\\\/]react[\\\\/]cjs[\\\\/]react\\.[^\\\\/]*\\.js$/.test(key)) hits.push(key);
-    else if (/[\\\\/]node_modules[\\\\/]react[\\\\/]index\\.js$/.test(key)) hits.push(key);
+    if (/[\\\\/](react|react-dom)[\\\\/]cjs[\\\\/]/.test(key)) hits.push(key);
+    else if (/[\\\\/]node_modules[\\\\/](react|react-dom)[\\\\/]index\\.js$/.test(key)) hits.push(key);
+    else if (/react-server-dom-esm/.test(key)) hits.push(key);
   }
   return hits;
 };
-await import(${JSON.stringify(SERVER_ENTRY)});
+await import(${JSON.stringify(entryAbsPath)});
 process.stdout.write(JSON.stringify(loaded()));
 `;
 
-describe("plugin react-server entry does not import React at load (bd 0uy)", () => {
-  it("loads zero React modules when the server entry is imported", () => {
-    // Built dist is a pretest:server prerequisite; skip loudly if absent so a
-    // bare `vitest` run without a build doesn't report a false failure.
-    if (!existsSync(SERVER_ENTRY)) {
-      throw new Error(
-        `${SERVER_ENTRY} not built — run \`npm run build\` before this test (pretest:server does this).`,
-      );
-    }
-    const env = { ...process.env };
-    delete env.NODE_ENV;
-    const out = execFileSync(
-      process.execPath,
-      ["--conditions", "react-server", "--input-type=module", "-e", PROBE],
-      { env, encoding: "utf8" },
+function reactModulesLoadedByImporting(
+  entryRelPath: string,
+  nodeConditions: string[],
+): string[] {
+  const entry = resolve(process.cwd(), entryRelPath);
+  // Built dist is a pretest:server prerequisite; fail loudly if absent so a
+  // bare `vitest` run without a build doesn't report a confusing false result.
+  if (!existsSync(entry)) {
+    throw new Error(
+      `${entry} not built — run \`npm run build\` first (pretest:server does this).`,
     );
-    expect(JSON.parse(out)).toEqual([]);
+  }
+  const env = { ...process.env };
+  delete env.NODE_ENV; // detect a pre-settle React load
+  const out = execFileSync(
+    process.execPath,
+    [
+      ...nodeConditions.flatMap((c) => ["--conditions", c]),
+      "--input-type=module",
+      "-e",
+      probe(entry),
+    ],
+    { env, encoding: "utf8" },
+  );
+  return JSON.parse(out);
+}
+
+describe("plugin entries do not import React at load (bd 0uy / 15t)", () => {
+  it("react-server entry loads zero React/react-dom/transport modules", () => {
+    expect(
+      reactModulesLoadedByImporting("dist/plugin/index.server.js", [
+        "react-server",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("client/default entry loads zero React/react-dom/transport modules", () => {
+    expect(
+      reactModulesLoadedByImporting("dist/plugin/index.client.js", []),
+    ).toEqual([]);
   });
 });

--- a/test/unit/plugin-import-no-react.test.ts
+++ b/test/unit/plugin-import-no-react.test.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 /**
- * Regression guard for bd 0uy / 15t: neither plugin entry may pull React (or
+ * Regression guard: neither plugin entry may pull React (or
  * react-dom, or the vendored react-server-dom-esm transport) into the module
  * graph at import time. React's CJS variant (dev/prod) locks to whatever loads
  * first; if a static import chain — the default Html/Root components, or the
@@ -64,7 +64,7 @@ function reactModulesLoadedByImporting(
   return JSON.parse(out);
 }
 
-describe("plugin entries do not import React at load (bd 0uy / 15t)", () => {
+describe("plugin entries do not import React at load", () => {
   it("react-server entry loads zero React/react-dom/transport modules", () => {
     expect(
       reactModulesLoadedByImporting("dist/plugin/index.server.js", [


### PR DESCRIPTION
## Problem

Importing either plugin entry evaluated React (and on the client side, react-dom + the vendored transport) at **module load** — i.e. during Vite config eval. React's CJS dev/prod variant locks to whatever loads first, so a process that settles `NODE_ENV`/condition *after* importing the plugin (programmatic builds, harnesses) is stuck with the wrong variant: the `lockReactFamily` warning case. It also added import cost on every load.

Two independent chains rooted React:
1. **Components chain** — the default `Html`/`Root`/`Css` components import React at module scope, pulled in statically by `config/defaults.tsx` (a dead `COMPONENTS` field), `dev-server/configureReactServer.server`, `react-static/renderPage.server`, `worker/rsc/messageHandler.server`, and the public helper `resolveWithDefaultRootAndHtml`.
2. **Vendor chain (client entry)** — `vendor.client.ts` required the vendored `react-server-dom-esm` transport, `react-dom/server`, and `react` at module scope.

## Changes

All conversions are point-of-use dynamic imports / lazy vendor proxies; every call site is already async.

- **`defaults.tsx`**: removed the dead `DEFAULT_CONFIG.COMPONENTS` field (nothing reads it; defaults load lazily in `createHandlerOptions.server` already).
- **`configureReactServer.server` / `renderPage.server` / `messageHandler.server`**: `await import("../components/{root,html}.js")` where the default is used (`messageHandler` already did this for `Html`; `Root` now matches).
- **`resolveWithDefaultRootAndHtml`**: now async, lazy-loads the defaults. **API note:** public helper becomes async; it had no live callers (only the unused `hydrateRscRenderMessage`, updated to `await`).
- **`vendor.client.ts`**: the transport / `react-dom/server` / `react` requires now go through `createLazyVendorModule` proxies — the same pattern `vendor.server.ts` uses. The **wrong-side guard is preserved**: `vendor.server` throws when evaluated *without* react-server; `vendor.client` is the mirror and must throw *under* react-server (`react-dom/server` is banned there, and `createHtmlStream.client` + the `stream-imports` test rely on that import rejecting). An eager probe through the lazy proxy, gated on `hasReactServerCondition()`, keeps it loud on the wrong side while staying lazy on the correct side.

## Verification

Empirical probe at plugin import (`NODE_ENV` unset): **both** entries now load **zero** React / react-dom / transport modules — react-server entry and client/default entry. A child-process regression test (`test/unit/plugin-import-no-react.test.ts`) asserts this for both.

Full gates green, **run sequentially** (running them concurrently races on the shared `dist/` because each `pretest` does `rm -rf dist`): `test:server` 584 passed, `test:client` 175 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)