### PR TITLE
feat(transform): support client-imported server functions (Server Functions parity)

### DIFF
--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -66,6 +66,11 @@ export const createTransformerPlugin = (
     let isSSR = true;
     const nodeEnv = getNodeEnv(process.env.NODE_ENV);
     let mode = nodeEnv;
+    // Vite's base, captured at configResolved. Injected as a literal into the
+    // client server-function proxy: this plugin is enforce:"post", so code we
+    // emit here is NOT re-scanned for `import.meta.env` replacement — a literal
+    // base is the robust way to give callServer its base URL.
+    let viteBase = "/";
     let runtimeResolvedUserOptions = resolvedUserOptions;
 
     // Use global cache for transformation results to ensure consistent hashing across all plugin instances
@@ -138,6 +143,7 @@ export const createTransformerPlugin = (
       configResolved(config) {
         isBuild = config.command === "build";
         isSSR = Boolean(config.build.ssr);
+        viteBase = config.base ?? "/";
         mode = config.mode as "development" | "production" | "test";
         if (!isValidEnv(mode)) {
           throw new Error(`Invalid mode: ${mode}`);
@@ -412,13 +418,19 @@ export const createTransformerPlugin = (
 
           // Client-imported server functions ("use server" module imported by a
           // "use client" component). In a non-server environment we must NOT
-          // bundle the server code into the browser — instead rewrite each export
-          // to a `createServerReference(id, callServer)` proxy that POSTs to the
-          // server, matching what React/Next do for Server Functions. The hosted
-          // id mirrors what the server registers (the module's moduleID), so the
-          // POST resolves through the existing server-action endpoint / gate.
-          // (This restores behaviour the pre-rsl loader had; before this, the
-          // directive was stripped and server-only code leaked into the browser.)
+          // bundle the server code in — instead replace each export with a
+          // reference (Server Functions parity; restores pre-rsl loader
+          // behaviour the extraction dropped). The two non-server environments
+          // need different shapes:
+          //  - BROWSER (env=client): a real createServerReference(id, callServer)
+          //    proxy that POSTs to the server. The hosted id mirrors what the
+          //    server registers (the module's moduleID), so it resolves through
+          //    the existing action endpoint / gate.
+          //  - SSR (env=ssr): the proxy's browser transport can't initialize in
+          //    the Node SSR/SSG render (it throws while prerendering). The server
+          //    function is never CALLED during render (it's an event handler), so
+          //    emit a render-safe stub that only throws if wrongly invoked. This
+          //    also keeps server-only code out of the SSR bundle.
           if (!isServerEnvironment) {
             const serverAnalysis = await analyzeModule(code, {
               loader: { parse: (src: string) => this.parse(src) as Program },
@@ -431,18 +443,29 @@ export const createTransformerPlugin = (
                 serverAnalysis.exports.exports.values()
               ).map((e) => e.exportName);
               if (exportNames.length > 0) {
-                const proxy = [
-                  `import { createServerReference } from "react-server-dom-esm/client.browser";`,
-                  `import { createCallServer } from "vite-plugin-react-server/utils";`,
-                  `const callServer = createCallServer(import.meta.env.BASE_URL);`,
-                  ...exportNames.map(
+                if (this.environment?.name === "client") {
+                  const proxy = [
+                    `import { createServerReference } from "react-server-dom-esm/client.browser";`,
+                    `import { createCallServer } from "vite-plugin-react-server/utils";`,
+                    `const callServer = createCallServer(${JSON.stringify(viteBase)});`,
+                    ...exportNames.map(
+                      (n) =>
+                        `export const ${n} = createServerReference(${JSON.stringify(
+                          `${finalModuleID}#${n}`
+                        )}, callServer);`
+                    ),
+                  ].join("\n");
+                  return { code: proxy, map: null };
+                }
+                const stub = exportNames
+                  .map(
                     (n) =>
-                      `export const ${n} = createServerReference(${JSON.stringify(
-                        `${finalModuleID}#${n}`
-                      )}, callServer);`
-                  ),
-                ].join("\n");
-                return { code: proxy, map: null };
+                      `export const ${n} = () => { throw new Error(${JSON.stringify(
+                        `Server function "${n}" cannot run during SSR; it executes in the browser via a server reference.`
+                      )}); };`
+                  )
+                  .join("\n");
+                return { code: stub, map: null };
               }
             }
           }

--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -410,15 +410,16 @@ export const createTransformerPlugin = (
             }
           }
 
-          // A "use server" module must never reach the browser bundle. It only
-          // lands in env=client when a "use client" component imports it
-          // directly — which bundles server-only code (e.g. node builtins) into
-          // the browser and surfaces as a cryptic "Module node:… externalized"
-          // crash at runtime. Fail fast with a pointer to the supported props
-          // pattern. SSR (env=ssr) and the RSC server env handle "use server"
-          // normally; this guard is scoped to the browser client environment,
-          // where the server-actions example proves action files never legitimately land.
-          if (this.environment?.name === "client") {
+          // Client-imported server functions ("use server" module imported by a
+          // "use client" component). In a non-server environment we must NOT
+          // bundle the server code into the browser — instead rewrite each export
+          // to a `createServerReference(id, callServer)` proxy that POSTs to the
+          // server, matching what React/Next do for Server Functions. The hosted
+          // id mirrors what the server registers (the module's moduleID), so the
+          // POST resolves through the existing server-action endpoint / gate.
+          // (This restores behaviour the pre-rsl loader had; before this, the
+          // directive was stripped and server-only code leaked into the browser.)
+          if (!isServerEnvironment) {
             const serverAnalysis = await analyzeModule(code, {
               loader: { parse: (src: string) => this.parse(src) as Program },
             });
@@ -426,11 +427,23 @@ export const createTransformerPlugin = (
               serverAnalysis.type === "success" &&
               serverAnalysis.directiveInfo?.fileLevel?.type === "server"
             ) {
-              throw new Error(
-                `[vite-plugin-react-server] "${id}" is a "use server" module but it reached the browser bundle — a "use client" component imported it directly. ` +
-                  `Server actions can't be bundled into the browser. Pass the action as a prop from a server/props file instead (see docs/server-actions.md), ` +
-                  `or move whatever the client imports out of the "use server" module.`
-              );
+              const exportNames = Array.from(
+                serverAnalysis.exports.exports.values()
+              ).map((e) => e.exportName);
+              if (exportNames.length > 0) {
+                const proxy = [
+                  `import { createServerReference } from "react-server-dom-esm/client.browser";`,
+                  `import { createCallServer } from "vite-plugin-react-server/utils";`,
+                  `const callServer = createCallServer(import.meta.env.BASE_URL);`,
+                  ...exportNames.map(
+                    (n) =>
+                      `export const ${n} = createServerReference(${JSON.stringify(
+                        `${finalModuleID}#${n}`
+                      )}, callServer);`
+                  ),
+                ].join("\n");
+                return { code: proxy, map: null };
+              }
             }
           }
 

--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -14,7 +14,7 @@ import { resolveRegExp } from "../config/resolveRegExp.js";
 import { userProjectRoot } from "../root.js";
 import { createDefaultModuleID } from "../config/createModuleID.js";
 import { buildClientPackagesPattern } from "../clientPackages/index.js";
-import { detectClientModule } from "react-server-loader/directives";
+import { detectClientModule, analyzeModule } from "react-server-loader/directives";
 import { isViteInjectedCode } from "../loader/isViteInjectedCode.js";
 
 export interface TransformerPluginOptions {
@@ -407,6 +407,30 @@ export const createTransformerPlugin = (
                 code: code,
                 map: null,
               };
+            }
+          }
+
+          // A "use server" module must never reach the browser bundle. It only
+          // lands in env=client when a "use client" component imports it
+          // directly — which bundles server-only code (e.g. node builtins) into
+          // the browser and surfaces as a cryptic "Module node:… externalized"
+          // crash at runtime. Fail fast with a pointer to the supported props
+          // pattern. SSR (env=ssr) and the RSC server env handle "use server"
+          // normally; this guard is scoped to the browser client environment,
+          // where the server-actions example proves action files never legitimately land.
+          if (this.environment?.name === "client") {
+            const serverAnalysis = await analyzeModule(code, {
+              loader: { parse: (src: string) => this.parse(src) as Program },
+            });
+            if (
+              serverAnalysis.type === "success" &&
+              serverAnalysis.directiveInfo?.fileLevel?.type === "server"
+            ) {
+              throw new Error(
+                `[vite-plugin-react-server] "${id}" is a "use server" module but it reached the browser bundle — a "use client" component imported it directly. ` +
+                  `Server actions can't be bundled into the browser. Pass the action as a prop from a server/props file instead (see docs/server-actions.md), ` +
+                  `or move whatever the client imports out of the "use server" module.`
+              );
             }
           }
 

--- a/test/dev/client-imports-server-action.test.ts
+++ b/test/dev/client-imports-server-action.test.ts
@@ -84,11 +84,15 @@ export const Page = () => <div>Test Page</div>;`
     expect(result?.code).not.toContain("return { ok:");
   });
 
-  it("also rewrites in the SSR environment (proxy is inert during render)", async () => {
+  it("emits a render-safe stub in the SSR environment (no browser transport, no server body)", async () => {
     const result = await server.environments.ssr.transformRequest(
       "/src/server/actions.server.ts"
     );
-    expect(result?.code).toContain("createServerReference");
+    // SSR must not pull in the browser transport (it throws during prerender) or
+    // the server body; the stub only errors if wrongly called during render.
+    expect(result?.code).not.toContain("createServerReference");
+    expect(result?.code).toContain("cannot run during SSR");
+    expect(result?.code).not.toContain("return { ok:");
   });
 
   it("the emitted proxy id round-trips through the server action endpoint", async () => {

--- a/test/dev/client-imports-server-action.test.ts
+++ b/test/dev/client-imports-server-action.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type ViteDevServer } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { testUserOptions } from "../test-config";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { resolve, join } from "node:path";
+
+/**
+ * Guard for the "client component imports a 'use server' module" footgun.
+ *
+ * A "use server" module must never reach the browser bundle. It only lands in
+ * the client (browser) environment when a "use client" component imports it
+ * directly — which would bundle server-only code into the browser and crash
+ * cryptically at runtime. The transformer fails fast in env=client with a clear
+ * message pointing at the props pattern. SSR and the RSC server environment
+ * still handle "use server" normally.
+ */
+
+let server: ViteDevServer;
+const port = 3133;
+const testDir = resolve(__dirname, "../fixtures/client-imports-server.test");
+
+describe("Client importing a 'use server' module", () => {
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(join(testDir, "src/server"), { recursive: true });
+    await mkdir(join(testDir, "src/page"), { recursive: true });
+
+    await writeFile(
+      join(testDir, "src/server/actions.server.ts"),
+      `"use server";
+export async function addItem(title: string): Promise<{ ok: boolean }> {
+  return { ok: !!title };
+}
+`
+    );
+    await writeFile(
+      join(testDir, "src/page/page.tsx"),
+      `import React from "react";
+export const Page = () => <div>Test Page</div>;`
+    );
+    await writeFile(
+      join(testDir, "src/page/props.ts"),
+      `export const props = () => ({});`
+    );
+
+    const parentNodeModules = resolve(__dirname, "../../node_modules");
+    const fixtureNodeModules = join(testDir, "node_modules");
+    try {
+      await symlink(parentNodeModules, fixtureNodeModules, "dir");
+    } catch {}
+
+    server = await createServer({
+      mode: "test",
+      root: testDir,
+      plugins: [
+        vitePluginReactServer({
+          ...testUserOptions,
+          projectRoot: testDir,
+          moduleBase: "src",
+          Page: () => `src/page/page.tsx`,
+          props: () => `src/page/props.ts`,
+        }),
+      ],
+      server: { port },
+    });
+    await server.listen();
+  });
+
+  afterAll(async () => {
+    await server?.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("fails fast in the browser (client) environment with a clear message", async () => {
+    await expect(
+      server.environments.client.transformRequest(
+        "/src/server/actions.server.ts"
+      )
+    ).rejects.toThrow(/reached the browser bundle/i);
+  });
+
+  it("does NOT reject the same module in the SSR environment", async () => {
+    // SSR runs server-side (Node) — a "use server" module is fine there.
+    await expect(
+      server.environments.ssr.transformRequest("/src/server/actions.server.ts")
+    ).resolves.toBeTruthy();
+  });
+});

--- a/test/dev/client-imports-server-action.test.ts
+++ b/test/dev/client-imports-server-action.test.ts
@@ -72,18 +72,50 @@ export const Page = () => <div>Test Page</div>;`
     await rm(testDir, { recursive: true, force: true });
   });
 
-  it("fails fast in the browser (client) environment with a clear message", async () => {
-    await expect(
-      server.environments.client.transformRequest(
-        "/src/server/actions.server.ts"
-      )
-    ).rejects.toThrow(/reached the browser bundle/i);
+  it("rewrites the module to createServerReference proxies in the browser env", async () => {
+    const result = await server.environments.client.transformRequest(
+      "/src/server/actions.server.ts"
+    );
+    expect(result?.code).toContain("createServerReference");
+    expect(result?.code).toContain("callServer");
+    // Each export becomes a server-reference proxy, and the server-only body
+    // (the original function source) is gone from the browser bundle.
+    expect(result?.code).toContain("export const addItem");
+    expect(result?.code).not.toContain("return { ok:");
   });
 
-  it("does NOT reject the same module in the SSR environment", async () => {
-    // SSR runs server-side (Node) — a "use server" module is fine there.
-    await expect(
-      server.environments.ssr.transformRequest("/src/server/actions.server.ts")
-    ).resolves.toBeTruthy();
+  it("also rewrites in the SSR environment (proxy is inert during render)", async () => {
+    const result = await server.environments.ssr.transformRequest(
+      "/src/server/actions.server.ts"
+    );
+    expect(result?.code).toContain("createServerReference");
+  });
+
+  it("the emitted proxy id round-trips through the server action endpoint", async () => {
+    // The whole point: the id the proxy embeds must be the same id the server
+    // resolves. Pull it out of the emitted proxy and POST it like callServer
+    // would; the server should run addItem and return its result.
+    const result = await server.environments.client.transformRequest(
+      "/src/server/actions.server.ts"
+    );
+    const match = result?.code.match(
+      /createServerReference\(\s*"([^"]+#addItem)"/
+    );
+    expect(match).toBeTruthy();
+    const actionId = match![1];
+
+    const res = await fetch(`http://localhost:${port}/`, {
+      method: "POST",
+      headers: {
+        Accept: "text/x-component",
+        "Content-Type": "application/json",
+        "x-rsc-action": actionId,
+      },
+      body: JSON.stringify(["hello"]),
+    });
+    const text = await res.text();
+    expect(text).toMatch(/^0:/); // RSC wire format, not an error
+    expect(text).toContain("ok"); // addItem returns { ok: !!title }
+    expect(text).toContain("true");
   });
 });


### PR DESCRIPTION
A `"use client"` component can now `import { action } from "./x.server"` and call it directly — the **Server Functions** pattern (React) / Server Actions imported into client components (Next). This is the client-import half of parity; the prop-passing half already worked.

## What changed
A `"use server"` module pulled into a **non-server** environment is rewritten instead of bundled:
- **Browser (env=client):** each export becomes a `createServerReference("<moduleID>#<export>", callServer)` proxy that POSTs to the server. The hosted id is the module's `moduleID`, matching what the server registers, so it resolves through the existing action endpoint / gate.
- **SSR (env=ssr):** a render-safe stub (the server fn is an event handler, never called during render) — avoids initializing the browser transport in the Node prerender and keeps server-only code out of the SSR bundle.

This **restores** behaviour vprs's pre-rsl loader had (`plugin/loader/moduleParser.ts` @ `7517b46`) that the rsl extraction dropped — the binding names still lived in `flightBindings.ts` and the transport still exports `createServerReference`. Before this, the directive was stripped and server code leaked into the browser (a cryptic `node:…` externalization crash).

## History note
First commit added a fail-fast guard (the conservative option); the next two replace it with the real rewrite + fixes found driving it in a browser (SSR stub; inject the resolved Vite base as a literal since `enforce:"post"` output isn't env-replaced).

## Tests
- `test/dev/client-imports-server-action.test.ts`: browser emits the proxy (server body gone); SSR emits the stub; and the emitted id **round-trips** through the dev action endpoint (the action runs, returns its result).
- Full suite green.
- **End-to-end in Chromium** against the prod express build (demo PR nicobrinkkemper/vite-plugin-react-server-demo-official#97): a client component importing `getTodos` and calling it on click round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)