### PR TITLE
chore: bump version to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from 2.1.0 to **3.0.0**.

## Why major

The release contains a breaking install-contract change: **`react-server-loader` is now a required peer dependency** (it was a regular dependency) — #118, landed as `feat!`. Impact:

- **npm 7+ / pnpm**: required peers auto-install, so `npm install vite-plugin-react-server react react-dom` still pulls it in — no change.
- **yarn (classic)**: does not auto-install peers, so `react-server-loader` must be added explicitly.

A new required peer is a breaking change for some install setups, so patch/minor would understate it. (Secondary, minor-impact breaking change: the undocumented `resolveWithDefaultRootAndHtml` helper became async; no known external callers.)

## Also in this line since 2.1.0

- React is kept out of the plugin-import graph on **both** entries (lazy components + lazy vendor), so a process that imports the plugin before `NODE_ENV` settles no longer pins the dev React variant.
- react-server-loader bumped to 19.2.9 (directive comment-tolerance fix).
- Docs: honest positioning/comparison, and the react-server-dom-esm-on-npm transport direction.

Version-only change (package.json + lock), via `npm run version:major`. Publishing stays manual.