### PR TITLE
feat(references): seal the reference gate from Vite's emitted server manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "default": "./dist/plugin/config/index.client.js"
     },
     "./error": "./dist/plugin/error/index.js",
+    "./references": "./dist/plugin/references/createSealedServerReferenceGate.server.js",
     "./vendor": {
       "react-server": "./dist/plugin/vendor/vendor.server.js",
       "default": "./dist/plugin/vendor/vendor.client.js"

--- a/plugin/references/createSealedServerReferenceGate.server.ts
+++ b/plugin/references/createSealedServerReferenceGate.server.ts
@@ -1,0 +1,73 @@
+import { join } from "node:path";
+import {
+  createReferenceGate,
+  type ReferenceGate,
+} from "react-server-loader/references";
+
+/** A Vite manifest entry (the fields we use). */
+export interface ViteManifestEntry {
+  file: string;
+  src?: string;
+  css?: string[];
+}
+
+export interface SealedServerReferenceGateOptions {
+  /**
+   * Vite's emitted server manifest — `JSON.parse(<serverRoot>/.vite/manifest.json)`.
+   * Keys are source paths (e.g. `src/server/actions.server.ts`); `entry.file` is
+   * the built output path. No bespoke manifest: this is what Vite already writes.
+   */
+  serverManifest: Record<string, ViteManifestEntry | undefined>;
+  /** Absolute path to the built server directory (where `entry.file` lives). */
+  serverRoot: string;
+  /** URL base the client prefixes onto reference ids (default `/`). */
+  base?: string;
+}
+
+/**
+ * Build a SEALED reference gate from Vite's emitted server manifest — the
+ * production trust boundary for resolving server-action ids on a server-backed
+ * deploy.
+ *
+ * A server action POST carries a client-supplied id of the form
+ * `<base><srcPath>#<exportName>`. The vendored transport would `import()` a path
+ * derived from that id (an open allowlist); this gate instead resolves it as a
+ * dictionary lookup against the modules the build actually emitted, with each
+ * importer bound to the manifest's real built file — never to anything derived
+ * from the incoming id. An id whose module the build never enumerated cannot
+ * resolve, which makes `../` traversal structurally impossible, and the gate's
+ * own post-import check still rejects an export that isn't a real server
+ * reference.
+ *
+ * Registration mirrors the client's id shape (`base` + manifest key) so
+ * resolution is an exact-key lookup. The gate is sealed before return: in
+ * production an unregistered id throws rather than falling back to an on-demand
+ * import.
+ *
+ * Static (no-backend) builds never reach this — there is no server runtime to
+ * call. It is for server-backed deploys (a Node server in front of the build).
+ */
+export function createSealedServerReferenceGate({
+  serverManifest,
+  serverRoot,
+  base = "/",
+}: SealedServerReferenceGateOptions): ReferenceGate {
+  const gate = createReferenceGate({ mode: "sealed" });
+  const prefix = base.endsWith("/") ? base : `${base}/`;
+
+  for (const [key, entry] of Object.entries(serverManifest)) {
+    if (!entry?.file) continue;
+    // Hosted id = base + source key, matching what the client sends. The
+    // importer is bound to the built file from the manifest, not the id.
+    const id = prefix + key.replace(/^\//, "");
+    const file = entry.file;
+    gate.register({
+      id,
+      kind: "server",
+      load: () => import(join(serverRoot, file)) as Promise<Record<string, unknown>>,
+    });
+  }
+
+  gate.seal();
+  return gate;
+}

--- a/test/unit/sealedServerReferenceGate.test.ts
+++ b/test/unit/sealedServerReferenceGate.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { createSealedServerReferenceGate } from "vite-plugin-react-server/references";
+
+/**
+ * The production sealing path (i0j): build a SEALED reference gate from Vite's
+ * emitted server manifest, so a server-backed deploy resolves a client-supplied
+ * action id by exact-key lookup instead of importing a path derived from the id.
+ */
+
+const serverRoot = resolve(__dirname, "../fixtures/sealed-gate.test/server");
+
+describe("createSealedServerReferenceGate", () => {
+  beforeAll(async () => {
+    await rm(serverRoot, { recursive: true, force: true });
+    await mkdir(serverRoot, { recursive: true });
+    // A built server-action module: `addItem` is a real server reference,
+    // `notAnAction` is a plain value that must never resolve as an action.
+    await writeFile(
+      join(serverRoot, "actions.mjs"),
+      `const TAG = Symbol.for("react.server.reference");
+export const addItem = Object.assign(async (title) => ({ ok: !!title }), { $$typeof: TAG });
+export const notAnAction = 42;
+`
+    );
+  });
+
+  afterAll(async () => {
+    await rm(serverRoot, { recursive: true, force: true });
+  });
+
+  const makeGate = () =>
+    createSealedServerReferenceGate({
+      serverRoot,
+      base: "/",
+      serverManifest: {
+        "src/server/actions.server.ts": {
+          file: "actions.mjs",
+          src: "src/server/actions.server.ts",
+        },
+      },
+    });
+
+  it("seals on creation", () => {
+    expect(makeGate().sealed).toBe(true);
+  });
+
+  it("resolves a manifest-registered action by its client-sent id", async () => {
+    const gate = makeGate();
+    const ref = await gate.resolveServerReference(
+      "/src/server/actions.server.ts#addItem"
+    );
+    expect(await (ref as (t: string) => Promise<{ ok: boolean }>)("x")).toEqual({
+      ok: true,
+    });
+  });
+
+  it("rejects an export that is not a real server reference", async () => {
+    const gate = makeGate();
+    await expect(
+      gate.resolveServerReference("/src/server/actions.server.ts#notAnAction")
+    ).rejects.toThrow(/not a registered server reference/);
+  });
+
+  it("rejects a forged id whose module was never in the manifest (sealed)", async () => {
+    const gate = makeGate();
+    await expect(
+      gate.resolveServerReference("/src/server/secrets.server.ts#steal")
+    ).rejects.toThrow(/Unknown server reference/);
+  });
+});


### PR DESCRIPTION
> Stacked on the reference-gate adoption branch (`feat/rsl-reference-gate`) — it needs `react-server-loader/references` (the ≥19.2.10 floor). Base retargets to `main` once that merges.

## What
`createSealedServerReferenceGate` (exported at `vite-plugin-react-server/references`): builds a **sealed** reference gate from Vite's **native** emitted server manifest (`<serverRoot>/.vite/manifest.json`) — the production trust boundary for resolving server-action ids on a server-backed deploy.

A server-action POST carries a client-supplied id `<base><srcPath>#<export>`. The vendored transport would `import()` a path derived from that id (open allowlist). This gate resolves it as an exact-key lookup against the modules the build emitted, each importer bound to the manifest's real built file — never to anything derived from the id. Unknown ids throw (sealed); `../` traversal is structurally impossible; the gate's post-import check still rejects a non-reference export.

## Why this shape
No bespoke manifest — it reuses what Vite already writes. The `bidoof-template` prod server already does manifest-validated action resolution by hand (`Action not found in manifest`); this replaces that with the gate as the single resolution authority. Static (no-backend) builds never reach it — there's no server runtime to call — so it's for Node-backed deploys.

## Test
`test/unit/sealedServerReferenceGate.test.ts`: seals on creation; resolves a manifest-registered action by its client id; rejects a non-reference export; rejects a forged unregistered id. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)