### PR TITLE
test: a file-level directive after comments no longer warns (rsl 19.2.9)

### DIFF
--- a/test/unit/analyzeModule/fileLevelWarnings.test.ts
+++ b/test/unit/analyzeModule/fileLevelWarnings.test.ts
@@ -43,7 +43,12 @@ export function test() {
     );
   });
 
-  test("should warn about file-level directive after comments", async () => {
+  // Comments are trivia, not code: a line or block comment (or a banner /
+  // JSDoc, common in compiled library output) above a file-level directive
+  // does NOT push it out of position, so no placement warning fires and the
+  // directive is still recognised. Matches react-server-loader's directive
+  // engine (≥ 19.2.9) and the documented "use client" contract.
+  test("should not warn about a file-level directive after comments", async () => {
     const result = await analyzeModule(
       `// Some comment
 /* Another comment */
@@ -53,7 +58,8 @@ export function test() {
 }`,
       testLoaderConfig
     );
-    expect(result.directiveInfo?.warnings).toHaveLength(1);
+    expect(result.directiveInfo?.warnings).toHaveLength(0);
+    expect(result.directiveInfo?.fileLevel?.type).toBe("client");
   });
 
   // Real-world libraries (e.g. compiled output of @chakra-ui/react,


### PR DESCRIPTION
react-server-loader 19.2.9 ships the directive-engine change where comments / JSDoc / `use strict` above a file-level `"use client"` / `"use server"` are trivia and don't trip the placement warning — the documented `"use client"` contract.

`fileLevelWarnings.test.ts` still asserted that a directive after comments produces a warning (the old behavior), so the bump to 19.2.9 turns that assertion red on `main`. Updated it to assert **no** warning and that the directive is still recognised as file-level client — matching the engine and the README.

Verified in isolation: `fileLevelWarnings.test.ts` 7/7, `detectorParity.test.ts` (the new parity suite) 16/16, both under `--conditions react-server`.