### PR TITLE
fix(utils): useRscHmr import-safe under react-server (2.4.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",

--- a/plugin/utils/useRscHmr.ts
+++ b/plugin/utils/useRscHmr.ts
@@ -1,4 +1,11 @@
-import { useEffect, useRef } from "react";
+// Namespace import (not `{ useEffect, useRef }`): this module is re-exported from
+// the react-server `/utils` barrel (index.server.ts), and a NAMED hook import is
+// not load-safe there. React's react-server build omits the client hooks, and on
+// the experimental train they aren't even cjs-module-lexer-detectable named
+// exports, so `import { useEffect } from "react"` throws at load under
+// `--conditions react-server`. The namespace import loads fine; the hooks are
+// only ever accessed when the hook actually runs (browser-only).
+import * as React from "react";
 import { RSC_HMR_EVENT } from "./createReactFetcher.js";
 import type { RscHmrData } from "./createReactFetcher.js";
 import { env } from "./env.js";
@@ -85,14 +92,14 @@ export function useRscHmr(
   // and since client-side RSC navigation re-renders the shell, an unmemoized
   // (inline) refetch callback would churn the listener (and re-log "Listening…")
   // on every navigation. The ref pattern makes inline callbacks safe.
-  const ref = useRef<{
+  const ref = React.useRef<{
     refetch: (url: string) => void;
     verbose: boolean;
     filter?: (data: RscHmrData) => boolean;
   }>({ refetch, verbose, filter });
   ref.current = { refetch, verbose, filter };
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (typeof import.meta.hot === 'undefined') return;
 
     const handler = (data: RscHmrData) => {


### PR DESCRIPTION
**Hotfix for 2.4.0 — it breaks the build for experimental-React consumers (e.g. mmc).**

## Cause
A regression from #152 (shipped in 2.4.0), found by `git bisect` (good `86cc636` 2.3.2 → bad main): #152 made `vite-plugin-react-server/utils` resolve the same surface under both conditions, so `index.server.ts` now re-exports `useRscHmr`. But `useRscHmr` did a **named** hook import — `import { useEffect, useRef } from "react"`. Under `--conditions react-server` that's not load-safe: React's react-server build omits the client hooks, and on the **experimental** train they aren't cjs-module-lexer-detectable named exports, so the import throws at module load (`Named export 'useEffect' not found … 'react' is a CommonJS module`), which cascades to `react/jsx-runtime not in cache` / "missing components" on every prerendered page.

It passed CI and the bidoof check because the **stable** react-server build *does* expose those as detectable (throw-on-call) named exports, so the import resolves there — only experimental consumers broke.

## Fix
Import React as a namespace (`import * as React from "react"`) and use `React.useRef` / `React.useEffect`. The namespace import loads under any condition; the hooks are only touched when the hook runs (browser-only).

## Verified
- **mmc** (experimental React): builds all **300 pages** and **hydrates clean** (0 #418 over 4 loads) with the patched plugin. (Was a hard build failure on 2.4.0.)
- **bidoof** (stable React): unaffected.

Bumps to **2.4.1**. After merge: `npm publish` (2FA), tag, then bump the demos to `^2.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)