### PR TITLE
chore(release): 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release 2.7.0 — server-action security hardening (and the supporting tooling) landed since 2.6.1.

## Included
- **#176** fix(security): contain server-action path resolution. The client-supplied action id was joined onto projectRoot with no containment, so `../` could escape the root and be imported. Now rejected.
- **#177** feat(security): seal server actions by default. `handleServerAction` auto-loads the build's server manifest and resolves through a sealed allowlist; **fails closed** when no manifest is found; refuses the open dev resolver under `NODE_ENV=production`. New options: `serverManifest`, `serverRoot` (`devOpen` is dev-internal).
- **#174** ci: publint + entrypoint guard in CI and `prepublishOnly`.
- **#175** docs: document the reference gate (RSC production safety).
- **#178** test: resolve the vendored `react-server-dom-esm` transport without relying on hoisting.

## ⚠️ Behavior change (security-motivated)
`handleServerAction` now seals by default and **throws** instead of resolving unsealed when it can't find the manifest. Default build layouts (`dist/server`) seal transparently; a custom `build.outDir` needs `serverRoot`. A consumer who relied on the old open resolution in production will get a clear error instead of a silent unsealed path. Hence the minor bump.

## Verification
- `npm run test-all` green: server + client + unit (455/455) + typecheck (20/20, no type errors).
- `prepublishOnly` runs `build && verify:package` (publint + entrypoint guard), so the manifest is checked on publish.

After merge: `npm publish` (needs your 2FA OTP).