### PR TITLE
refactor(config): extract createConfiguredWorker (collapse worker blocks)

### DIFF
--- a/plugin/config/createHandlerOptions.client.ts
+++ b/plugin/config/createHandlerOptions.client.ts
@@ -1,7 +1,6 @@
 import type { CreateHandlerOptions } from "../types.js";
 import { getRouteFiles } from "../helpers/getRouteFiles.js";
 import { routeToURL } from "../utils/routeToURL.js";
-import { createWorker } from "../worker/createWorker.js";
 import {
   serializedOptions,
   serializeResolvedConfig,
@@ -20,6 +19,7 @@ import {
   createDefaultOptions,
   resolveAutoDiscoveredFiles,
   buildSharedHandlerOptions,
+  createConfiguredWorker,
 } from "./createHandlerOptions.shared.js";
 import { getCondition } from "./getCondition.js";
 
@@ -127,22 +127,17 @@ export async function createHandlerOptions(
     (userOptions.build?.useRscWorker && isBuildMode);
 
   if (shouldCreateRscWorker) {
-    if (userOptions.verbose) {
-      logger.info(
-        `[createHandlerOptions.client] Creating RSC worker for route: ${route}`
-      );
-    }
+    const serializedUserOptions = userOptions
+      ? serializedOptions(userOptions, autoDiscoveredFiles)
+      : undefined;
 
-    try {
-      const serializedUserOptions = userOptions
-        ? serializedOptions(userOptions, autoDiscoveredFiles)
-        : undefined;
+    const serializedResolvedConfig = config
+      ? serializeResolvedConfig(config)
+      : undefined;
 
-      const serializedResolvedConfig = config
-        ? serializeResolvedConfig(config)
-        : undefined;
-
-      const workerResult = await createWorker({
+    rscWorker = await createConfiguredWorker(
+      `[createHandlerOptions.client] RSC worker (route ${route})`,
+      {
         currentCondition: "react-client",
         workerPath: userOptions.rscWorkerPath,
         verbose: userOptions.verbose,
@@ -153,34 +148,10 @@ export async function createHandlerOptions(
           resolvedConfig: serializedResolvedConfig,
           configEnv,
         },
-      });
-
-      if (workerResult.type === "error") {
-        logger.warn(
-          `[createHandlerOptions.client] Failed to create RSC worker: ${workerResult.error?.message}`
-        );
-        rscWorker = undefined;
-      } else if (workerResult.type === "skip") {
-        logger.warn(
-          `[createHandlerOptions.client] RSC worker creation skipped: ${workerResult.reason}`
-        );
-        rscWorker = undefined;
-      } else {
-        rscWorker = workerResult.worker;
-        if (userOptions.verbose) {
-          logger.info(
-            `[createHandlerOptions.client] RSC worker created successfully`
-          );
-        }
-      }
-    } catch (error) {
-      logger.warn(
-        `[createHandlerOptions.client] RSC worker creation failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-      rscWorker = undefined;
-    }
+      },
+      logger,
+      userOptions.verbose
+    );
   }
 
   // Create HTML worker if:
@@ -191,56 +162,51 @@ export async function createHandlerOptions(
     (userOptions.build?.useHtmlWorker && isBuildMode);
 
   if (shouldCreateHtmlWorker) {
-    if (userOptions.verbose) {
-      logger.info(
-        `[createHandlerOptions.client] Creating HTML worker for route: ${route}`
-      );
-    }
+    // Create fallback defaults based on configEnv
+    const fallbackDefaults = {
+      verbose: false,
+      panicThreshold: 1000,
+      moduleRootPath: "",
+      moduleBaseURL: "",
+      moduleBasePath: "",
+      projectRoot: process.cwd(),
+      htmlTimeout: 30000,
+      serverPipeableStreamOptions: {},
+      clientPipeableStreamOptions: {},
+      build: {
+        useHtmlWorker: isBuildMode,
+        useRscWorker: isBuildMode,
+        pages: [],
+      },
+      dev: {
+        useHtmlWorker: false,
+        useRscWorker: true,
+      },
+    };
 
-    try {
-      // Create fallback defaults based on configEnv
-      const fallbackDefaults = {
-        verbose: false,
-        panicThreshold: 1000,
-        moduleRootPath: "",
-        moduleBaseURL: "",
-        moduleBasePath: "",
-        projectRoot: process.cwd(),
-        htmlTimeout: 30000,
-        serverPipeableStreamOptions: {},
-        clientPipeableStreamOptions: {},
-        build: {
-          useHtmlWorker: isBuildMode,
-          useRscWorker: isBuildMode,
-          pages: [],
-        },
-        dev: {
-          useHtmlWorker: false,
-          useRscWorker: true,
-        },
-      };
+    const serializedUserOptions = userOptions
+      ? serializedOptions(userOptions, autoDiscoveredFiles)
+      : serializedOptions(fallbackDefaults as any, autoDiscoveredFiles);
 
-      const serializedUserOptions = userOptions
-        ? serializedOptions(userOptions, autoDiscoveredFiles)
-        : serializedOptions(fallbackDefaults as any, autoDiscoveredFiles);
+    const serializedResolvedConfig = config
+      ? serializeResolvedConfig(config)
+      : {
+          mode: configEnv?.mode || mode || "development",
+          root: process.cwd(),
+          logLevel: "info",
+          env: {},
+          envPrefix: "VITE_",
+          base: "/",
+          publicDir: "public",
+          cacheDir: "node_modules/.vite",
+          command: configEnv?.command || "serve",
+          isSsrBuild: configEnv?.command === "build",
+          isPreview: false,
+        };
 
-      const serializedResolvedConfig = config
-        ? serializeResolvedConfig(config)
-        : {
-            mode: configEnv?.mode || mode || "development",
-            root: process.cwd(),
-            logLevel: "info",
-            env: {},
-            envPrefix: "VITE_",
-            base: "/",
-            publicDir: "public",
-            cacheDir: "node_modules/.vite",
-            command: configEnv?.command || "serve",
-            isSsrBuild: configEnv?.command === "build",
-            isPreview: false,
-          };
-
-      const htmlWorkerResult = await createWorker({
+    htmlWorker = await createConfiguredWorker(
+      `[createHandlerOptions.client] HTML worker (route ${route})`,
+      {
         currentCondition: "react-client", // We are in a .client file
         reverseCondition: "react-client", // The user still requested a worker, which uses the same condition
         workerPath: userOptions.htmlWorkerPath,
@@ -252,34 +218,10 @@ export async function createHandlerOptions(
           resolvedConfig: serializedResolvedConfig,
           configEnv,
         },
-      });
-
-      if (htmlWorkerResult.type === "error") {
-        logger.warn(
-          `[createHandlerOptions.client] Failed to create HTML worker: ${htmlWorkerResult.error?.message}`
-        );
-        htmlWorker = undefined;
-      } else if (htmlWorkerResult.type === "skip") {
-        logger.warn(
-          `[createHandlerOptions.client] HTML worker creation skipped: ${htmlWorkerResult.reason}`
-        );
-        htmlWorker = undefined;
-      } else {
-        htmlWorker = htmlWorkerResult.worker;
-        if (userOptions.verbose) {
-          logger.info(
-            `[createHandlerOptions.client] HTML worker created successfully`
-          );
-        }
-      }
-    } catch (error) {
-      logger.warn(
-        `[createHandlerOptions.client] HTML worker creation failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-      htmlWorker = undefined;
-    }
+      },
+      logger,
+      userOptions.verbose
+    );
   }
 
   // Create client-specific handler options. The shared fields are assembled by

--- a/plugin/config/createHandlerOptions.server.ts
+++ b/plugin/config/createHandlerOptions.server.ts
@@ -15,10 +15,10 @@ import {
   createDefaultOptions,
   resolveAutoDiscoveredFiles,
   buildSharedHandlerOptions,
+  createConfiguredWorker,
 } from "./createHandlerOptions.shared.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
 import { serializedOptions } from "../helpers/serializeUserOptions.js";
-import { createWorker } from "../worker/createWorker.js";
 
 /**
  * Server-specific handler options creation for React Server Components (RSC).
@@ -270,17 +270,9 @@ export async function createHandlerOptions(
                                (userOptions.build?.useRscWorker && isBuildMode);
   
   if (shouldCreateRscWorker) {
-    if (userOptions.verbose) {
-      logger.info(`[createHandlerOptions.server] Creating RSC worker for route: ${route}`);
-    }
-    
-    try {
-      
-      const serializedUserOptions = serializedOptions(userOptions, autoDiscoveredFiles);
-      
-      // We don't need to create the RSC worker, but if the user wants to use their own worker
-      // it can be done by setting dev.useRscWorker=true or build.useRscWorker=true
-      const workerResult = await createWorker({
+    rscWorker = await createConfiguredWorker(
+      `[createHandlerOptions.server] RSC worker (route ${route})`,
+      {
         currentCondition: "react-server",
         // same CONDITION as the current one (this worker may be redundant)
         reverseCondition: "react-server",
@@ -289,30 +281,13 @@ export async function createHandlerOptions(
         logger,
         workerData: {
           id: route,
-          userOptions: serializedUserOptions,
-          resolvedConfig: {
-            configEnv,
-            mode,
-          },
+          userOptions: serializedOptions(userOptions, autoDiscoveredFiles),
+          resolvedConfig: { configEnv, mode },
         },
-      });
-
-      if (workerResult.type === "error") {
-        logger.warn(`[createHandlerOptions.server] Failed to create RSC worker: ${workerResult.error?.message}`);
-        rscWorker = undefined;
-      } else if (workerResult.type === "skip") {
-        logger.warn(`[createHandlerOptions.server] RSC worker creation skipped: ${workerResult.reason}`);
-        rscWorker = undefined;
-      } else {
-        rscWorker = workerResult.worker;
-        if (userOptions.verbose) {
-          logger.info(`[createHandlerOptions.server] RSC worker created successfully`);
-        }
-      }
-    } catch (error) {
-      logger.warn(`[createHandlerOptions.server] RSC worker creation failed: ${error instanceof Error ? error.message : String(error)}`);
-      rscWorker = undefined;
-    }
+      },
+      logger,
+      userOptions.verbose
+    );
   }
 
   // Create HTML worker if:
@@ -323,15 +298,9 @@ export async function createHandlerOptions(
                                 (userOptions.build?.useHtmlWorker && isBuildMode);
   
   if (shouldCreateHtmlWorker) {
-    if (userOptions.verbose) {
-      logger.info(`[createHandlerOptions.server] Creating HTML worker for route: ${route}`);
-    }
-    
-    try {
-      
-      const serializedUserOptions = serializedOptions(userOptions, autoDiscoveredFiles);
-      
-      const workerResult = await createWorker({
+    htmlWorker = await createConfiguredWorker(
+      `[createHandlerOptions.server] HTML worker (route ${route})`,
+      {
         currentCondition: "react-server",
         reverseCondition: "react-client", // HTML worker needs react-client condition
         workerPath: userOptions.htmlWorkerPath,
@@ -339,30 +308,13 @@ export async function createHandlerOptions(
         logger,
         workerData: {
           id: route,
-          userOptions: serializedUserOptions,
-          resolvedConfig: {
-            configEnv,
-            mode,
-          },
+          userOptions: serializedOptions(userOptions, autoDiscoveredFiles),
+          resolvedConfig: { configEnv, mode },
         },
-      });
-
-      if (workerResult.type === "error") {
-        logger.warn(`[createHandlerOptions.server] Failed to create HTML worker: ${workerResult.error?.message}`);
-        htmlWorker = undefined;
-      } else if (workerResult.type === "skip") {
-        logger.warn(`[createHandlerOptions.server] HTML worker creation skipped: ${workerResult.reason}`);
-        htmlWorker = undefined;
-      } else {
-        htmlWorker = workerResult.worker;
-        if (userOptions.verbose) {
-          logger.info(`[createHandlerOptions.server] HTML worker created successfully`);
-        }
-      }
-    } catch (error) {
-      logger.warn(`[createHandlerOptions.server] HTML worker creation failed: ${error instanceof Error ? error.message : String(error)}`);
-      htmlWorker = undefined;
-    }
+      },
+      logger,
+      userOptions.verbose
+    );
   }
 
   // Create server-specific handler options. The shared fields are assembled by

--- a/plugin/config/createHandlerOptions.shared.ts
+++ b/plugin/config/createHandlerOptions.shared.ts
@@ -16,6 +16,7 @@ import type { Logger, ConfigEnv, ResolvedConfig } from "vite";
 import type { AutoDiscoveredFiles, ResolvedUserOptions } from "../types.js";
 import { resolveAutoDiscover } from "./autoDiscover/resolveAutoDiscover.js";
 import { DEFAULT_CONFIG } from "./defaults.js";
+import { createWorker } from "../worker/createWorker.js";
 import type {
   CreateHandlerOptionsParams,
   ResolvedDefaults,
@@ -146,4 +147,42 @@ export function buildSharedHandlerOptions(input: SharedHandlerOptionsInput) {
     rscWorker,
     htmlWorker,
   };
+}
+
+/**
+ * Run a createWorker() call and reduce its tagged result to a worker-or-undefined,
+ * logging error/skip uniformly.
+ *
+ * Both variants create up to two workers (RSC + HTML), and each block wrapped the
+ * createWorker() call in byte-identical try/catch + result-handling boilerplate —
+ * only the createWorker ARGS differ per side and per kind. This centralizes the
+ * boilerplate; the per-call args stay at the call site.
+ *
+ * Covered by test/unit/createConfiguredWorker.test.ts (the createHandlerOptions
+ * characterization test runs workers-disabled, so this carries its own coverage).
+ */
+export async function createConfiguredWorker(
+  label: string,
+  args: Parameters<typeof createWorker>[0],
+  logger: Logger,
+  verbose?: boolean
+): Promise<unknown> {
+  try {
+    const result = await createWorker(args);
+    if (result.type === "error") {
+      logger.warn(`${label} failed: ${result.error?.message}`);
+      return undefined;
+    }
+    if (result.type === "skip") {
+      logger.warn(`${label} skipped: ${result.reason}`);
+      return undefined;
+    }
+    if (verbose) logger.info(`${label} created successfully`);
+    return result.worker;
+  } catch (error) {
+    logger.warn(
+      `${label} failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return undefined;
+  }
 }

--- a/test/unit/createConfiguredWorker.test.ts
+++ b/test/unit/createConfiguredWorker.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit coverage for createConfiguredWorker — the shared reducer that wraps a
+ * createWorker() call and collapses its tagged {type} result to a
+ * worker-or-undefined, logging error/skip/throw uniformly.
+ *
+ * The createHandlerOptions characterization test runs with workers DISABLED, so
+ * this is the dedicated coverage that makes folding the four (server/client x
+ * rsc/html) worker blocks onto one helper safe (see createHandlerOptions.shared.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { createWorkerMock } = vi.hoisted(() => ({ createWorkerMock: vi.fn() }));
+vi.mock("../../plugin/worker/createWorker.js", () => ({
+  createWorker: createWorkerMock,
+}));
+
+import { createConfiguredWorker } from "../../plugin/config/createHandlerOptions.shared.js";
+
+function fakeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+}
+
+// Representative createWorker args — the helper passes them through unchanged.
+const ARGS = {
+  currentCondition: "react-server",
+  workerPath: "/some/worker.js",
+  logger: fakeLogger(),
+  workerData: { id: "route" },
+} as any;
+
+beforeEach(() => createWorkerMock.mockReset());
+
+describe("createConfiguredWorker", () => {
+  it("returns the worker on success and forwards args verbatim to createWorker", async () => {
+    const worker = { kind: "rsc" };
+    createWorkerMock.mockResolvedValue({ type: "success", worker });
+    const logger = fakeLogger();
+
+    const result = await createConfiguredWorker("RSC worker", ARGS, logger, true);
+
+    expect(result).toBe(worker);
+    expect(createWorkerMock).toHaveBeenCalledTimes(1);
+    expect(createWorkerMock).toHaveBeenCalledWith(ARGS);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("created successfully")
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined and warns (with the cause) on an error result", async () => {
+    createWorkerMock.mockResolvedValue({ type: "error", error: new Error("boom") });
+    const logger = fakeLogger();
+
+    const result = await createConfiguredWorker("RSC worker", ARGS, logger);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("boom"));
+  });
+
+  it("returns undefined and warns (with the reason) on a skip result", async () => {
+    createWorkerMock.mockResolvedValue({ type: "skip", reason: "no worker path" });
+    const logger = fakeLogger();
+
+    const result = await createConfiguredWorker("HTML worker", ARGS, logger);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("no worker path")
+    );
+  });
+
+  it("stays quiet on success when verbose is falsy", async () => {
+    createWorkerMock.mockResolvedValue({ type: "success", worker: {} });
+    const logger = fakeLogger();
+
+    await createConfiguredWorker("RSC worker", ARGS, logger, false);
+
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Continues the 66g condition-split consolidation.

`createHandlerOptions.{server,client}.ts` each create up to two workers (RSC + HTML), and every block wrapped its `createWorker()` call in **byte-identical** try/catch + tagged-result handling — only the `createWorker` ARGS differ per side and per kind. This extracts that reducer to `createConfiguredWorker` in the shared module; the four blocks collapse to their per-call args + one call each.

## Changes
- **`createConfiguredWorker(label, args, logger, verbose?)`** in `createHandlerOptions.shared.ts` — runs `createWorker(args)` and reduces the tagged result to a worker-or-undefined, logging `error`/`skip`/throw uniformly.
- **server + client**: the four worker blocks now just build their args and call the helper (net **−67 LOC** of source). The per-side specifics (conditions, `workerData`, the client's `fallbackDefaults`/`serializeResolvedConfig`) stay at the call site.
- **New `test/unit/createConfiguredWorker.test.ts`**: the `createHandlerOptions` characterization test runs workers-disabled (its header flagged that unifying the worker blocks needed coverage first), so this covers the reduction — success → worker; `error`/`skip` → undefined + warn; verbose gating.

## Testing
- build clean; package entrypoints 101 (`verify-package-entrypoints` + publint)
- `test:unit` 472 pass (was 468; +4 new); `test:server` 655 pass / 4 skip

The remaining createHandlerOptions duplication (the shared skeleton and the server-only component-loader, injectable) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
