### PR TITLE
docs(comparison): honest pass — fix contradictions, add the hand-built-basis upside

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -7,9 +7,13 @@ Vite-based ways to run React Server Components. The short version: vprs is a
 If you want a framework to make the decisions for you, Waku or Vike are likely
 the better fit; if you want the official low-level building block, that is
 `@vitejs/plugin-rsc`. vprs is the niche in between: a small RSC dev/build setup,
-like the official plugin in spirit, but with portable output you own. (The RSC
-transport underneath is supplied by `react-server-loader`, not a defining trait
-of vprs — see the table below.)
+like the official plugin in spirit, but with portable output you host yourself.
+What mostly defines vprs is what it withholds: it takes no opinion on how your
+React app is built, so the optimizations that fit your app are yours to add
+rather than a general-purpose set baked in for you (more on that under
+[What you get for wiring it yourself](#what-you-get-for-wiring-it-yourself)).
+The RSC transport underneath is supplied by `react-server-loader`; treat it as
+an implementation detail, not a knob you tune.
 
 ## At a glance
 
@@ -21,12 +25,15 @@ of vprs — see the table below.)
 | RSC transport | `react-server-dom-esm`, via `react-server-loader` | `react-server-dom-webpack`, vendored (BYO to pin a version) | managed by the framework | managed by the extension |
 | Build output | `static/` + `client/` + `server/` portable ESM | app bundle via multi-environment build | framework-managed | framework-managed |
 | Host anywhere (static / Express / Hono) | Yes, you wire the server | Yes | Via the framework's server | Via vike-server |
-| Node `--conditions react-server` | Optional (both modes work by design) | Used internally | Managed | Managed |
+| Node `--conditions react-server` | Optional; works either way (see [below](#the-react-server-condition-is-optional)) | Used internally | Managed | Managed |
 | Maturity (mid-2026) | 2.x | 0.5.x, official and actively developed | 1.0 beta | extension is early-stage |
 
-Versions move fast; check each project for current numbers. The rows above
-describe positioning, not a scorecard, and every tool here is a legitimate
-choice for the job it is built for.
+Versions move fast; check each project for current numbers. One caveat on that
+Maturity row: vprs's `2.x` is not a maturity claim over the official plugin's
+`0.5.x`. vprs is the younger project with the smaller community; the two version
+lines simply count different things. The rows above describe positioning, not a
+scorecard, and every tool here is a legitimate choice for the job it is built
+for.
 
 ## When each one fits
 
@@ -73,6 +80,43 @@ on the experimental train. See
 [React Compatibility](./react-type-compatibility.md) for the support matrix and
 how to pin the versions.
 
+## What you get for wiring it yourself
+
+The flip side of the "you provide the server" model is the actual reason to
+reach for vprs: because vprs has no opinion on how your app renders, you can fit
+the rendering strategy to each route instead of inheriting one general-purpose
+strategy from a framework.
+
+Concretely, the build prerenders your pages to static HTML with each route's RSC
+payload inlined into the page, so a static route hydrates in place on first
+paint with no extra round-trip for its data. A route whose content depends on
+per-request data can render its HTML per request instead. You decide per route;
+nothing forces a single model across the whole app.
+
+This is not a claim that vprs is faster out of the box. A framework that bakes a
+strategy in is doing real work you would otherwise do yourself, and for many
+apps that is the better deal. The honest trade is that a framework picks the
+optimization for you and vprs declines to, leaving both the ceiling and the
+assembly in your hands.
+
+## The `react-server` condition is optional
+
+vprs works the same whether or not you launch Node with
+`--conditions react-server`. A worker thread always mirrors whichever condition
+your main thread is not on, so the server-component half and the client half
+each get the context they need either way.
+
+Running your *main* thread under the condition is a choice, not a requirement,
+and the reasons to do it are developer experience rather than correctness: stack
+traces for your server components stay on the main thread where they are easier
+to read, and any plain Node script you run in that process gains React and RSC
+support, including your `vite.config`.
+
+It is also a footgun. The condition is process-global, so it changes module
+resolution for everything in that process, which is easy to forget you turned
+on. RSC is still early in the wider ecosystem, so we do not assume you want any
+of this. vprs allows it and leaves the call to you.
+
 ## What vprs deliberately does NOT do
 
 Being a plugin rather than a framework is the whole point, so a lot is out of
@@ -91,11 +135,12 @@ scope on purpose:
 - **No deployment/hosting layer.** The build emits ESM and a static directory;
   wiring them into a host (static CDN, Express, Hono, serverless) is up to you.
   See [Build Output](./build-output.md).
-- **No arbitrary React-channel brokering.** vprs binds to the vendored ESM
-  transport (`react-server-loader`), which ships a stable train and an
-  experimental train; you pick a train (see "React" above), not any React build
-  via a swapped bundler transport the way `@vitejs/plugin-rsc` does with
-  `react-server-dom-webpack`.
+- **Two React trains, not any React build.** vprs pins React through
+  `react-server-loader`, which ships a stable train and an experimental train;
+  you pick one (see "React" above). `@vitejs/plugin-rsc` instead lets you bring
+  any `react-server-dom-webpack` build you install, canary included. That is
+  genuinely more flexible. vprs trades it for a version-locked transport you do
+  not have to assemble or keep in sync yourself.
 
 It is also younger and has a smaller community than the official plugin or the
 established frameworks. If those matter more to you than the plugin-only,


### PR DESCRIPTION
A pass on `docs/comparison.md` driven by hunting the "wtf?" moments a skeptical reader hits.

## Fixes
1. **Maturity contradiction** — the table's `2.x` (vprs) vs `0.5.x` (official) read as "vprs is more mature," contradicting the closing prose. Added an explicit caveat that semver isn't maturity here; vprs is the younger, smaller project.
2. **React channel sold both ways** — the "no arbitrary React-channel brokering" bullet humblebragged about avoiding flexibility the table presents as the official plugin's advantage. Reframed as a plain trade (official is more flexible; vprs trades it for a version-locked transport).
3. **"react-server is optional" vs every example using it** — new section stating it straight: both modes work, the reason to flip it on is DX (main-thread stack traces; React in any node script incl. `vite.config`), and it's a process-global footgun. We don't assume you want it.
4. **Transport over-mention** — opening stops protesting "not a defining trait, see table"; it's named an implementation detail once.
5. **All cost, no ceiling** — new "What you get for wiring it yourself" section: no opinion on your app means optimizations are yours to fit per route. Deliberately not claiming vprs is "faster out of the box."