### PR TITLE
docs: react-server-dom-esm npm publication path (transport direction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ train automatically (yarn users add it explicitly); to run the experimental
 React train, install `react-server-loader@experimental` alongside
 `react@experimental`. See
 [React Compatibility](./docs/react-type-compatibility.md). The
-`react-server-loader` peer is transitional: once `react-server-dom-esm` is
-published to npm ([react/react#36768](https://github.com/react/react/pull/36768))
-and a vprs release adopts it, the transport comes straight from React and the
-loader is no longer required. Upgrading from 1.x? See the
+`react-server-loader` peer may be transitional: there's an open proposal to
+publish `react-server-dom-esm` to npm
+([react/react#36768](https://github.com/react/react/pull/36768), still under
+review). If it lands and a vprs release adopts it, the transport could come
+straight from React and the loader peer would no longer be required — follow
+the PR if you want to track it. Upgrading from 1.x? See the
 [migration notes](./docs/getting-started.md#upgrading-from-1x).
 
 ## Minimal Example

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ peer dependency, which version-mirrors React. npm and pnpm install the stable
 train automatically (yarn users add it explicitly); to run the experimental
 React train, install `react-server-loader@experimental` alongside
 `react@experimental`. See
-[React Compatibility](./docs/react-type-compatibility.md). Upgrading from 1.x? See the
+[React Compatibility](./docs/react-type-compatibility.md). The
+`react-server-loader` peer is transitional: once `react-server-dom-esm` is
+published to npm ([react/react#36768](https://github.com/react/react/pull/36768))
+and a vprs release adopts it, the transport comes straight from React and the
+loader is no longer required. Upgrading from 1.x? See the
 [migration notes](./docs/getting-started.md#upgrading-from-1x).
 
 ## Minimal Example

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -65,13 +65,16 @@ for why the versions line up the way they do.
 `react-server-loader` vendors the `react-server-dom-esm` transport because, to
 date, that package has never been published to npm — installing it directly
 gives an empty `0.0.1` placeholder, so downstream tools have had to build and
-bundle it from React source for each release. That is changing: React is
-publishing `react-server-dom-esm` to npm, tracked in
-[react/react#36768](https://github.com/react/react/pull/36768). Once it lands
-and a vprs release adopts it, the transport will be installed straight from
-React's own published package, and `react-server-loader` will no longer be the
-required peer for it. Until then, install `react-server-loader` as described
-above; follow the React PR to track progress.
+bundle it from React source for each release.
+
+There's an open proposal to change that:
+[react/react#36768](https://github.com/react/react/pull/36768) would publish
+`react-server-dom-esm` to npm. It's still under review and not guaranteed to
+land. *If* it ships and a future vprs release adopts it, the transport could be
+installed straight from React's own published package and `react-server-loader`
+would no longer be the required peer for it. Nothing changes until then —
+install `react-server-loader` as described above. Follow the PR if you want to
+track where this goes.
 
 ## ESM Transport
 

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -60,6 +60,19 @@ for why the versions line up the way they do.
 > shipped in stable React, and 2.0 moved the transport out to
 > `react-server-loader`.
 
+## Looking ahead: `react-server-dom-esm` on npm
+
+`react-server-loader` vendors the `react-server-dom-esm` transport because, to
+date, that package has never been published to npm — installing it directly
+gives an empty `0.0.1` placeholder, so downstream tools have had to build and
+bundle it from React source for each release. That is changing: React is
+publishing `react-server-dom-esm` to npm, tracked in
+[react/react#36768](https://github.com/react/react/pull/36768). Once it lands
+and a vprs release adopts it, the transport will be installed straight from
+React's own published package, and `react-server-loader` will no longer be the
+required peer for it. Until then, install `react-server-loader` as described
+above; follow the React PR to track progress.
+
 ## ESM Transport
 
 The plugin consumes a vendored build of `react-server-dom-esm` from the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,8 +21,9 @@ Open the browser DevTools console (F12). The plugin streams detailed errors ther
 
 ## `react-server-dom-esm` Resolution Errors
 
-The transport ships inside the `react-server-loader` dependency (a normal
-install), so no separate transport install is needed. The plugin resolves bare
+The transport ships inside the `react-server-loader` peer dependency (npm and
+pnpm install it automatically; yarn users add it explicitly), so there is no
+separate transport package to install. The plugin resolves bare
 `react-server-dom-esm/*` imports for you. For scripts outside Vite:
 
 ```bash


### PR DESCRIPTION
## What

Adds a forward-looking note about the vendored transport, now that `react-server-loader` is a required peer dependency (#118).

`react-server-loader` exists to vendor the `react-server-dom-esm` transport, because that package has never been published to npm (a direct install yields an empty `0.0.1` placeholder). There's an open proposal to change that — [react/react#36768](https://github.com/react/react/pull/36768), "Publish react-server-dom-esm to npm" — but it's **still under review and not guaranteed to land**. The docs frame it conditionally: *if* it ships and a future vprs release adopts it, the transport could install straight from React and `react-server-loader` would no longer be the required peer. Nothing changes until then.

## Changes (docs only)

- **README → Install**: a hedged forward-looking sentence linking the proposal, for people who want to track it.
- **docs/react-type-compatibility.md**: a "Looking ahead: `react-server-dom-esm` on npm" section explaining why the loader vendors the transport today and what *could* change if the npm package ships.
- **docs/troubleshooting.md**: corrects a stale "a normal install" line — `react-server-loader` is a peer dependency now (npm/pnpm auto-install it; yarn users add it explicitly).

#118 already documents the peer-dependency breaking change itself; this layers the (conditional) future direction on top.
