### PR TITLE
test(dev): bound server teardown in client-imports-server-action

### DIFF
--- a/test/dev/client-imports-server-action.test.ts
+++ b/test/dev/client-imports-server-action.test.ts
@@ -68,9 +68,22 @@ export const Page = () => <div>Test Page</div>;`
   }, 60_000); // dev-server startup can be slow under full-suite contention
 
   afterAll(async () => {
-    await server?.close();
+    // server.close() awaits environment + ws teardown, which can stall well
+    // past the default 30s hook budget under full-suite CI contention (same
+    // reason beforeAll carries a 60s override). The assertions have already
+    // run by here, so bound the close and move on rather than let a slow
+    // teardown fail the suite.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      server?.close(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, 15_000);
+        timer.unref?.();
+      }),
+    ]);
+    clearTimeout(timer);
     await rm(testDir, { recursive: true, force: true });
-  });
+  }, 30_000);
 
   it("rewrites the module to createServerReference proxies in the browser env", async () => {
     const result = await server.environments.client.transformRequest(


### PR DESCRIPTION
## Problem

Intermittent CI failure in the `client-imports-server-action` dev suite:

```
Error: Hook timed out in 30000ms.
```

`afterAll` had no hook-timeout override, so it ran on the 30s default. `server.close()` awaits environment + WebSocket teardown, which occasionally exceeds 30s under full-suite contention (the reason `beforeAll` already carries a 60s override). Assertions have already passed by teardown, so this is a teardown-budget flake.

## Fix

Bound `server.close()` with a 15s race, then proceed to fixture cleanup. No product behavior changes.

The same unbounded `await server?.close()` teardown exists in sibling dev tests (`server-actions`, `css-hmr`); left untouched to keep this scoped to the test that flaked.