### PR TITLE
feat(build): inlineFlight option — flash-free first render in both build modes

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -676,6 +676,7 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
       (options.build?.pages && (Array.isArray(options.build.pages) || typeof options.build.pages === 'function')) ? true : DEFAULT_CONFIG.BUILD.useHtmlWorker,
     renderMode: options.build?.renderMode ?? "parallel",
     batchSize: options.build?.batchSize ?? 8,
+    inlineFlight: options.build?.inlineFlight ?? false,
   } satisfies ResolvedUserOptions["build"];
 
   // Development configuration

--- a/plugin/react-static/maybeInlineFlight.ts
+++ b/plugin/react-static/maybeInlineFlight.ts
@@ -1,0 +1,57 @@
+/**
+ * maybeInlineFlight.ts
+ *
+ * Shared post-SSG step invoked by BOTH static plugins (server-static and
+ * client-static) at the same point — right after the pages are written and
+ * before the `build.ssg.end` event. If `build.inlineFlight` is enabled it
+ * inlines each route's flight payload into its `index.html`.
+ *
+ * The whole reason this lives in the plugin (rather than a consumer's own
+ * `closeBundle`) is determinism across build modes: a consumer `closeBundle`
+ * sees finalized HTML in server-first builds but runs BEFORE the deferred write
+ * in client-first builds, so hand-rolled inlining silently worked in one mode
+ * and not the other. Running it here, from the same code path both plugins
+ * reach post-write, makes flash-free first render identical whether the build
+ * is client-first or server-first — honoring the "both modes work by design"
+ * contract. `inlineFlightPayload` is idempotent (htmlHasInlineFlight guard).
+ */
+import { resolve } from "node:path";
+import type { Logger } from "vite";
+import { inlineFlightPayload } from "./inlineFlightPayload.js";
+
+export interface MaybeInlineFlightOptions {
+  build: {
+    inlineFlight?: boolean;
+    outDir?: string;
+    static?: string;
+    htmlOutputPath?: string;
+    rscOutputPath?: string;
+  };
+  logger?: Logger;
+  verbose?: boolean;
+}
+
+/**
+ * Returns the number of pages inlined, or null when the option is disabled.
+ */
+export async function maybeInlineFlight(
+  options: MaybeInlineFlightOptions
+): Promise<number | null> {
+  if (!options.build?.inlineFlight) return null;
+
+  const staticDir = resolve(
+    options.build.outDir ?? "dist",
+    options.build.static ?? "static"
+  );
+
+  const count = await inlineFlightPayload({
+    staticDir,
+    htmlFileName: options.build.htmlOutputPath,
+    rscFileName: options.build.rscOutputPath,
+    logger: options.logger,
+    verbose: options.verbose,
+  });
+
+  options.logger?.info(`[vprs] inlined flight payload into ${count} page(s)`);
+  return count;
+}

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -46,6 +46,7 @@ import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
 import { createWorkerStartupMetrics } from "../metrics/createWorkerStartupMetrics.js";
 import { processCssFilesForPages } from "./processCssFilesForPages.js";
 import { createBuildLoader } from "./createBuildLoader.client.js";
+import { maybeInlineFlight } from "./maybeInlineFlight.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
 import { toError } from "../error/toError.js";
 import {
@@ -782,6 +783,16 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         if (userOptions.verbose) {
           logger?.info("[react-static-client] Static generation completed");
         }
+
+        // Flash-free first render: inline each route's flight payload if
+        // build.inlineFlight is enabled. The server-static plugin runs the
+        // SAME call at the same post-write point, so the outcome is identical
+        // in both build modes (runs before build.ssg.end so consumers see it).
+        await maybeInlineFlight({
+          build: userOptions.build,
+          logger,
+          verbose: userOptions.verbose,
+        });
 
         // Emit the static site generation completion event once
         if (typeof userOptions.onEvent === "function") {

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -44,6 +44,7 @@ import { baseURL } from "../utils/envUrls.node.js";
 import { handleError } from "../error/handleError.js";
 import { shouldCausePanic } from "../error/panicThresholdHandler.js";
 import { renderPage } from "./renderPage.server.js";
+import { maybeInlineFlight } from "./maybeInlineFlight.js";
 import { temporaryReferences } from "./temporaryReferences.server.js";
 import { configurePreviewServer } from "./configurePreviewServer.js";
 import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
@@ -536,6 +537,16 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         this.info(
           `Rendered ${finalResult.completedRoutes.size} pages in ${duration}ms`
         );
+
+        // Flash-free first render: inline each route's flight payload if
+        // build.inlineFlight is enabled. The client-static plugin runs the
+        // SAME call at the same post-write point, so the outcome is identical
+        // in both build modes (runs before build.ssg.end so consumers see it).
+        await maybeInlineFlight({
+          build: userOptions.build,
+          logger,
+          verbose: userOptions.verbose,
+        });
 
         // Emit the static site generation completion event once
         if (typeof userOptions.onEvent === "function") {

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1136,6 +1136,16 @@ export type BuildConfig = {
    * @default 8
    */
   batchSize?: number;
+  /**
+   * Inline each prerendered route's flight payload into its own `index.html`
+   * (a non-executable `<script id="vprs-flight">`), so the browser has the
+   * initial RSC payload at load and hydrates in place with no `index.rsc`
+   * round-trip or flash. The plugin runs this itself at the post-SSG point in
+   * BOTH build modes (client-first and server-first), so the outcome is
+   * identical regardless of `--conditions react-server`. Idempotent.
+   * @default false
+   */
+  inlineFlight?: boolean;
 };
 
 export type DevConfig = {

--- a/test/examples/inline-flight-build.test.ts
+++ b/test/examples/inline-flight-build.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { setupTestProject } from "../setup.js";
+import { getSharedBuild } from "./shared-build.js";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+// The documented inline-flight script id (see plugin/utils/inlineFlight.ts).
+const INLINE_FLIGHT_ID = "vprs-flight";
+
+/**
+ * build.inlineFlight, under BOTH module conditions.
+ *
+ * This file is run once per condition by `test:both` (plain vitest = client,
+ * NODE_OPTIONS='--conditions react-server' = server). The whole point of the
+ * option is that the plugin runs the inline step itself at the post-SSG point
+ * in EITHER mode, so the inlined <script id="vprs-flight"> must appear in every
+ * route's index.html regardless of which static plugin (client-static or
+ * server-static) did the rendering. A consumer's own closeBundle could not
+ * guarantee that — it ran before the deferred write in client-first builds.
+ */
+async function findIndexHtml(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  const walk = async (d: string) => {
+    let entries;
+    try {
+      entries = await readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = join(d, e.name);
+      if (e.isDirectory()) await walk(full);
+      else if (e.name === "index.html") out.push(full);
+    }
+  };
+  await walk(dir);
+  return out;
+}
+
+describe("build.inlineFlight (both conditions)", () => {
+  let staticDir: string;
+
+  beforeAll(async () => {
+    const result = await getSharedBuild("inline-flight", "inline-flight", {
+      setupProject: setupTestProject,
+      pages: ["/", "/page2"],
+      verbose: false,
+      // Fixed outDir so we can read the inlined HTML straight off disk (the
+      // inline step rewrites files post-write, so it's not in the build events).
+      build: { inlineFlight: true, outDir: "dist-inline-flight" },
+    });
+    staticDir = join(result.testDir, "dist-inline-flight", "static");
+  });
+
+  it("inlines the flight payload into every prerendered index.html", async () => {
+    // The SSG page writes flush asynchronously after the build promise resolves
+    // (the harness drains them in afterAll); a real `vite build` waits for the
+    // process to settle, which is why this is reliable in production. Poll until
+    // every prerendered index.html carries the inline-flight script, then assert.
+    const deadline = Date.now() + 15_000;
+    let files: string[] = [];
+    let allInlined = false;
+    while (Date.now() < deadline) {
+      files = await findIndexHtml(staticDir);
+      if (files.length > 0) {
+        const contents = await Promise.all(files.map((f) => readFile(f, "utf-8")));
+        allInlined = contents.every((c) => c.includes(`id="${INLINE_FLIGHT_ID}"`));
+        if (allInlined) break;
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(files.length, "expected at least one prerendered index.html").toBeGreaterThan(0);
+    expect(
+      allInlined,
+      `every prerendered index.html under ${staticDir} should carry the inline-flight <script id="${INLINE_FLIGHT_ID}">`
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`vite build --app` loads exactly **one** static plugin depending on the process condition (the package main export is condition-resolved, and each static plugin asserts its condition at module load): `server-static` under `--conditions react-server`, `client-static` without it. The two write each route's `index.html` at **different lifecycle points** — `server-static` eagerly in `writeBundle`, `client-static` in the deferred generation that runs *after* every `closeBundle`.

So a consumer that inlined the flight payload from its own `closeBundle` (to get flash-free first render) saw finalized HTML in **server-first** builds but ran **before** the deferred write in **client-first** builds — silently producing a non-flash-free build in one mode. This broke the documented "both modes work by design" invariant. (The rendered `#root` markup is byte-identical between modes; only the post-write seam differed.)

## Fix

Add an opt-in `build.inlineFlight` and run the inline step **inside the plugin**, from a shared helper (`maybeInlineFlight`) invoked by **both** static plugins at the same post-write point (just before `build.ssg.end`). The outcome is now identical regardless of `--conditions react-server`. Default `false`, so existing builds are unchanged. `inlineFlightPayload` is idempotent.

This also removes the hand-rolled `closeBundle` inline plugin that consumers (e.g. the docs site) had each copied — the footgun is gone.

## Verification

- A real `vite build --app` of a 300-page consumer inlines **300/300 in both** client-first and server-first.
- New `test/examples/inline-flight-build.test.ts` asserts every prerendered `index.html` carries `<script id="vprs-flight">`, and passes under **both** conditions (`test:both`).
- Build-path regression suite (`build`, `build-cross-env`, `inline-flight`) green in both conditions: 14/14 each.

## Usage

```ts
vitePluginReactServer({ /* ... */, build: { inlineFlight: true } })
```