### PR TITLE
refactor(config): extract createHandlerOptions.shared for the test-covered overlap

### DIFF
--- a/plugin/config/createHandlerOptions.client.ts
+++ b/plugin/config/createHandlerOptions.client.ts
@@ -1,8 +1,6 @@
-import type { CreateHandlerOptions, AutoDiscoveredFiles } from "../types.js";
-import type { Logger } from "vite";
+import type { CreateHandlerOptions } from "../types.js";
 import { getRouteFiles } from "../helpers/getRouteFiles.js";
 import { routeToURL } from "../utils/routeToURL.js";
-import { resolveAutoDiscover } from "./autoDiscover/resolveAutoDiscover.js";
 import { createWorker } from "../worker/createWorker.js";
 import {
   serializedOptions,
@@ -17,11 +15,12 @@ import {
 } from "./stashedOptionsState.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { createLogger } from "vite";
-import { DEFAULT_CONFIG } from "./defaults.js";
-import type {
-  CreateHandlerOptionsParams,
-  ResolvedDefaults,
-} from "./createHandlerOptions.types.js";
+import type { CreateHandlerOptionsParams } from "./createHandlerOptions.types.js";
+import {
+  createDefaultOptions,
+  resolveAutoDiscoveredFiles,
+  buildSharedHandlerOptions,
+} from "./createHandlerOptions.shared.js";
 import { getCondition } from "./getCondition.js";
 
 /**
@@ -49,42 +48,6 @@ import { getCondition } from "./getCondition.js";
  * });
  * ```
  */
-
-function createDefaultOptions(): ResolvedDefaults {
-  return {
-    pageExportName: DEFAULT_CONFIG.PAGE_EXPORT_NAME,
-    propsExportName: DEFAULT_CONFIG.PROPS_EXPORT_NAME,
-    rootExportName: DEFAULT_CONFIG.ROOT_EXPORT_NAME,
-    htmlExportName: DEFAULT_CONFIG.HTML_EXPORT_NAME,
-    cssFiles: new Map(),
-    globalCss: new Map(),
-    manifest: {},
-    css: DEFAULT_CONFIG.CSS,
-  };
-}
-
-async function resolveAutoDiscoveredFiles(
-  options: CreateHandlerOptionsParams,
-  stashedOptions: any,
-  logger: Logger
-): Promise<AutoDiscoveredFiles> {
-  if (options.autoDiscoveredFiles) {
-    return options.autoDiscoveredFiles;
-  }
-
-  const result = await resolveAutoDiscover({
-    config: options.config || {},
-    configEnv: options.configEnv || { mode: "production", command: "build" },
-    userOptions: stashedOptions,
-    logger,
-  });
-
-  if (result.type === "error") {
-    throw result.error || new Error("Failed to resolve autoDiscover");
-  }
-
-  return result.autoDiscoveredFiles;
-}
 
 export async function createHandlerOptions(
   route: string,
@@ -319,80 +282,37 @@ export async function createHandlerOptions(
     }
   }
 
-  // Create client-specific handler options
+  // Create client-specific handler options. The shared fields are assembled by
+  // buildSharedHandlerOptions; only the client-specific tail lives here.
+  //
+  // File-path handling note: pagePath/rootPath/htmlPath are passed straight to
+  // the worker, which distinguishes undefined (built-in default) vs "" (headless
+  // / React.Fragment) vs a string path (resolve custom component).
   const handlerOptions: CreateHandlerOptions = {
     ...userOptions,
-    // File paths - these are passed directly to the worker for component resolution
-    // The worker handles the distinction between undefined vs "" for Root and Html:
-    // - undefined = use built-in default component
-    // - "" = explicitly disable (headless mode for Html, React.Fragment for Root)
-    // - string path = resolve custom component from specified path
-    // This approach maintains consistency between server and client paradigms
-    pagePath: routeFilesResult.page,
-    propsPath: routeFilesResult.props,
-    rootPath: routeFilesResult.root,
-    htmlPath: routeFilesResult.html,
+    ...buildSharedHandlerOptions({
+      route,
+      url,
+      id,
+      userOptions,
+      defaults,
+      routeFiles: routeFilesResult,
+      logger,
+      rscWorker,
+      htmlWorker,
+    }),
 
-    // Export names
-    pageExportName: userOptions.pageExportName,
-    propsExportName: userOptions.propsExportName,
-    rootExportName: userOptions.rootExportName,
-    htmlExportName: userOptions.htmlExportName,
-
-    // Route and loader
-    route,
-    loader: defaults.loader || (() => Promise.resolve({})),
-
-    // Configuration
-    panicThreshold: userOptions.panicThreshold,
-    verbose: userOptions.verbose,
-    moduleBaseURL: userOptions.moduleBaseURL,
-    build: userOptions.build,
-    dev: {
-      useHtmlWorker: userOptions.dev.useHtmlWorker,
-      useRscWorker: userOptions.dev.useRscWorker,
-    },
-    logger,
-
-    // Required properties
-    normalizer: userOptions.normalizer,
-    onEvent: userOptions.onEvent,
-    onMetrics: userOptions.onMetrics,
-    autoDiscover: userOptions.autoDiscover,
-    css: userOptions.css,
-    projectRoot: userOptions.projectRoot,
-    moduleBase: userOptions.moduleBase,
-    moduleBasePath: userOptions.moduleBasePath,
-    moduleRootPath: userOptions.moduleRootPath,
-    moduleID: userOptions.moduleID,
-    url,
-    manifest: defaults.manifest,
-    cssFiles: defaults.cssFiles,
-    globalCss: defaults.globalCss,
-
-    // Timeouts and paths
-    rscTimeout: userOptions.rscTimeout,
-    htmlTimeout: userOptions.htmlTimeout,
-    fileWriteTimeout: userOptions.fileWriteTimeout,
-    workerShutdownTimeout: userOptions.workerShutdownTimeout,
-    rscWorkerPath: userOptions.rscWorkerPath,
-    htmlWorkerPath: userOptions.htmlWorkerPath,
-    publicOrigin: userOptions.publicOrigin,
-
-    // Stream options
-    serverPipeableStreamOptions: userOptions.serverPipeableStreamOptions,
+    // Stream options: client passes the value through as-is (no `|| {}`)
     clientPipeableStreamOptions: userOptions.clientPipeableStreamOptions,
 
-    // Client-specific
-    id,
-    // Client needs component placeholders since it can't load server modules directly
+    // Client needs component placeholders since it can't load server modules
     HtmlComponent: undefined,
     PageComponent: undefined,
     RootComponent: undefined,
-    // Workers for client environment - provide both for specific use cases
-    worker: condition === "react-server" ? rscWorker : htmlWorker, // Backward compatibility: prefer HTML worker if available
-    rscWorker,
-    htmlWorker,
+
+    // Backward compatibility: prefer the condition-appropriate worker
+    worker: condition === "react-server" ? rscWorker : htmlWorker,
+
     // Children provided directly via options
     children,
   };

--- a/plugin/config/createHandlerOptions.server.ts
+++ b/plugin/config/createHandlerOptions.server.ts
@@ -1,8 +1,6 @@
-import type { CreateHandlerOptions, AutoDiscoveredFiles, RootComponentType, HtmlComponentType } from "../types.js";
-import type { Logger } from "vite";
+import type { CreateHandlerOptions, RootComponentType, HtmlComponentType } from "../types.js";
 import { getRouteFiles } from "../helpers/getRouteFiles.js";
 import { routeToURL } from "../utils/routeToURL.js";
-import { resolveAutoDiscover } from "./autoDiscover/resolveAutoDiscover.js";
 import {
   getStashedUserOptions,
   getStashedHandlerOptions,
@@ -12,8 +10,12 @@ import {
 
 import { getNodeEnv } from "./getNodeEnv.js";
 import { createLogger } from "vite";
-import { DEFAULT_CONFIG } from "./defaults.js";
-import type { CreateHandlerOptionsParams, ResolvedDefaults } from "./createHandlerOptions.types.js";
+import type { CreateHandlerOptionsParams } from "./createHandlerOptions.types.js";
+import {
+  createDefaultOptions,
+  resolveAutoDiscoveredFiles,
+  buildSharedHandlerOptions,
+} from "./createHandlerOptions.shared.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
 import { serializedOptions } from "../helpers/serializeUserOptions.js";
 import { createWorker } from "../worker/createWorker.js";
@@ -42,42 +44,6 @@ import { createWorker } from "../worker/createWorker.js";
  * });
  * ```
  */
-
-function createDefaultOptions(): ResolvedDefaults {
-  return {
-    pageExportName: DEFAULT_CONFIG.PAGE_EXPORT_NAME,
-    propsExportName: DEFAULT_CONFIG.PROPS_EXPORT_NAME,
-    rootExportName: DEFAULT_CONFIG.ROOT_EXPORT_NAME,
-    htmlExportName: DEFAULT_CONFIG.HTML_EXPORT_NAME,
-    cssFiles: new Map(),
-    globalCss: new Map(),
-    manifest: {},
-    css: DEFAULT_CONFIG.CSS,
-  };
-}
-
-async function resolveAutoDiscoveredFiles(
-  options: CreateHandlerOptionsParams,
-  stashedOptions: any,
-  logger: Logger
-): Promise<AutoDiscoveredFiles> {
-  if (options.autoDiscoveredFiles) {
-    return options.autoDiscoveredFiles;
-  }
-
-  const result = await resolveAutoDiscover({
-    config: options.config || {},
-    configEnv: options.configEnv || { mode: "production", command: "build" },
-    userOptions: stashedOptions,
-    logger,
-  });
-
-  if (result.type === "error") {
-    throw result.error || new Error("Failed to resolve autoDiscover");
-  }
-
-  return result.autoDiscoveredFiles;
-}
 
 export async function createHandlerOptions(
   route: string,
@@ -399,76 +365,33 @@ export async function createHandlerOptions(
     }
   }
 
-  // Create server-specific handler options
+  // Create server-specific handler options. The shared fields are assembled by
+  // buildSharedHandlerOptions; only the server-specific tail lives here.
   const handlerOptions: CreateHandlerOptions = {
     ...userOptions,
-    // File paths
-    pagePath: routeFilesResult.page,
-    propsPath: routeFilesResult.props,
-    rootPath: routeFilesResult.root,
-    htmlPath: routeFilesResult.html,
-    
-    // Export names
-    pageExportName: userOptions.pageExportName,
-    propsExportName: userOptions.propsExportName,
-    rootExportName: userOptions.rootExportName,
-    htmlExportName: userOptions.htmlExportName,
-    
-    // Route and loader
-    route,
-    loader: defaults.loader || (() => Promise.resolve({})),
-    
-    // Configuration
-    panicThreshold: userOptions.panicThreshold,
-    verbose: userOptions.verbose,
-    moduleBaseURL: userOptions.moduleBaseURL,
-    build: userOptions.build,
-    dev: {
-      useHtmlWorker: userOptions.dev.useHtmlWorker,
-      useRscWorker: userOptions.dev.useRscWorker,
-    },
-    logger,
-    
-    // Required properties
-    normalizer: userOptions.normalizer,
-    onEvent: userOptions.onEvent,
-    onMetrics: userOptions.onMetrics,
-    autoDiscover: userOptions.autoDiscover,
-    css: userOptions.css,
-    projectRoot: userOptions.projectRoot,
-    moduleBase: userOptions.moduleBase,
-    moduleBasePath: userOptions.moduleBasePath,
-    moduleRootPath: userOptions.moduleRootPath,
-    moduleID: userOptions.moduleID,
-    url,
-    manifest: defaults.manifest,
-    cssFiles: defaults.cssFiles,
-    globalCss: defaults.globalCss,
-    
-    // Timeouts and paths
-    rscTimeout: userOptions.rscTimeout,
-    htmlTimeout: userOptions.htmlTimeout,
-    fileWriteTimeout: userOptions.fileWriteTimeout,
-    workerShutdownTimeout: userOptions.workerShutdownTimeout,
-    rscWorkerPath: userOptions.rscWorkerPath,
-    htmlWorkerPath: userOptions.htmlWorkerPath,
-    publicOrigin: userOptions.publicOrigin,
-    
-    // Stream options
-    serverPipeableStreamOptions: userOptions.serverPipeableStreamOptions,
+    ...buildSharedHandlerOptions({
+      route,
+      url,
+      id,
+      userOptions,
+      defaults,
+      routeFiles: routeFilesResult,
+      logger,
+      rscWorker,
+      htmlWorker,
+    }),
+
+    // Stream options: server coerces an undefined value to {}
     clientPipeableStreamOptions: userOptions.clientPipeableStreamOptions || {},
     components: userOptions.components,
-    
-    // Server-specific
-    id,
-    // Always use the inverse worker for the main "worker" field
+
+    // Always use the inverse (HTML) worker for the main "worker" field
     worker: htmlWorker,
-    rscWorker,
-    htmlWorker,
+
     // Loaded components (server loads them at configuration time)
     PageComponent,
-    RootComponent, 
-    HtmlComponent
+    RootComponent,
+    HtmlComponent,
   };
 
   // Cache and return

--- a/plugin/config/createHandlerOptions.shared.ts
+++ b/plugin/config/createHandlerOptions.shared.ts
@@ -1,0 +1,149 @@
+/**
+ * createHandlerOptions.shared.ts
+ *
+ * Logic shared verbatim by createHandlerOptions.server.ts and .client.ts.
+ *
+ * Scope note: this intentionally covers only the parts that are byte-identical
+ * across the two variants AND guarded by test/unit/createHandlerOptions.test.ts
+ * — the default options, the auto-discovery resolution, and the assembly of the
+ * fields that are the same in both. The worker-creation blocks and the
+ * variant-specific tail (components vs placeholders, clientPipeableStreamOptions
+ * coercion, worker selection, children) deliberately stay in each variant; the
+ * characterization test runs with workers disabled, so unifying the worker
+ * blocks needs its own coverage first.
+ */
+import type { Logger, ConfigEnv, ResolvedConfig } from "vite";
+import type { AutoDiscoveredFiles, ResolvedUserOptions } from "../types.js";
+import { resolveAutoDiscover } from "./autoDiscover/resolveAutoDiscover.js";
+import { DEFAULT_CONFIG } from "./defaults.js";
+import type {
+  CreateHandlerOptionsParams,
+  ResolvedDefaults,
+} from "./createHandlerOptions.types.js";
+
+export function createDefaultOptions(): ResolvedDefaults {
+  return {
+    pageExportName: DEFAULT_CONFIG.PAGE_EXPORT_NAME,
+    propsExportName: DEFAULT_CONFIG.PROPS_EXPORT_NAME,
+    rootExportName: DEFAULT_CONFIG.ROOT_EXPORT_NAME,
+    htmlExportName: DEFAULT_CONFIG.HTML_EXPORT_NAME,
+    cssFiles: new Map(),
+    globalCss: new Map(),
+    manifest: {},
+    css: DEFAULT_CONFIG.CSS,
+  };
+}
+
+export async function resolveAutoDiscoveredFiles(
+  options: CreateHandlerOptionsParams,
+  stashedOptions: any,
+  logger: Logger
+): Promise<AutoDiscoveredFiles> {
+  if (options.autoDiscoveredFiles) {
+    return options.autoDiscoveredFiles;
+  }
+
+  const result = await resolveAutoDiscover({
+    config: (options.config as ResolvedConfig) || ({} as ResolvedConfig),
+    configEnv:
+      (options.configEnv as ConfigEnv) ||
+      ({ mode: "production", command: "build" } as ConfigEnv),
+    userOptions: stashedOptions,
+    logger,
+  });
+
+  if (result.type === "error") {
+    throw result.error || new Error("Failed to resolve autoDiscover");
+  }
+
+  return result.autoDiscoveredFiles;
+}
+
+export interface SharedHandlerOptionsInput {
+  route: string;
+  url: string;
+  id: string;
+  userOptions: ResolvedUserOptions;
+  defaults: ResolvedDefaults;
+  routeFiles: {
+    page: string;
+    props?: string | undefined;
+    root?: string | undefined;
+    html?: string | undefined;
+  };
+  logger: Logger;
+  rscWorker: any;
+  htmlWorker: any;
+}
+
+/**
+ * The handler-options fields that are identical in both variants. Each variant
+ * spreads `...userOptions`, then this, then its own divergent tail
+ * (components/placeholders, clientPipeableStreamOptions, worker, children).
+ */
+export function buildSharedHandlerOptions(input: SharedHandlerOptionsInput) {
+  const { route, url, id, userOptions, defaults, routeFiles, logger, rscWorker, htmlWorker } =
+    input;
+
+  return {
+    // File paths
+    pagePath: routeFiles.page,
+    propsPath: routeFiles.props,
+    rootPath: routeFiles.root,
+    htmlPath: routeFiles.html,
+
+    // Export names
+    pageExportName: userOptions.pageExportName,
+    propsExportName: userOptions.propsExportName,
+    rootExportName: userOptions.rootExportName,
+    htmlExportName: userOptions.htmlExportName,
+
+    // Route and loader
+    route,
+    loader: defaults.loader || (() => Promise.resolve({})),
+
+    // Configuration
+    panicThreshold: userOptions.panicThreshold,
+    verbose: userOptions.verbose,
+    moduleBaseURL: userOptions.moduleBaseURL,
+    build: userOptions.build,
+    dev: {
+      useHtmlWorker: userOptions.dev.useHtmlWorker,
+      useRscWorker: userOptions.dev.useRscWorker,
+    },
+    logger,
+
+    // Required properties
+    normalizer: userOptions.normalizer,
+    onEvent: userOptions.onEvent,
+    onMetrics: userOptions.onMetrics,
+    autoDiscover: userOptions.autoDiscover,
+    css: userOptions.css,
+    projectRoot: userOptions.projectRoot,
+    moduleBase: userOptions.moduleBase,
+    moduleBasePath: userOptions.moduleBasePath,
+    moduleRootPath: userOptions.moduleRootPath,
+    moduleID: userOptions.moduleID,
+    url,
+    manifest: defaults.manifest,
+    cssFiles: defaults.cssFiles,
+    globalCss: defaults.globalCss,
+
+    // Timeouts and paths
+    rscTimeout: userOptions.rscTimeout,
+    htmlTimeout: userOptions.htmlTimeout,
+    fileWriteTimeout: userOptions.fileWriteTimeout,
+    workerShutdownTimeout: userOptions.workerShutdownTimeout,
+    rscWorkerPath: userOptions.rscWorkerPath,
+    htmlWorkerPath: userOptions.htmlWorkerPath,
+    publicOrigin: userOptions.publicOrigin,
+
+    // Stream options (server-side; clientPipeableStreamOptions is variant-specific)
+    serverPipeableStreamOptions: userOptions.serverPipeableStreamOptions,
+
+    // Identity + workers (the `worker` field selection is variant-specific)
+    id,
+    rscWorker,
+    htmlWorker,
+  };
+}

--- a/test/unit/collectStreamContent.test.ts
+++ b/test/unit/collectStreamContent.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Characterization tests for collectRscContent / collectHtmlContent.
+ *
+ * These two helpers are ~95% identical and are slated to be consolidated into a
+ * single `collectStreamContent` helper. They are part of the public
+ * `./react-static` subpath but have no internal callers and (until now) no
+ * tests, so this file pins their CURRENT observable behavior first.
+ *
+ * Two quirks this locks in (both worth fixing during consolidation, not
+ * preserving blindly):
+ *  - The returned `pipe` wrapper is single-use; real reuse is via
+ *    `bufferedContent` (the "can be piped multiple times" comment is wishful).
+ *  - Completion is TIMEOUT-bound, not stream-bound: the internal `consumer`
+ *    PassThrough is never drained, so the `"end"` event never fires and each
+ *    call resolves only when its timeout elapses (rscTimeout for RSC, a
+ *    hard-coded 15s for HTML). The metrics are still captured correctly because
+ *    the Transform counts chunks as they flow. Tests therefore use a short
+ *    rscTimeout; the single HTML test pays the fixed 15s once on purpose.
+ *
+ * If the consolidation changes any of these expectations, that is a deliberate
+ * decision to make in review — not a silent regression.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { PassThrough, Writable } from "node:stream";
+import { createLogger } from "vite";
+import { collectRscContent } from "../../plugin/react-static/collectRscContent.js";
+import { collectHtmlContent } from "../../plugin/react-static/collectHtmlContent.js";
+
+type Source = PassThrough & { abort: ReturnType<typeof vi.fn> };
+
+/** A pre-filled source stream that also satisfies the `.abort()` contract. */
+function makeSource(chunks: Buffer[], { end = true } = {}): Source {
+  const pt = new PassThrough() as Source;
+  // No-arg destroy avoids emitting an "error" event with a truthy reason.
+  pt.abort = vi.fn((reason?: unknown) => pt.destroy(reason as Error));
+  for (const c of chunks) pt.write(c);
+  if (end) pt.end();
+  return pt;
+}
+
+const baseOptions = (over: Record<string, unknown> = {}) =>
+  ({
+    verbose: false,
+    logger: createLogger("silent"),
+    route: "/",
+    rscTimeout: 200,
+    ...over,
+  }) as any;
+
+/** Drain a wrapper's `pipe()` into a single Buffer. */
+async function drain(wrapper: {
+  pipe: (dest: Writable) => Writable;
+}): Promise<Buffer> {
+  const out: Buffer[] = [];
+  const sink = new Writable({
+    write(chunk, _enc, cb) {
+      out.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+  await new Promise<void>((resolve, reject) => {
+    sink.on("finish", resolve);
+    sink.on("error", reject);
+    wrapper.pipe(sink);
+  });
+  return Buffer.concat(out);
+}
+
+describe("collectRscContent", () => {
+  const chunks = [Buffer.from("hello "), Buffer.from("rsc "), Buffer.from("world")];
+  const expected = Buffer.concat(chunks);
+
+  it("tracks chunk and byte metrics for the consumed stream", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(result.metrics.chunks).toBe(chunks.length);
+    expect(result.metrics.bytes).toBe(expected.length);
+    expect(typeof result.metrics.duration).toBe("number");
+    expect(result.metrics.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("exposes the full content as bufferedContent (the reuse mechanism)", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(Array.isArray(result.bufferedContent)).toBe(true);
+    expect(Buffer.concat(result.bufferedContent!)).toEqual(expected);
+  });
+
+  it("pipes the collected content through once", async () => {
+    const result = await collectRscContent(makeSource(chunks), baseOptions());
+    expect(await drain(result)).toEqual(expected);
+  });
+
+  it("resolves via rscTimeout when the source never ends", async () => {
+    const result = await collectRscContent(
+      makeSource([Buffer.from("partial")], { end: false }),
+      baseOptions({ rscTimeout: 50 })
+    );
+    // Timed out rather than hung; the one delivered chunk is still buffered.
+    expect(result.metrics.bytes).toBe("partial".length);
+  });
+
+  it("propagates abort to the source stream", async () => {
+    const source = makeSource(chunks);
+    const result = await collectRscContent(source, baseOptions());
+    result.abort();
+    expect(source.abort).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("collectHtmlContent", () => {
+  // One test pays the hard-coded 15s completion timeout once and asserts the
+  // full contract (metrics + single pipe + abort propagation) together.
+  it("collects metrics, pipes content once, and propagates abort", async () => {
+    const chunks = [Buffer.from("<html>"), Buffer.from("<body/>"), Buffer.from("</html>")];
+    const expected = Buffer.concat(chunks);
+    const source = makeSource(chunks);
+
+    const result = await collectHtmlContent(source, baseOptions());
+
+    expect(result.metrics.chunks).toBe(chunks.length);
+    expect(result.metrics.bytes).toBe(expected.length);
+    expect(await drain(result)).toEqual(expected);
+
+    result.abort();
+    expect(source.abort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/createHandlerOptions.test.ts
+++ b/test/unit/createHandlerOptions.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Characterization tests for createHandlerOptions.server / .client.
+ *
+ * The two variants are ~90% identical and are slated to be consolidated behind
+ * a shared `.shared.ts`. They have already drifted in a few places, and the
+ * point of this file is to pin EXACTLY where their resolved-options output
+ * differs for identical input, so the consolidation can preserve (or
+ * deliberately change) each difference rather than regress it silently.
+ *
+ * Runs under the react-server condition only (test/unit/** is gated to it).
+ * Workers are disabled and components are pre-supplied so neither variant
+ * spawns a thread or performs a dynamic import — this stays a pure unit test.
+ *
+ * Findings this locks in (some correct earlier assumptions, some not):
+ *  - clientPipeableStreamOptions: server coerces undefined -> {} ("|| {}"),
+ *    client passes undefined through. REAL divergence.
+ *  - Components: server loads PageComponent/RootComponent/HtmlComponent eagerly;
+ *    client sets all three to undefined (placeholders). REAL divergence.
+ *  - `components` field: BOTH carry it (via the `...userOptions` spread), so the
+ *    "client drops components" assumption is FALSE — they match.
+ *  - `children`: client threads it through; server omits it.
+ *  - Shared scalar fields (route/url/paths/timeouts/build/dev) match.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { createLogger } from "vite";
+import { resolveOptions } from "vite-plugin-react-server/config";
+import { testUserOptions } from "../test-config.js";
+import { createHandlerOptions as createServerHandlerOptions } from "../../plugin/config/createHandlerOptions.server.js";
+import { createHandlerOptions as createClientHandlerOptions } from "../../plugin/config/createHandlerOptions.client.js";
+
+const PageStub = () => null;
+const RootStub = () => null;
+const HtmlStub = () => null;
+const CHILDREN = { marker: "children-passthrough" };
+
+function emptyAutoDiscoveredFiles(): any {
+  return {
+    clientInputs: {},
+    serverInputs: {},
+    staticManifest: {},
+    staticInputs: {},
+    workerPaths: {},
+    serverEntry: null,
+    clientEntry: {},
+    serverActions: {},
+    propsMap: new Map(),
+    pageMap: new Map(),
+    rootMap: new Map(),
+    htmlMap: new Map(),
+    routeMap: new Map(),
+    urlMap: new Map(),
+    errors: [],
+  };
+}
+
+let server: any;
+let client: any;
+
+beforeAll(async () => {
+  const userOptions: any = resolveOptions(testUserOptions).userOptions!;
+
+  // Pre-supply components so the server variant skips component loading, and
+  // force undefined stream options so the "|| {}" divergence is observable.
+  userOptions.components = { Page: PageStub, Root: RootStub, Html: HtmlStub };
+  userOptions.clientPipeableStreamOptions = undefined;
+
+  // Disable every worker path so neither variant spawns a thread. Under the
+  // react-server condition + build mode, build.useHtmlWorker would default true.
+  userOptions.dev = { ...userOptions.dev, useRscWorker: false, useHtmlWorker: false };
+  userOptions.build = { ...userOptions.build, useRscWorker: false, useHtmlWorker: false };
+
+  // Seed the route resolution so getRouteFiles takes the cache fast-path and
+  // returns a headless ("") root/html without touching the filesystem.
+  const autoDiscoveredFiles = emptyAutoDiscoveredFiles();
+  autoDiscoveredFiles.urlMap.set("/", {
+    page: "src/page/page.tsx",
+    props: undefined,
+    root: "",
+    html: "",
+  });
+
+  const common = {
+    userOptions,
+    autoDiscoveredFiles,
+    configEnv: { mode: "production", command: "build" } as const,
+    mode: "production",
+    logger: createLogger("silent"),
+  };
+
+  server = await createServerHandlerOptions("/", { ...common, id: "char-server" });
+  client = await createClientHandlerOptions("/", {
+    ...common,
+    id: "char-client",
+    children: CHILDREN,
+  });
+});
+
+describe("createHandlerOptions: shared output (must survive consolidation)", () => {
+  it("resolves the same route, url and file paths", () => {
+    expect(server.route).toBe("/");
+    expect(client.route).toBe(server.route);
+    expect(client.url).toBe(server.url);
+    expect(client.pagePath).toBe(server.pagePath);
+    expect(client.rootPath).toBe(server.rootPath);
+    expect(client.htmlPath).toBe(server.htmlPath);
+  });
+
+  it("resolves the same timeouts and build/dev config", () => {
+    expect(client.rscTimeout).toBe(server.rscTimeout);
+    expect(client.htmlTimeout).toBe(server.htmlTimeout);
+    expect(client.build).toEqual(server.build);
+    expect(client.dev).toEqual(server.dev);
+  });
+
+  it("carries the components map on BOTH variants (via the spread)", () => {
+    // Corrects the assumption that the client variant drops `components`.
+    expect(server.components).toBe(client.components);
+    expect(server.components).toEqual({ Page: PageStub, Root: RootStub, Html: HtmlStub });
+  });
+
+  it("creates no workers when all worker flags are disabled", () => {
+    expect(server.worker).toBeUndefined();
+    expect(server.rscWorker).toBeUndefined();
+    expect(server.htmlWorker).toBeUndefined();
+    expect(client.worker).toBeUndefined();
+    expect(client.rscWorker).toBeUndefined();
+    expect(client.htmlWorker).toBeUndefined();
+  });
+});
+
+describe("createHandlerOptions: documented divergences", () => {
+  it("coerces undefined clientPipeableStreamOptions to {} on server, passes through on client", () => {
+    expect(server.clientPipeableStreamOptions).toEqual({});
+    expect(client.clientPipeableStreamOptions).toBeUndefined();
+  });
+
+  it("loads components eagerly on server, leaves placeholders on client", () => {
+    expect(server.PageComponent).toBe(PageStub);
+    expect(server.RootComponent).toBe(RootStub);
+    expect(server.HtmlComponent).toBe(HtmlStub);
+
+    expect(client.PageComponent).toBeUndefined();
+    expect(client.RootComponent).toBeUndefined();
+    expect(client.HtmlComponent).toBeUndefined();
+  });
+
+  it("threads `children` through on client only", () => {
+    expect(client.children).toBe(CHILDREN);
+    expect(server.children).toBeUndefined();
+  });
+});


### PR DESCRIPTION
> Stacked on #142 (the characterization tests). Merge #142 first; GitHub will retarget this to `main` automatically.

## What

`createHandlerOptions.server.ts` and `.client.ts` shared ~90% of their bodies. This extracts the overlap that is **both byte-identical and guarded by `test/unit/createHandlerOptions.test.ts`** into a new `createHandlerOptions.shared.ts`:
- `createDefaultOptions()`
- `resolveAutoDiscoveredFiles()`
- `buildSharedHandlerOptions()` — the ~40 identical fields of the resolved options object.

Each variant now spreads the shared assembler and keeps only its divergent tail. Net: the two variants drop ~270 lines of duplication for one ~150-line shared module.

## Deliberately left per-variant (not yet covered)

- **The worker-creation blocks.** The characterization test runs with workers disabled, so these are uncovered. Unifying them needs its own coverage first — tracked as follow-up.
- **The divergent tail**, which the test pins and a shared impl must preserve: server coerces `clientPipeableStreamOptions` `undefined → {}` and loads components eagerly; client passes the value through, uses placeholders, and threads `children`; the `worker` field selection differs by condition.

## Behavior preserved

Pure refactor. The characterization test passes **unchanged**.

## Testing
- `npm run build:types` — clean
- `npm run test:server` — 89 files, 622 passed / 3 skipped
- `npm run test:client` — 47 files, 180 passed / 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)