### PR TITLE
feat(docs): dark mode (prefers-color-scheme) + sticky mobile top bar

### DIFF
--- a/docs-site/src/page/page.tsx
+++ b/docs-site/src/page/page.tsx
@@ -16,9 +16,10 @@ import { BASE, listDocs, loadMarkdown } from "./docs.js";
  * head content here would be re-hoisted on the client and duplicate the <head>.
  */
 
-// Shiki theme + the languages our docs actually use. github-light matches the
-// site's light palette.
-const SHIKI_THEME = "github-light";
+// Shiki themes (dual: light + dark) + the languages our docs actually use.
+// github-light/github-dark match the site's light and dark palettes; the active
+// one follows prefers-color-scheme via CSS variables (see style.ts).
+const SHIKI_THEMES = { light: "github-light", dark: "github-dark" } as const;
 const SHIKI_LANGS = [
   "typescript",
   "tsx",
@@ -36,7 +37,7 @@ const SHIKI_LANGS = [
 // One highlighter for the whole build. The top-level await loads grammars and
 // theme once, so codeToHast() is a sync call afterwards and Page stays sync.
 const highlighter: Highlighter = await createHighlighter({
-  themes: [SHIKI_THEME],
+  themes: [SHIKI_THEMES.light, SHIKI_THEMES.dark],
   langs: SHIKI_LANGS,
 });
 
@@ -69,7 +70,13 @@ function CodeBlock({ children }: { children?: React.ReactNode }) {
   const code = textOf(codeEl?.props?.children).replace(/\n$/, "");
   if (lang) {
     try {
-      const hast = highlighter.codeToHast(code, { lang, theme: SHIKI_THEME });
+      // defaultColor:false emits both themes' colors as --shiki-light/--shiki-dark
+      // CSS vars per token; style.ts selects per prefers-color-scheme.
+      const hast = highlighter.codeToHast(code, {
+        lang,
+        themes: SHIKI_THEMES,
+        defaultColor: false,
+      });
       return toJsxRuntime(hast, { Fragment, jsx, jsxs }) as React.ReactElement;
     } catch {
       // unloaded/unknown language — fall through to a plain block

--- a/docs-site/src/page/style.ts
+++ b/docs-site/src/page/style.ts
@@ -6,9 +6,13 @@
  * only swap #root).
  */
 export const STYLE = `
-:root { --fg: #1a1a1a; --muted: #6b7280; --accent: #646cff; --border: #e5e7eb; --code-bg: #f6f8fa; }
+:root { --fg: #1a1a1a; --muted: #6b7280; --accent: #646cff; --border: #e5e7eb; --code-bg: #f6f8fa; --bg: #ffffff; }
+/* Dark mode follows the browser/OS preference (prefers-color-scheme) — no toggle, no JS. */
+@media (prefers-color-scheme: dark) {
+  :root { --fg: #c9d1d9; --muted: #8b949e; --accent: #58a6ff; --border: #30363d; --code-bg: #161b22; --bg: #0d1117; }
+}
 * { box-sizing: border-box; }
-body { margin: 0; color: var(--fg); font: 16px/1.65 system-ui, -apple-system, "Segoe UI", sans-serif; }
+body { margin: 0; color: var(--fg); background: var(--bg); font: 16px/1.65 system-ui, -apple-system, "Segoe UI", sans-serif; }
 .layout { display: flex; min-height: 100vh; }
 nav.sidebar { width: 240px; flex-shrink: 0; border-right: 1px solid var(--border); padding: 1.5rem 1rem; position: sticky; top: 0; align-self: flex-start; max-height: 100vh; overflow-y: auto; }
 nav.sidebar .brand { font-weight: 700; display: block; margin-bottom: 1rem; color: var(--accent); text-decoration: none; }
@@ -20,8 +24,14 @@ main.doc { flex: 1; min-width: 0; max-width: 52rem; padding: 2rem 2.5rem 4rem; }
 main.doc h1, main.doc h2, main.doc h3 { line-height: 1.3; }
 main.doc h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.3rem; margin-top: 2.2rem; }
 main.doc pre { background: var(--code-bg); padding: 1rem; border-radius: 8px; overflow-x: auto; font-size: 0.88rem; }
-/* Shiki sets an inline (white) background per theme; keep the site's subtle code background instead. */
+/* Shiki dual-theme (defaultColor:false): each token carries --shiki-light and
+   --shiki-dark CSS vars; pick the set that matches the color scheme. The code
+   block keeps the site's subtle --code-bg (which is itself dark in dark mode). */
 main.doc pre.shiki { background: var(--code-bg) !important; }
+main.doc .shiki, main.doc .shiki span { color: var(--shiki-light); }
+@media (prefers-color-scheme: dark) {
+  main.doc .shiki, main.doc .shiki span { color: var(--shiki-dark); }
+}
 main.doc code { background: var(--code-bg); padding: 0.15em 0.35em; border-radius: 4px; font-size: 0.9em; }
 main.doc pre code { padding: 0; background: none; }
 main.doc table { border-collapse: collapse; width: 100%; }
@@ -32,9 +42,10 @@ footer.docfoot { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(
 .nav-toggle, .nav-toggle-label { display: none; }
 @media (max-width: 760px) {
   .layout { flex-direction: column; }
-  /* On mobile the sidebar is an in-flow top bar (not sticky) so the expanded
-     hamburger menu pushes content down instead of overlaying it. */
-  nav.sidebar { width: auto; border-right: none; border-bottom: 1px solid var(--border); padding: 0.75rem 1rem; position: static; align-self: auto; max-height: none; overflow-y: visible; }
+  /* On mobile the sidebar is a full-width top bar, sticky to the top of the
+     viewport (inherits position:sticky; top:0; from the base rule). align-self
+     resets to stretch so it spans the full width in the column layout. */
+  nav.sidebar { width: auto; border-right: none; border-bottom: 1px solid var(--border); padding: 0.75rem 1rem; align-self: stretch; }
   nav.sidebar .brand { display: inline-block; margin: 0; }
   .nav-toggle-label { display: inline-block; float: right; cursor: pointer; user-select: none; padding: 0.2rem 0.7rem; border: 1px solid var(--border); border-radius: 6px; font-size: 0.9rem; }
   .navlinks { display: none; clear: both; padding-top: 0.75rem; }


### PR DESCRIPTION
Follows up #156 with the rest of the docs-site polish.

## Dark mode — follows the browser default
The site now respects `prefers-color-scheme` — no toggle, no client JS. The `:root` color variables flip under a `@media (prefers-color-scheme: dark)` block, and Shiki now emits **dual-theme** tokens (`themes: { light: github-light, dark: github-dark }`, `defaultColor: false`), so each token carries `--shiki-light`/`--shiki-dark` CSS vars and code blocks recolor with the scheme. Code-block background uses the site's `--code-bg` (itself dark in dark mode).

## Sticky mobile top bar
The mobile sidebar is now sticky to the top of the viewport too (it was in-flow). Reconsidered the earlier "mobile stays static" call per the request.

## Verified (production build, base path)
- **0 hydration failures** over repeated loads (dual-theme Shiki renders identically on both streams; on top of the #155 hotfix the hydration stays clean).
- Emulated `prefers-color-scheme`: light → body `#fff`, dark → body `#0d1117`; a code token recolors `rgb(111,66,193)` → `rgb(179,146,240)`; code bg `#161b22` in dark.
- `position: sticky` on the sidebar at both 1280px (desktop) and 375px (mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)