### PR TITLE
chore(release): 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Release cut for the unreleased delta on `main` since 2.5.0.

Minor bump (additive, opt-in feature):
- **feat(build): `inlineFlight` option** — flash-free first render in both build modes (#169)
- docs(comparison): honest pass (#168)

`bump-version.mjs` updated `package.json` + `package-lock.json` to **2.6.0**. Merge, then `npm publish` when ready (`prepublishOnly` runs the build).