### PR TITLE
refactor(stream): extract shared ./stream barrel (last 66g barrel)

### DIFF
--- a/plugin/stream/index.client.ts
+++ b/plugin/stream/index.client.ts
@@ -1,46 +1,23 @@
-// RSC Stream handling
+// Client aggregator for the public ./stream subpath under the default condition.
+// The condition-neutral surface lives in index.shared.ts; the per-condition
+// stream impls are below.
+export * from "./index.shared.js";
+
+// RSC stream handling (worker)
 export * from "./handleRscStream.client.js";
 export * from "./createRscStream.client.js";
 
-// HTML Stream handling
+// HTML stream handling
 export * from "./createRenderToPipeableStreamHandler.client.js";
 
-// Node Stream handling
+// Node stream handling (RSC flight -> React elements)
 export * from "./createFromNodeStream.client.js";
 
-// HTML Stream creation
+// HTML stream creation
 export * from "./createHtmlStream.client.js";
 
-// High-level dynamic-route renderer (react-client barrel: clear "use react-server" error)
+// High-level dynamic-route renderer (clear "run under --conditions react-server" error)
 export * from "./createInlineFlightRenderer.client.js";
 
-// Worker Stream handling - using unified API
-export * from "./createRscWorkerStream.js";
-// Shared type exports
-export type { CreateRenderToPipeableStreamHandlerFn } from "./createRenderToPipeableStreamHandler.types.js";
-export type { 
-  CreateRscStreamFn,
-  CreateRscStreamFnUnified,
-  CreateRscStreamOptions,
-  ClientRscStreamOptions,
-  ServerRscStreamOptions,
-  RscStreamResult,
-  ClientRscStreamResult,
-  ServerRscStreamResult,
-  BaseRscStreamResult,
-} from "./createRscStream.types.js";
-export type { HandleRscStreamFn } from "./handleRscStream.types.js";
-
-// RSC Stream utilities
-export {
-  validateRscStreamOptions,
-  createBaseRscStreamResult,
-  handleRscStreamError,
-  createRscStreamMetrics,
-  setupRscStreamEventHandlers,
-} from "./createRscStream.utils.js";
-
-// Shared utilities
-export { pipeToResponse } from "../helpers/pipeToResponse.js";
+// Element resolution (decode flight)
 export { resolveStreamElements } from "../helpers/resolveStreamElements.client.js";
-export type { ResolveStreamElementsOptions } from "../helpers/resolveStreamElements.types.js";

--- a/plugin/stream/index.server.ts
+++ b/plugin/stream/index.server.ts
@@ -1,46 +1,23 @@
-// RSC Stream handling
+// Server aggregator for the public ./stream subpath under react-server. The
+// condition-neutral surface lives in index.shared.ts; the per-condition stream
+// impls are below.
+export * from "./index.shared.js";
+
+// RSC stream handling (in-process)
 export * from "./handleRscStream.server.js";
 export * from "./createRscStream.server.js";
 
-// RSC Stream creation
+// RSC -> pipeable stream
 export * from "./createRenderToPipeableStreamHandler.server.js";
 
-// HTML Stream creation
+// HTML stream creation
 export * from "./createHtmlStream.server.js";
 
-// HTML Stream creation with inlined flight payload (flash-free dynamic SSR)
+// HTML stream creation with inlined flight payload (flash-free dynamic SSR)
 export * from "./createHtmlStreamWithInlineFlight.server.js";
 
 // High-level dynamic-route renderer (worker + dual-flight + manifest wiring)
 export * from "./createInlineFlightRenderer.server.js";
 
-// Worker Stream handling - using unified API
-export * from "./createRscWorkerStream.js";
-// Shared type exports
-export type { CreateRenderToPipeableStreamHandlerFn } from "./createRenderToPipeableStreamHandler.types.js";
-export type { 
-  CreateRscStreamFn,
-  CreateRscStreamFnUnified,
-  CreateRscStreamOptions,
-  ClientRscStreamOptions,
-  ServerRscStreamOptions,
-  RscStreamResult,
-  ClientRscStreamResult,
-  ServerRscStreamResult,
-  BaseRscStreamResult,
-} from "./createRscStream.types.js";
-export type { HandleRscStreamFn } from "./handleRscStream.types.js";
-
-// RSC Stream utilities
-export {
-  validateRscStreamOptions,
-  createBaseRscStreamResult,
-  handleRscStreamError,
-  createRscStreamMetrics,
-  setupRscStreamEventHandlers,
-} from "./createRscStream.utils.js";
-
-// Shared utilities
-export { pipeToResponse } from "../helpers/pipeToResponse.js";
+// Element resolution (in-process compose)
 export { resolveStreamElements } from "../helpers/resolveStreamElements.server.js";
-export type { ResolveStreamElementsOptions } from "../helpers/resolveStreamElements.types.js";

--- a/plugin/stream/index.shared.ts
+++ b/plugin/stream/index.shared.ts
@@ -1,0 +1,37 @@
+// Condition-neutral surface shared by the public ./stream barrel under BOTH
+// conditions. The per-condition stream impls (handleRscStream, createRscStream,
+// createRenderToPipeableStreamHandler, createHtmlStream, createInlineFlightRenderer,
+// resolveStreamElements) and the condition-only ones
+// (createHtmlStreamWithInlineFlight — server; createFromNodeStream — client) live
+// in index.{server,client}.ts.
+
+// Worker Stream handling - using unified API
+export * from "./createRscWorkerStream.js";
+
+// Shared type exports
+export type { CreateRenderToPipeableStreamHandlerFn } from "./createRenderToPipeableStreamHandler.types.js";
+export type {
+  CreateRscStreamFn,
+  CreateRscStreamFnUnified,
+  CreateRscStreamOptions,
+  ClientRscStreamOptions,
+  ServerRscStreamOptions,
+  RscStreamResult,
+  ClientRscStreamResult,
+  ServerRscStreamResult,
+  BaseRscStreamResult,
+} from "./createRscStream.types.js";
+export type { HandleRscStreamFn } from "./handleRscStream.types.js";
+
+// RSC Stream utilities
+export {
+  validateRscStreamOptions,
+  createBaseRscStreamResult,
+  handleRscStreamError,
+  createRscStreamMetrics,
+  setupRscStreamEventHandlers,
+} from "./createRscStream.utils.js";
+
+// Shared utilities
+export { pipeToResponse } from "../helpers/pipeToResponse.js";
+export type { ResolveStreamElementsOptions } from "../helpers/resolveStreamElements.types.js";


### PR DESCRIPTION
The last barrel in the 66g condition-split pass, same surface-preserving shape as the config/helpers/root barrels already merged.

The `./stream` barrel's condition-neutral surface — `createRscWorkerStream`, the RSC-stream type exports, the RSC-stream utilities (`validateRscStreamOptions` etc.), `pipeToResponse`, and the `ResolveStreamElementsOptions` type — was duplicated across `index.{server,client}.ts`. Move it to `index.shared.ts`; each entry now does `export * from "./index.shared.js"` plus its per-condition stream impls.

Per-condition residue stays in the entries: `handleRscStream`, `createRscStream`, `createRenderToPipeableStreamHandler`, `createHtmlStream`, `createInlineFlightRenderer`, `resolveStreamElements` (`.server`/`.client`), plus the condition-only ones (`createHtmlStreamWithInlineFlight` — server; `createFromNodeStream` — client).

## Testing
- `./stream` exposes 14 runtime names under **both** conditions (unchanged)
- build clean; package entrypoints 101 (`verify-package-entrypoints` + publint)
- `test:unit` 472; `test:server` 655 pass / 4 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
