### PR TITLE
refactor: extract shared barrels (helpers, root entry) + dedup dev-server

### DIFF
--- a/plugin/dev-server/index.client.ts
+++ b/plugin/dev-server/index.client.ts
@@ -1,6 +1,5 @@
 export * from "./handleServerAction.client.js";
 export * from "./configureReactServer.client.js";
 export * from "./cleanupServerAction.client.js";
-export * from "./handleServerAction.client.js";
 export * from "./configureRequestHandler.client.js";
 export * from "./plugin.client.js";

--- a/plugin/helpers/index.client.ts
+++ b/plugin/helpers/index.client.ts
@@ -1,54 +1,11 @@
-// Route and file handling
-export * from "./getRouteFiles.js";
-export * from "./resolvePage.js";
-export * from "./resolveProps.js";
-export * from "./resolvePageAndProps.js";
+// Client-side aggregator for the public ./helpers subpath under the default
+// (react-client) condition. The condition-neutral surface lives in
+// index.shared.ts; this file adds the client-only resolveComponentsClient and
+// the client-side handleServerAction binding.
 
-export * from "./requestInfo.js";
-export * from "./requestToRoute.js";
+export * from "./index.shared.js";
 
-// Configuration and options
-export * from "./serializeUserOptions.js";
-export * from "./cleanObject.js";
-export * from "./inputNormalizer.js";
-
-// CSS handling
-export * from "./collectManifestCss.js";
-export * from "./collectViteModuleGraphCss.js";
-export * from "./createCssProps.js";
-
-// Stream and handler creation
-// Stream-related functions are now exported from ../stream/index.js
-
-// Hydrate user options
-export * from "./hydrateUserOptions.js";
-
-// Metrics and monitoring
-export * from "./formatMetrics.js";
-export * from "./metrics.js";
-
-// Manifest handling
-export * from "./tryManifest.js";
-export * from "./getBundleManifest.js";
-
-// Module handling
-export * from "./moduleRefs.js";
-
-// Utility functions
-
-// Unified render helpers
-export * from "./validateRscRenderMessage.js";
-export * from "./resolveRenderUrl.js";
-export * from "./mergeMessageWithDefaults.js";
-export * from "./resolveWithDefaultRootAndHtml.js";
 export { resolveComponents as resolveComponentsClient } from "./resolveComponents.client.js";
-
-export * from "./logRenderStart.js";
-export * from "./createSerializableHandlerOptions.js";
-
-export * from "./createPatternMatcher.js";
-
-export * from "./createUnifiedCssProcessor.js";
 
 // Server action handling
 export { handleServerAction } from "./handleServerAction.client.js";

--- a/plugin/helpers/index.server.ts
+++ b/plugin/helpers/index.server.ts
@@ -1,59 +1,12 @@
-// Route and file handling
-export * from "./getRouteFiles.js";
-export * from "./resolvePage.js";
-export * from "./resolveProps.js";
-export * from "./resolvePageAndProps.js";
-
-export * from "./requestInfo.js";
-export * from "./requestToRoute.js";
-
-// Configuration and options
-export * from "./serializeUserOptions.js";
-export * from "./cleanObject.js";
-export * from "./inputNormalizer.js";
-
-// CSS handling
-export * from "./collectManifestCss.js";
-export * from "./collectViteModuleGraphCss.js";
-export * from "./createCssProps.js";
-
-// Stream and handler creation
-// Stream-related functions are now exported from ../stream/index.js
-
-// Hydrate user options
-export * from "./hydrateUserOptions.js";
-
-// Metrics and monitoring
-export * from "./formatMetrics.js";
-export * from "./metrics.js";
-
-// Manifest handling
-export * from "./tryManifest.js";
-export * from "./getBundleManifest.js";
-
-// Module handling
-export * from "./moduleRefs.js";
-
-// Utility functions
-
-// Unified render helpers
-export * from "./validateRscRenderMessage.js";
-export * from "./resolveRenderUrl.js";
-export * from "./mergeMessageWithDefaults.js";
-export * from "./resolveWithDefaultRootAndHtml.js";
-// Server-side resolveComponents lives in resolveComponents.ts (no .client suffix)
-// or is intentionally absent here. Re-exporting resolveComponents.client.js from
-// a .server.ts aggregator violates the .server/.client split — under
+// Server-side aggregator for the public ./helpers subpath under react-server.
+// The condition-neutral surface lives in index.shared.ts; this file adds only
+// the server-side handleServerAction binding.
+//
+// resolveComponents.client is intentionally NOT re-exported here: under
 // react-server, ESM static linking would evaluate the .client module's
-// transitive deps (e.g. vendor.client.js → react-dom/server) and crash.
-// See bd-6pi.
+// transitive deps (vendor.client.js -> react-dom/server) and crash. See bd-6pi.
 
-export * from "./logRenderStart.js";
-export * from "./createSerializableHandlerOptions.js";
-
-export * from "./createPatternMatcher.js";
-
-export * from "./createUnifiedCssProcessor.js";
+export * from "./index.shared.js";
 
 // Server action handling
 export { handleServerAction } from "./handleServerAction.server.js";

--- a/plugin/helpers/index.shared.ts
+++ b/plugin/helpers/index.shared.ts
@@ -1,0 +1,51 @@
+// Condition-neutral surface shared by the public ./helpers barrel under BOTH
+// conditions. Only modules that are import-safe under react-server AND
+// react-client belong here. The per-condition residue lives in
+// index.{server,client}.ts: the `handleServerAction` binding, and the client-only
+// `resolveComponentsClient` (re-exporting resolveComponents.client under
+// react-server would static-link vendor.client -> react-dom/server and crash —
+// see bd-6pi).
+
+// Route and file handling
+export * from "./getRouteFiles.js";
+export * from "./resolvePage.js";
+export * from "./resolveProps.js";
+export * from "./resolvePageAndProps.js";
+
+export * from "./requestInfo.js";
+export * from "./requestToRoute.js";
+
+// Configuration and options
+export * from "./serializeUserOptions.js";
+export * from "./cleanObject.js";
+export * from "./inputNormalizer.js";
+
+// CSS handling
+export * from "./collectManifestCss.js";
+export * from "./collectViteModuleGraphCss.js";
+export * from "./createCssProps.js";
+
+// Hydrate user options
+export * from "./hydrateUserOptions.js";
+
+// Metrics and monitoring
+export * from "./formatMetrics.js";
+export * from "./metrics.js";
+
+// Manifest handling
+export * from "./tryManifest.js";
+export * from "./getBundleManifest.js";
+
+// Module handling
+export * from "./moduleRefs.js";
+
+// Unified render helpers
+export * from "./validateRscRenderMessage.js";
+export * from "./resolveRenderUrl.js";
+export * from "./mergeMessageWithDefaults.js";
+export * from "./resolveWithDefaultRootAndHtml.js";
+
+export * from "./logRenderStart.js";
+export * from "./createSerializableHandlerOptions.js";
+export * from "./createPatternMatcher.js";
+export * from "./createUnifiedCssProcessor.js";

--- a/plugin/index.client.ts
+++ b/plugin/index.client.ts
@@ -1,43 +1,22 @@
 // `.` package entry under default (react-client) resolution.
 //
-// IMPORTANT: this entry is the one a consumer's `vite.config.ts` reaches
-// when imported as `import {...} from "vite-plugin-react-server"`. When
-// Vite's `loadConfigFromFile` bundles that config, esbuild does NOT honor
-// the `react-server` condition — even if Node will run the bundle under
-// react-server, esbuild picks the `default` (client) entry and bundles
-// the .client subtree. To stay safe, this entry's `vitePluginReactServer`
-// uses the neutral TLA dispatcher in `orchestrator/createPluginOrchestrator.ts`,
-// which dispatches to the correct side at runtime via Vite's
-// dynamic-import-helper. See bd-6pi.
+// IMPORTANT: this entry is the one a consumer's `vite.config.ts` reaches when
+// imported as `import {...} from "vite-plugin-react-server"`. When Vite's
+// `loadConfigFromFile` bundles that config, esbuild does NOT honor the
+// `react-server` condition — even if Node will run the bundle under react-server,
+// esbuild picks the `default` (client) entry. To stay safe, the shared factory in
+// index.shared.ts builds the plugin through the neutral TLA dispatcher in
+// orchestrator/createPluginOrchestrator.ts, which dispatches to the correct side
+// at runtime via Vite's dynamic-import-helper. See bd-6pi.
 //
-// The explicit-side `vite-plugin-react-server/client` and
-// `vite-plugin-react-server/server` subpaths still use the direct
-// per-side plugin entries (plugin.client.ts / plugin.server.ts) so a
-// consumer who explicitly opts into the wrong side gets a noisy failure.
+// The explicit-side `vite-plugin-react-server/client` and `/server` subpaths
+// still use the direct per-side plugin entries (plugin.client.ts /
+// plugin.server.ts) so a consumer who explicitly opts into the wrong side gets a
+// noisy failure.
 
-import type { VitePluginMainFn } from "./types.js";
-import { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.js";
-import type { UserOptions, Strategy } from "./orchestrator/types.js";
+import { makeVitePluginReactServer } from "./index.shared.js";
 
-export const vitePluginReactServer: VitePluginMainFn =
-  function _vitePluginReactServer(options, strategy?: Strategy) {
-    if (options == null) {
-      throw new Error("options is required");
-    }
-    const userStrategy = (options as UserOptions).strategy || {};
-    const finalStrategy: Strategy = {
-      mode: "auto",
-      importContext: "react-client",
-      environmentTargets: new Map([["client", "client"], ["ssr", "ssr"], ["server", "server"]]),
-      ...userStrategy,
-      ...strategy,
-    };
-    return createPluginOrchestrator({
-      ...options,
-      strategy: finalStrategy,
-    });
-  };
-
+export const vitePluginReactServer = makeVitePluginReactServer("react-client");
 export const vitePluginReactClient = vitePluginReactServer;
-export { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.js";
-export { getCondition } from "./config/getCondition.js";
+
+export { createPluginOrchestrator, getCondition } from "./index.shared.js";

--- a/plugin/index.server.ts
+++ b/plugin/index.server.ts
@@ -1,35 +1,15 @@
 // `.` package entry under react-server condition resolution.
 //
-// Symmetric to index.client.ts: uses the neutral TLA dispatcher in
-// `orchestrator/createPluginOrchestrator.ts` to keep wrong-side ESM
-// linking from forcing module-init crashes. The explicit-side
-// `vite-plugin-react-server/server` subpath still goes through
-// plugin.server.ts directly, so consumers who explicitly opt into a side
-// fail noisily under the wrong condition. See bd-6pi.
+// Symmetric to index.client.ts: the shared factory in index.shared.ts builds the
+// plugin through the neutral TLA dispatcher in
+// orchestrator/createPluginOrchestrator.ts, so wrong-side ESM linking can't force
+// module-init crashes. The explicit-side `vite-plugin-react-server/server`
+// subpath still goes through plugin.server.ts directly, so consumers who
+// explicitly opt into a side fail noisily under the wrong condition. See bd-6pi.
 
-import type { VitePluginMainFn } from "./types.js";
-import { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.js";
-import type { UserOptions, Strategy } from "./orchestrator/types.js";
+import { makeVitePluginReactServer } from "./index.shared.js";
 
-export const vitePluginReactServer: VitePluginMainFn =
-  function _vitePluginReactServer(options, strategy?: Strategy) {
-    if (options == null) {
-      throw new Error("options is required");
-    }
-    const userStrategy = (options as UserOptions).strategy || {};
-    const finalStrategy: Strategy = {
-      mode: "auto",
-      importContext: "react-server",
-      environmentTargets: new Map([["client", "client"], ["ssr", "ssr"], ["server", "server"]]),
-      ...userStrategy,
-      ...strategy,
-    };
-    return createPluginOrchestrator({
-      ...options,
-      strategy: finalStrategy,
-    });
-  };
-
+export const vitePluginReactServer = makeVitePluginReactServer("react-server");
 export const vitePluginReactClient = vitePluginReactServer;
-export { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.js";
-export { getCondition } from "./config/getCondition.js";
+
+export { createPluginOrchestrator, getCondition } from "./index.shared.js";

--- a/plugin/index.shared.ts
+++ b/plugin/index.shared.ts
@@ -1,0 +1,41 @@
+// Shared implementation for the `.` package entry. Both index.server.ts and
+// index.client.ts build the same plugin factory and differ only in the
+// `importContext` default they bake in ("react-server" vs "react-client").
+//
+// Both sides route through the NEUTRAL TLA dispatcher in
+// orchestrator/createPluginOrchestrator.ts, which dispatches to the correct
+// per-side implementation at runtime — so this shared module carries no
+// static-linking hazard (it never imports a .server/.client subtree). See bd-6pi.
+
+import type { VitePluginMainFn } from "./types.js";
+import { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.js";
+import type { UserOptions, Strategy } from "./orchestrator/types.js";
+
+export function makeVitePluginReactServer(
+  importContext: Strategy["importContext"],
+): VitePluginMainFn {
+  return function _vitePluginReactServer(options, strategy?: Strategy) {
+    if (options == null) {
+      throw new Error("options is required");
+    }
+    const userStrategy = (options as UserOptions).strategy || {};
+    const finalStrategy: Strategy = {
+      mode: "auto",
+      importContext,
+      environmentTargets: new Map([
+        ["client", "client"],
+        ["ssr", "ssr"],
+        ["server", "server"],
+      ]),
+      ...userStrategy,
+      ...strategy,
+    };
+    return createPluginOrchestrator({
+      ...options,
+      strategy: finalStrategy,
+    });
+  };
+}
+
+export { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.js";
+export { getCondition } from "./config/getCondition.js";


### PR DESCRIPTION
Continues the 66g condition-split consolidation — the barrel dedups that were dropped in an earlier stacked-squash merge race, re-landed clean on current `main` and re-verified.

Same surface-preserving shape as the already-merged config barrel:

- **`helpers/index.shared.ts`** holds the ~43-line neutral re-export block; each entry keeps only its per-condition residue: the `handleServerAction` binding, and the client-only `resolveComponentsClient` (re-exporting `resolveComponents.client` under react-server would static-link `vendor.client` → `react-dom/server` and crash — bd-6pi).
- **`index.shared.ts`** factors the root `.` plugin entry into `makeVitePluginReactServer(importContext)`; `index.{server,client}.ts` each bake in their side. Both still route through the neutral orchestrator dispatcher (no static-link hazard).
- **`dev-server/index.client.ts`**: drop a duplicate `handleServerAction.client` re-export.

## Testing
Export surface verified under both conditions:
- root `.` identical (4 names: `vitePluginReactServer`, `vitePluginReactClient`, `createPluginOrchestrator`, `getCondition`)
- `./helpers` 40 shared + the intended client-only `resolveComponentsClient`

build clean; package entrypoints 101 (`verify-package-entrypoints` + publint); `test:unit` 472; `test:server` 655 pass / 4 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
