### PR TITLE
chore(release): 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release to ship the root-entrypoint fix from #172.

## Why
`vite-plugin-react-server@2.6.0` shipped `main`/`module` → `dist/plugin/index.js` and `types` → `dist/plugin/index.d.ts`, **none of which are in the npm tarball**. #172 corrects them to the emitted `dist/index.*` and adds a `types` condition to the root export. Since 2.6.0 can't be republished, this bumps to **2.6.1** so the fix actually reaches consumers.

## Contents
- `package.json` / `package-lock.json`: 2.6.0 → 2.6.1 (via `npm run version:patch`). No other changes.

## Verified on this branch
- `npm run build` clean
- `npm run test:package` passes (109 entrypoint targets)
- `npm pack --dry-run` includes `dist/index.js`, `dist/index.d.ts`, `dist/plugin/index.{client,server}.js`
- full `npm test` (both envs) green on the same tree

## Note
`prepublishOnly` still only runs `npm run build`, so the new `test:package` guard from #172 won't run automatically on publish. Optional follow-up: set `prepublishOnly` to `npm run build && npm run test:package` so a broken manifest can't ship again.