### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Bumps `vite-plugin-react-server` **2.3.2 → 2.4.0** (minor — new public export).

## What's in this release (published-package changes since 2.3.2)
- **feat:** inline the initial flight payload into prerendered HTML — new export `react-static/inlineFlightPayload`, and `createReactFetcher` consumes an inlined payload before falling back to the network (#153). New public surface ⇒ minor.
- **fix:** `/utils` resolves to the same exports under both the `react-server` and `react-client` conditions, with a regression test (#152).

(The docs-site / `docs/` changes since 2.3.2 are not part of the npm package.)

## Pre-publish validation (per `docs/releasing.md`)
- **CI gate on main: green.**
- Built the package, packed a tarball, and installed it (real npm-consumer path) into both official demos:
  - **bidoof-template:** `build:preview` succeeds; hydration **clean over 12 loads, zero #418** under its real GH-Pages base path.
  - **mmc:** clean `npm ci` + `build` succeeds (**300 pages**); hydration **clean over 5 loads, zero #418**. (An earlier build failure was a perturbed `node_modules` in the validation sandbox — a clean install builds fine.)
- The at-risk hydration path (`createReactFetcher` + `use()`, the recent #418 fix) is validated clean against both consumers.
- Both demo repos left clean (`git status` unchanged).

## Remaining steps (human — after merge)
1. `npm publish` (requires 2FA).
2. Tag `v2.4.0` and `git push --tags`.
3. Bump the demo repos to `^2.4.0` (`bidoof-template`, `mmc`) per `docs/releasing.md` and confirm their deploy CI stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)