### PR TITLE
feat(security): harden the server-action endpoint (CSRF, body cap, no-stack, containment)

### DIFF
--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -172,6 +172,39 @@ Whatever resolves the id, these stay yours per action:
   values it captures, so treat anything an exposed action closes over as visible
   to the client. Pass an id and look the value up on the server instead.
 
+### Endpoint hardening
+
+The sealed gate decides *which function* a request may resolve — it confirms the
+*target* is a real action, not that the *caller* is allowed to call it or that the
+request is well-sized. Two opt-in options on `handleServerAction` cover the
+endpoint itself; both are off by default so they never silently change an existing
+deploy:
+
+```ts
+await handleServerAction(req, res, {
+  projectRoot,
+  allowedOrigins: ["https://app.example.com"], // CSRF guard (see below)
+  maxBodyBytes: 1024 * 1024,                    // reject bodies over 1 MiB with 413
+});
+```
+
+- **`allowedOrigins` (CSRF / cross-origin).** A server action is a cookie-bearing,
+  state-changing POST, so a page on another origin can drive a logged-in user's
+  browser to invoke one. When set, a request whose `Origin` header is present and
+  not in the allowlist is rejected with `403` before the action runs (mirrors
+  Next's `serverActions.allowedOrigins`). A *missing* `Origin` is allowed: a page
+  cannot suppress it on a cross-origin browser POST, so its absence means
+  same-origin or a non-browser client, which is not a CSRF vector.
+- **`maxBodyBytes` (DoS).** The handler buffers the POST body in memory to decode
+  the arguments. When set, a body exceeding the cap is rejected with `413` before
+  it is fully buffered, so an unauthenticated client cannot exhaust memory.
+
+Error responses never include a stack trace — only `{ success: false, error }`.
+The full error (with stack) goes to the server log via your Vite logger, not to
+the client. If you mount your own handler instead of `handleServerAction`, keep
+the same three properties: an origin check, a body cap, and no stack in the
+response.
+
 ## Limitations
 
 - Server actions don't support CSS collection or custom prop functions

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -101,11 +101,27 @@ export async function handleServerAction(
       logger?.info("[handleServerAction:server] Processing server action request");
     }
 
+    // CSRF / cross-origin guard (opt-in). When allowedOrigins is configured, a
+    // browser-driven cross-site POST carries an Origin header set to the calling
+    // site; reject anything not in the allowlist. A missing Origin is allowed: a
+    // page cannot suppress it on a cross-origin fetch, so its absence means
+    // same-origin or a non-browser client (not a CSRF vector).
+    if (options.allowedOrigins && options.allowedOrigins.length > 0) {
+      const origin = (req.headers.origin as string | undefined) ?? "";
+      if (origin && !options.allowedOrigins.includes(origin)) {
+        res.statusCode = 403;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ success: false, error: "Origin not allowed" }));
+        return;
+      }
+    }
+
     // Parse the server action request
     const { id, args } = await parseServerActionRequestHelper(
       req,
       verbose,
-      logger
+      logger,
+      options.maxBodyBytes
     );
 
     let action: Function;

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -32,6 +32,21 @@ export type ServerActionHandlerOptions = {
    * stale). Consumers should not set this in production.
    */
   devOpen?: boolean;
+  /**
+   * Opt-in CSRF guard. When set, a request whose `Origin` header is present and
+   * not in this allowlist is rejected with 403 before the action runs. A missing
+   * `Origin` is allowed: a page cannot suppress it on a cross-origin browser POST,
+   * so its absence means same-origin or a non-browser client (not a CSRF vector).
+   * List your own origins, e.g. `["https://app.example.com"]`. Off by default to
+   * avoid breaking existing deploys; the endpoint is otherwise the host's to guard.
+   */
+  allowedOrigins?: string[];
+  /**
+   * Opt-in cap on the server-action request body, in bytes. When set, a body that
+   * exceeds it is rejected with 413 instead of being buffered into memory. Off by
+   * default (no limit). Recommended for any internet-facing deploy.
+   */
+  maxBodyBytes?: number;
 };
 
 export type ServerActionRequest = {
@@ -97,7 +112,8 @@ export function setupServerActionHeaders(res: ServerResponse) {
 export async function parseServerActionRequest(
   req: IncomingMessage,
   verbose = false,
-  logger?: Logger
+  logger?: Logger,
+  maxBodyBytes?: number
 ): Promise<ServerActionRequest> {
   // Get action ID from x-rsc-action header (preferred) or URL
   let id = (req.headers["x-rsc-action"] as string) ?? req.url?.split("?")[0] ?? "";
@@ -111,7 +127,18 @@ export async function parseServerActionRequest(
   let args: unknown[];
   try {
     const chunks: Buffer[] = [];
+    let received = 0;
     for await (const chunk of req) {
+      received += chunk.length;
+      if (maxBodyBytes !== undefined && received > maxBodyBytes) {
+        // Reject oversized bodies before buffering them all into memory. Tagged
+        // with a statusCode so the handler answers 413, not a generic 500.
+        const err = new Error(
+          `Server action request body exceeds maxBodyBytes (${maxBodyBytes})`
+        ) as Error & { statusCode?: number };
+        err.statusCode = 413;
+        throw err;
+      }
       chunks.push(chunk);
     }
     const body = Buffer.concat(chunks).toString();
@@ -146,6 +173,11 @@ export async function parseServerActionRequest(
       args = [body]; // Pass raw body as first arg, worker will decode
     }
   } catch (error: unknown) {
+    // Preserve a tagged status (e.g. 413 from the size cap) rather than masking it
+    // as a generic parse failure.
+    if (error instanceof Error && "statusCode" in error) {
+      throw error;
+    }
     throw new Error(`Failed to parse server action request`, {
       cause: error,
     });
@@ -292,14 +324,16 @@ export function handleServerActionError(
   res: ServerResponse,
   logger?: Logger
 ): void {
-  const err = toError(error);
+  const err = toError(error) as Error & { statusCode?: number };
   logError(err, logger);
-  
-  res.statusCode = 500;
+
+  // Honor a tagged status (403 origin, 413 oversized) else 500.
+  res.statusCode = typeof err.statusCode === "number" ? err.statusCode : 500;
   res.setHeader("Content-Type", "application/json");
-  res.end(JSON.stringify({ 
-    success: false, 
+  // Never ship err.stack to the client — it exposes absolute paths and internal
+  // module ids. The full error (with stack) is written to the server log above.
+  res.end(JSON.stringify({
+    success: false,
     error: err.message,
-    stack: err.stack 
   }));
 } 

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -1,5 +1,6 @@
 import { logError, toError } from "../error/index.js";
-import { join, relative, isAbsolute } from "node:path";
+import { join } from "node:path";
+import { isPathWithin } from "./isPathWithin.js";
 import type { Logger } from "vite";
 import type { ServerResponse } from "node:http";
 import type { IncomingMessage } from "node:http";
@@ -222,8 +223,7 @@ export function resolveServerAction(
   // and invoked. Reject anything that escapes projectRoot. (This is defense in
   // depth; resolving against the build's server manifest is the stronger gate —
   // see docs/server-actions.md and bead i0j.)
-  const rel = relative(projectRoot, fullPath);
-  if (!rel || rel.startsWith("..") || isAbsolute(rel)) {
+  if (!isPathWithin(projectRoot, fullPath)) {
     throw new Error(
       `Server action id resolves outside the project root: ${id}`
     );

--- a/plugin/helpers/isPathWithin.ts
+++ b/plugin/helpers/isPathWithin.ts
@@ -1,4 +1,4 @@
-import { relative, isAbsolute } from "node:path";
+import { relative, isAbsolute, sep } from "node:path";
 
 /**
  * Containment guard. Returns true when `target` is `base` itself or resolves to
@@ -10,5 +10,11 @@ import { relative, isAbsolute } from "node:path";
  */
 export function isPathWithin(base: string, target: string): boolean {
   const rel = relative(base, target);
-  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  // An escape is `..` itself or anything below it (`../x`). Match the segment,
+  // not a bare prefix, so a contained file whose name merely starts with `..`
+  // (e.g. `..foo.ts`) is not falsely rejected.
+  return (
+    rel === "" ||
+    (rel !== ".." && !rel.startsWith(".." + sep) && !isAbsolute(rel))
+  );
 }

--- a/plugin/helpers/isPathWithin.ts
+++ b/plugin/helpers/isPathWithin.ts
@@ -1,0 +1,14 @@
+import { relative, isAbsolute } from "node:path";
+
+/**
+ * Containment guard. Returns true when `target` is `base` itself or resolves to
+ * a path inside it. Use before importing or streaming a path derived from
+ * client-supplied input: `join`/`resolve` collapse `../`, so a crafted id could
+ * otherwise escape the expected root.
+ *
+ * Both arguments must already be absolute (the result of `join`/`resolve`).
+ */
+export function isPathWithin(base: string, target: string): boolean {
+  const rel = relative(base, target);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}

--- a/plugin/react-static/configurePreviewServer.ts
+++ b/plugin/react-static/configurePreviewServer.ts
@@ -1,7 +1,7 @@
 import type {  
   StreamError,  
 } from "../types.js";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
@@ -34,6 +34,15 @@ export const configurePreviewServer: ConfigurePreviewServerFn =
       
       // Handle static files including CSS
       if (filePath && (isRscRequest)) {
+        // Containment assertion (defense in depth). `filePath` is
+        // resolve(staticHostDir, <route>); route normalization already clamps
+        // `../`, but assert the resolved path stays under the static dir so a
+        // future change to URL handling cannot silently reintroduce traversal.
+        if (filePath !== staticHostDir && !filePath.startsWith(staticHostDir + sep)) {
+          res.statusCode = 403;
+          res.end("Forbidden");
+          return;
+        }
         try {
           const stats = await stat(filePath);
           if (stats.isFile()) {

--- a/plugin/react-static/configurePreviewServer.ts
+++ b/plugin/react-static/configurePreviewServer.ts
@@ -1,10 +1,11 @@
 import type {  
   StreamError,  
 } from "../types.js";
-import { join, sep } from "node:path";
+import { join } from "node:path";
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
+import { isPathWithin } from "../helpers/isPathWithin.js";
 import { requestInfo } from "../helpers/requestInfo.js";
 import { logError } from "../error/logError.js";
 import type { ConfigurePreviewServerFn } from "./types.js";
@@ -38,7 +39,7 @@ export const configurePreviewServer: ConfigurePreviewServerFn =
         // resolve(staticHostDir, <route>); route normalization already clamps
         // `../`, but assert the resolved path stays under the static dir so a
         // future change to URL handling cannot silently reintroduce traversal.
-        if (filePath !== staticHostDir && !filePath.startsWith(staticHostDir + sep)) {
+        if (!isPathWithin(staticHostDir, filePath)) {
           res.statusCode = 403;
           res.end("Forbidden");
           return;

--- a/plugin/worker/rsc/state.server.ts
+++ b/plugin/worker/rsc/state.server.ts
@@ -2,7 +2,8 @@ import { workerData } from "node:worker_threads";
 import { createCssProps } from "../../helpers/createCssProps.js";
 import type { CssContent, ResolvedUserOptions, HmrState } from "../../types.js";
 import type { PassThrough } from "node:stream";
-import { relative, join, isAbsolute } from "node:path";
+import { relative, join } from "node:path";
+import { isPathWithin } from "../../helpers/isPathWithin.js";
 import { createReferenceGate } from "react-server-loader/references";
 import { registerServerReference } from "react-server-dom-esm/server";
 import { createLazyTemporaryReferenceSet } from "../../react-static/temporaryReferences.server.js";
@@ -67,8 +68,7 @@ export const referenceGate = createReferenceGate({
     // boundary, but `join` collapses `../`, so without this a crafted id could
     // resolve and import a module outside the project root. Mirrors the
     // main-thread resolveServerAction guard.
-    const rel = relative(projectRoot, fullPath);
-    if (!rel || rel.startsWith("..") || isAbsolute(rel)) {
+    if (!isPathWithin(projectRoot, fullPath)) {
       throw new Error(
         `Server action id resolves outside the project root: ${key}`
       );

--- a/plugin/worker/rsc/state.server.ts
+++ b/plugin/worker/rsc/state.server.ts
@@ -2,7 +2,7 @@ import { workerData } from "node:worker_threads";
 import { createCssProps } from "../../helpers/createCssProps.js";
 import type { CssContent, ResolvedUserOptions, HmrState } from "../../types.js";
 import type { PassThrough } from "node:stream";
-import { relative, join } from "node:path";
+import { relative, join, isAbsolute } from "node:path";
 import { createReferenceGate } from "react-server-loader/references";
 import { registerServerReference } from "react-server-dom-esm/server";
 import { createLazyTemporaryReferenceSet } from "../../react-static/temporaryReferences.server.js";
@@ -62,10 +62,18 @@ export const referenceGate = createReferenceGate({
       moduleBasePath && key.startsWith(moduleBasePath)
         ? key.slice(moduleBasePath.length)
         : key;
-    const mod = (await import(join(projectRoot, actionPath))) as Record<
-      string,
-      unknown
-    >;
+    const fullPath = join(projectRoot, actionPath);
+    // Containment guard (defense in depth). Open mode is dev-only and not a trust
+    // boundary, but `join` collapses `../`, so without this a crafted id could
+    // resolve and import a module outside the project root. Mirrors the
+    // main-thread resolveServerAction guard.
+    const rel = relative(projectRoot, fullPath);
+    if (!rel || rel.startsWith("..") || isAbsolute(rel)) {
+      throw new Error(
+        `Server action id resolves outside the project root: ${key}`
+      );
+    }
+    const mod = (await import(fullPath)) as Record<string, unknown>;
     return tagServerExports(key, mod);
   },
 });

--- a/test/unit/handleServerActionHardening.test.ts
+++ b/test/unit/handleServerActionHardening.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from "vitest";
+import { Readable, PassThrough } from "node:stream";
+import { handleServerAction } from "../../dist/plugin/helpers/handleServerAction.server.js";
+
+// Endpoint hardening on the production server-action path: the opt-in CSRF
+// (allowedOrigins) and body-size (maxBodyBytes) guards, plus the rule that error
+// responses never ship a stack trace to the client.
+
+function mockReq(id: string, body = "[]", headers: Record<string, string> = {}) {
+  const req = Readable.from([Buffer.from(body)]) as any;
+  req.headers = { "x-rsc-action": id, ...headers };
+  req.url = "/__server-action";
+  return req;
+}
+
+function mockRes() {
+  const res = new PassThrough() as any;
+  res.statusCode = 200;
+  res.setHeader = () => {};
+  const chunks: Buffer[] = [];
+  const origEnd = res.end.bind(res);
+  res.end = (data?: unknown) => {
+    if (data) chunks.push(Buffer.from(data as Buffer));
+    return origEnd(data);
+  };
+  res.body = () => Buffer.concat(chunks).toString();
+  return res as any;
+}
+
+const MANIFEST = {
+  "src/server/actions.server.ts": {
+    file: "assets/actions-abc.js",
+    src: "src/server/actions.server.ts",
+  },
+};
+
+describe("server-action endpoint hardening", () => {
+  describe("allowedOrigins (CSRF guard)", () => {
+    it("rejects a request whose Origin is not in the allowlist (403), before parsing", async () => {
+      const ssrLoadModule = vi.fn();
+      const res = mockRes();
+      await handleServerAction(
+        mockReq("src/server/actions.server.ts#addTodo", "[]", {
+          origin: "https://evil.example",
+        }),
+        res,
+        {
+          projectRoot: "/proj",
+          serverManifest: MANIFEST,
+          serverRoot: "/proj/dist/server",
+          allowedOrigins: ["https://app.example"],
+          ssrLoadModule,
+        }
+      );
+      expect(res.statusCode).toBe(403);
+      expect(ssrLoadModule).not.toHaveBeenCalled();
+    });
+
+    it("allows a request with an allowed Origin", async () => {
+      const res = mockRes();
+      await handleServerAction(
+        mockReq("forged.server.ts#pwn", "[]", { origin: "https://app.example" }),
+        res,
+        {
+          projectRoot: "/proj",
+          serverManifest: MANIFEST,
+          serverRoot: "/proj/dist/server",
+          allowedOrigins: ["https://app.example"],
+        }
+      );
+      // Origin passed the guard; it fails later on the unknown id, not 403.
+      expect(res.statusCode).not.toBe(403);
+    });
+
+    it("allows a request with no Origin header (not a CSRF vector)", async () => {
+      const res = mockRes();
+      await handleServerAction(mockReq("forged.server.ts#pwn"), res, {
+        projectRoot: "/proj",
+        serverManifest: MANIFEST,
+        serverRoot: "/proj/dist/server",
+        allowedOrigins: ["https://app.example"],
+      });
+      expect(res.statusCode).not.toBe(403);
+    });
+  });
+
+  describe("maxBodyBytes (DoS guard)", () => {
+    it("rejects an oversized body with 413 without resolving the action", async () => {
+      const ssrLoadModule = vi.fn();
+      const res = mockRes();
+      const big = JSON.stringify(["x".repeat(1000)]);
+      await handleServerAction(
+        mockReq("src/server/actions.server.ts#addTodo", big),
+        res,
+        {
+          projectRoot: "/proj",
+          serverManifest: MANIFEST,
+          serverRoot: "/proj/dist/server",
+          maxBodyBytes: 16,
+          ssrLoadModule,
+        }
+      );
+      expect(res.statusCode).toBe(413);
+      expect(ssrLoadModule).not.toHaveBeenCalled();
+    });
+
+    it("allows a body within the limit", async () => {
+      const res = mockRes();
+      await handleServerAction(
+        mockReq("forged.server.ts#pwn", "[]"),
+        res,
+        {
+          projectRoot: "/proj",
+          serverManifest: MANIFEST,
+          serverRoot: "/proj/dist/server",
+          maxBodyBytes: 1024,
+        }
+      );
+      // Under the cap → not a 413; fails later on the unknown id.
+      expect(res.statusCode).not.toBe(413);
+    });
+  });
+
+  describe("error responses", () => {
+    it("never includes a stack trace in the client response", async () => {
+      const res = mockRes();
+      await handleServerAction(mockReq("forged.server.ts#pwn"), res, {
+        projectRoot: "/proj",
+        serverManifest: MANIFEST,
+        serverRoot: "/proj/dist/server",
+      });
+      expect(res.statusCode).toBe(500);
+      const body = res.body();
+      expect(body).not.toContain("stack");
+      expect(body).not.toMatch(/\.ts:\d+|\/proj\//); // no file paths / line refs
+    });
+  });
+});

--- a/test/unit/isPathWithin.test.ts
+++ b/test/unit/isPathWithin.test.ts
@@ -27,4 +27,14 @@ describe("isPathWithin", () => {
   it("rejects an unrelated absolute path", () => {
     expect(isPathWithin(BASE, "/etc/passwd")).toBe(false);
   });
+
+  it("accepts a contained file whose name starts with '..'", () => {
+    // `..foo.ts` is a legit in-tree filename, not a traversal — a bare
+    // startsWith('..') prefix check would wrongly reject it.
+    expect(isPathWithin(BASE, "/proj/..foo.ts")).toBe(true);
+  });
+
+  it("rejects real parent traversal", () => {
+    expect(isPathWithin(BASE, "/proj/../secret.ts")).toBe(false);
+  });
 });

--- a/test/unit/isPathWithin.test.ts
+++ b/test/unit/isPathWithin.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { isPathWithin } from "../../dist/plugin/helpers/isPathWithin.js";
+
+// Shared containment primitive behind the server-action resolver, the dev worker
+// gate, and the preview static server. Inputs are always absolute (join/resolve
+// output); the guard rejects anything that escapes the base.
+const BASE = "/proj";
+
+describe("isPathWithin", () => {
+  it("accepts a path inside the base", () => {
+    expect(isPathWithin(BASE, "/proj/src/a.server.ts")).toBe(true);
+  });
+
+  it("accepts the base itself", () => {
+    expect(isPathWithin(BASE, "/proj")).toBe(true);
+  });
+
+  it("rejects a sibling that shares a name prefix", () => {
+    // /proj-secret must not count as inside /proj
+    expect(isPathWithin(BASE, "/proj-secret/x")).toBe(false);
+  });
+
+  it("rejects a parent path", () => {
+    expect(isPathWithin(BASE, "/")).toBe(false);
+  });
+
+  it("rejects an unrelated absolute path", () => {
+    expect(isPathWithin(BASE, "/etc/passwd")).toBe(false);
+  });
+});


### PR DESCRIPTION
A security review of the server-action surface found that, while the sealed
reference gate correctly governs *which* function a request can resolve, the
endpoint itself (a cookie-bearing, state-changing POST) lacked the conventional
request-level protections and leaked stack traces on error. This PR closes those
gaps; all new behavior is opt-in and off by default, so existing deploys are
unchanged.

## Production handler (`handleServerAction`)

- **`allowedOrigins` (opt-in CSRF guard).** When set, a request whose `Origin`
  header is present and not in the allowlist is rejected with `403` before the
  action runs (mirrors Next's `serverActions.allowedOrigins`). A *missing* `Origin`
  is allowed: a page cannot suppress it on a cross-origin browser POST, so its
  absence means same-origin or a non-browser client, which is not a CSRF vector.
- **`maxBodyBytes` (opt-in DoS guard).** When set, a request body exceeding the cap
  is rejected with `413` before it is fully buffered into memory.
- **No stack traces in responses.** Error responses now return `{ success, error }`
  only; the full error (with stack) still goes to the server log via the Vite
  logger. Previously `err.stack` was serialized into the 500 body, exposing
  absolute paths and internal module ids. The error responder also honors a tagged
  `statusCode` (403/413).

## Defense-in-depth (dev / preview)

Neither is a production trust boundary, but both are cheap to make robust:

- **Worker open reference gate** (`state.server.ts` `devResolve`): the on-demand
  dev resolver did `import(join(projectRoot, id))` with no traversal guard, unlike
  its main-thread twin `resolveServerAction`. Added the same `relative()`/`..`
  containment check before import.
- **Preview static server** (`configurePreviewServer.ts`): the resolved file path
  was streamed with no explicit containment check (traversal-safe only because
  route normalization clamps `../`). Now asserts the path stays under the static
  dir before `stat`/stream, responding `403` otherwise.

## Tests & docs

- `test/unit/handleServerActionHardening.test.ts`: origin allow/deny/missing,
  oversized `413`, and no-stack-in-response. Full unit suite green (461 passed).
- `docs/server-actions.md`: documents the two options and the no-stack guarantee
  under "Endpoint hardening".

The dev/preview guards mirror the already-tested `resolveServerActionContainment`
pattern and are not separately unit-tested, as both sites are module-scoped /
middleware that would require a brittle worker/preview harness to exercise in
isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: consolidated containment guard

The three containment checks (`resolveServerAction`, the dev worker gate in
`state.server.ts`, and the preview static server) shared the same intent through
two different idioms. They now route through one helper, `isPathWithin(base,
target)` (`plugin/helpers/isPathWithin.ts`), with a direct unit test
(`test/unit/isPathWithin.test.ts`) covering the in-tree, base-itself,
shared-prefix-sibling (`/proj` vs `/proj-secret`), parent, and unrelated cases.
Behavior is unchanged; the dev/preview logic is now a pure, testable function
rather than inline middleware code. Full unit suite green (466 passed).