### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Minor version bump for the new `createHtmlStreamWithInlineFlight` export added in #166 (additive, backward compatible).

The bump was pushed to the #166 branch after it had already been squash-merged, so it never reached main — main still read 2.4.1 despite carrying the new export. This lands it: `package.json` + lockfile self-version, no dependency churn.