### PR TITLE
test: characterize createHandlerOptions + collect*Content before consolidation

### DIFF
--- a/test/unit/collectStreamContent.test.ts
+++ b/test/unit/collectStreamContent.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Characterization tests for collectRscContent / collectHtmlContent.
+ *
+ * These two helpers are ~95% identical and are slated to be consolidated into a
+ * single `collectStreamContent` helper. They are part of the public
+ * `./react-static` subpath but have no internal callers and (until now) no
+ * tests, so this file pins their CURRENT observable behavior first.
+ *
+ * Two quirks this locks in (both worth fixing during consolidation, not
+ * preserving blindly):
+ *  - The returned `pipe` wrapper is single-use; real reuse is via
+ *    `bufferedContent` (the "can be piped multiple times" comment is wishful).
+ *  - Completion is TIMEOUT-bound, not stream-bound: the internal `consumer`
+ *    PassThrough is never drained, so the `"end"` event never fires and each
+ *    call resolves only when its timeout elapses (rscTimeout for RSC, a
+ *    hard-coded 15s for HTML). The metrics are still captured correctly because
+ *    the Transform counts chunks as they flow. Tests therefore use a short
+ *    rscTimeout; the single HTML test pays the fixed 15s once on purpose.
+ *
+ * If the consolidation changes any of these expectations, that is a deliberate
+ * decision to make in review — not a silent regression.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { PassThrough, Writable } from "node:stream";
+import { createLogger } from "vite";
+import { collectRscContent } from "../../plugin/react-static/collectRscContent.js";
+import { collectHtmlContent } from "../../plugin/react-static/collectHtmlContent.js";
+
+type Source = PassThrough & { abort: ReturnType<typeof vi.fn> };
+
+/** A pre-filled source stream that also satisfies the `.abort()` contract. */
+function makeSource(chunks: Buffer[], { end = true } = {}): Source {
+  const pt = new PassThrough() as Source;
+  // No-arg destroy avoids emitting an "error" event with a truthy reason.
+  pt.abort = vi.fn((reason?: unknown) => pt.destroy(reason as Error));
+  for (const c of chunks) pt.write(c);
+  if (end) pt.end();
+  return pt;
+}
+
+const baseOptions = (over: Record<string, unknown> = {}) =>
+  ({
+    verbose: false,
+    logger: createLogger("silent"),
+    route: "/",
+    rscTimeout: 200,
+    ...over,
+  }) as any;
+
+/** Drain a wrapper's `pipe()` into a single Buffer. */
+async function drain(wrapper: {
+  pipe: (dest: Writable) => Writable;
+}): Promise<Buffer> {
+  const out: Buffer[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      out.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+  await new Promise<void>((resolve, reject) => {
+    sink.on("finish", resolve);
+    sink.on("error", reject);
+    wrapper.pipe(sink);
+  });
+  return Buffer.concat(out);
+}
+
+describe("collectRscContent", () => {
+  const chunks = [Buffer.from("hello "), Buffer.from("rsc "), Buffer.from("world")];
+  const expected = Buffer.concat(chunks);
+
+  it("tracks chunk and byte metrics for the consumed stream", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(result.metrics.chunks).toBe(chunks.length);
+    expect(result.metrics.bytes).toBe(expected.length);
+    expect(typeof result.metrics.duration).toBe("number");
+    expect(result.metrics.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("exposes the full content as bufferedContent (the reuse mechanism)", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(Array.isArray(result.bufferedContent)).toBe(true);
+    expect(Buffer.concat(result.bufferedContent!)).toEqual(expected);
+  });
+
+  it("pipes the collected content through once", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(await drain(result)).toEqual(expected);
+  });
+
+  it("resolves via rscTimeout when the source never ends", async () => {
+    const result = await collectRscContent(
+      makeSource([Buffer.from("partial")], { end: false }),
+      baseOptions({ rscTimeout: 50 })
+    );
+    // Timed out rather than hung; the one delivered chunk is still buffered.
+    expect(result.metrics.bytes).toBe("partial".length);
+  });
+
+  it("propagates abort to the source stream", async () => {
+    const source = makeSource(chunks);
+    const result = await collectRscContent(source, baseOptions());
+    result.abort();
+    expect(source.abort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("collectHtmlContent", () => {
+  // One test pays the hard-coded 15s completion timeout once and asserts the
+  // full contract (metrics + single pipe + abort propagation) together.
+  it("collects metrics, pipes content once, and propagates abort", async () => {
+    const chunks = [Buffer.from("<html>"), Buffer.from("<body/>"), Buffer.from("</html>")];
+    const expected = Buffer.concat(chunks);
+    const source = makeSource(chunks);
+
+    const result = await collectHtmlContent(source, baseOptions());
+
+    expect(result.metrics.chunks).toBe(chunks.length);
+    expect(result.metrics.bytes).toBe(expected.length);
+    expect(await drain(result)).toEqual(expected);
+
+    result.abort();
+    expect(source.abort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/createHandlerOptions.test.ts
+++ b/test/unit/createHandlerOptions.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Characterization tests for createHandlerOptions.server / .client.
+ *
+ * The two variants are ~90% identical and are slated to be consolidated behind
+ * a shared `.shared.ts`. They have already drifted in a few places, and the
+ * point of this file is to pin EXACTLY where their resolved-options output
+ * differs for identical input, so the consolidation can preserve (or
+ * deliberately change) each difference rather than regress it silently.
+ *
+ * Runs under the react-server condition only (test/unit/** is gated to it).
+ * Workers are disabled and components are pre-supplied so neither variant
+ * spawns a thread or performs a dynamic import — this stays a pure unit test.
+ *
+ * Findings this locks in (some correct earlier assumptions, some not):
+ *  - clientPipeableStreamOptions: server coerces undefined -> {} ("|| {}"),
+ *    client passes undefined through. REAL divergence.
+ *  - Components: server loads PageComponent/RootComponent/HtmlComponent eagerly;
+ *    client sets all three to undefined (placeholders). REAL divergence.
+ *  - `components` field: BOTH carry it (via the `...userOptions` spread), so the
+ *    "client drops components" assumption is FALSE — they match.
+ *  - `children`: client threads it through; server omits it.
+ *  - Shared scalar fields (route/url/paths/timeouts/build/dev) match.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { createLogger } from "vite";
+import { resolveOptions } from "vite-plugin-react-server/config";
+import { testUserOptions } from "../test-config.js";
+import { createHandlerOptions as createServerHandlerOptions } from "../../plugin/config/createHandlerOptions.server.js";
+import { createHandlerOptions as createClientHandlerOptions } from "../../plugin/config/createHandlerOptions.client.js";
+
+const PageStub = () => null;
+const RootStub = () => null;
+const HtmlStub = () => null;
+const CHILDREN = { marker: "children-passthrough" };
+
+function emptyAutoDiscoveredFiles(): any {
+  return {
+    clientInputs: {},
+    serverInputs: {},
+    staticManifest: {},
+    staticInputs: {},
+    workerPaths: {},
+    serverEntry: null,
+    clientEntry: {},
+    serverActions: {},
+    propsMap: new Map(),
+    pageMap: new Map(),
+    rootMap: new Map(),
+    htmlMap: new Map(),
+    routeMap: new Map(),
+    urlMap: new Map(),
+    errors: [],
+  };
+}
+
+let server: any;
+let client: any;
+
+beforeAll(async () => {
+  const userOptions: any = resolveOptions(testUserOptions).userOptions!;
+
+  // Pre-supply components so the server variant skips component loading, and
+  // force undefined stream options so the "|| {}" divergence is observable.
+  userOptions.components = { Page: PageStub, Root: RootStub, Html: HtmlStub };
+  userOptions.clientPipeableStreamOptions = undefined;
+
+  // Disable every worker path so neither variant spawns a thread. Under the
+  // react-server condition + build mode, build.useHtmlWorker would default true.
+  userOptions.dev = { ...userOptions.dev, useRscWorker: false, useHtmlWorker: false };
+  userOptions.build = { ...userOptions.build, useRscWorker: false, useHtmlWorker: false };
+
+  // Seed the route resolution so getRouteFiles takes the cache fast-path and
+  // returns a headless ("") root/html without touching the filesystem.
+  const autoDiscoveredFiles = emptyAutoDiscoveredFiles();
+  autoDiscoveredFiles.urlMap.set("/", {
+    page: "src/page/page.tsx",
+    props: undefined,
+    root: "",
+    html: "",
+  });
+
+  const common = {
+    userOptions,
+    autoDiscoveredFiles,
+    configEnv: { mode: "production", command: "build" } as const,
+    mode: "production",
+    logger: createLogger("silent"),
+  };
+
+  server = await createServerHandlerOptions("/", { ...common, id: "char-server" });
+  client = await createClientHandlerOptions("/", {
+    ...common,
+    id: "char-client",
+    children: CHILDREN,
+  });
+});
+
+describe("createHandlerOptions: shared output (must survive consolidation)", () => {
+  it("resolves the same route, url and file paths", () => {
+    expect(server.route).toBe("/");
+    expect(client.route).toBe(server.route);
+    expect(client.url).toBe(server.url);
+    expect(client.pagePath).toBe(server.pagePath);
+    expect(client.rootPath).toBe(server.rootPath);
+    expect(client.htmlPath).toBe(server.htmlPath);
+  });
+
+  it("resolves the same timeouts and build/dev config", () => {
+    expect(client.rscTimeout).toBe(server.rscTimeout);
+    expect(client.htmlTimeout).toBe(server.htmlTimeout);
+    expect(client.build).toEqual(server.build);
+    expect(client.dev).toEqual(server.dev);
+  });
+
+  it("carries the components map on BOTH variants (via the spread)", () => {
+    // Corrects the assumption that the client variant drops `components`.
+    expect(server.components).toBe(client.components);
+    expect(server.components).toEqual({ Page: PageStub, Root: RootStub, Html: HtmlStub });
+  });
+
+  it("creates no workers when all worker flags are disabled", () => {
+    expect(server.worker).toBeUndefined();
+    expect(server.rscWorker).toBeUndefined();
+    expect(server.htmlWorker).toBeUndefined();
+    expect(client.worker).toBeUndefined();
+    expect(client.rscWorker).toBeUndefined();
+    expect(client.htmlWorker).toBeUndefined();
+  });
+});
+
+describe("createHandlerOptions: documented divergences", () => {
+  it("coerces undefined clientPipeableStreamOptions to {} on server, passes through on client", () => {
+    expect(server.clientPipeableStreamOptions).toEqual({});
+    expect(client.clientPipeableStreamOptions).toBeUndefined();
+  });
+
+  it("loads components eagerly on server, leaves placeholders on client", () => {
+    expect(server.PageComponent).toBe(PageStub);
+    expect(server.RootComponent).toBe(RootStub);
+    expect(server.HtmlComponent).toBe(HtmlStub);
+
+    expect(client.PageComponent).toBeUndefined();
+    expect(client.RootComponent).toBeUndefined();
+    expect(client.HtmlComponent).toBeUndefined();
+  });
+
+  it("threads `children` through on client only", () => {
+    expect(client.children).toBe(CHILDREN);
+    expect(server.children).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Pure test additions (no production-code change) that pin the current behavior of two areas slated for de-duplication, so the upcoming consolidations are guarded against silent regressions.

### `test/unit/createHandlerOptions.test.ts`
Characterizes the `.server` vs `.client` variants for **identical input**, locking the genuine divergences a shared implementation must preserve:
- **`clientPipeableStreamOptions`** — server coerces `undefined → {}` (`|| {}`); client passes it through.
- **Components** — server loads `PageComponent`/`RootComponent`/`HtmlComponent` eagerly; client leaves them `undefined` (placeholders).
- **`children`** — threaded through on client only.
- **`components` map** — present on **both** (via the `...userOptions` spread); this corrects the assumption that the client variant drops it.
- Shared scalar fields (route/url/paths/timeouts/build/dev) match.

Workers are disabled and components are pre-supplied, so it runs as a pure unit test — no worker threads, no dynamic imports.

### `test/unit/collectStreamContent.test.ts`
Characterizes `collectRscContent` / `collectHtmlContent` (metrics, `bufferedContent`, single pipe-through, abort propagation). It documents two quirks worth addressing during consolidation rather than preserving:
- the returned `pipe` wrapper is **single-use** (real reuse is via `bufferedContent`);
- completion is **timeout-bound** — the internal `consumer` PassThrough is never drained, so each call resolves only when its timeout elapses (configurable `rscTimeout` for RSC, a hard-coded 15s for HTML).

## Testing
- `npm run test:server` — 89 files, 622 passed / 3 skipped (+13 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)