### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Release cut for the reference-gate + Server Functions work now on main.

## Highlights since 2.2.0
- **Reference gate** (#130) — server actions resolve through a closed allowlist instead of a path derived from the client-supplied id; non-breaking (open mode in dev), with the dev fix that tags devResolve exports.
- **Client-imported server functions** (#133) — a `"use client"` component can `import { action } from "./x.server"` and call it; the import is rewritten to a `createServerReference` proxy that POSTs to the server. Server Functions / Next parity. Verified end-to-end in a browser.
- **`createSealedServerReferenceGate`** (#135) — build a sealed gate from Vite's emitted server manifest for server-backed prod deploys.
- Dev-format-flight hydration check (#132); community scaffolding (#131).

Non-breaking — `^2.2.0` consumers pick it up. Pairs with the held demo PRs (#96/#97) which exercise the prod + client-import paths and unblock on this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)