### PR TITLE
refactor(react-static): dedupe collect{Rsc,Html}Content into collectStreamContent

### DIFF
--- a/plugin/react-static/collectHtmlContent.ts
+++ b/plugin/react-static/collectHtmlContent.ts
@@ -1,131 +1,22 @@
 /**
- * collectHtmlContent.client.ts
+ * collectHtmlContent.ts
  *
- * PURPOSE: Collects HTML stream with metrics
+ * PURPOSE: Collects an HTML stream with metrics.
  *
- * This module:
- * 1. Takes an HTML stream and collects it
- * 2. Tracks metrics (chunks, bytes, duration)
- * 3. Returns buffered content and metrics
- * 4. Does NOT create HTML streams - that's the caller's responsibility
- * 5. Does NOT write files - that's the caller's responsibility
+ * Thin wrapper over the shared `collectStreamContent` helper; the HTML variant
+ * uses a fixed 15s completion timeout. Does NOT create HTML streams and does
+ * NOT write files — that's the caller's responsibility.
  */
 
-import { Transform } from "node:stream";
-import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
+import { collectStreamContent } from "./collectStreamContent.js";
 import type { CollectHtmlContentFn } from "./types.js";
 
 export const collectHtmlContent: CollectHtmlContentFn =
   async function _collectHtmlContent(html, handlerOptions) {
-    const metrics = createStreamMetrics();
-    const startTime = performance.now();
-    const htmlBuffer: Buffer[] = [];
-
-    if (handlerOptions.verbose) {
-      handlerOptions.logger.info(
-        `[collectHtmlContent.client] Starting HTML collection for route: ${handlerOptions.route}`
-      );
-    }
-
-    try {
-      // Create a transform stream to collect HTML content and track metrics
-      const metricsTransform = new Transform({
-        transform(chunk, encoding, callback) {
-          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding as BufferEncoding);
-          htmlBuffer.push(buffer);
-          metrics.chunks++;
-          metrics.bytes += buffer.length;
-          
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectHtmlContent.client] HTML chunk ${metrics.chunks}, bytes: ${buffer.length}, total: ${metrics.bytes}`
-            );
-          }
-          
-          callback(null, chunk);
-        },
-        flush(callback) {
-          metrics.duration = performance.now() - startTime;
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectHtmlContent.client] HTML collection completed: ${metrics.bytes} bytes in ${metrics.duration}ms`
-            );
-          }
-          callback();
-        }
-      });
-
-      // Create a PassThrough stream to consume the transform
-      const { PassThrough } = await import("node:stream");
-      const consumer = new PassThrough();
-      
-      // Pipe HTML stream through metrics tracking to consumer
-      html.pipe(metricsTransform).pipe(consumer);
-
-      // Wait for stream to complete with timeout
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectHtmlContent.client] Stream timeout reached, forcing completion`
-            );
-          }
-          resolve();
-        }, 15000); // 15 second timeout for HTML content collection
-
-        consumer.on("end", () => {
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectHtmlContent.client] Stream ended with ${metrics.bytes} bytes`
-            );
-          }
-          clearTimeout(timeout);
-          resolve();
-        });
-
-        consumer.on("error", (error) => {
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectHtmlContent.client] Stream error: ${error}`
-            );
-          }
-          clearTimeout(timeout);
-          reject(error);
-        });
-      });
-
-      // Create a readable stream from the buffered content that can be piped multiple times
-      const { Readable } = await import("node:stream");
-      const readableStream = new Readable({
-        read() {
-          // Push all buffered content
-          for (const chunk of htmlBuffer) {
-            this.push(chunk);
-          }
-          this.push(null); // End the stream
-        }
-      });
-
-      // Return buffered content and metrics - file writing is caller's responsibility
-      return {
-        pipe: readableStream.pipe.bind(readableStream),
-        abort: (reason?: unknown) => {
-          html.abort(reason);
-          readableStream.destroy(reason as Error);
-        },
-        metrics,
-        // Include buffered content for reuse
-        bufferedContent: htmlBuffer,
-      };
-
-    } catch (error) {
-      if (handlerOptions.verbose) {
-        handlerOptions.logger.info(`[collectHtmlContent.client] Error: ${error}`);
-      }
-      html.abort(new Error("HTML Stream aborted"));
-      if (error != null) {
-        throw error;
-      }
-      throw new Error("Failed to collect HTML content");
-    }
-  }; 
+    return collectStreamContent(html, {
+      timeout: 15000,
+      logTag: "collectHtmlContent.client",
+      verbose: handlerOptions.verbose,
+      logger: handlerOptions.logger,
+    });
+  };

--- a/plugin/react-static/collectRscContent.ts
+++ b/plugin/react-static/collectRscContent.ts
@@ -1,21 +1,18 @@
 /**
  * collectRscContent.ts
  *
- * PURPOSE: Collects RSC content from a stream with metrics
+ * PURPOSE: Collects RSC content from a stream with metrics.
  *
- * This module:
- * 1. Collects RSC content from the provided stream
- * 2. Tracks metrics (chunks, bytes, duration)
- * 3. Returns buffered content and metrics
- * 4. Does NOT write files - that's the caller's responsibility
+ * Thin wrapper over the shared `collectStreamContent` helper; the RSC variant
+ * uses the configurable `rscTimeout` (default 5s). Returns buffered content and
+ * metrics; does NOT write files — that's the caller's responsibility.
  */
 
-import { Transform } from "node:stream";
-import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
+import { collectStreamContent } from "./collectStreamContent.js";
 import type { CollectRscContentFn } from "./types.js";
 
 /**
- * Collects RSC content from a stream with metrics
+ * Collects RSC content from a stream with metrics.
  *
  * @param rsc The stream containing the RSC content
  * @param handlerOptions The options for the handler
@@ -23,110 +20,10 @@ import type { CollectRscContentFn } from "./types.js";
  */
 export const collectRscContent: CollectRscContentFn =
   async function _collectRscContent(rsc, handlerOptions) {
-    const metrics = createStreamMetrics();
-    const startTime = performance.now();
-
-    // Buffer to store RSC content for reuse
-    const rscBuffer: Buffer[] = [];
-
-    // Create transform to track metrics and buffer content
-    const metricsTransform = new Transform({
-      transform(chunk, _encoding, callback) {
-        metrics.chunks++;
-        metrics.bytes += chunk.length;
-        // Buffer the chunk for reuse
-        rscBuffer.push(Buffer.from(chunk));
-        callback(null, chunk);
-      },
-      flush(callback) {
-        metrics.duration = performance.now() - startTime;
-        if (handlerOptions.verbose) {
-          handlerOptions.logger.info(
-            `[collectRscContent] Transform flush: ${metrics.chunks} chunks, ${metrics.duration}ms`
-          );
-        }
-        callback();
-      },
+    return collectStreamContent(rsc, {
+      timeout: handlerOptions.rscTimeout || 5000,
+      logTag: "collectRscContent",
+      verbose: handlerOptions.verbose,
+      logger: handlerOptions.logger,
     });
-
-    try {
-      // Create a PassThrough stream to consume the transform
-      const { PassThrough } = await import("node:stream");
-      const consumer = new PassThrough();
-      
-      // Pipe RSC stream through metrics tracking to consumer
-      rsc.pipe(metricsTransform).pipe(consumer);
-
-      // Wait for stream to complete with timeout
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectRscContent] Stream timeout reached, forcing completion`
-            );
-          }
-          resolve();
-        }, handlerOptions.rscTimeout || 5000); // 5 second timeout
-
-        consumer.on("end", () => {
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectRscContent] Stream ended with ${metrics.bytes} bytes`
-            );
-          }
-          clearTimeout(timeout);
-          resolve();
-        });
-
-        consumer.on("error", (error) => {
-          if (handlerOptions.verbose) {
-            handlerOptions.logger.info(
-              `[collectRscContent] Stream error: ${error}`
-            );
-          }
-          clearTimeout(timeout);
-          reject(error);
-        });
-      });
-
-      if (handlerOptions.verbose) {
-        handlerOptions.logger.info(
-          `[collectRscContent] Collection completed with ${metrics.bytes} bytes`
-        );
-      }
-
-      // Create a readable stream from the buffered content that can be piped multiple times
-      const { Readable } = await import("node:stream");
-      const readableStream = new Readable({
-        read() {
-          // Push all buffered content
-          for (const chunk of rscBuffer) {
-            this.push(chunk);
-          }
-          this.push(null); // End the stream
-        }
-      });
-
-      // Return buffered content and metrics - file writing is caller's responsibility
-      return {
-        pipe: readableStream.pipe.bind(readableStream),
-        abort: (reason?: unknown) => {
-          rsc.abort(reason);
-          readableStream.destroy(reason as Error);
-        },
-        metrics,
-        // Include buffered content for reuse
-        bufferedContent: rscBuffer,
-      };
-    } catch (error) {
-      if (handlerOptions.verbose) {
-        handlerOptions.logger.info(`[collectRscContent] Error: ${error}`);
-      }
-      metricsTransform.destroy();
-      rsc.abort(new Error("RSC Stream aborted"));
-      if (error != null) {
-        throw error;
-      }
-      throw new Error("Failed to collect RSC content");
-    }
   };

--- a/plugin/react-static/collectStreamContent.ts
+++ b/plugin/react-static/collectStreamContent.ts
@@ -1,0 +1,147 @@
+/**
+ * collectStreamContent.ts
+ *
+ * Shared implementation behind collectRscContent and collectHtmlContent, which
+ * were ~95% identical. Both buffer a source stream while tracking metrics, then
+ * expose the buffered content for reuse.
+ *
+ * NOTE: completion here is timeout-bound, not stream-bound — the internal
+ * `consumer` PassThrough is never drained, so the "end" event does not fire and
+ * each call resolves only when `timeout` elapses. This faithfully preserves the
+ * original behavior of both collectors; see
+ * test/unit/collectStreamContent.test.ts for the characterization, and the
+ * follow-up bead for fixing the timeout/single-use quirks deliberately.
+ */
+
+import { Transform } from "node:stream";
+import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
+import type { Logger } from "vite";
+import type { StreamMetrics } from "../types.js";
+
+export type CollectStreamSource = {
+  abort: (reason?: unknown) => void;
+  pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => Writable;
+};
+
+export type CollectStreamContentOptions = {
+  /** Resolve after this many ms if the source has not completed. */
+  timeout: number;
+  /** Log prefix, e.g. "collectRscContent" or "collectHtmlContent.client". */
+  logTag: string;
+  verbose?: boolean | undefined;
+  logger: Logger;
+};
+
+export type CollectStreamContentReturn = {
+  pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => Writable;
+  abort: (reason?: unknown) => void;
+  metrics: StreamMetrics;
+  bufferedContent: Buffer[];
+};
+
+export async function collectStreamContent(
+  source: CollectStreamSource,
+  options: CollectStreamContentOptions
+): Promise<CollectStreamContentReturn> {
+  const { timeout, logTag, verbose, logger } = options;
+  const metrics = createStreamMetrics();
+  const startTime = performance.now();
+
+  // Buffer to store content for reuse.
+  const buffer: Buffer[] = [];
+
+  const metricsTransform = new Transform({
+    transform(chunk, encoding, callback) {
+      const buffered = Buffer.isBuffer(chunk)
+        ? chunk
+        : Buffer.from(chunk, encoding as BufferEncoding);
+      metrics.chunks++;
+      metrics.bytes += buffered.length;
+      buffer.push(buffered);
+
+      if (verbose) {
+        logger.info(
+          `[${logTag}] chunk ${metrics.chunks}, bytes: ${buffered.length}, total: ${metrics.bytes}`
+        );
+      }
+
+      callback(null, chunk);
+    },
+    flush(callback) {
+      metrics.duration = performance.now() - startTime;
+      if (verbose) {
+        logger.info(
+          `[${logTag}] Transform flush: ${metrics.chunks} chunks, ${metrics.duration}ms`
+        );
+      }
+      callback();
+    },
+  });
+
+  try {
+    const { PassThrough } = await import("node:stream");
+    const consumer = new PassThrough();
+
+    source.pipe(metricsTransform).pipe(consumer);
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (verbose) {
+          logger.info(`[${logTag}] Stream timeout reached, forcing completion`);
+        }
+        resolve();
+      }, timeout);
+
+      consumer.on("end", () => {
+        if (verbose) {
+          logger.info(`[${logTag}] Stream ended with ${metrics.bytes} bytes`);
+        }
+        clearTimeout(timer);
+        resolve();
+      });
+
+      consumer.on("error", (error) => {
+        if (verbose) {
+          logger.info(`[${logTag}] Stream error: ${error}`);
+        }
+        clearTimeout(timer);
+        reject(error);
+      });
+    });
+
+    if (verbose) {
+      logger.info(`[${logTag}] Collection completed with ${metrics.bytes} bytes`);
+    }
+
+    // A readable that replays the buffered content; single-use (see header).
+    const { Readable } = await import("node:stream");
+    const readableStream = new Readable({
+      read() {
+        for (const chunk of buffer) {
+          this.push(chunk);
+        }
+        this.push(null);
+      },
+    });
+
+    return {
+      pipe: readableStream.pipe.bind(readableStream),
+      abort: (reason?: unknown) => {
+        source.abort(reason);
+        readableStream.destroy(reason as Error);
+      },
+      metrics,
+      bufferedContent: buffer,
+    };
+  } catch (error) {
+    if (verbose) {
+      logger.info(`[${logTag}] Error: ${error}`);
+    }
+    metricsTransform.destroy();
+    source.abort(new Error(`${logTag} aborted`));
+    if (error != null) {
+      throw error;
+    }
+    throw new Error(`Failed to collect content (${logTag})`);
+  }
+}

--- a/test/unit/collectStreamContent.test.ts
+++ b/test/unit/collectStreamContent.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Characterization tests for collectRscContent / collectHtmlContent.
+ *
+ * These two helpers are ~95% identical and are slated to be consolidated into a
+ * single `collectStreamContent` helper. They are part of the public
+ * `./react-static` subpath but have no internal callers and (until now) no
+ * tests, so this file pins their CURRENT observable behavior first.
+ *
+ * Two quirks this locks in (both worth fixing during consolidation, not
+ * preserving blindly):
+ *  - The returned `pipe` wrapper is single-use; real reuse is via
+ *    `bufferedContent` (the "can be piped multiple times" comment is wishful).
+ *  - Completion is TIMEOUT-bound, not stream-bound: the internal `consumer`
+ *    PassThrough is never drained, so the `"end"` event never fires and each
+ *    call resolves only when its timeout elapses (rscTimeout for RSC, a
+ *    hard-coded 15s for HTML). The metrics are still captured correctly because
+ *    the Transform counts chunks as they flow. Tests therefore use a short
+ *    rscTimeout; the single HTML test pays the fixed 15s once on purpose.
+ *
+ * If the consolidation changes any of these expectations, that is a deliberate
+ * decision to make in review — not a silent regression.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { PassThrough, Writable } from "node:stream";
+import { createLogger } from "vite";
+import { collectRscContent } from "../../plugin/react-static/collectRscContent.js";
+import { collectHtmlContent } from "../../plugin/react-static/collectHtmlContent.js";
+
+type Source = PassThrough & { abort: ReturnType<typeof vi.fn> };
+
+/** A pre-filled source stream that also satisfies the `.abort()` contract. */
+function makeSource(chunks: Buffer[], { end = true } = {}): Source {
+  const pt = new PassThrough() as Source;
+  // No-arg destroy avoids emitting an "error" event with a truthy reason.
+  pt.abort = vi.fn((reason?: unknown) => pt.destroy(reason as Error));
+  for (const c of chunks) pt.write(c);
+  if (end) pt.end();
+  return pt;
+}
+
+const baseOptions = (over: Record<string, unknown> = {}) =>
+  ({
+    verbose: false,
+    logger: createLogger("silent"),
+    route: "/",
+    rscTimeout: 200,
+    ...over,
+  }) as any;
+
+/** Drain a wrapper's `pipe()` into a single Buffer. */
+async function drain(wrapper: {
+  pipe: (dest: Writable) => Writable;
+}): Promise<Buffer> {
+  const out: Buffer[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      out.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+  await new Promise<void>((resolve, reject) => {
+    sink.on("finish", resolve);
+    sink.on("error", reject);
+    wrapper.pipe(sink);
+  });
+  return Buffer.concat(out);
+}
+
+describe("collectRscContent", () => {
+  const chunks = [Buffer.from("hello "), Buffer.from("rsc "), Buffer.from("world")];
+  const expected = Buffer.concat(chunks);
+
+  it("tracks chunk and byte metrics for the consumed stream", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(result.metrics.chunks).toBe(chunks.length);
+    expect(result.metrics.bytes).toBe(expected.length);
+    expect(typeof result.metrics.duration).toBe("number");
+    expect(result.metrics.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("exposes the full content as bufferedContent (the reuse mechanism)", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(Array.isArray(result.bufferedContent)).toBe(true);
+    expect(Buffer.concat(result.bufferedContent!)).toEqual(expected);
+  });
+
+  it("pipes the collected content through once", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(await drain(result)).toEqual(expected);
+  });
+
+  it("resolves via rscTimeout when the source never ends", async () => {
+    const result = await collectRscContent(
+      makeSource([Buffer.from("partial")], { end: false }),
+      baseOptions({ rscTimeout: 50 })
+    );
+    // Timed out rather than hung; the one delivered chunk is still buffered.
+    expect(result.metrics.bytes).toBe("partial".length);
+  });
+
+  it("propagates abort to the source stream", async () => {
+    const source = makeSource(chunks);
+    const result = await collectRscContent(source, baseOptions());
+    result.abort();
+    expect(source.abort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("collectHtmlContent", () => {
+  // One test pays the hard-coded 15s completion timeout once and asserts the
+  // full contract (metrics + single pipe + abort propagation) together.
+  it("collects metrics, pipes content once, and propagates abort", async () => {
+    const chunks = [Buffer.from("<html>"), Buffer.from("<body/>"), Buffer.from("</html>")];
+    const expected = Buffer.concat(chunks);
+    const source = makeSource(chunks);
+
+    const result = await collectHtmlContent(source, baseOptions());
+
+    expect(result.metrics.chunks).toBe(chunks.length);
+    expect(result.metrics.bytes).toBe(expected.length);
+    expect(await drain(result)).toEqual(expected);
+
+    result.abort();
+    expect(source.abort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/createHandlerOptions.test.ts
+++ b/test/unit/createHandlerOptions.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Characterization tests for createHandlerOptions.server / .client.
+ *
+ * The two variants are ~90% identical and are slated to be consolidated behind
+ * a shared `.shared.ts`. They have already drifted in a few places, and the
+ * point of this file is to pin EXACTLY where their resolved-options output
+ * differs for identical input, so the consolidation can preserve (or
+ * deliberately change) each difference rather than regress it silently.
+ *
+ * Runs under the react-server condition only (test/unit/** is gated to it).
+ * Workers are disabled and components are pre-supplied so neither variant
+ * spawns a thread or performs a dynamic import — this stays a pure unit test.
+ *
+ * Findings this locks in (some correct earlier assumptions, some not):
+ *  - clientPipeableStreamOptions: server coerces undefined -> {} ("|| {}"),
+ *    client passes undefined through. REAL divergence.
+ *  - Components: server loads PageComponent/RootComponent/HtmlComponent eagerly;
+ *    client sets all three to undefined (placeholders). REAL divergence.
+ *  - `components` field: BOTH carry it (via the `...userOptions` spread), so the
+ *    "client drops components" assumption is FALSE — they match.
+ *  - `children`: client threads it through; server omits it.
+ *  - Shared scalar fields (route/url/paths/timeouts/build/dev) match.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { createLogger } from "vite";
+import { resolveOptions } from "vite-plugin-react-server/config";
+import { testUserOptions } from "../test-config.js";
+import { createHandlerOptions as createServerHandlerOptions } from "../../plugin/config/createHandlerOptions.server.js";
+import { createHandlerOptions as createClientHandlerOptions } from "../../plugin/config/createHandlerOptions.client.js";
+
+const PageStub = () => null;
+const RootStub = () => null;
+const HtmlStub = () => null;
+const CHILDREN = { marker: "children-passthrough" };
+
+function emptyAutoDiscoveredFiles(): any {
+  return {
+    clientInputs: {},
+    serverInputs: {},
+    staticManifest: {},
+    staticInputs: {},
+    workerPaths: {},
+    serverEntry: null,
+    clientEntry: {},
+    serverActions: {},
+    propsMap: new Map(),
+    pageMap: new Map(),
+    rootMap: new Map(),
+    htmlMap: new Map(),
+    routeMap: new Map(),
+    urlMap: new Map(),
+    errors: [],
+  };
+}
+
+let server: any;
+let client: any;
+
+beforeAll(async () => {
+  const userOptions: any = resolveOptions(testUserOptions).userOptions!;
+
+  // Pre-supply components so the server variant skips component loading, and
+  // force undefined stream options so the "|| {}" divergence is observable.
+  userOptions.components = { Page: PageStub, Root: RootStub, Html: HtmlStub };
+  userOptions.clientPipeableStreamOptions = undefined;
+
+  // Disable every worker path so neither variant spawns a thread. Under the
+  // react-server condition + build mode, build.useHtmlWorker would default true.
+  userOptions.dev = { ...userOptions.dev, useRscWorker: false, useHtmlWorker: false };
+  userOptions.build = { ...userOptions.build, useRscWorker: false, useHtmlWorker: false };
+
+  // Seed the route resolution so getRouteFiles takes the cache fast-path and
+  // returns a headless ("") root/html without touching the filesystem.
+  const autoDiscoveredFiles = emptyAutoDiscoveredFiles();
+  autoDiscoveredFiles.urlMap.set("/", {
+    page: "src/page/page.tsx",
+    props: undefined,
+    root: "",
+    html: "",
+  });
+
+  const common = {
+    userOptions,
+    autoDiscoveredFiles,
+    configEnv: { mode: "production", command: "build" } as const,
+    mode: "production",
+    logger: createLogger("silent"),
+  };
+
+  server = await createServerHandlerOptions("/", { ...common, id: "char-server" });
+  client = await createClientHandlerOptions("/", {
+    ...common,
+    id: "char-client",
+    children: CHILDREN,
+  });
+});
+
+describe("createHandlerOptions: shared output (must survive consolidation)", () => {
+  it("resolves the same route, url and file paths", () => {
+    expect(server.route).toBe("/");
+    expect(client.route).toBe(server.route);
+    expect(client.url).toBe(server.url);
+    expect(client.pagePath).toBe(server.pagePath);
+    expect(client.rootPath).toBe(server.rootPath);
+    expect(client.htmlPath).toBe(server.htmlPath);
+  });
+
+  it("resolves the same timeouts and build/dev config", () => {
+    expect(client.rscTimeout).toBe(server.rscTimeout);
+    expect(client.htmlTimeout).toBe(server.htmlTimeout);
+    expect(client.build).toEqual(server.build);
+    expect(client.dev).toEqual(server.dev);
+  });
+
+  it("carries the components map on BOTH variants (via the spread)", () => {
+    // Corrects the assumption that the client variant drops `components`.
+    expect(server.components).toBe(client.components);
+    expect(server.components).toEqual({ Page: PageStub, Root: RootStub, Html: HtmlStub });
+  });
+
+  it("creates no workers when all worker flags are disabled", () => {
+    expect(server.worker).toBeUndefined();
+    expect(server.rscWorker).toBeUndefined();
+    expect(server.htmlWorker).toBeUndefined();
+    expect(client.worker).toBeUndefined();
+    expect(client.rscWorker).toBeUndefined();
+    expect(client.htmlWorker).toBeUndefined();
+  });
+});
+
+describe("createHandlerOptions: documented divergences", () => {
+  it("coerces undefined clientPipeableStreamOptions to {} on server, passes through on client", () => {
+    expect(server.clientPipeableStreamOptions).toEqual({});
+    expect(client.clientPipeableStreamOptions).toBeUndefined();
+  });
+
+  it("loads components eagerly on server, leaves placeholders on client", () => {
+    expect(server.PageComponent).toBe(PageStub);
+    expect(server.RootComponent).toBe(RootStub);
+    expect(server.HtmlComponent).toBe(HtmlStub);
+
+    expect(client.PageComponent).toBeUndefined();
+    expect(client.RootComponent).toBeUndefined();
+    expect(client.HtmlComponent).toBeUndefined();
+  });
+
+  it("threads `children` through on client only", () => {
+    expect(client.children).toBe(CHILDREN);
+    expect(server.children).toBeUndefined();
+  });
+});


### PR DESCRIPTION
> Stacked on #142 (the characterization tests). Merge #142 first; GitHub will retarget this to `main` automatically.

## What

`collectRscContent` and `collectHtmlContent` (under `plugin/react-static/`) were ~95% identical buffered-stream collectors. This extracts the shared logic into a single `collectStreamContent(source, { timeout, logTag, verbose, logger })`; both collectors are now thin wrappers that differ only in:
- **timeout source** — RSC uses `rscTimeout || 5000`; HTML uses a fixed `15000`;
- **log tag**.

Net: ~250 duplicated lines collapse to one helper + two small wrappers.

## Behavior preserved

This is a pure refactor — no behavior change intended. The characterization tests from #142 pass **unchanged**, including the two documented quirks (timeout-bound completion because the internal consumer is never drained, and the single-use `pipe` wrapper). Those are intentionally left for a separate, deliberate fix rather than smuggled into a dedupe.

## Testing
- `npm run build:types` — clean
- `npm run test:server` — 89 files, 622 passed / 3 skipped
- `npm run test:client` — 47 files, 180 passed / 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)