### PR TITLE
refactor(worker,dev-server): collapse duplicated dispatch in handlers + HMR restart

### DIFF
--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -102,29 +102,17 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
       // Define restart function for HMR (needs serializedUserOptions)
       if (!restartWorkerForHMR) {
         restartWorkerForHMR = async () => {
-          if (currentWorker) {
-            currentWorker = await restartWorker({
-              server,
-              autoDiscoveredFiles,
-              userOptions: serializedUserOptions,
-              configEnv: configEnv,
-              hmrChannel,
-            });
-            if (currentWorker && restartWorkerForHMR) {
-              onWorkerCreated?.(currentWorker, restartWorkerForHMR);
-            }
-          } else {
-            // Worker doesn't exist yet, create it
-            currentWorker = await restartWorker({
-              server,
-              autoDiscoveredFiles,
-              userOptions: serializedUserOptions,
-              configEnv: configEnv,
-              hmrChannel,
-            });
-            if (currentWorker && restartWorkerForHMR) {
-              onWorkerCreated?.(currentWorker, restartWorkerForHMR);
-            }
+          // Same path whether or not a worker already exists — restartWorker
+          // tears down any current worker before spawning the replacement.
+          currentWorker = await restartWorker({
+            server,
+            autoDiscoveredFiles,
+            userOptions: serializedUserOptions,
+            configEnv: configEnv,
+            hmrChannel,
+          });
+          if (currentWorker && restartWorkerForHMR) {
+            onWorkerCreated?.(currentWorker, restartWorkerForHMR);
           }
         };
       }

--- a/plugin/dev-server/restartWorker.client.ts
+++ b/plugin/dev-server/restartWorker.client.ts
@@ -2,7 +2,7 @@ import { createWorker } from "../worker/createWorker.js";
 import { cleanupWorker } from "../helpers/workerCleanup.js";
 import { serializedDevServerConfig } from "../helpers/serializeUserOptions.js";
 import { MessageChannel, type Worker } from "node:worker_threads";
-import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
 import { React } from "../vendor/vendor.client.js";
 import type { RestartWorkerFn } from "../react-client/types.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
@@ -142,12 +142,7 @@ export const restartWorker: RestartWorkerFn = async function _restartWorker({
       reverseCondition: "react-server",
       currentCondition: "react-client",
       maxListeners: maxListeners,
-      envPrefix:
-        typeof server.config.envPrefix === "string"
-          ? server.config.envPrefix
-          : Array.isArray(server.config.envPrefix)
-          ? server.config.envPrefix[0]
-          : DEFAULT_CONFIG.ENV_PREFIX,
+      envPrefix: envPrefixFromConfig(server.config),
       workerData: {
         userOptions: userOptions,
         resolvedConfig: serializedDevServerConfig(server.config),

--- a/plugin/worker/rsc/handlers.ts
+++ b/plugin/worker/rsc/handlers.ts
@@ -12,51 +12,36 @@ import type { MessagePort } from "node:worker_threads";
 export function createHandlers(fromWorker?: MessagePort, toWorker?: MessagePort): ServerStreamHandlers {
   // Create writable stream for fromWorker if available
   const messagePortWritable = fromWorker ? new MessagePortWritable(fromWorker, toWorker) : null;
+  // In two-port mode control messages go back through toWorker; otherwise they
+  // go through the single-port sendMessage channel.
+  const post = (payload: Parameters<typeof sendMessage>[0]) => {
+    if (toWorker) {
+      toWorker.postMessage(payload);
+    } else {
+      sendMessage(payload);
+    }
+  };
   return {
     onRscRender: (id) => {
-      if (toWorker) {
-        toWorker.postMessage({
-          type: "RSC_RENDER_START",
-          id: id,
-        });
-      } else {
-        sendMessage({
-          type: "RSC_RENDER_START",
-          id: id,
-        });
-      }
+      post({
+        type: "RSC_RENDER_START",
+        id: id,
+      });
     },
     onError: (id, error, errorInfo) => {
-      if (toWorker) {
-        toWorker.postMessage({
-          type: "ERROR",
-          id: id,
-          errorInfo: serializeErrorInfo(errorInfo),
-          error: serializeError(error),
-        });
-      } else {
-        sendMessage({
-          type: "ERROR",
-          id: id,
-          errorInfo: serializeErrorInfo(errorInfo),
-          error: serializeError(error),
-        });
-      }
+      post({
+        type: "ERROR",
+        id: id,
+        errorInfo: serializeErrorInfo(errorInfo),
+        error: serializeError(error),
+      });
     },
     onShellError: (id, error) => {
-      if (toWorker) {
-        toWorker.postMessage({
-          type: "SHELL_ERROR",
-          id: id,
-          error: serializeError(error),
-        });
-      } else {
-        sendMessage({
-          type: "SHELL_ERROR",
-          id: id,
-          error: serializeError(error),
-        });
-      }
+      post({
+        type: "SHELL_ERROR",
+        id: id,
+        error: serializeError(error),
+      });
     },
     onData: (id, data) => {
       // In two-port mode, data goes through the writable stream
@@ -82,35 +67,20 @@ export function createHandlers(fromWorker?: MessagePort, toWorker?: MessagePort)
         }
       }
       
-      if (toWorker) {
-        toWorker.postMessage({
-          type: "RSC_END",
-          id: id,
-        });
-      } else {
-        sendMessage({
-          type: "RSC_END",
-          id: id,
-        });
-      }
+      post({
+        type: "RSC_END",
+        id: id,
+      });
     },
     onMetrics: (id, metrics) => {
       if (metrics.type === "html" || metrics.type === "worker-startup" || metrics.type === "module-resolution") {
         return;
       }
-      if (toWorker) {
-        toWorker.postMessage({
-          type: "RSC_METRICS",
-          id: id,
-          metrics: metrics as any,
-        });
-      } else {
-        sendMessage({
-          type: "RSC_METRICS",
-          id: id,
-          metrics: metrics as any,
-        });
-      }
+      post({
+        type: "RSC_METRICS",
+        id: id,
+        metrics: metrics as any,
+      });
     },
     // Expose the writable stream for direct piping in two-port mode
     ...(messagePortWritable && { getWritable: () => messagePortWritable }),


### PR DESCRIPTION
## What

Behavior-preserving cleanups from the green-batch backlog, each already guarded by existing tests. Two of the three planned items; the third (`emitFileWriteMetrics` extraction across `renderPages`/`renderPagesBatched`) is deferred — it's a larger lift left on the tracking issue.

- **`worker/rsc/handlers.ts`** — hoist one `post()` for the repeated `toWorker ? toWorker.postMessage(p) : sendMessage(p)` branch (`onRscRender`, `onError`, `onShellError`, `onEnd`, `onMetrics`). Payloads are unchanged. Guarded by `test/unit/handleWorkerRscStream.test.ts`.
- **`dev-server/restartWorker.client.ts`** — replace the inline `envPrefix` ternary with the existing `envPrefixFromConfig(server.config)` (byte-identical; `restartWorker.server.ts` already uses it).
- **`dev-server/configureRequestHandler.client.ts`** — collapse the byte-identical `if/else` in `restartWorkerForHMR`; both branches called `restartWorker` with the same args, and `restartWorker` already tears down any current worker before spawning. Guarded by `test/dev/hmr.test.ts`.

Net −47 lines.

## Testing
- `npm run build:types` — clean
- `npm run test:server` — 87 files, 609 passed / 3 skipped
- `npm run test:client` — 47 files, 180 passed / 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)