### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -38,8 +38,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -50,7 +50,7 @@ jobs:
       - run: npm run build:docs-site
         env:
           BASE_URL: /${{ github.event.repository.name }}/
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         if: github.event_name != 'pull_request'
         with:
           path: docs-site/dist/static
@@ -64,4 +64,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
Silences the CI warning: *"Node 20 is being deprecated. This workflow is running with Node 24 by default."*

Bumps the actions to their current majors (Node 24 runtimes), matching the `mmc` and `bidoof-template` demo workflows:

- `actions/checkout@v4 → v6`
- `actions/setup-node@v4 → v6`
- `actions/upload-pages-artifact@v3 → v5`
- `actions/deploy-pages@v4 → v5`

The build's own Node version is unchanged (`node-version-file: .nvmrc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)