### PR TITLE
feat(docs): sticky sidebar + open the docs-site links in a new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ pages to static HTML + RSC payloads and emits your components as portable ESM
 that runs under any HTTP server: static hosting, Express/Hono, or anything in
 between.
 
-📖 **[Documentation site →](https://nicobrinkkemper.github.io/vite-plugin-react-server/)**
+📖 **<a href="https://nicobrinkkemper.github.io/vite-plugin-react-server/" target="_blank" rel="noopener">Documentation site →</a>**
 — the full docs, and itself a vprs app (the site dogfoods the plugin).
 
 vprs is the low-level layer rather than a framework: it handles the RSC
@@ -157,7 +157,7 @@ It strips the vprs plugin from Storybook's builder, resolves the
 ## Documentation
 
 Everything below is also published as a browsable site at
-**[nicobrinkkemper.github.io/vite-plugin-react-server](https://nicobrinkkemper.github.io/vite-plugin-react-server/)**,
+**<a href="https://nicobrinkkemper.github.io/vite-plugin-react-server/" target="_blank" rel="noopener">nicobrinkkemper.github.io/vite-plugin-react-server</a>**,
 which is itself built with vprs.
 
 | Doc | What it covers |

--- a/docs-site/src/page/style.ts
+++ b/docs-site/src/page/style.ts
@@ -10,7 +10,7 @@ export const STYLE = `
 * { box-sizing: border-box; }
 body { margin: 0; color: var(--fg); font: 16px/1.65 system-ui, -apple-system, "Segoe UI", sans-serif; }
 .layout { display: flex; min-height: 100vh; }
-nav.sidebar { width: 240px; flex-shrink: 0; border-right: 1px solid var(--border); padding: 1.5rem 1rem; }
+nav.sidebar { width: 240px; flex-shrink: 0; border-right: 1px solid var(--border); padding: 1.5rem 1rem; position: sticky; top: 0; align-self: flex-start; max-height: 100vh; overflow-y: auto; }
 nav.sidebar .brand { font-weight: 700; display: block; margin-bottom: 1rem; color: var(--accent); text-decoration: none; }
 nav.sidebar a { display: block; padding: 0.3rem 0.5rem; border-radius: 6px; color: var(--fg); text-decoration: none; font-size: 0.92rem; }
 nav.sidebar a:hover { background: var(--code-bg); }
@@ -32,7 +32,9 @@ footer.docfoot { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(
 .nav-toggle, .nav-toggle-label { display: none; }
 @media (max-width: 760px) {
   .layout { flex-direction: column; }
-  nav.sidebar { width: auto; border-right: none; border-bottom: 1px solid var(--border); padding: 0.75rem 1rem; }
+  /* On mobile the sidebar is an in-flow top bar (not sticky) so the expanded
+     hamburger menu pushes content down instead of overlaying it. */
+  nav.sidebar { width: auto; border-right: none; border-bottom: 1px solid var(--border); padding: 0.75rem 1rem; position: static; align-self: auto; max-height: none; overflow-y: visible; }
   nav.sidebar .brand { display: inline-block; margin: 0; }
   .nav-toggle-label { display: inline-block; float: right; cursor: pointer; user-select: none; padding: 0.2rem 0.7rem; border: 1px solid var(--border); border-radius: 6px; font-size: 0.9rem; }
   .navlinks { display: none; clear: both; padding-top: 0.75rem; }


### PR DESCRIPTION
Two small docs improvements in one PR.

## Sticky sidebar
The docs sidebar now sticks on desktop (`position: sticky; top: 0`, with its own `overflow-y: auto` so a long nav scrolls independently) — it stays visible while you scroll a long doc. On mobile it stays an in-flow top bar (not sticky), so the expanded hamburger menu pushes content down instead of overlaying it.

Verified headless: at 1280px the sidebar computes `position: sticky` and stays at `top: 0` after scrolling 1500px; at 375px it computes `position: static`.

## README links open in a new tab
The README's two links to the live documentation site now use `target="_blank" rel="noopener"`, so following them opens a new tab instead of navigating away from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)