### PR TITLE
fix(dev): client-imported server functions in dev (2.3.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/plugin/orchestrator/createPluginOrchestrator.client.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.client.ts
@@ -4,6 +4,7 @@ import { createBuildEventPlugin } from "../environments/createBuildEventPlugin.j
 import { vitePluginReactDevServer } from "../dev-server/plugin.client.js";
 import { reactStaticPlugin } from "../react-static/plugin.client.js";
 import { createTransformerPlugin } from "../transformer/createTransformerPlugin.js";
+import { serverReferenceClientPlugin } from "../transformer/serverReferenceClientPlugin.js";
 import { virtualRscHmrPlugin } from "../dev-server/virtualRscHmrPlugin.js";
 import { vitePluginVendorAlias } from "../vendor/vendor-alias.js";
 import { clientPackagesDiscoveryPlugin } from "../clientPackages/index.js";
@@ -34,6 +35,11 @@ export const createPluginOrchestrator = (
 
   // Virtual module for RSC HMR utilities (works in both dev and build)
   plugins.push(virtualRscHmrPlugin());
+
+  // Redirect client-side imports of "use server" modules to a virtual client
+  // proxy (createServerReference) so they resolve in dev. Must precede the
+  // transformer so the .server module is never client-transformed directly.
+  plugins.push(serverReferenceClientPlugin(userOptions));
   
   // Add transformer first so it runs before other plugins
   plugins.push(

--- a/plugin/orchestrator/createPluginOrchestrator.server.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.server.ts
@@ -4,6 +4,7 @@ import { createBuildEventPlugin } from "../environments/createBuildEventPlugin.j
 import { vitePluginReactDevServer } from "../dev-server/plugin.server.js";
 import { reactStaticPlugin } from "../react-static/plugin.server.js";
 import { createTransformerPlugin } from "../transformer/createTransformerPlugin.js";
+import { serverReferenceClientPlugin } from "../transformer/serverReferenceClientPlugin.js";
 import { virtualRscHmrPlugin } from "../dev-server/virtualRscHmrPlugin.js";
 import { vitePluginVendorAlias } from "../vendor/vendor-alias.js";
 import { clientPackagesDiscoveryPlugin } from "../clientPackages/index.js";
@@ -40,7 +41,12 @@ export const createPluginOrchestrator = (
 
   // Virtual module for RSC HMR utilities (works in both dev and build)
   plugins.push(virtualRscHmrPlugin());
-  
+
+  // Redirect client-side imports of "use server" modules to a virtual client
+  // proxy (createServerReference) so they resolve in dev (client/ssr envs are
+  // served here too in dev:rsc). Must precede the transformer.
+  plugins.push(serverReferenceClientPlugin(userOptions));
+
   // Add transformer first so it runs before other plugins
   plugins.push(
     createTransformerPlugin({

--- a/plugin/transformer/serverReferenceClientPlugin.ts
+++ b/plugin/transformer/serverReferenceClientPlugin.ts
@@ -1,0 +1,141 @@
+import type { ConfigEnv } from "vite";
+import { transformWithEsbuild } from "vite";
+import { readFile } from "node:fs/promises";
+import type { Program } from "acorn";
+import { resolveOptions } from "../config/resolveOptions.js";
+import { createDefaultModuleID } from "../config/createModuleID.js";
+import { analyzeModule } from "react-server-loader/directives";
+import type { VitePluginFn } from "../types.js";
+
+// Virtual id prefix for the client-side server-reference proxy. The real
+// `.server` module path is encoded after the prefix.
+const PREFIX = "\0vprs-server-ref:";
+const SERVER_SUFFIX = /\.server\.[tj]sx?$/;
+
+/**
+ * Client-imported server functions, the dev-correct way.
+ *
+ * When a `"use client"` component imports a `"use server"` module, the browser
+ * needs a `createServerReference` proxy — not the server code. Emitting that
+ * proxy AS the `.server` module's transform output fails in dev: a browser-
+ * served `.server` module bypasses client import-analysis, so the proxy's
+ * transport import (`react-server-dom-esm/client.browser`) reaches the browser
+ * as an unresolved bare specifier.
+ *
+ * Instead, in the client/SSR environments we REDIRECT the import to a virtual
+ * client module (`\0vprs-server-ref:<path>`) and emit the proxy there. A virtual
+ * module IS import-analyzed like any client module, so its transport import
+ * resolves to the dev-optimized URL. The `.server` module itself is only ever
+ * loaded in the server environment (its real functions, registerServerReference).
+ *
+ * The hosted id baked into each `createServerReference(...)` is the module's
+ * `moduleID` — identical to what the server registers — so the action POST
+ * resolves through the existing endpoint / gate. The SSR environment gets a
+ * render-safe stub (the function is an event handler, never called during
+ * render; and the browser transport can't init under Node SSG).
+ */
+export const serverReferenceClientPlugin: VitePluginFn = (userOptions) => {
+  const resolved = resolveOptions(userOptions);
+  let moduleID: ((path: string, source: string, isClient: boolean) => string) | undefined =
+    resolved.type === "success" ? resolved.userOptions.loader?.moduleID : undefined;
+  let normalizer = (resolved.type === "success"
+    ? resolved.userOptions.normalizer
+    : undefined) as ((p: string) => [unknown, string]) | undefined;
+  let viteBase = "/";
+
+  return {
+    name: "vite-plugin-react-server:server-reference-client",
+    enforce: "pre",
+    configResolved(config) {
+      viteBase = config.base ?? "/";
+      // Recreate moduleID with the runtime configEnv/mode, mirroring
+      // createTransformerPlugin, so the hosted id matches the server side.
+      const r = resolveOptions(
+        { ...userOptions, loader: { ...userOptions.loader, mode: config.mode } },
+        true
+      );
+      if (r.type === "success") {
+        normalizer = r.userOptions.normalizer as typeof normalizer;
+        if (r.userOptions.loader) {
+          const env: ConfigEnv = {
+            command: config.command,
+            mode: config.mode,
+            isSsrBuild: Boolean(config.build.ssr),
+            isPreview: false,
+          };
+          r.userOptions.loader.moduleID = createDefaultModuleID(
+            r.userOptions,
+            env,
+            config.mode as "development" | "production" | "test"
+          );
+          moduleID = r.userOptions.loader.moduleID;
+        }
+      }
+    },
+
+    async resolveId(source, importer) {
+      const env = this.environment?.name;
+      if (env !== "client" && env !== "ssr") return null;
+      if (source.startsWith(PREFIX)) return source; // already ours
+      const clean = source.split("?")[0];
+      if (!SERVER_SUFFIX.test(clean)) return null;
+      const real = await this.resolve(source, importer, { skipSelf: true });
+      if (!real || real.external) return null;
+      return PREFIX + real.id;
+    },
+
+    async load(id) {
+      if (!id.startsWith(PREFIX)) return null;
+      const realPath = id.slice(PREFIX.length).split("?")[0];
+      const src = await readFile(realPath, "utf8");
+
+      // Strip TS types before analysis — we read the raw .server source, and the
+      // Rollup parser (this.parse) is JS-only. esbuild preserves the top-level
+      // "use server" directive and the export names, which is all we need.
+      const isTsx = /\.[tj]sx$/.test(realPath);
+      const { code: js } = await transformWithEsbuild(src, realPath, {
+        loader: isTsx ? "tsx" : "ts",
+      });
+      const analysis = await analyzeModule(js, {
+        loader: { parse: (s: string) => this.parse(s) as Program },
+      });
+      if (
+        analysis.type !== "success" ||
+        analysis.directiveInfo?.fileLevel?.type !== "server"
+      ) {
+        // Not actually a "use server" module — hand back the real source.
+        return src;
+      }
+      const exportNames = Array.from(analysis.exports.exports.values()).map(
+        (e) => e.exportName
+      );
+      if (exportNames.length === 0) return src;
+
+      const normalizedPath = normalizer ? normalizer(realPath)[1] : realPath;
+      const hostedId = moduleID ? moduleID(normalizedPath, src, false) : normalizedPath;
+
+      if (this.environment?.name === "client") {
+        return [
+          `import { createServerReference } from "react-server-dom-esm/client.browser";`,
+          `import { createCallServer } from "vite-plugin-react-server/utils";`,
+          `const callServer = createCallServer(${JSON.stringify(viteBase)});`,
+          ...exportNames.map(
+            (n) =>
+              `export const ${n} = createServerReference(${JSON.stringify(
+                `${hostedId}#${n}`
+              )}, callServer);`
+          ),
+        ].join("\n");
+      }
+      // SSR: render-safe stub (never called during render; no browser transport).
+      return exportNames
+        .map(
+          (n) =>
+            `export const ${n} = () => { throw new Error(${JSON.stringify(
+              `Server function "${n}" cannot run during SSR; it executes in the browser via a server reference.`
+            )}); };`
+        )
+        .join("\n");
+    },
+  };
+};

--- a/test/dev/client-imports-server-action.test.ts
+++ b/test/dev/client-imports-server-action.test.ts
@@ -65,7 +65,7 @@ export const Page = () => <div>Test Page</div>;`
       server: { port },
     });
     await server.listen();
-  });
+  }, 60_000); // dev-server startup can be slow under full-suite contention
 
   afterAll(async () => {
     await server?.close();

--- a/test/dev/client-imports-server-action.test.ts
+++ b/test/dev/client-imports-server-action.test.ts
@@ -82,6 +82,12 @@ export const Page = () => <div>Test Page</div>;`
     // (the original function source) is gone from the browser bundle.
     expect(result?.code).toContain("export const addItem");
     expect(result?.code).not.toContain("return { ok:");
+    // DEV regression (2.3.1): the transport import must be RESOLVED for the
+    // browser, not left as a bare specifier. A bare specifier reaches the
+    // browser unremapped and throws "bare specifier ... was not remapped".
+    expect(result?.code).not.toMatch(
+      /from\s+["']react-server-dom-esm\/client\.browser["']/
+    );
   });
 
   it("emits a render-safe stub in the SSR environment (no browser transport, no server body)", async () => {

--- a/test/e2e/dev-client-imported-server-fn.spec.ts
+++ b/test/e2e/dev-client-imported-server-fn.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Dev regression for client-imported server functions (the 2.3.1 fix).
+ *
+ * A "use client" component that imports a "use server" module directly must work
+ * in the DEV server, in BOTH paradigms:
+ *   - dev:ssr  (client-first)  — NODE_OPTIONS without the react-server condition
+ *   - dev:rsc  (server-first)  — NODE_OPTIONS with --conditions react-server
+ *
+ * The 2.3.0 bug: the emitted createServerReference proxy's transport import
+ * reached the browser as a bare specifier ("react-server-dom-esm/client.browser"
+ * was not remapped), so the page errored. The fix redirects the client-side
+ * import to a virtual client module that Vite import-analyzes, so the transport
+ * resolves to a dev URL. Prod (Rollup-bundled) always worked.
+ *
+ * Drives bidoof-template's ServerFnProbe (a "use client" component that imports
+ * getTodos directly and calls it on click). Requires the demo's client-imported
+ * server-function probe (vite-plugin-react-server-demo-official#97).
+ */
+import { test, expect } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bidoofDir = join(__dirname, "../../../bidoof-template");
+
+async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
+}
+
+const MODES = [
+  { label: "dev:ssr (client-first)", condition: "", basePort: 33000 },
+  { label: "dev:rsc (server-first)", condition: "--conditions react-server", basePort: 34000 },
+];
+
+for (const mode of MODES) {
+  test.describe(`client-imported server function — ${mode.label}`, () => {
+    const PORT = mode.basePort + Math.floor(Math.random() * 1000);
+    const BASE_URL = `http://localhost:${PORT}`;
+    let server: ChildProcess | undefined;
+
+    test.beforeAll(async () => {
+      server = spawn("npx", ["vite", "--port", String(PORT), "--strictPort"], {
+        cwd: bidoofDir,
+        shell: true,
+        env: {
+          ...process.env,
+          NODE_OPTIONS: mode.condition,
+          NODE_ENV: "development",
+          BASE_URL: "/",
+          PUBLIC_ORIGIN: BASE_URL,
+          FORCE_COLOR: "1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      server.stdout?.on("data", (d) => process.stdout.write(`[${mode.label}] ${d}`));
+      server.stderr?.on("data", (d) => process.stderr.write(`[${mode.label}] ${d}`));
+      await waitForServer(BASE_URL, 60_000);
+    }, 90_000);
+
+    test.afterAll(async () => {
+      if (server && server.exitCode === null && server.signalCode === null) {
+        await new Promise<void>((resolve) => {
+          server!.once("exit", () => resolve());
+          server!.kill("SIGTERM");
+          setTimeout(() => {
+            if (server && server.exitCode === null && server.signalCode === null) {
+              server.kill("SIGKILL");
+            }
+          }, 2000);
+        });
+      }
+    });
+
+    test("imports a server function directly and calls it (no bare-specifier error)", async ({
+      page,
+    }) => {
+      const errors: string[] = [];
+      page.on("console", (m) => m.type() === "error" && errors.push(m.text()));
+      page.on("pageerror", (e) => errors.push(e.message));
+
+      await page.goto(`${BASE_URL}/todos/`);
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(1000); // let the client hydrate
+
+      // ServerFnProbe imports getTodos ("use server") directly; the click calls
+      // it. If the transport import were bare, the module would fail to load and
+      // the button would never hydrate/update.
+      const probe = page.getByTestId("server-fn-probe");
+      await expect(probe).toHaveText("Probe server fn");
+      await probe.click();
+      await expect(probe).toHaveText(/server says: \d+ todos/);
+
+      // No "bare specifier ... was not remapped" (or any) errors.
+      expect(errors.join("\n")).not.toMatch(/bare specifier|not remapped/i);
+      expect(errors).toEqual([]);
+    });
+  });
+}


### PR DESCRIPTION
Fixes the dev-only regression in 2.3.0's client-imported server functions.

## The bug
A `"use client"` component importing a `"use server"` module worked in **prod** but errored in **dev**: the emitted `createServerReference` proxy's transport import reached the browser as a **bare specifier** — `"react-server-dom-esm/client.browser" was not remapped`. Root cause: a browser-served `.server` module bypasses client import-analysis (a normal `.client` module importing the same specifier resolves fine), so the proxy's imports were never rewritten to dev URLs. Rollup bundled them in prod, which is why the prod e2e missed it.

## The fix
`serverReferenceClientPlugin` (`enforce: "pre"`) redirects a **client/SSR** import of a `"use server"` module to a **virtual client module** (`\0vprs-server-ref:<path>`) and emits the proxy there. A virtual module *is* import-analyzed like any client module, so the transport resolves (`/node_modules/.vite/deps/...`). The `.server` module itself is only ever loaded in the server env (its real functions). SSR gets a render-safe stub. The hosted id baked into each `createServerReference(...)` is the same `moduleID` the server registers, so the action POST still resolves. (esbuild strips TS types before analysis since we read the raw `.server` source.)

## Validation
- **dev:rsc and dev:ssr** both serve the proxy with a **resolved** transport import (verified against bidoof's real config).
- **prod e2e** still green (the redirect bundles in build too).
- Full vprs suite green.

## Tests
- `test/dev/client-imports-server-action.test.ts` — now asserts the transport import is **not** bare (the regression).
- `test/e2e/dev-client-imported-server-fn.spec.ts` — drives a real browser in **both** dev:ssr (client-first) and dev:rsc (server-first), clicking a client component that imports a server function directly. Requires the demo's probe (vite-plugin-react-server-demo-official#97).

Bumps to **2.3.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)