### PR TITLE
chore: community scaffolding (CONTRIBUTING, issue + PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Something doesn't work as documented
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A **minimal reproduction** is by far the most
+        useful thing you can provide — it usually decides how fast this gets fixed.
+        For questions or "is this a bug?", please use
+        [Discussions](https://github.com/nicobrinkkemper/vite-plugin-react-server/discussions)
+        instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: I imported X and ran `vite build --app`; expected Y; got Z.
+    validations:
+      required: true
+  - type: input
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Link to a repo, StackBlitz, or gist that reproduces it. Strip everything unrelated.
+      placeholder: https://github.com/you/vprs-bug-repro
+    validations:
+      required: false
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Which mode?
+      description: Where does it happen?
+      options:
+        - Static build (vite build --app, no backend)
+        - Dev server (dev:ssr)
+        - SSR / Node server at runtime
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: react-channel
+    attributes:
+      label: React channel
+      options:
+        - Stable (react ^19.2)
+        - Experimental (react@experimental)
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: versions
+    attributes:
+      label: Versions
+      description: Output of `npx envinfo --binaries --npmPackages vite,react,react-dom,vite-plugin-react-server,react-server-loader` (or just paste the versions you know).
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack trace
+      description: Relevant console output. Re-run with `verbose: true` in the plugin options if you can.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/nicobrinkkemper/vite-plugin-react-server/discussions
+    about: Usage questions, ideas, and "is this a bug?" — start here.
+  - name: Documentation
+    url: https://github.com/nicobrinkkemper/vite-plugin-react-server/tree/main/docs
+    about: Getting started, API reference, and troubleshooting.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a capability or improvement
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Open-ended ideas and "would it make sense to…" are often a better fit for
+        [Discussions](https://github.com/nicobrinkkemper/vite-plugin-react-server/discussions).
+        Use this template when you have a concrete capability in mind.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case, not the solution. What can't you do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the API / behaviour look like? A code sketch helps.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or how other tools (Waku, @vitejs/plugin-rsc, Next) handle it.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Keep PRs small and focused. Conventional Commit title (feat/fix/chore/refactor/docs/test).
+Make this description stand on its own — what changed and why.
+-->
+
+## What & why
+
+<!-- What does this change and what problem does it solve? -->
+
+Fixes #
+
+## Checklist
+
+- [ ] `npm test` is green (both client and server environments)
+- [ ] `npm run build` is clean
+- [ ] Docs updated if behaviour or public API changed
+- [ ] PR is focused on a single change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to vite-plugin-react-server
+
+Thanks for considering a contribution. `vite-plugin-react-server` (vprs) brings
+React Server Components to plain Vite on **stable React** — no framework, no
+experimental build required. Bug reports, repros, docs fixes, and PRs are all
+welcome.
+
+## Prerequisites
+
+- **Node.js ≥ 22** (see `engines` in `package.json`).
+- **npm** — this repo uses `package-lock.json`. Please don't introduce a second
+  package manager.
+
+## Setup
+
+```bash
+git clone https://github.com/nicobrinkkemper/vite-plugin-react-server.git
+cd vite-plugin-react-server
+npm install
+```
+
+## The test gate
+
+RSC splits the module graph into a server environment (loaded under the
+`react-server` export condition) and a normal client environment, so vprs runs
+its suite in **both**. The single command that runs the full gate is:
+
+```bash
+npm test          # = scripts/test-both.sh: client + server runs
+```
+
+Under the hood that's two passes you can also run individually while iterating:
+
+```bash
+npm run test:client                                  # vitest run
+npm run test:server                                  # NODE_OPTIONS='--conditions react-server' vitest run
+```
+
+If a test needs fixtures, generate them first:
+
+```bash
+npm run setup:test-fixtures
+```
+
+Run the **full** `npm test` (both environments) before pushing — a change that
+passes client but not server, or vice versa, is the most common way to break
+RSC.
+
+## Build and lint
+
+```bash
+npm run build     # clean + build:types + build:vite
+npm run lint      # eslint ./plugin --fix
+```
+
+## Opening a pull request
+
+- Keep PRs small and focused on one change.
+- Green `npm test` and a clean `npm run build` before you push.
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for the title
+  and commits: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`,
+  `perf:`. Scope is optional, e.g. `fix(rsc): …`.
+- Link the issue your PR addresses (`Fixes #123`), or describe in the PR why the
+  change is needed.
+- Make the PR body stand on its own — what changed and why, not the discussion
+  that led there.
+
+## Where to ask
+
+- **Questions / ideas / "is this a bug?"** → open a
+  [Discussion](https://github.com/nicobrinkkemper/vite-plugin-react-server/discussions).
+- **Reproducible bugs and concrete feature requests** → open an
+  [Issue](https://github.com/nicobrinkkemper/vite-plugin-react-server/issues/new/choose)
+  using a template.
+- **Docs** → start at [`docs/`](./docs) and the
+  [getting-started guide](./docs/getting-started.md).
+
+By contributing you agree your contributions are licensed under the project's
+[MIT License](./LICENSE).


### PR DESCRIPTION
Closes the community-scaffolding task: make it easy for a first confused user to become a first contributor.

## What's here
- **CONTRIBUTING.md** — Node ≥22 + npm, the **dual test gate** (`npm test` runs both the client pass and the `--conditions react-server` server pass), build, lint, and Conventional-Commit PR conventions, grounded in the repo's actual scripts.
- **Issue forms** (`.github/ISSUE_TEMPLATE/`):
  - `bug_report.yml` — captures the fields triage always needs: mode (static / dev:ssr / SSR runtime), React channel (stable vs experimental), versions, and a minimal repro.
  - `feature_request.yml` — problem-first, with room for an API sketch and alternatives.
  - `config.yml` — disables blank issues, routes questions to Discussions and docs.
- **PULL_REQUEST_TEMPLATE.md** — what/why + a checklist mirroring the test gate.

## Follow-up (repo settings, not in this PR)
- Enable GitHub Discussions (the templates link to it).
- Tag a few starter issues `good first issue` once there are issues to tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)