### PR TITLE
docs: document the reference gate (RSC production-safety)

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -117,6 +117,23 @@ resolution for everything in that process, which is easy to forget you turned
 on. RSC is still early in the wider ecosystem, so we do not assume you want any
 of this. vprs allows it and leaves the call to you.
 
+## Is the ESM transport safe in production?
+
+A fair question, because `react-server-dom-esm` is published with a warning that
+it is for internal testing, not production. That warning is about the transport
+in isolation. On its own it resolves a client-supplied reference id by importing
+the path the id encodes, guarded only by a prefix check. It has no manifest of
+which references are real, which is the trust boundary the webpack-family
+transports get from their bundler plugin.
+
+vprs supplies that boundary in the layer above the transport. References resolve
+through a sealed gate built from the build's own manifest: an exact lookup that
+binds each id to a real built module and throws on anything the build did not
+emit, so a crafted id cannot import an arbitrary path. A static build has no
+server runtime, so it has no callable surface at all. See
+[Server Actions → Security](./server-actions.md#security) for the action
+endpoint specifics and the app-level responsibilities that remain yours.
+
 ## What vprs deliberately does NOT do
 
 Being a plugin rather than a framework is the whole point, so a lot is out of

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -115,6 +115,33 @@ node --conditions react-server dist/server/index.js
 
 Server actions work in both the client environment's `rsc-worker` and the server environment's main thread. See [Build Output](./build-output.md) and [Examples](./examples.md) for server setup details.
 
+## Security
+
+A server action is a callable endpoint. The client POSTs a reference id of the
+form `<base><path>#<export>` and the server runs the matching function. vprs
+resolves that id through a sealed reference gate, rather than importing a path
+derived from the id.
+
+- The gate is built from the build's own manifest. An id maps to a real built
+  module by exact lookup, and the importer is bound to that module, never to
+  anything parsed out of the incoming id. An id the build never emitted does not
+  resolve, so `../` path traversal is structurally impossible, and an export that
+  was not registered as a server reference is rejected.
+- In production the gate is sealed: an unknown id throws, with no on-demand
+  import fallback. Development keeps an open fallback for iteration speed; that is
+  not a trust boundary and is not meant to face untrusted clients.
+- A static (no-server) build has no runtime to POST to, so it has no server
+  action surface at all.
+
+The gate decides *which* functions are reachable, not *what* arguments they
+accept. Inside each action you still own the rest:
+
+- Validate and authorize every argument. Treat all of them as untrusted input.
+- Do not close over secrets in an action you hand to a client component. The ESM
+  transport serializes a reference for that function and does not encrypt the
+  values it captures, so treat anything an exposed action closes over as visible
+  to the client. Pass an id and look the value up on the server instead.
+
 ## Limitations
 
 - Server actions don't support CSS collection or custom prop functions


### PR DESCRIPTION
vprs's production trust boundary for resolving server/client references — the **sealed reference gate** — is implemented and wired (`react-server-loader/references`, used in `plugin/worker/rsc/state.server.ts`) but was **undocumented**. So the well-known "`react-server-dom-esm` is not for production" warning had nothing in the docs to answer it.

## Changes
- **`docs/server-actions.md`** — new **Security** section: how an action id resolves through the sealed gate (build-manifest exact lookup, importer bound to a real built module, no client-derived import so `../` traversal is structurally impossible, unregistered export rejected), sealed-in-prod vs open-in-dev, static builds have no callable surface, plus the app-level duties that remain (validate/authorize every argument; don't close over secrets in client-facing actions, since the ESM transport serializes a reference and does not encrypt captured values).
- **`docs/comparison.md`** — new "Is the ESM transport safe in production?" section that meets the concern head-on: the warning is about the transport in isolation (prefix-check, no reference manifest); vprs supplies the missing trust boundary in the layer above.

## Accuracy
- Gate verified present and wired against current source before writing.
- No encryption-key guidance, because vprs surfaces no encryption key — the doc says so plainly rather than implying a protection that isn't there.