### PR TITLE
feat: flash-free dynamic SSR tooling (createInlineFlightRenderer + hydrateOrRender)

### DIFF
--- a/docs-site/src/client.tsx
+++ b/docs-site/src/client.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 /**
  * Client-side navigation for the docs site.
  *
@@ -12,7 +13,7 @@
  * Everything degrades gracefully: with JS disabled, the same `<a href>` links
  * are ordinary full-page navigations between the prerendered HTML files.
  */
-import { useEffect, useState, useTransition } from "react";
+import React, { useEffect, useState, useTransition } from "react";
 import type { ReactNode } from "react";
 import { createRoot, hydrateRoot } from "react-dom/client";
 import { createReactFetcher } from "vite-plugin-react-server/utils";

--- a/docs-site/src/client.tsx
+++ b/docs-site/src/client.tsx
@@ -15,8 +15,7 @@
  */
 import React, { useEffect, useState, useTransition } from "react";
 import type { ReactNode } from "react";
-import { createRoot, hydrateRoot } from "react-dom/client";
-import { createReactFetcher } from "vite-plugin-react-server/utils";
+import { createReactFetcher, hydrateOrRender } from "vite-plugin-react-server/utils";
 
 const BASE = import.meta.env.BASE_URL || "/";
 
@@ -159,23 +158,12 @@ function App({ initialNode }: { initialNode: ReactNode }) {
 
 const root = document.getElementById("root");
 if (root) {
-  // Fully resolve the initial payload (dynamic import + flight decode) to a
-  // ReactNode BEFORE mounting, then render that node directly — a synchronous
-  // first render with no Suspense boundary, so hydrateRoot matches the
-  // prerendered HTML exactly. (createReactFetcher returns a native promise that
-  // dynamically imports the flight client; use()-ing it, or wrapping the root in
-  // <Suspense> the server never rendered, mismatches the prerender → React #418.)
-  const initial = createReactFetcher();
-  const mount = (initialNode: ReactNode) => {
-    if (root.hasChildNodes()) {
-      hydrateRoot(root, <App initialNode={initialNode} />);
-    } else {
-      createRoot(root).render(<App initialNode={initialNode} />);
-    }
-  };
-  // On failure, stay on the prerendered static HTML (links fall back to normal
-  // full-page navigation) rather than hydrating a blank or broken tree.
-  Promise.resolve(initial).then(mount, (err) => {
-    console.error("[docs] initial RSC payload failed to load; staying static", err);
-  });
+  // Resolve the initial flight payload to a ReactNode, wrap it in <App>, and
+  // mount — hydrateOrRender does the #418-safe dance (fully resolve before the
+  // first render, no client-only Suspense, hydrate prerendered markup in place).
+  // On failure it leaves the prerendered static HTML up, so links fall back to
+  // ordinary full-page navigation.
+  hydrateOrRender(root, async () => (
+    <App initialNode={await createReactFetcher()} />
+  ));
 }

--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -130,6 +130,41 @@ app.listen(3000);
 
 For a real-world example, see the [bidoof-template](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official) demo.
 
+## Where it runs: static anywhere, dynamic on Node
+
+The three build outputs do not all target the same runtime, so it is worth being
+precise about what deploys where.
+
+**`dist/static/` runs anywhere.** It is just files — HTML, `.rsc` payloads,
+hashed JS/CSS. Serve it from any static host, CDN, or edge network (GitHub
+Pages, Netlify, S3/CloudFront, Cloudflare Pages). There is no runtime
+requirement. For a fully static site this is the entire deployment.
+
+**Dynamic SSR runs on Node, not on the edge.** The moment you render HTML per
+request — the flash-free dynamic-route path (`createInlineFlightRenderer` and
+the html-worker behind it) — you need Node. vprs renders the react-dom HTML in a
+worker thread that runs in the *opposite* React condition from your main thread
+(server components resolve under `--conditions react-server`; react-dom renders
+the client half without it). That worker is `node:worker_threads`, and the
+streams it speaks are `node:stream` / `MessagePort`. Edge runtimes such as
+Cloudflare Workers and Deno Deploy have no `worker_threads`, so this path does
+not run there. The cross-condition worker is also what lets the single-condition
+ESM transport render both halves at all — see
+[Workers](./internals/workers.md) and [How vprs compares](./comparison.md).
+
+The runtime RSC-payload and server-action helpers are likewise implemented on
+Node primitives today. A *static* build has no server runtime and therefore no
+callable surface, so this only applies once you stand up a dynamic server.
+
+**The pattern for an edge deployment today is hybrid:** serve `dist/static/`
+from the edge/CDN (instant, global, no runtime) and put any dynamic SSR or
+server actions on a Node origin behind it. vprs does not currently ship an
+in-process edge SSR path (`react-dom/server.edge`, no worker); whether to add
+one is an open question, not a present feature. If first-class edge SSR is a
+hard requirement, `@vitejs/plugin-rsc` reaches the edge in-process today (via
+Vite's environment API and Cloudflare's child-environment workers) and is the
+better fit.
+
 ## Stream Types
 
 ### Headless RSC Stream (`index.rsc`)

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -153,7 +153,9 @@ scope on purpose:
   needs the webpack transport, use `@vitejs/plugin-rsc`.
 - **No deployment/hosting layer.** The build emits ESM and a static directory;
   wiring them into a host (static CDN, Express, Hono, serverless) is up to you.
-  See [Build Output](./build-output.md).
+  The static output runs anywhere (including the edge); dynamic SSR is Node-only
+  today, because the flash-free HTML path renders in a `worker_threads` worker.
+  See [Build Output → Where it runs](./build-output.md#where-it-runs-static-anywhere-dynamic-on-node).
 - **Two React trains, not any React build.** vprs pins React through
   `react-server-loader`, which ships a stable train and an experimental train;
   you pick one (see "React" above). `@vitejs/plugin-rsc` instead lets you bring

--- a/package.json
+++ b/package.json
@@ -324,6 +324,7 @@
     "test:client": "vitest run",
     "test:examples": "npm run test:both -- test/examples",
     "test:streams": "npm run test:both -- test/streams",
+    "test:inline-renderer": "./scripts/test-both.sh test/streams/inline-flight-renderer.test.ts",
     "test:dev": "NODE_OPTIONS='--conditions react-server' vitest run test/dev",
     "pretest:both": "npm run build",
     "test:both": "./scripts/test-both.sh",

--- a/plugin/stream/createHtmlStream.server.ts
+++ b/plugin/stream/createHtmlStream.server.ts
@@ -5,6 +5,32 @@ import { createSerializableHandlerOptions } from "../helpers/createSerializableH
 import { toError } from "../error/toError.js";
 import { serializeError } from "../error/serializeError.js";
 import { createMessageChannels } from "./createMessageChannels.js";
+
+/**
+ * A null React hook dispatcher during worker SSR (`Cannot read properties of null
+ * (reading 'useState')`) almost always means the worker resolved a "use client"
+ * chunk that bundles its OWN copy of React, separate from the worker's
+ * react-dom/server. Point the worker's moduleRootPath at the `--ssr` client build
+ * (bare react/react-dom externals), not the browser bundle. Augment the message so
+ * this isn't a cryptic dead end.
+ */
+function augmentHtmlWorkerError(error: Error): Error {
+  if (
+    /Cannot read properties of null \(reading '(use[A-Zёa-z]*|use)'\)/.test(
+      error.message
+    ) ||
+    /null is not an object.*\.use[A-Z]/.test(error.message)
+  ) {
+    error.message +=
+      "\n\n[vite-plugin-react-server] This null React hook dispatcher during HTML " +
+      "rendering usually means the html-worker resolved a 'use client' chunk that " +
+      "bundles its own React. Point the worker's moduleRootPath at the --ssr client " +
+      "build (where react/react-dom are bare-specifier externals), not the browser " +
+      "bundle that ships its own React copy.";
+  }
+  return error;
+}
+
 /**
  * Creates an HTML stream using a MessagePort for direct communication with the HTML worker
  */
@@ -212,7 +238,9 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
         }
         break;
       case "ERROR":
-        const error = toError(message.error, message.errorInfo);
+        const error = augmentHtmlWorkerError(
+          toError(message.error, message.errorInfo)
+        );
         htmlStream.destroy(error);
 
         // Call the error callback if provided

--- a/plugin/stream/createInlineFlightRenderer.client.ts
+++ b/plugin/stream/createInlineFlightRenderer.client.ts
@@ -1,0 +1,35 @@
+/**
+ * createInlineFlightRenderer.client.ts
+ *
+ * react-client condition barrel. Serving a route with inline flight from a
+ * react-client process means RSC must be produced in an rsc-worker (the RSC
+ * server renderer isn't available under this condition) and HTML rendered in the
+ * main thread — the inverse of the react-server path. That serving model is much
+ * less common than running the prod server under `--conditions react-server`
+ * (RSC in-process + html-worker), and isn't implemented yet.
+ *
+ * This barrel keeps the export import-safe under react-client (no react-server-only
+ * imports) and fails with an actionable message instead of a confusing crash.
+ */
+import { assertNonReactServer } from "../config/getCondition.js";
+import type { CreateInlineFlightRendererFn } from "./createInlineFlightRenderer.types.js";
+
+export type {
+  InlineFlightRendererConfig,
+  RenderRouteOptions,
+  InlineFlightRenderer,
+  InlineFlightHtmlStream,
+  CreateInlineFlightRendererFn,
+} from "./createInlineFlightRenderer.types.js";
+
+assertNonReactServer();
+
+export const createInlineFlightRenderer: CreateInlineFlightRendererFn =
+  function _createInlineFlightRendererClient() {
+    throw new Error(
+      "createInlineFlightRenderer is only implemented for the react-server serving " +
+        "condition (RSC in-process + html-worker). This process is running under the " +
+        "react-client condition. Run your production server with " +
+        "NODE_OPTIONS='--conditions react-server' to serve dynamic routes with inline flight."
+    );
+  };

--- a/plugin/stream/createInlineFlightRenderer.server.ts
+++ b/plugin/stream/createInlineFlightRenderer.server.ts
@@ -1,0 +1,186 @@
+/**
+ * createInlineFlightRenderer.server.ts
+ *
+ * High-level helper for serving a DYNAMIC route (per-request, live data) as a
+ * flash-free HTML document: the page is rendered to HTML and the matching flight
+ * payload is inlined, so the browser hydrates the server markup in place — live
+ * data in the initial HTML, no empty-shell flash, no index.rsc round-trip. It is
+ * the runtime counterpart to the build's inlineFlightPayload, and collapses the
+ * worker + dual-flight + manifest boilerplate a consumer would otherwise hand-roll
+ * (see the bidoof-template /todos server).
+ *
+ * CONDITION: this is the `react-server` serving path — RSC is rendered in-process
+ * and HTML in an html-worker (react-client). It is exported under the react-server
+ * condition only; the react-client serving counterpart (RSC in a worker, HTML in
+ * the main thread) is a separate, less common model — see createInlineFlightRenderer.client.ts.
+ *
+ * The two flights come from the SAME components and props via the canonical
+ * `createElementWithReact` composition (through createRscStream):
+ *  - FULL:     <Html Root Page .../>  → the whole document, streamed to the worker.
+ *  - HEADLESS: <Root as={Fragment} Page cssFiles/>  → page content only (Page + Css,
+ *              no #root wrapper) — exactly what the client renders into #root.
+ * Same Root + same props ⇒ the markup and the inline payload agree (clean hydrate).
+ */
+import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import type { Readable } from "node:stream";
+import { React } from "../vendor/vendor.server.js";
+import { assertReactServer } from "../config/getCondition.js";
+import { createRenderToPipeableStreamHandler } from "./createRenderToPipeableStreamHandler.server.js";
+import { createHtmlStreamWithInlineFlight } from "./createHtmlStreamWithInlineFlight.server.js";
+import { createWorker } from "../worker/createWorker.js";
+import { Root as DefaultRoot } from "../components/root.js";
+import type {
+  CreateInlineFlightRendererFn,
+} from "./createInlineFlightRenderer.types.js";
+
+export type {
+  InlineFlightRendererConfig,
+  RenderRouteOptions,
+  InlineFlightRenderer,
+  InlineFlightHtmlStream,
+  CreateInlineFlightRendererFn,
+} from "./createInlineFlightRenderer.types.js";
+
+assertReactServer();
+
+/** Read the build manifest's entry module as a bootstrap module URL. */
+function deriveBootstrapModules(staticDir: string, base: string): string[] {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(join(staticDir, ".vite/manifest.json"), "utf-8")
+    ) as Record<string, { file: string; isEntry?: boolean }>;
+    const entry =
+      manifest["index.html"]?.file ??
+      Object.values(manifest).find((e) => e.isEntry)?.file;
+    return entry ? [base + entry] : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Buffer an RSC flight stream to its raw bytes (the inline payload). */
+async function collectFlight(stream: Readable): Promise<Uint8Array> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return new Uint8Array(Buffer.concat(chunks));
+}
+
+export const createInlineFlightRenderer: CreateInlineFlightRendererFn = function _createInlineFlightRenderer(
+  config
+) {
+  const {
+    Html,
+    Root = DefaultRoot,
+    buildDir,
+    base = process.env["BASE_URL"] || "/",
+    verbose = false,
+  } = config;
+  const clientDir = config.clientDir ?? (buildDir ? join(buildDir, "client") : undefined);
+  const staticDir = config.staticDir ?? (buildDir ? join(buildDir, "static") : undefined);
+  if (!clientDir) {
+    throw new Error(
+      "createInlineFlightRenderer: clientDir (or buildDir) is required — the html-worker resolves 'use client' chunks from the --ssr client build."
+    );
+  }
+  const projectRoot = config.projectRoot ?? process.cwd();
+  const bootstrapModules =
+    config.bootstrapModules ??
+    (staticDir ? deriveBootstrapModules(staticDir, base) : []);
+
+  // One long-lived html-worker, created on first render and reused. createWorker
+  // flips the condition (react-server → react-client) and now defaults the
+  // startup timeout, so a minimal userOptions is enough.
+  let workerPromise: Promise<any> | null = null;
+  const getWorker = (): Promise<any> => {
+    if (!workerPromise) {
+      workerPromise = createWorker({
+        projectRoot,
+        ...(config.htmlWorkerPath ? { workerPath: config.htmlWorkerPath } : {}),
+        currentCondition: "react-server",
+        reverseCondition: "react-client",
+        mode: "production",
+        verbose,
+        workerData: {
+          // The worker reads only clientPipeableStreamOptions / panicThreshold /
+          // logLevel; everything else flows per-render via the INIT message. The
+          // SerializedUserOptions type wants the full set, hence the cast.
+          userOptions: { verbose, clientPipeableStreamOptions: {} } as any,
+          resolvedConfig: { logLevel: verbose ? "info" : "warn" } as any,
+        },
+      }).then((result: any) => {
+        if (result.type !== "success") {
+          workerPromise = null;
+          throw result.error ?? new Error("html-worker failed to start");
+        }
+        return result.worker;
+      });
+    }
+    return workerPromise;
+  };
+
+  return {
+    async render({ route, Page, props = {}, cssFiles, globalCss, id }) {
+      const htmlWorker = await getWorker();
+      // createRenderToPipeableStreamHandler renders directly from components via
+      // createElementWithReact (no pagePath needed). Its option type requires the
+      // full handler-option set even though only these fields matter here, so we
+      // cast — components compose exactly as the build does.
+      const common = {
+        route,
+        PageComponent: Page,
+        RootComponent: Root,
+        pageProps: props,
+        cssFiles,
+        globalCss,
+        moduleBaseURL: base,
+        moduleBasePath: "/",
+        as: "div",
+        verbose,
+      };
+
+      // FULL document flight (Html-wrapped) → the html-worker renders it to HTML.
+      const full = createRenderToPipeableStreamHandler({
+        ...common,
+        id: `${id ?? route}-full`,
+        HtmlComponent: Html,
+      } as any);
+
+      // HEADLESS flight (Root with as=Fragment → Page + Css, no #root wrapper):
+      // the payload the client decodes into #root. Same Root + props as FULL.
+      const headless = createRenderToPipeableStreamHandler({
+        ...common,
+        id: `${id ?? route}-headless`,
+        HtmlComponent: React.Fragment,
+      } as any);
+
+      return createHtmlStreamWithInlineFlight({
+        route,
+        id: id ?? route,
+        htmlWorker,
+        rscStream: full.rscStream,
+        inlineFlight: collectFlight(headless.rscStream as Readable),
+        moduleRootPath: clientDir,
+        moduleBaseURL: base,
+        moduleBasePath: "/",
+        projectRoot: clientDir,
+        clientPipeableStreamOptions: { bootstrapModules },
+        verbose,
+      } as Parameters<typeof createHtmlStreamWithInlineFlight>[0]);
+    },
+
+    async close() {
+      if (!workerPromise) return;
+      try {
+        const worker = await workerPromise;
+        await worker?.terminate?.();
+      } catch {
+        /* already gone */
+      } finally {
+        workerPromise = null;
+      }
+    },
+  };
+}

--- a/plugin/stream/createInlineFlightRenderer.types.ts
+++ b/plugin/stream/createInlineFlightRenderer.types.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared (condition-agnostic) types for createInlineFlightRenderer — the
+ * react-server and react-client barrels both import these so the public surface
+ * is identical across conditions.
+ */
+import type { CssContent } from "../types.js";
+
+export interface InlineFlightRendererConfig {
+  /** The document component (renders <html>…<div id="root">…). */
+  Html: React.ComponentType<any>;
+  /** Root layout rendered inside #root. Defaults to the vprs Root (Page + Css). */
+  Root?: React.ComponentType<any>;
+  /**
+   * The `--ssr` client build dir (e.g. `dist/client`). The html-worker resolves
+   * "use client" chunks from here: it externalizes react/react-dom as bare
+   * specifiers, so they share the worker's React. Do NOT point this at the
+   * browser bundle (e.g. `dist/static`) — those chunks bundle their own React
+   * copy and SSR fails with a null hook dispatcher.
+   */
+  clientDir?: string;
+  /** The static/browser build dir (manifest + assets). Defaults to `${buildDir}/static`. */
+  staticDir?: string;
+  /** Convenience: sets clientDir=`${buildDir}/client`, staticDir=`${buildDir}/static`. */
+  buildDir?: string;
+  /** Base URL / public path. Default: `process.env.BASE_URL || "/"`. */
+  base?: string;
+  /** Project root for the worker's module resolution (NODE_PATH). Default: cwd. */
+  projectRoot?: string;
+  /**
+   * Explicit path to the html-worker entry. Defaults to the file shipped next to
+   * this module (resolved from dist when imported as a package). Set it only for
+   * non-standard installs, or when driving the renderer from source.
+   */
+  htmlWorkerPath?: string;
+  /**
+   * Client entry module(s) React must bootstrap so the hydrating <script> ships
+   * in the SSR HTML. Default: derived from the static build manifest's entry.
+   */
+  bootstrapModules?: string[];
+  verbose?: boolean;
+}
+
+export interface RenderRouteOptions {
+  /** Route path, e.g. "/todos". */
+  route: string;
+  /** The page (server) component for this route. */
+  Page: React.ComponentType<any>;
+  /** Serializable props for the page (the live data). */
+  props?: Record<string, unknown>;
+  /** Per-route stylesheet links rendered inside #root (and inlined). */
+  cssFiles?: Map<string, CssContent>;
+  /** Global stylesheet links rendered into <head>. */
+  globalCss?: Map<string, CssContent>;
+  /** Stream id; defaults to the route. */
+  id?: string;
+}
+
+export interface InlineFlightHtmlStream {
+  pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => Writable;
+  abort: (reason?: unknown) => void;
+}
+
+export interface InlineFlightRenderer {
+  /** Render a route to an HTML stream with the matching flight inlined. */
+  render(options: RenderRouteOptions): Promise<InlineFlightHtmlStream>;
+  /** Terminate the underlying worker. */
+  close(): Promise<void>;
+}
+
+export type CreateInlineFlightRendererFn = (
+  config: InlineFlightRendererConfig
+) => InlineFlightRenderer;

--- a/plugin/stream/index.client.ts
+++ b/plugin/stream/index.client.ts
@@ -11,6 +11,9 @@ export * from "./createFromNodeStream.client.js";
 // HTML Stream creation
 export * from "./createHtmlStream.client.js";
 
+// High-level dynamic-route renderer (react-client barrel: clear "use react-server" error)
+export * from "./createInlineFlightRenderer.client.js";
+
 // Worker Stream handling - using unified API
 export * from "./createRscWorkerStream.js";
 // Shared type exports

--- a/plugin/stream/index.server.ts
+++ b/plugin/stream/index.server.ts
@@ -14,6 +14,9 @@ export * from "./createHtmlStream.server.js";
 // HTML Stream creation with inlined flight payload (flash-free dynamic SSR)
 export * from "./createHtmlStreamWithInlineFlight.server.js";
 
+// High-level dynamic-route renderer (worker + dual-flight + manifest wiring)
+export * from "./createInlineFlightRenderer.server.js";
+
 // Worker Stream handling - using unified API
 export * from "./createRscWorkerStream.js";
 // Shared type exports

--- a/plugin/utils/hydrateOrRender.ts
+++ b/plugin/utils/hydrateOrRender.ts
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+
+export interface HydrateOrRenderOptions {
+  /**
+   * Called when `getInitialNode()` rejects (e.g. the initial RSC payload fails
+   * to load). The default logs and leaves the prerendered static HTML in place,
+   * so in-site links fall back to ordinary full-page navigation rather than the
+   * page mounting a blank or broken tree. Provide your own to customize the
+   * fallback.
+   */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * #418-safe client mount for vprs apps.
+ *
+ * The prerendered / SSR'd shell is already sitting in `root` as static HTML. To
+ * hydrate it in place without tripping React #418, the initial tree must be
+ * FULLY RESOLVED before the first render — no pending thenable, no client-only
+ * `<Suspense>` the server never rendered (either mismatches the prerendered
+ * markup). This helper encodes that contract: it resolves `getInitialNode()` to
+ * a concrete `ReactNode`, then mounts synchronously — `hydrateRoot` when the
+ * shell is prerendered, `createRoot().render` when `root` is an empty client
+ * shell.
+ *
+ * `react-dom/client` is imported lazily (in parallel with resolving the node) so
+ * this module stays import-safe under the `react-server` condition — a static
+ * import would drag `react-dom/client` into a server graph — matching the rest
+ * of the `/utils` barrel.
+ *
+ * @example
+ * import { createReactFetcher, hydrateOrRender } from "vite-plugin-react-server/utils";
+ *
+ * const root = document.getElementById("root");
+ * if (root) {
+ *   // Resolve the flight payload first, wrap it in your app shell, then mount.
+ *   hydrateOrRender(root, async () => (
+ *     <App initialNode={await createReactFetcher()} />
+ *   ));
+ * }
+ */
+export function hydrateOrRender(
+  root: Element,
+  getInitialNode: () => ReactNode | PromiseLike<ReactNode>,
+  options: HydrateOrRenderOptions = {}
+): void {
+  const onError =
+    options.onError ??
+    ((error: unknown) =>
+      console.error(
+        "[vprs] hydrateOrRender: initial payload failed; staying static",
+        error
+      ));
+
+  // Resolve the node and import react-dom/client concurrently; mount only once
+  // BOTH are ready. Promise.all consumes both, so a rejection on either path
+  // routes to onError without leaving a dangling unhandled rejection.
+  Promise.all([
+    Promise.resolve().then(getInitialNode),
+    import("react-dom/client"),
+  ])
+    .then(([initialNode, { createRoot, hydrateRoot }]) => {
+      // hasChildNodes(): a prerendered/SSR'd shell already holds the server
+      // markup, so hydrate it; an empty client-only shell gets a fresh render.
+      if (root.hasChildNodes()) {
+        hydrateRoot(root, initialNode);
+      } else {
+        createRoot(root).render(initialNode);
+      }
+    })
+    .catch(onError);
+}

--- a/plugin/utils/index.client.ts
+++ b/plugin/utils/index.client.ts
@@ -1,5 +1,6 @@
 // Client barrel: includes all utils including browser-only ones
 export * from "./createReactFetcher.js";
+export * from "./hydrateOrRender.js";
 export * from "./useRscHmr.js";
 export * from "./callServer.js";
 export * from "./urls.js";

--- a/plugin/utils/index.server.ts
+++ b/plugin/utils/index.server.ts
@@ -5,6 +5,7 @@
 // resolves to the same surface in both conditions. The helpers still only *run*
 // in the browser; importing them here never evaluates the browser flight client.
 export * from "./createReactFetcher.js";
+export * from "./hydrateOrRender.js";
 export * from "./useRscHmr.js";
 export * from "./callServer.js";
 export * from "./urls.js";

--- a/plugin/utils/index.ts
+++ b/plugin/utils/index.ts
@@ -8,6 +8,7 @@
 // The `./utils/rsc-client` subpath re-exports just the RSC-client helpers
 // (createReactFetcher, callServer) for browser apps that want them in isolation.
 export * from "./createReactFetcher.js";
+export * from "./hydrateOrRender.js";
 export * from "./useRscHmr.js";
 export * from "./callServer.js";
 export * from "./urls.js";

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -359,15 +359,27 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
 
     return await new Promise<CreateWorkerSuccess | CreateWorkerSkip>(
       (resolve, reject) => {
-        // Use appropriate timeout based on worker type
+        // Use appropriate timeout based on worker type. Fall back to the
+        // DEFAULT_CONFIG value when the caller didn't pre-resolve it — createWorker
+        // is a public entry (exported as `vite-plugin-react-server/worker`), and
+        // an undefined timeout makes `setTimeout(reject, undefined)` fire on the
+        // next tick, so the worker "times out" before it can even start.
         const workerType = reverseCondition === "react-server" ? "rsc" : "html";
         const startupTimeout =
-          workerType === "rsc"
+          (workerType === "rsc"
             ? options.workerData.userOptions?.rscWorkerStartupTimeout
-            : options.workerData.userOptions?.htmlWorkerStartupTimeout;
+            : options.workerData.userOptions?.htmlWorkerStartupTimeout) ??
+          (workerType === "rsc"
+            ? DEFAULT_CONFIG.RSC_WORKER_STARTUP_TIMEOUT
+            : DEFAULT_CONFIG.HTML_WORKER_STARTUP_TIMEOUT);
 
         const timeout = setTimeout(() => {
-          reject({ type: "error", error: new Error("Worker ready timeout") });
+          reject({
+            type: "error",
+            error: new Error(
+              `Worker ready timeout after ${startupTimeout}ms (worker/${workerType})`
+            ),
+          });
         }, startupTimeout);
         const exitHandler = (code: number) => {
           clearTimeout(timeout);
@@ -458,7 +470,17 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
         });
       }
     );
-  } catch (error) {
+  } catch (rawError) {
+    // The startup Promise rejects with a { type: "error", error: Error } shape
+    // (timeout / non-zero exit / worker 'error'). Unwrap it to the real Error so
+    // the cause survives instead of being stringified to "[object Object]".
+    const error =
+      rawError &&
+      typeof rawError === "object" &&
+      "error" in rawError &&
+      (rawError as { error?: unknown }).error instanceof Error
+        ? (rawError as { error: Error }).error
+        : rawError;
     if (verbose) {
       logger.error(
         `[create:${id}] Caught error during worker creation: ${

--- a/scripts/validate-sibling.sh
+++ b/scripts/validate-sibling.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# validate-sibling.sh — validate this package against a sibling consumer via a
+# real npm tarball (NOT a file: link, which masks version/packaging issues).
+#
+# Packs vite-plugin-react-server, installs the tarball into the sibling, runs the
+# sibling's test command, then restores the sibling's node_modules. This is the
+# on-demand integration loop — it is intentionally NOT wired into `test-all`, so
+# the fast unit loop (`npm run test:inline-renderer`) stays the default and this
+# only runs when you ask for it.
+#
+# Usage:
+#   scripts/validate-sibling.sh <sibling-dir> [test-cmd...]
+#   scripts/validate-sibling.sh ../bidoof-template "npm run test:e2e"
+#   SKIP_BUILD=1 scripts/validate-sibling.sh ../bidoof-template   # reuse current dist/pack
+#
+# Knobs:
+#   SKIP_BUILD=1   skip `npm run build` (use the existing dist)
+#   KEEP=1         leave the tarball installed in the sibling (skip restore)
+set -euo pipefail
+
+SIBLING="${1:?usage: validate-sibling.sh <sibling-dir> [test-cmd...]}"
+shift || true
+TEST_CMD="${*:-npm run test:e2e}"
+
+VPRS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SIBLING_DIR="$(cd "$SIBLING" && pwd)"
+PKG_NAME="vite-plugin-react-server"
+
+echo "▶ validate-sibling: $PKG_NAME → $SIBLING_DIR"
+echo "  test cmd: $TEST_CMD"
+
+cd "$VPRS_DIR"
+if [ "${SKIP_BUILD:-0}" != "1" ]; then
+  echo "▶ building $PKG_NAME (full: types + vite)…"
+  npm run build
+fi
+
+echo "▶ packing tarball…"
+rm -f "$PKG_NAME"-*.tgz
+TARBALL="$(npm pack | tail -1)"
+TARBALL_ABS="$VPRS_DIR/$TARBALL"
+echo "  $TARBALL_ABS"
+
+cd "$SIBLING_DIR"
+echo "▶ installing tarball into sibling (no package.json change)…"
+npm install "$TARBALL_ABS" --no-save
+
+cleanup() {
+  if [ "${KEEP:-0}" = "1" ]; then
+    echo "▶ KEEP=1 — leaving tarball installed; restore with: (cd $SIBLING_DIR && npm ci)"
+    return
+  fi
+  echo "▶ restoring sibling node_modules ($PKG_NAME)…"
+  cd "$SIBLING_DIR"
+  # Reinstall the version pinned in the lockfile, replacing the tarball copy.
+  npm install "$PKG_NAME" --no-save >/dev/null 2>&1 || npm ci >/dev/null 2>&1 || true
+  rm -f "$TARBALL_ABS"
+}
+trap cleanup EXIT
+
+echo "▶ running sibling test command…"
+set +e
+eval "$TEST_CMD"
+STATUS=$?
+set -e
+
+if [ $STATUS -eq 0 ]; then
+  echo "✅ sibling validation passed: $SIBLING_DIR"
+else
+  echo "❌ sibling validation FAILED ($STATUS): $SIBLING_DIR"
+fi
+exit $STATUS

--- a/test/streams/inline-flight-renderer.test.ts
+++ b/test/streams/inline-flight-renderer.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { Writable } from "node:stream";
+import { getCondition } from "../../plugin/config/getCondition.js";
+
+// Imported from the package (dist) so the html-worker + its register-vendor
+// import resolve from dist the way a real consumer's would. The loop builds the
+// JS first: `npm run build:vite && npm run test:inline-renderer` (esbuild only,
+// no tsc — fast). The renderer logic also has unit coverage that doesn't spawn a
+// worker, but this end-to-end case is the real proof.
+
+/**
+ * createInlineFlightRenderer — fast, source-level, both-condition loop.
+ *
+ *  - react-server: exercises the real path (html-worker startup + dual-flight +
+ *    inline injection + document structure) with a server-only page, so no built
+ *    client chunks are needed. Run it with `npm run test:both -- test/streams/
+ *    inline-flight-renderer.test.ts` (no build — vitest transforms the source;
+ *    the html-worker resolves from the existing dist).
+ *  - react-client: asserts the barrel is import-safe and fails with an actionable
+ *    message (serving with inline flight is a react-server-condition activity).
+ */
+
+const INLINE_FLIGHT_ID = "vprs-flight";
+const isServer = getCondition() === "react-server";
+
+// Server-only fixtures (no "use client"), so the worker SSRs pure markup and
+// needs no client-chunk resolution. Components are passed to the renderer, which
+// builds the elements with its own (vendored) React.
+function TestPage(props: { title?: string }) {
+  return React.createElement(
+    "main",
+    null,
+    React.createElement("h1", null, props.title ?? "untitled"),
+    React.createElement("p", null, "PAGE_BODY_MARKER")
+  );
+}
+function TestHtml({ Root, Page, pageProps, cssFiles, as }: any) {
+  return React.createElement(
+    "html",
+    null,
+    React.createElement(
+      "head",
+      null,
+      React.createElement("title", null, pageProps?.title ?? "Test")
+    ),
+    React.createElement(
+      "body",
+      null,
+      React.createElement(Root, { as, id: "root", cssFiles, Page, pageProps })
+    )
+  );
+}
+
+async function collectHtml(stream: { pipe: (d: Writable) => Writable }): Promise<string> {
+  const chunks: string[] = [];
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("HTML stream timed out")), 15000);
+    const writable = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(chunk.toString());
+        cb();
+      },
+    });
+    writable.on("finish", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    writable.on("error", (e) => {
+      clearTimeout(timeout);
+      reject(e);
+    });
+    stream.pipe(writable);
+  });
+  return chunks.join("");
+}
+
+describe("createInlineFlightRenderer", () => {
+  (isServer ? it : it.skip)(
+    "react-server: streams an HTML document with the matching flight inlined (flash-free)",
+    async () => {
+      const { createInlineFlightRenderer } = await import(
+        "vite-plugin-react-server/stream"
+      );
+
+      const renderer = createInlineFlightRenderer({
+        Html: TestHtml,
+        clientDir: process.cwd(), // no client refs in this fixture, so unused for imports
+        base: "/",
+        bootstrapModules: ["/entry-test.js"],
+      });
+
+      try {
+        const stream = await renderer.render({
+          route: "/probe",
+          Page: TestPage,
+          props: { title: "Probe Title" },
+        });
+        const html = await collectHtml(stream);
+
+        // Real streamed document with the page server-rendered into #root.
+        expect(html).toContain("<!DOCTYPE html>");
+        expect(html).toContain("Probe Title");
+        expect(html).toContain("PAGE_BODY_MARKER");
+        expect(html).toContain('id="root"');
+
+        // Bootstrap module shipped so the client hydrates.
+        expect(html).toContain("/entry-test.js");
+
+        // Inline flight present, base64, before </body>.
+        const match = html.match(
+          new RegExp(
+            `<script type="text/x-component" id="${INLINE_FLIGHT_ID}" data-encoding="base64">([^<]*)</script>`
+          )
+        );
+        expect(match, "inline-flight <script> must be present").toBeTruthy();
+        expect(html.indexOf(`id="${INLINE_FLIGHT_ID}"`)).toBeLessThan(
+          html.lastIndexOf("</body>")
+        );
+
+        // The inlined payload decodes to non-empty flight bytes.
+        const decoded = Buffer.from(match![1], "base64");
+        expect(decoded.length).toBeGreaterThan(0);
+      } finally {
+        await renderer.close();
+      }
+    }
+  );
+
+  (!isServer ? it : it.skip)(
+    "react-client: import-safe, factory throws an actionable error",
+    async () => {
+      const { createInlineFlightRenderer } = await import(
+        "vite-plugin-react-server/stream"
+      );
+      expect(() =>
+        createInlineFlightRenderer({ Html: (() => null) as any, clientDir: "x" })
+      ).toThrow(/react-server/);
+    }
+  );
+});


### PR DESCRIPTION
Raises the floor for user-defined **dynamic** (per-request, live-data) routes that render flash-free HTML and hydrate in place. Previously a consumer hand-rolled ~140 lines of worker + dual-flight + manifest wiring per route, plus two cryptic footguns.

## What's included

- **`createInlineFlightRenderer`** (server) — one call to serve a dynamic route flash-free: live data in the initial HTML, the matching flight inlined, hydrate in place (the runtime counterpart to the build's `inlineFlight`). Condition-split: react-server does the real work (in-process RSC + html-worker); react-client is import-safe and throws an actionable "run under `--conditions react-server`" error rather than crashing. The full (Html-wrapped) and headless (Page-only) flights compose off the **same** Root, so the document markup and the inline payload agree (clean hydrate). The html-worker is memoized; `close()` tears it down.

- **Two html-worker production footguns fixed** —
  - `createWorker` now defaults the READY-handshake startup timeout: an `undefined` timeout made `setTimeout(reject)` fire on the next tick, so the worker "timed out" before it could start. The `{type,error}` reject shape is also unwrapped so the real cause survives instead of stringifying to `[object Object]`.
  - `createHtmlStream` augments a null React hook-dispatcher SSR error with its real cause (the worker resolved a `"use client"` chunk bundling its own React — point `moduleRootPath` at the `--ssr` build, not the browser bundle).

- **`hydrateOrRender`** (`/utils`) — a #418-safe client mount helper. It resolves the initial node first, then mounts synchronously — `hydrateRoot` for prerendered/SSR'd markup, `createRoot` for an empty client shell. `react-dom/client` is imported lazily so the `/utils` barrel stays import-safe under the react-server condition. Replaces a copy-pasted, easy-to-get-wrong snippet; the docs-site adopts it as the reference consumer.

- **Docs** — documents the **edge vs Node runtime boundary**: the static build output deploys anywhere (including the edge); dynamic SSR is Node-only because the flash-free HTML path renders in a `worker_threads` worker. Describes the hybrid pattern (static on edge + Node origin) and that an in-process edge SSR path is not shipped.

## Testing

- `test:server` 651 pass / 4 skip; `test:unit` 468 pass
- New `test/streams/inline-flight-renderer.test.ts` exercises both conditions
- docs-site prod build hydrates clean over repeated loads (no #418); client-side RSC navigation verified (window-global survives -> no full reload)
- On-demand `scripts/validate-sibling.sh` verified `createInlineFlightRenderer` end-to-end against the bidoof-template demo (`/todos` flash-free, live data in initial HTML, zero refetch, no hydration error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
