### PR TITLE
feat(security): seal server actions by default (auto-load build manifest)

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -126,17 +126,15 @@ the path the id encodes, guarded only by a prefix check. It has no manifest of
 which references are real, which is the trust boundary the webpack-family
 transports get from their bundler plugin.
 
-The other transports get that boundary from their bundler plugin, automatically.
-vprs is lower-level: it does not yet ship an automatic sealed resolver, so on a
-server-backed deploy **you** supply the boundary in the server you run. The
-pieces are there for it: the build emits a server manifest (the allowlist of real
-server modules) and exposes a reference-gate primitive
-(`vite-plugin-react-server/references`), and the rule is to resolve an incoming id
-against that manifest and reject anything not in it rather than importing the
-id's path. A static build has no server runtime, so it has no callable surface at
-all. See [Server Actions → Security](./server-actions.md#security) for the recipe
-and the responsibilities that remain yours; wiring this in by default is in
-progress.
+The other transports get that boundary from their bundler plugin. vprs supplies
+it through `handleServerAction`, which seals automatically: in production it reads
+the build's server manifest and resolves actions through a sealed allowlist
+(lookup-or-throw, importer bound to the manifest's real file), so an id the build
+never emitted is rejected — no extra wiring on your part. In development it falls
+back to the open dev resolver, which is not a trust boundary. A static build has
+no server runtime, so it has no callable surface at all. See
+[Server Actions → Security](./server-actions.md#security) for the details and the
+responsibilities that remain yours.
 
 ## What vprs deliberately does NOT do
 

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -144,20 +144,25 @@ await handleServerAction(req, res, { projectRoot, serverRoot, base });
 `build.outDir`. You can also pass `serverManifest` directly to override (e.g. a
 manifest you already hold). The manifest lookup is cached, so it reads disk once.
 
-If no manifest is found (development, or an unbuilt tree), the handler falls back
-to the open dev resolver (project-root resolution with a traversal guard, then
-on-demand `import`). That path is **not** a trust boundary — the Vite dev wrapper
-forces it, and it never auto-seals against a possibly stale built manifest. The
-underlying primitive is exported as `vite-plugin-react-server/references`
+It **fails closed**: if no manifest can be found and you are not in the dev path,
+the handler refuses the request rather than falling back to unsealed resolution.
+A missing manifest is a misconfiguration (wrong `serverRoot`, or an unbuilt tree),
+and silently reopening the boundary would defeat the point. If you hit this in
+production, point `serverRoot` at your build's server dir (or pass `serverManifest`).
+The underlying primitive is exported as `vite-plugin-react-server/references`
 (`createSealedServerReferenceGate`) if you wire your own handler.
+
+The only unsealed path is development: the Vite dev wrapper sets `devOpen`, which
+resolves actions on demand against live source (project-root resolution with a
+traversal guard, no build manifest exists yet). That is **not** a trust boundary —
+it is reachable only via the dev wrapper, never from a missing manifest in prod.
 
 Two more notes:
 
 - A static (no-server) build has no runtime to POST to, so it has no server
   action surface at all.
-- In development vprs resolves actions on demand (it imports the path the id
-  encodes) for iteration speed. That is **not** a trust boundary; keep the dev
-  server off untrusted networks.
+- Keep the dev server off untrusted networks (its on-demand resolver is not a
+  trust boundary).
 
 Whatever resolves the id, these stay yours per action:
 

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -119,31 +119,37 @@ Server actions work in both the client environment's `rsc-worker` and the server
 
 A server action is a callable endpoint. The client POSTs a reference id of the
 form `<base><path>#<export>` and the server runs the matching function. That id
-is attacker-controllable, so resolving it is a trust boundary, and **on a
-server-backed deploy that boundary is the server you run**. vprs renders through
-the ESM transport, which on its own resolves a reference by the path the id
-encodes with only a prefix check, no allowlist. There is no automatic sealed
-resolver yet, so do not assume one.
+is attacker-controllable, so resolving it is a trust boundary. vprs renders
+through the ESM transport, which on its own resolves a reference by the path the
+id encodes with only a prefix check, no allowlist, so the boundary has to be
+enforced one level up.
 
-The rule for your handler is simple: **resolve the incoming id against the
-build's server manifest and reject anything not in it. Never `import()` a path
-derived from the id.** The build writes that manifest
-(`<serverRoot>/.vite/manifest.json`); its keys are the real server modules, which
-is exactly the allowlist you want.
+**`handleServerAction` seals automatically — you do not pass anything extra.** In
+production it reads the build's server manifest from
+`<serverRoot>/.vite/manifest.json` and resolves the id through a sealed allowlist:
+an id the build never emitted is rejected before any import, and the importer is
+bound to the manifest's real file, never to a path derived from the id.
 
 ```ts
-// Safe resolution sketch (the official demo, bidoof-template, has a full one)
-const [key, exportName] = id.split("#");
-const stripped = key.startsWith(base) ? key.slice(base.length) : key;
-const file = serverSrcToFile.get(stripped);            // manifest lookup
-if (!file) throw new Error("action not in manifest");  // reject unknown ids
-const mod = await import(join(serverRoot, file));       // import the manifest's file, not the id
+import { handleServerAction } from "vite-plugin-react-server/helpers";
+
+// Default build layout (dist/server): nothing else needed — this is sealed.
+await handleServerAction(req, res, { projectRoot });
+
+// Custom build output? Point it at the server dir; still no manifest to load.
+await handleServerAction(req, res, { projectRoot, serverRoot, base });
 ```
 
-vprs ships the pieces for this: the server manifest above, and a reference-gate
-primitive (`vite-plugin-react-server/references`, `createSealedServerReferenceGate`)
-that wraps the lookup-or-throw. A built-in sealed resolver that wires this for you
-is in progress; until it lands, add the manifest check yourself.
+`serverRoot` defaults to `<projectRoot>/dist/server`; pass it only if you changed
+`build.outDir`. You can also pass `serverManifest` directly to override (e.g. a
+manifest you already hold). The manifest lookup is cached, so it reads disk once.
+
+If no manifest is found (development, or an unbuilt tree), the handler falls back
+to the open dev resolver (project-root resolution with a traversal guard, then
+on-demand `import`). That path is **not** a trust boundary — the Vite dev wrapper
+forces it, and it never auto-seals against a possibly stale built manifest. The
+underlying primitive is exported as `vite-plugin-react-server/references`
+(`createSealedServerReferenceGate`) if you wire your own handler.
 
 Two more notes:
 

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -34,8 +34,9 @@ const manifestByRoot = new Map<string, ServerManifest | null>();
  *  1. an explicit `serverManifest` option (with its serverRoot), else
  *  2. auto-load `<serverRoot>/.vite/manifest.json` (serverRoot defaults to
  *     `<projectRoot>/dist/server`) — so production seals with no extra args.
- * Returns null when none is found (dev, or an unbuilt/custom layout) → caller
- * falls back to the open dev resolver.
+ * Returns null only when no manifest exists; the caller then FAILS CLOSED rather
+ * than falling back to the open resolver. (The open resolver is reachable only via
+ * the dev wrapper's `devOpen`, handled before this is called.)
  */
 async function resolveServerManifest(
   options: ServerActionHandlerOptions
@@ -46,7 +47,6 @@ async function resolveServerManifest(
       serverRoot: options.serverRoot ?? join(options.projectRoot, "dist", "server"),
     };
   }
-  if (options.devOpen) return null; // dev serves live source; a built manifest would be stale
   const serverRoot = options.serverRoot ?? join(options.projectRoot, "dist", "server");
   if (!manifestByRoot.has(serverRoot)) {
     try {
@@ -108,28 +108,12 @@ export async function handleServerAction(
       logger
     );
 
-    // Resolve (or auto-load) the build manifest; its presence seals by default.
-    const resolved = await resolveServerManifest(options);
-
     let action: Function;
-    if (resolved) {
-      // SEALED path (production trust boundary): resolve the client-supplied id
-      // through a gate built from the build's server manifest. An id the build
-      // never emitted is rejected before any import; the importer is bound to the
-      // manifest's real file, never to a path derived from the id.
-      let gate = sealedGates.get(resolved.serverManifest);
-      if (!gate) {
-        gate = createSealedServerReferenceGate({
-          serverManifest: resolved.serverManifest,
-          serverRoot: resolved.serverRoot,
-          base,
-        });
-        sealedGates.set(resolved.serverManifest, gate);
-      }
-      action = (await gate.resolveServerReference(id)) as Function;
-    } else {
-      // Open path (development / preview only — not a trust boundary). Resolve
-      // against the project root with a traversal guard, then load on demand.
+    if (options.devOpen) {
+      // OPEN path — reachable ONLY when the Vite dev wrapper opts in. Dev serves
+      // live source, so there is no build manifest to seal against. NOT a trust
+      // boundary; never used in production. Resolve against the project root with
+      // a traversal guard, then load on demand.
       const { fullPath, exportName } = resolveServerAction(
         id,
         projectRoot,
@@ -146,6 +130,32 @@ export async function handleServerAction(
         verbose,
         logger
       );
+    } else {
+      // SEALED path (production trust boundary). Resolve the client-supplied id
+      // through a gate built from the build's server manifest: an id the build
+      // never emitted is rejected before any import; the importer is bound to the
+      // manifest's real file, never to a path derived from the id.
+      const resolved = await resolveServerManifest(options);
+      if (!resolved) {
+        // FAIL CLOSED. A missing manifest in production must NOT silently fall back
+        // to the open resolver — that would reopen the boundary we are enforcing.
+        throw new Error(
+          `[handleServerAction] No server manifest found (looked for ` +
+            `${join(options.serverRoot ?? join(projectRoot, "dist", "server"), ".vite", "manifest.json")}). ` +
+            `Server actions resolve through a sealed allowlist; pass serverRoot for a ` +
+            `custom build.outDir, or serverManifest directly. Refusing unsealed resolution.`
+        );
+      }
+      let gate = sealedGates.get(resolved.serverManifest);
+      if (!gate) {
+        gate = createSealedServerReferenceGate({
+          serverManifest: resolved.serverManifest,
+          serverRoot: resolved.serverRoot,
+          base,
+        });
+        sealedGates.set(resolved.serverManifest, gate);
+      }
+      action = (await gate.resolveServerReference(id)) as Function;
     }
 
     // Execute the server action

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -14,6 +14,51 @@ import {
   sendServerActionResponse,
   handleServerActionError as handleServerActionErrorHelper,
 } from "./handleServerActionHelper.js";
+import { createSealedServerReferenceGate } from "../references/createSealedServerReferenceGate.server.js";
+import type { ReferenceGate } from "react-server-loader/references";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+type ServerManifest = Record<string, { file: string; src?: string } | undefined>;
+
+// Cache the sealed gate per server manifest object so it is built once, not per
+// request. Keyed by the manifest reference (one per running server).
+const sealedGates = new WeakMap<object, ReferenceGate>();
+
+// Cache the on-disk manifest lookup per serverRoot (read at most once; `null`
+// means "looked, not found" so we don't re-stat every request in dev).
+const manifestByRoot = new Map<string, ServerManifest | null>();
+
+/**
+ * Resolve the server manifest that turns on the SEALED gate. Order:
+ *  1. an explicit `serverManifest` option (with its serverRoot), else
+ *  2. auto-load `<serverRoot>/.vite/manifest.json` (serverRoot defaults to
+ *     `<projectRoot>/dist/server`) — so production seals with no extra args.
+ * Returns null when none is found (dev, or an unbuilt/custom layout) → caller
+ * falls back to the open dev resolver.
+ */
+async function resolveServerManifest(
+  options: ServerActionHandlerOptions
+): Promise<{ serverManifest: ServerManifest; serverRoot: string } | null> {
+  if (options.serverManifest) {
+    return {
+      serverManifest: options.serverManifest,
+      serverRoot: options.serverRoot ?? join(options.projectRoot, "dist", "server"),
+    };
+  }
+  if (options.devOpen) return null; // dev serves live source; a built manifest would be stale
+  const serverRoot = options.serverRoot ?? join(options.projectRoot, "dist", "server");
+  if (!manifestByRoot.has(serverRoot)) {
+    try {
+      const raw = await readFile(join(serverRoot, ".vite", "manifest.json"), "utf8");
+      manifestByRoot.set(serverRoot, JSON.parse(raw) as ServerManifest);
+    } catch {
+      manifestByRoot.set(serverRoot, null);
+    }
+  }
+  const manifest = manifestByRoot.get(serverRoot) ?? null;
+  return manifest ? { serverManifest: manifest, serverRoot } : null;
+}
 
 // Use shared helper instead of duplicating logic
 
@@ -49,7 +94,7 @@ export async function handleServerAction(
   res: ServerResponse,
   options: ServerActionHandlerOptions
 ): Promise<void> {
-  const { projectRoot, verbose = false, logger, ssrLoadModule } = options;
+  const { projectRoot, verbose = false, logger, ssrLoadModule, base } = options;
 
   try {
     if (verbose) {
@@ -63,26 +108,45 @@ export async function handleServerAction(
       logger
     );
 
-    // Resolve the server action
-    const { fullPath, exportName } = resolveServerAction(
-      id,
-      projectRoot,
-      verbose,
-      logger
-    );
+    // Resolve (or auto-load) the build manifest; its presence seals by default.
+    const resolved = await resolveServerManifest(options);
 
-    // Load the server action (if ssrLoadModule is provided)
-    if (!ssrLoadModule) {
-      throw new Error("ssrLoadModule is required for server action execution");
+    let action: Function;
+    if (resolved) {
+      // SEALED path (production trust boundary): resolve the client-supplied id
+      // through a gate built from the build's server manifest. An id the build
+      // never emitted is rejected before any import; the importer is bound to the
+      // manifest's real file, never to a path derived from the id.
+      let gate = sealedGates.get(resolved.serverManifest);
+      if (!gate) {
+        gate = createSealedServerReferenceGate({
+          serverManifest: resolved.serverManifest,
+          serverRoot: resolved.serverRoot,
+          base,
+        });
+        sealedGates.set(resolved.serverManifest, gate);
+      }
+      action = (await gate.resolveServerReference(id)) as Function;
+    } else {
+      // Open path (development / preview only — not a trust boundary). Resolve
+      // against the project root with a traversal guard, then load on demand.
+      const { fullPath, exportName } = resolveServerAction(
+        id,
+        projectRoot,
+        verbose,
+        logger
+      );
+      if (!ssrLoadModule) {
+        throw new Error("ssrLoadModule is required for server action execution");
+      }
+      action = await loadServerAction(
+        fullPath,
+        exportName,
+        ssrLoadModule,
+        verbose,
+        logger
+      );
     }
-
-    const action = await loadServerAction(
-      fullPath,
-      exportName,
-      ssrLoadModule,
-      verbose,
-      logger
-    );
 
     // Execute the server action
     const result = await executeServerAction(
@@ -139,6 +203,9 @@ export async function handleServerActionWithViteServer(
     verbose: handlerOptions.verbose,
     logger: server.config.customLogger || server.config.logger,
     ssrLoadModule,
+    // Dev serves live source via the runner; never auto-seal against a possibly
+    // stale built manifest on disk.
+    devOpen: true,
   });
 }
 

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -112,8 +112,16 @@ export async function handleServerAction(
     if (options.devOpen) {
       // OPEN path — reachable ONLY when the Vite dev wrapper opts in. Dev serves
       // live source, so there is no build manifest to seal against. NOT a trust
-      // boundary; never used in production. Resolve against the project root with
-      // a traversal guard, then load on demand.
+      // boundary. Defense in depth: refuse it under NODE_ENV=production so a
+      // misconfigured prod deploy can never take the unsealed path even if the
+      // flag leaks in.
+      if (process.env.NODE_ENV === "production") {
+        throw new Error(
+          "[handleServerAction] devOpen (the unsealed dev resolver) was requested " +
+            "under NODE_ENV=production. Server actions must be sealed in production; refusing."
+        );
+      }
+      // Resolve against the project root with a traversal guard, then load on demand.
       const { fullPath, exportName } = resolveServerAction(
         id,
         projectRoot,

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -9,6 +9,29 @@ export type ServerActionHandlerOptions = {
   verbose?: boolean;
   logger?: Logger;
   ssrLoadModule?: (path: string) => Promise<any>;
+  /**
+   * Vite's emitted server manifest. Optional: in production the handler auto-loads
+   * it from `<serverRoot>/.vite/manifest.json`, so you normally do not pass this.
+   * Provide it only to override (e.g. a manifest you already hold in memory).
+   * When a manifest is available, actions resolve through a SEALED gate — an
+   * allowlist that rejects any id the build did not emit.
+   */
+  serverManifest?: Record<string, { file: string; src?: string } | undefined>;
+  /**
+   * Absolute path to the built server dir (where manifest `entry.file` and
+   * `.vite/manifest.json` live). Defaults to `<projectRoot>/dist/server`. When the
+   * manifest is found there (or passed via `serverManifest`), the sealed gate is
+   * used automatically — no need to load or pass the manifest yourself.
+   */
+  serverRoot?: string;
+  /** URL base the client prefixes onto reference ids (default `/`). */
+  base?: string;
+  /**
+   * Force the open dev resolver and skip manifest auto-loading. Set internally by
+   * the Vite dev wrapper (dev serves live source, so a built manifest would be
+   * stale). Consumers should not set this in production.
+   */
+  devOpen?: boolean;
 };
 
 export type ServerActionRequest = {

--- a/test/unit/handleServerActionSealed.test.ts
+++ b/test/unit/handleServerActionSealed.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { Readable, PassThrough } from "node:stream";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleServerAction } from "../../dist/plugin/helpers/handleServerAction.server.js";
+
+// When a server manifest is provided, handleServerAction must resolve through the
+// SEALED gate (allowlist) and reject any id the build did not emit — without ever
+// falling back to the open, path-derived import.
+function mockReq(id: string, body = "[]") {
+  const req = Readable.from([Buffer.from(body)]) as any;
+  req.headers = { "x-rsc-action": id };
+  req.url = "/__server-action";
+  return req;
+}
+function mockRes() {
+  const res = new PassThrough() as any;
+  res.statusCode = 200;
+  res.setHeader = () => {};
+  return res as any;
+}
+
+const MANIFEST = {
+  "src/server/actions.server.ts": {
+    file: "assets/actions-abc.js",
+    src: "src/server/actions.server.ts",
+  },
+};
+
+describe("handleServerAction sealed path", () => {
+  it("rejects a forged id not in the manifest, without falling back to import", async () => {
+    const ssrLoadModule = vi.fn();
+    const res = mockRes();
+    await handleServerAction(mockReq("../../etc/evil.server.ts#pwn"), res, {
+      projectRoot: "/proj",
+      serverManifest: MANIFEST,
+      serverRoot: "/proj/dist/server",
+      base: "/",
+      ssrLoadModule,
+    });
+    expect(res.statusCode).toBe(500);
+    // The sealed path threw on the unknown id; it must never reach the open loader.
+    expect(ssrLoadModule).not.toHaveBeenCalled();
+  });
+
+  it("auto-loads the manifest from serverRoot and seals — no serverManifest arg, no import fallback", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vprs-sa-"));
+    await mkdir(join(dir, ".vite"), { recursive: true });
+    await writeFile(join(dir, ".vite", "manifest.json"), JSON.stringify(MANIFEST));
+
+    const ssrLoadModule = vi.fn();
+    const res = mockRes();
+    await handleServerAction(mockReq("../../etc/evil.server.ts#pwn"), res, {
+      projectRoot: "/proj",
+      serverRoot: dir, // no serverManifest passed — handler reads it from disk
+      ssrLoadModule,
+    });
+    expect(res.statusCode).toBe(500); // forged id rejected by the auto-loaded sealed gate
+    expect(ssrLoadModule).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the open dev resolver when devOpen is set (no auto-seal)", async () => {
+    const ssrLoadModule = vi.fn(async () => ({ addTodo: () => "ok" }));
+    const res = mockRes();
+    await handleServerAction(mockReq("src/server/actions.server.ts#addTodo"), res, {
+      projectRoot: "/proj",
+      devOpen: true,
+      ssrLoadModule,
+    });
+    expect(ssrLoadModule).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/handleServerActionSealed.test.ts
+++ b/test/unit/handleServerActionSealed.test.ts
@@ -85,4 +85,22 @@ describe("handleServerAction sealed path", () => {
     });
     expect(ssrLoadModule).toHaveBeenCalledTimes(1);
   });
+
+  it("refuses devOpen under NODE_ENV=production (defense in depth)", async () => {
+    const prev = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const ssrLoadModule = vi.fn(async () => ({ addTodo: () => "ok" }));
+      const res = mockRes();
+      await handleServerAction(mockReq("src/server/actions.server.ts#addTodo"), res, {
+        projectRoot: "/proj",
+        devOpen: true,
+        ssrLoadModule,
+      });
+      expect(res.statusCode).toBe(500); // refused even though devOpen was set
+      expect(ssrLoadModule).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = prev;
+    }
+  });
 });

--- a/test/unit/handleServerActionSealed.test.ts
+++ b/test/unit/handleServerActionSealed.test.ts
@@ -60,7 +60,22 @@ describe("handleServerAction sealed path", () => {
     expect(ssrLoadModule).not.toHaveBeenCalled();
   });
 
-  it("falls back to the open dev resolver when devOpen is set (no auto-seal)", async () => {
+  it("FAILS CLOSED when no manifest is found and devOpen is not set", async () => {
+    // Empty dir → no .vite/manifest.json. A production call must refuse, NOT fall
+    // back to the open resolver, even though ssrLoadModule is available.
+    const dir = await mkdtemp(join(tmpdir(), "vprs-sa-empty-"));
+    const ssrLoadModule = vi.fn(async () => ({ addTodo: () => "ok" }));
+    const res = mockRes();
+    await handleServerAction(mockReq("src/server/actions.server.ts#addTodo"), res, {
+      projectRoot: "/proj",
+      serverRoot: dir,
+      ssrLoadModule,
+    });
+    expect(res.statusCode).toBe(500); // refused
+    expect(ssrLoadModule).not.toHaveBeenCalled(); // never reached the open resolver
+  });
+
+  it("uses the open dev resolver ONLY when devOpen is set", async () => {
     const ssrLoadModule = vi.fn(async () => ({ addTodo: () => "ok" }));
     const res = mockRes();
     await handleServerAction(mockReq("src/server/actions.server.ts#addTodo"), res, {


### PR DESCRIPTION
Follow-up to #176 (merged — containment guard + docs correction). Closes the server-action trust boundary **by default**, fail-closed.

## What
`handleServerAction` auto-loads `<serverRoot>/.vite/manifest.json` (`serverRoot` defaults to `<projectRoot>/dist/server`) and resolves the client-supplied id through `createSealedServerReferenceGate` — an allowlist that rejects any id the build never emitted and binds the importer to the manifest's real file, never to a path derived from the id.

```ts
await handleServerAction(req, res, { projectRoot });              // default layout → sealed
await handleServerAction(req, res, { projectRoot, serverRoot });  // custom build.outDir → sealed
```

## Fail closed
The open resolver is reachable **only** via the dev wrapper's `devOpen` flag. In any other context the handler **must** seal; if no manifest is found it **throws** rather than falling back to unsealed resolution. A missing manifest is a misconfiguration (wrong `serverRoot` / unbuilt tree), surfaced loudly instead of silently reopening the boundary this PR exists to close.

- Manifest lookup cached per `serverRoot` (reads disk once).
- `serverManifest` accepted as an explicit override.

## Tests
- `handleServerActionSealed.test.ts`: explicit-manifest rejects forged id; auto-load from `serverRoot` rejects forged id without import fallback; **no manifest + no devOpen → fails closed (500), open resolver never reached**; `devOpen` uses the open resolver.
- `resolveServerActionContainment.test.ts` (from #176) still green.
- Unrelated pre-existing failure: `createReactFetcher.test.ts` (`react-server-dom-esm/client.browser` not resolvable in a non-hoisted local install). CI on a clean install is the arbiter.

## Follow-up (separate PR)
Switch the bidoof demo to `handleServerAction({ projectRoot })` and drop its hand-rolled allowlist.