### PR TITLE
chore: bump react-server-loader to 19.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4667,9 +4667,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.8.tgz",
-      "integrity": "sha512-4xYQ2QkP24Jw49hkrVXCjn97Jg1RpNS20n+kqINhABvgNgD8SKYWBNfaXiPGZg2ZfGvqgPTSZm2bHulD1eACDg==",
+      "version": "19.2.9",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.9.tgz",
+      "integrity": "sha512-UQ87YKr1S6rQb7kzfuBGZ1YOU0O/8JZkvO994py5l9R2p3UfkQigm3KH3hawP0Oxq9XBMHNEq922gBD3lXOyNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Lockfile bump to `react-server-loader@19.2.9`, which carries the directive-engine fix (comments / JSDoc / `use strict` tolerated above a file-level `"use client"` / `"use server"` directive).

Lockfile-only — the `^19.2.8` dev/peer range already admits it; this advances the `npm ci` pin so CI installs the published 19.2.9. Verified safe by react-server-loader's own release gate (its `verify-release` ran vprs's server + client suites against the 19.2.9 tarball and passed).