### PR TITLE
chore(release): 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release 2.8.0.

## Highlights

**Server-action endpoint hardening (#180).** Opt-in, off by default, so existing deploys are unchanged:

- `allowedOrigins` — CSRF / cross-origin guard on the production `handleServerAction` (`vite-plugin-react-server/helpers`). A present `Origin` not in the allowlist is rejected with `403`; a missing `Origin` is allowed.
- `maxBodyBytes` — rejects an oversized request body with `413` before it is buffered into memory.
- Error responses no longer ship `err.stack` to the client; the full error still goes to the server log.
- Defense-in-depth containment on the dev worker reference gate and the preview static server.
- Containment logic consolidated into a shared, unit-tested `isPathWithin(base, target)` helper (fixes a latent false-rejection of in-tree filenames beginning with `..`).

## Upgrade notes

Drop-in. The new options are opt-in; no consumer code changes are required to upgrade. For internet-facing deploys that mount the production `handleServerAction`, consider setting `allowedOrigins` and `maxBodyBytes` (see `docs/server-actions.md` → "Endpoint hardening"). Static-only hosts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)