### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from 2.1.0 to **2.2.0** (minor).

## Why minor, not major

Everything in this line since 2.1.0 is non-breaking:

- React is kept out of the plugin-import graph on both entries (lazy components + lazy vendor) — internal.
- react-server-loader bumped to 19.2.9 (directive comment-tolerance fix).
- Docs: positioning/comparison, transport direction, CSS-preloading guidance.

The one change that would have forced a major — react-server-loader as a required *peer* dependency — is reverted in **#128**: it's a regular dual-train dependency again, so the install contract is unchanged (stable auto-installs everywhere; experimental is a clean opt-in that dedupes). 

(One non-public detail: the undocumented `resolveWithDefaultRootAndHtml` helper became async. It's exported only via the `…/helpers` barrel, isn't part of the documented API, and has no known external callers, so it doesn't gate the version.)

**Merge after #128** (the dependency revert) so the non-breaking state is what ships. Version-only change via `npm run version:minor`; publishing stays manual.