### PR TITLE
feat: react-server-loader as a regular dual-train dependency (not a required peer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,28 @@ at Waku or Vike. Full breakdown, including what vprs does **not** do:
 npm install -D vite-plugin-react-server react react-dom
 ```
 
-vprs 2.0 runs on **stable React 19.2+**. Everything React-version-locked —
-the `react-server-dom-esm` transport (server side AND the flight client your
-browser bundle ships), the directive engine, the Node loader — lives in the
+vprs runs on **stable React 19.2+** out of the box. Everything
+React-version-locked — the `react-server-dom-esm` transport (server side AND
+the flight client your browser bundle ships), the directive engine, the Node
+loader — lives in the
 [`react-server-loader`](https://www.npmjs.com/package/react-server-loader)
-peer dependency, which version-mirrors React. npm and pnpm install the stable
-train automatically (yarn users add it explicitly); to run the experimental
-React train, install `react-server-loader@experimental` alongside
-`react@experimental`. See
-[React Compatibility](./docs/react-type-compatibility.md). The
-`react-server-loader` peer may be transitional: there's an open proposal to
-publish `react-server-dom-esm` to npm
-([react/react#36768](https://github.com/react/react/pull/36768), still under
-review). If it lands and a vprs release adopts it, the transport could come
-straight from React and the loader peer would no longer be required — follow
-the PR if you want to track it. Upgrading from 1.x? See the
-[migration notes](./docs/getting-started.md#upgrading-from-1x).
+dependency, installed for you (every package manager). The command above is all
+you need.
+
+**Want correct CSS preloading?** Stable React 19.2.x emits its CSS preload hint
+as an invalid `as="stylesheet"`, so browsers ignore the preload (styles still
+load, just not preloaded) and log a warning. The fix is on React's experimental
+channel today (and reaches stable when React ships it). To opt in, install the
+experimental train — all three pinned together:
+
+```bash
+npm install react@experimental react-dom@experimental react-server-loader@experimental
+```
+
+That's the whole step: `react-server-loader`'s range admits both trains, so npm
+collapses to a single experimental copy — no `overrides`, no duplicate. See
+[React Compatibility](./docs/react-type-compatibility.md). Upgrading from 1.x?
+See the [migration notes](./docs/getting-started.md#upgrading-from-1x).
 
 ## Minimal Example
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,13 +6,14 @@
 npm install -D vite-plugin-react-server react react-dom
 ```
 
-vprs 2.0 runs on **stable React 19.2+** (`react` / `react-dom` at `^19.2.7`).
-The `react-server-dom-esm` ESM transport is provided by the
+vprs runs on **stable React 19.2+** (`react` / `react-dom` at `^19.2.7`). The
+`react-server-dom-esm` ESM transport is provided by the
 [`react-server-loader`](https://www.npmjs.com/package/react-server-loader)
-peer dependency. npm and pnpm install the stable train automatically; yarn
-users add it explicitly. Switching to the experimental React train is a
-direct install — `react-server-loader@experimental` next to
-`react@experimental` — see
+dependency, installed for you by every package manager — no extra step. To
+switch to the experimental React train (e.g. for correct CSS preloading),
+install all three at `@experimental` — `react@experimental`,
+`react-dom@experimental`, `react-server-loader@experimental` — which npm
+dedupes to a single copy. See
 [React Compatibility](./react-type-compatibility.md).
 
 ## Upgrading from 1.x

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -29,28 +29,29 @@ npm view react-server-loader@experimental peerDependencies
 npm install react@<that-exact-version> react-dom@<that-exact-version>
 ```
 
-`react-server-loader` is a **peer dependency** whose range admits both
-trains (`^19.2.8 || >=0.0.0-0 <0.0.1`). npm ≥7 and pnpm ≥8 auto-install
-the stable train by default — installing the plugin needs no extra step.
-To run the experimental train, install the loader (and its matching React)
-directly; a direct dependency satisfies the peer and there is exactly one
-copy in the tree:
+`react-server-loader` is a regular **dependency** whose range admits both
+trains (`^19.2.8 || >=0.0.0-0 <0.0.1`), so every package manager installs it
+for you — the stable train by default, no extra step (yarn included).
+
+To run the experimental train, install all three React packages at the
+`@experimental` tag. The loader's range also admits experimental, so npm
+collapses to a single copy alongside your experimental React — no `overrides`,
+no duplicate in the tree:
 
 ```bash
-npm install react-server-loader@experimental react@experimental react-dom@experimental
+npm install react@experimental react-dom@experimental react-server-loader@experimental
 ```
 
-Yarn does not auto-install peers — install `react-server-loader` explicitly
-there even for the stable train.
+One practical reason to run experimental today: stable React 19.2.x emits its
+CSS preload hint as an invalid `as="stylesheet"`, so browsers ignore the
+preload — styles still load, just not preloaded (see
+[troubleshooting](./troubleshooting.md)). The experimental channel already
+carries the fix, and it reaches stable when React ships it.
 
-One practical reason to run experimental today: stable React 19.2.x emits
-the cosmetic `as="stylesheet"` preload warning
-(see [troubleshooting](./troubleshooting.md)); the experimental channel
-already carries the fix.
-
-**Peer dependency**: `react: "^19.2.7"`. The transport binds to a single React
-build's internals and throws on a mismatch, so install a `react` / `react-dom`
-that satisfies the peer (a plain install does). See
+**React peer**: `react` / `react-dom` at `^19.2.7 || >=0.0.0-0 <0.0.1` (admits
+both trains). The transport binds to a single React build's internals and
+throws on a mismatch, so keep `react`, `react-dom`, and `react-server-loader`
+on the same train. See
 [`react-server-loader`'s versioning](https://www.npmjs.com/package/react-server-loader)
 for why the versions line up the way they do.
 
@@ -72,9 +73,9 @@ There's an open proposal to change that:
 `react-server-dom-esm` to npm. It's still under review and not guaranteed to
 land. *If* it ships and a future vprs release adopts it, the transport could be
 installed straight from React's own published package and `react-server-loader`
-would no longer be the required peer for it. Nothing changes until then —
-install `react-server-loader` as described above. Follow the PR if you want to
-track where this goes.
+would no longer be the dependency that carries it. Nothing changes until then —
+`react-server-loader` is installed for you as described above. Follow the PR if
+you want to track where this goes.
 
 ## ESM Transport
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
+        "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -29,7 +30,6 @@
         "playwright": "^1.58.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-server-loader": "^19.2.8",
         "source-map": "^0.7.4",
         "supports-color": "^10.0.0",
         "ts-node": "^10.9.2",
@@ -44,9 +44,8 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
+        "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
         "vite": "*"
       },
       "peerDependenciesMeta": {
@@ -4640,7 +4639,6 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4650,7 +4648,6 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -4670,7 +4667,6 @@
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.9.tgz",
       "integrity": "sha512-UQ87YKr1S6rQb7kzfuBGZ1YOU0O/8JZkvO994py5l9R2p3UfkQigm3KH3hawP0Oxq9XBMHNEq922gBD3lXOyNA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -4900,7 +4896,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -5088,7 +5083,6 @@
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -380,10 +380,9 @@
   },
   "homepage": "https://github.com/nicobrinkkemper/vite-plugin-react-server#readme",
   "peerDependencies": {
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "vite": "*",
-    "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1"
+    "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
+    "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
+    "vite": "*"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -419,12 +418,12 @@
     "typescript-eslint": "^8.33.1",
     "vite": "^6.3.5",
     "vitest": "^3.0.4",
-    "webpack-sources": "^3.2.3",
-    "react-server-loader": "^19.2.8"
+    "webpack-sources": "^3.2.3"
   },
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
+    "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }


### PR DESCRIPTION
## What

Moves `react-server-loader` from a **required peer dependency** back to a regular **dependency**, keeping the dual-train range `^19.2.8 || >=0.0.0-0 <0.0.1`. Also widens the `react`/`react-dom` peer to `^19.2.7 || >=0.0.0-0 <0.0.1` so the experimental train installs warning-free.

## Why

The peer model (the prior change) made the install contract breaking — yarn-classic doesn't auto-install peers, so those users had to add `react-server-loader` by hand, and it forced a major bump. The thing the peer move was actually solving — the "two copies" problem when a consumer wants the experimental train — turns out to be solved by the **range**, not the dependency **type**:

- **Default:** the regular dep installs the stable train automatically, on every package manager (yarn included). Zero-config.
- **Experimental:** `npm install react@experimental react-dom@experimental react-server-loader@experimental` — the loader's range admits experimental, so npm collapses to a **single** copy alongside the consumer's experimental React. No `overrides`, no duplicate.

Verified empirically (scratch installs): default → one stable copy; experimental → one deduped experimental copy.

The experimental train matters because it's the path to **correct CSS preloading** (stable React 19.2.x emits an invalid `as="stylesheet"` preload hint that browsers ignore), so it should be a clean opt-in — which this delivers without a breaking install change.

## Result

Install stays non-breaking → the release can be a minor, not a major. Docs (README, getting-started, react-type-compatibility) updated to the regular-dependency framing and the CSS-preloading rationale.