### PR TITLE
test: resolve react-server-dom-esm from the vendored transport (fix flaky unit run)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,24 @@
+import { join } from "node:path";
 import { defineConfig } from "vitest/config";
 import { getCondition } from "./plugin/config/getCondition.js";
+import { transportPkgDir } from "./plugin/vendor/transportDir.js";
 
 export default defineConfig({
   mode: "development",
   resolve: {
-    conditions: getCondition() === "react-server" 
-      ? ["react-server", "node", "import"] 
+    conditions: getCondition() === "react-server"
+      ? ["react-server", "node", "import"]
       : ["node", "import"],
+    // `react-server-dom-esm` is not a direct dependency — it ships vendored
+    // inside `react-server-loader`, and at runtime the plugin resolves it from
+    // there. Tests that import it in-process (e.g. createReactFetcher) otherwise
+    // depend on it being hoisted to top-level node_modules, which is not
+    // guaranteed. Point the one browser subpath they use at the vendored copy,
+    // the same place the plugin resolves it. (Only this condition-free subpath is
+    // aliased; aliasing the whole package would bypass its conditional exports.)
+    alias: {
+      "react-server-dom-esm/client.browser": join(transportPkgDir, "client.browser.js"),
+    },
   },
   ssr: {
     resolve: {


### PR DESCRIPTION
## Problem
`test/unit/createReactFetcher.test.ts` imports `react-server-dom-esm/client.browser` in-process. `react-server-dom-esm` is **not** a direct dependency — it ships vendored inside `react-server-loader`, and the plugin resolves it from there at runtime. So the test only passed when the package happened to be hoisted to top-level `node_modules`; in a clean or non-hoisted install it failed:

```
Failed to load url react-server-dom-esm/client.browser (resolved id: react-server-dom-esm/client.browser) ... Does the file exist?
```

(This is the failure flagged on #172 and that showed up as the lone red test across the recent security PRs.)

## Fix
Alias that one browser-only subpath to the vendored copy in the vitest config, using the codebase's own `transportPkgDir` locator (`plugin/vendor/transportDir.ts`) — the same place the plugin resolves it at runtime.

```ts
resolve: {
  alias: {
    "react-server-dom-esm/client.browser": join(transportPkgDir, "client.browser.js"),
  },
}
```

Only this condition-free subpath is aliased on purpose — aliasing the whole package would bypass its conditional (`react-server`) exports for subpaths like `./server`.

## Result
`npm run test:unit` is now **455/455 green** regardless of hoisting.

No source/runtime change — test config only.