### PR TITLE
fix: correct root package entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "2.6.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
-  "main": "./dist/plugin/index.js",
-  "module": "./dist/plugin/index.js",
-  "types": "./dist/plugin/index.d.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
     "plugin",
@@ -18,6 +18,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "react-server": "./dist/plugin/index.server.js",
       "default": "./dist/plugin/index.client.js"
     },
@@ -310,6 +311,7 @@
     "build": "npm run clean && npm run build:types && npm run build:vite",
     "build:types": "tsc --build --force",
     "build:vite": "vite build",
+    "test:package": "node scripts/verify-package-entrypoints.mjs",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build",
     "lint": "eslint ./plugin --fix",

--- a/scripts/verify-package-entrypoints.mjs
+++ b/scripts/verify-package-entrypoints.mjs
@@ -1,0 +1,60 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import pkg from "../package.json" with { type: "json" };
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const directFields = ["main", "module", "types"];
+
+const targets = [];
+for (const field of directFields) {
+  if (typeof pkg[field] === "string") {
+    targets.push([field, pkg[field]]);
+  }
+}
+
+function collectExports(value, label) {
+  if (typeof value === "string") {
+    targets.push([label, value]);
+    return;
+  }
+  if (!value || typeof value !== "object") {
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    collectExports(child, `${label}.${key}`);
+  }
+}
+
+collectExports(pkg.exports, "exports");
+
+const packed = JSON.parse(
+  execFileSync("npm", ["pack", "--dry-run", "--ignore-scripts", "--json", "."], {
+    cwd: root,
+    encoding: "utf8",
+  }),
+)[0];
+const packedFiles = new Set(packed.files.map((file) => file.path));
+
+const missing = [];
+for (const [label, target] of targets) {
+  if (target.includes("*") || target.startsWith("#")) {
+    continue;
+  }
+  const relative = target.replace(/^\.\//, "");
+  const path = join(root, relative);
+  if (!existsSync(path)) {
+    missing.push(`${label}: ${target} is missing from the build output`);
+    continue;
+  }
+  if (!packedFiles.has(relative)) {
+    missing.push(`${label}: ${target} is not included by npm pack`);
+  }
+}
+
+if (missing.length > 0) {
+  throw new Error(`Package entrypoint verification failed:\n${missing.join("\n")}`);
+}
+
+console.log(`Verified ${targets.length} package entrypoint targets.`);


### PR DESCRIPTION
## What & why

The published `vite-plugin-react-server@2.6.0` package points its legacy root package entry fields at files that are not emitted or packed:

- `main`: `./dist/plugin/index.js`
- `module`: `./dist/plugin/index.js`
- `types`: `./dist/plugin/index.d.ts`

The npm tarball instead includes the neutral root entry at `dist/index.js` and `dist/index.d.ts`, plus the conditional root exports at `dist/plugin/index.client.js` and `dist/plugin/index.server.js`.

This PR points `main`, `module`, and `types` at the emitted root files and adds a `types` condition to the root export. It also adds a small package-entry verification script so future builds fail if package metadata points at files missing from the build output or packed tarball.

Fixes #

## Validation

- Reproduced the published package issue with `vite-plugin-react-server@2.6.0`: `main`, `module`, and `types` all pointed to missing files in the npm tarball.
- Watched the new `npm run test:package` check fail before the manifest fix with missing `./dist/plugin/index.js` and `./dist/plugin/index.d.ts`.
- `npm run build`
- `npm run test:package`
- `npm pack --dry-run --ignore-scripts --json .` and verified `dist/index.js`, `dist/index.d.ts`, `dist/plugin/index.client.js`, and `dist/plugin/index.server.js` are packed.
- Installed the packed tarball into a temporary TypeScript consumer project and verified `import { vitePluginReactServer } from "vite-plugin-react-server"` compiles with `moduleResolution: "NodeNext"`.
- `git diff --check`

I also tried `npm run test:unit`; it currently fails in `test/unit/createReactFetcher.test.ts` because `react-server-dom-esm/client.browser` is not resolvable in the local install. That appears unrelated to this manifest-only change, and the package-entry/build/consumer checks above cover the changed surface.

## Checklist

- [ ] `npm test` is green (both client and server environments)
- [x] `npm run build` is clean
- [ ] Docs updated if behaviour or public API changed
- [x] PR is focused on a single change
