### PR TITLE
fix(utils): make /utils resolve the same under both conditions

### DIFF
--- a/docs-site/src/client.tsx
+++ b/docs-site/src/client.tsx
@@ -15,10 +15,7 @@
 import { use, useEffect, useState, useTransition, Suspense } from "react";
 import type { ReactNode } from "react";
 import { createRoot } from "react-dom/client";
-// `/utils/rsc-client` is the condition-stable browser entry (createReactFetcher,
-// callServer). Importing from `/utils` would resolve to the server variant under
-// the docs-site's `--conditions react-server` build, which omits these.
-import { createReactFetcher } from "vite-plugin-react-server/utils/rsc-client";
+import { createReactFetcher } from "vite-plugin-react-server/utils";
 
 const BASE = import.meta.env.BASE_URL || "/";
 

--- a/plugin/utils/createCallServer.ts
+++ b/plugin/utils/createCallServer.ts
@@ -1,11 +1,13 @@
-import {
-  createFromFetch,
-  encodeReply,
-} from "react-server-dom-esm/client.browser";
-
+// The browser flight client is imported lazily, at call time, so this module is
+// import-safe under the `react-server` condition (importing it statically would
+// pull react-dom/client into the server graph). callServer only ever runs in the
+// browser, where the dynamic import resolves from the module cache.
 
 export const createCallServer = (moduleBaseURL: string) => {
   const callServer = async (id: string, args: unknown[]) => {
+    const { createFromFetch, encodeReply } = await import(
+      "react-server-dom-esm/client.browser"
+    );
     const response = await createFromFetch(
       fetch(moduleBaseURL, {
         method: "POST",

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -1,5 +1,4 @@
 import type React from "react";
-import { createFromFetch } from "react-server-dom-esm/client.browser";
 import { createCallServer } from "./createCallServer.js";
 import { env } from "./env.js";
 import { createPageURL } from "./urls.js";
@@ -34,15 +33,21 @@ export function createReactFetcher({
     publicOrigin,
     env.DEV
   )(url, indexRSC);
-  const content = createFromFetch(
-    fetch(parsedURL.indexRSC, {
-      headers: headers,
-      signal,
-    }),
-    {
-      callServer: createCallServer(parsedURL.moduleBaseURL),
-      moduleBaseURL: parsedURL.moduleBaseURL,
-    }
+  // Start the flight fetch immediately, but pull in the browser flight client
+  // lazily so this module is import-safe under the `react-server` condition (a
+  // static import of client.browser would drag react-dom/client into the server
+  // graph). In the browser, where this runs, the dynamic import resolves from
+  // the module cache.
+  const responsePromise = fetch(parsedURL.indexRSC, {
+    headers: headers,
+    signal,
+  });
+  const content = import("react-server-dom-esm/client.browser").then(
+    ({ createFromFetch }) =>
+      createFromFetch(responsePromise, {
+        callServer: createCallServer(parsedURL.moduleBaseURL),
+        moduleBaseURL: parsedURL.moduleBaseURL,
+      })
   );
   if (!signal) {
     return content;

--- a/plugin/utils/index.server.ts
+++ b/plugin/utils/index.server.ts
@@ -1,6 +1,13 @@
-// Server barrel: excludes browser-only modules that import from
-// react-server-dom-esm/client.browser or use React hooks:
-//   - createReactFetcher, useRscHmr, createCallServer, callServer
+// Server barrel: now mirrors the default/browser barrel. The browser-facing
+// helpers (createReactFetcher, callServer, createCallServer) defer their
+// `react-server-dom-esm/client.browser` import to call time, so they are
+// import-safe under the `react-server` condition — `vite-plugin-react-server/utils`
+// resolves to the same surface in both conditions. The helpers still only *run*
+// in the browser; importing them here never evaluates the browser flight client.
+export * from "./createReactFetcher.js";
+export * from "./useRscHmr.js";
+export * from "./callServer.js";
 export * from "./urls.js";
 export * from "./env.js";
+export * from "./createCallServer.js";
 export * from "./routeToURL.js";

--- a/plugin/utils/index.ts
+++ b/plugin/utils/index.ts
@@ -1,13 +1,12 @@
-// Default barrel: same as client (includes all utils)
-// Under react-server condition, package.json exports map to index.server.js
-// which excludes browser-only modules.
+// Default barrel — includes every util, and index.server.ts now exposes the
+// same surface, so `vite-plugin-react-server/utils` resolves identically under
+// either condition. The browser-facing helpers (createReactFetcher, callServer,
+// createCallServer) load `react-server-dom-esm/client.browser` lazily at call
+// time, which keeps this barrel import-safe under `react-server`; they still
+// only run in the browser.
 //
-// Note: the RSC-client helpers (createReactFetcher, useRscHmr, callServer,
-// createCallServer) hard-import react-server-dom-esm/client.browser, which
-// is declared as an optional peer. Consumers who only need the pure helpers
-// (urls, env, routeToURL) can import them from `./rsc-client` instead — see
-// the `./utils/rsc-client` subpath — to keep their bundle graph clear of
-// the peer.
+// The `./utils/rsc-client` subpath re-exports just the RSC-client helpers
+// (createReactFetcher, callServer) for browser apps that want them in isolation.
 export * from "./createReactFetcher.js";
 export * from "./useRscHmr.js";
 export * from "./callServer.js";

--- a/test/unit/utils-export-parity.test.ts
+++ b/test/unit/utils-export-parity.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression: a public subpath that is meant to expose the SAME API under both
+ * the `react-server` and the browser/default condition must not silently drop
+ * (or gain) exports in one of them.
+ *
+ * This is the class of bug that hid `createReactFetcher` (and callServer /
+ * createCallServer) from `vite-plugin-react-server/utils` under the
+ * `react-server` condition: the two condition targets had different export
+ * surfaces, so a client module importing from `/utils` built fine in one
+ * environment and failed in the other.
+ *
+ * NOTE: not every condition-split export belongs here. Many (`.`, the plugin,
+ * react-static, the dev-server entries) are genuinely different server/client
+ * implementations — and some client variants aren't even importable outside a
+ * browser. Only list a subpath in SYMMETRIC_SUBPATHS once it's confirmed to be
+ * a same-API-different-impl export, where divergent *names* are a real bug.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const pkg = JSON.parse(
+  readFileSync(resolve(root, "package.json"), "utf-8")
+) as { exports: Record<string, any> };
+
+// Public subpaths whose export-name surface must match across conditions.
+const SYMMETRIC_SUBPATHS = ["./utils"];
+
+const runtimeNames = (mod: Record<string, unknown>): string[] =>
+  Object.keys(mod)
+    .filter((name) => name !== "default")
+    .sort();
+
+const importTarget = (relTarget: string) =>
+  import(pathToFileURL(resolve(root, relTarget)).href) as Promise<
+    Record<string, unknown>
+  >;
+
+describe("export-surface parity across conditions", () => {
+  for (const sub of SYMMETRIC_SUBPATHS) {
+    it(`${sub} exposes the same names under react-server and browser/default`, async () => {
+      const entry = pkg.exports[sub];
+      const serverTarget: string | undefined = entry?.["react-server"];
+      const browserTarget: string | undefined = entry?.browser ?? entry?.default;
+      expect(serverTarget, `${sub} has a react-server target`).toBeTruthy();
+      expect(browserTarget, `${sub} has a browser/default target`).toBeTruthy();
+
+      const [server, browser] = await Promise.all([
+        importTarget(serverTarget!),
+        importTarget(browserTarget!),
+      ]);
+
+      // Different impls are fine; different export NAMES break a consumer that
+      // imports the subpath under the other condition.
+      expect(runtimeNames(server)).toEqual(runtimeNames(browser));
+    });
+  }
+
+  it("/utils exposes the RSC-client helpers under the react-server condition", async () => {
+    const serverTarget: string = pkg.exports["./utils"]["react-server"];
+    const mod = await importTarget(serverTarget);
+    for (const name of [
+      "createReactFetcher",
+      "callServer",
+      "createCallServer",
+      "useRscHmr",
+    ]) {
+      expect(mod, `${name} missing from /utils under react-server`).toHaveProperty(
+        name
+      );
+    }
+  });
+});


### PR DESCRIPTION
## The bug

`vite-plugin-react-server/utils` resolved to a **different surface depending on build condition**. Under `--conditions react-server` it maps to `index.server.js`, whose barrel deliberately omitted `createReactFetcher` / `callServer` / `createCallServer` — they statically imported `react-server-dom-esm/client.browser`, which would pull `react-dom/client` into the server graph and crash it.

Consequence: a **client** module importing `createReactFetcher` from `/utils` failed to build under a react-server main-thread build (which the docs-site does), forcing the `/utils/rsc-client` workaround. The tool didn't behave the same in both environments.

## The fix

Defer the browser flight-client import to **call time** in `createReactFetcher` and `createCallServer` (dynamic `import("react-server-dom-esm/client.browser")`), making those modules import-safe under any condition. `index.server.ts` now mirrors the default barrel, so `/utils` exposes the **same surface in both conditions**.

- The helpers still only *run* in the browser; the dynamic chunk never evaluates server-side and resolves from the module cache in the browser.
- `createReactFetcher` still starts its `fetch()` synchronously — only the flight-client import is lazy.
- Tradeoff worth noting: the flight client (`client.browser`) becomes a lazily-loaded chunk in the client build rather than inlined into the entry. It's needed at mount so it loads immediately and is cached; real-world impact is negligible, but flagging it.

Also corrected the misleading `./rsc-client` comment in `index.ts`, and **reverted the docs-site client to import from `/utils`** — the acceptance proof that the workaround is no longer needed.

## Verified

- `npm run build:types` — clean (and `useRscHmr` in the server barrel links fine)
- `npm run build:docs-site` — all 28 pages render with the plain `/utils` import under `--conditions react-server`
- `npm run test:server` — 622 passed / 3 skipped
- `npm run test:client` — 180 passed / 4 skipped
- Headless (Playwright): client navigation still swaps route + content + active link with no full reload, code stays Shiki-highlighted, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)