### PR TITLE
refactor(orchestrator): collapse server/client onto one impl

### DIFF
--- a/plugin/orchestrator/createPluginOrchestrator.client.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.client.ts
@@ -1,74 +1,17 @@
 import type { Plugin } from "vite";
-import { createEnvironmentPlugin } from "../environments/createEnvironmentPlugin.js";
-import { createBuildEventPlugin } from "../environments/createBuildEventPlugin.js";
 import { vitePluginReactDevServer } from "../dev-server/plugin.client.js";
 import { reactStaticPlugin } from "../react-static/plugin.client.js";
-import { createTransformerPlugin } from "../transformer/createTransformerPlugin.js";
-import { serverReferenceClientPlugin } from "../transformer/serverReferenceClientPlugin.js";
-import { virtualRscHmrPlugin } from "../dev-server/virtualRscHmrPlugin.js";
-import { vitePluginVendorAlias } from "../vendor/vendor-alias.js";
-import { clientPackagesDiscoveryPlugin } from "../clientPackages/index.js";
+import { createPluginOrchestratorImpl } from "./createPluginOrchestrator.impl.js";
 
-// Client-first orchestrator - includes client SSG plugin for reverse paradigm
-export const createPluginOrchestrator = (
-  userOptions: any
-): Plugin[] => {
-  // Client-first logic - provide all environments for Environment API builds
-  const availableEnvironments = ["client", "ssr", "server"];
-
-  const plugins: Plugin[] = [];
-
-  // Auto-discover packages that opt into the `"use client"` convention via
-  // `react` in peerDependencies, and merge with any manual `clientPackages`
-  // the user supplied. Mutates `userOptions.clientPackages` so downstream
-  // plugins read the merged list when their own hooks fire.
-  //
-  // INVARIANT: every plugin below must receive the same `userOptions`
-  // *reference*. Spreading (`{...userOptions, foo}`) into a new object
-  // breaks the chain — the spread copy keeps the pre-discovery value of
-  // `clientPackages` and silently regresses node_modules `"use client"`
-  // handling. Mutate fields on userOptions directly instead.
-  plugins.push(clientPackagesDiscoveryPlugin(userOptions));
-
-  // Alias react-server-dom-esm to our vendored copy
-  plugins.push(vitePluginVendorAlias());
-
-  // Virtual module for RSC HMR utilities (works in both dev and build)
-  plugins.push(virtualRscHmrPlugin());
-
-  // Redirect client-side imports of "use server" modules to a virtual client
-  // proxy (createServerReference) so they resolve in dev. Must precede the
-  // transformer so the .server module is never client-transformed directly.
-  plugins.push(serverReferenceClientPlugin(userOptions));
-  
-  // Add transformer first so it runs before other plugins
-  plugins.push(
-    createTransformerPlugin({
-      name: "dynamic",
-      defaultEnvironment: "client",
-      allowedEnvironments: ["client", "ssr", "server"],
-    })(userOptions)
-  );
-  
-  // Core plugins. Mutating `availableEnvironments` on userOptions (rather
-  // than spreading into a new object) preserves the shared reference per
-  // the invariant above.
-  (userOptions as { availableEnvironments?: unknown }).availableEnvironments =
-    availableEnvironments;
-  plugins.push(createEnvironmentPlugin(userOptions));
-  plugins.push(createBuildEventPlugin(userOptions));
-  const devServerPlugins = vitePluginReactDevServer(userOptions);
-  if (Array.isArray(devServerPlugins)) {
-    plugins.push(...devServerPlugins);
-  } else {
-    plugins.push(devServerPlugins);
-  }
-
-  // Client SSG plugin for reverse paradigm
-  plugins.push(reactStaticPlugin(userOptions));
-
-  return plugins;
-};
+// Client-first orchestrator — pulls the .client dev-server / react-static plugins
+// and runs the transformer with a "client" default environment. The shared body
+// lives in createPluginOrchestrator.impl.ts.
+export const createPluginOrchestrator = (userOptions: any): Plugin[] =>
+  createPluginOrchestratorImpl(userOptions, {
+    defaultEnvironment: "client",
+    devServerPlugin: vitePluginReactDevServer,
+    staticPlugin: reactStaticPlugin,
+  });
 
 
 export interface Strategy {

--- a/plugin/orchestrator/createPluginOrchestrator.impl.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.impl.ts
@@ -1,0 +1,83 @@
+import type { Plugin } from "vite";
+import { createEnvironmentPlugin } from "../environments/createEnvironmentPlugin.js";
+import { createBuildEventPlugin } from "../environments/createBuildEventPlugin.js";
+import { createTransformerPlugin } from "../transformer/createTransformerPlugin.js";
+import { serverReferenceClientPlugin } from "../transformer/serverReferenceClientPlugin.js";
+import { virtualRscHmrPlugin } from "../dev-server/virtualRscHmrPlugin.js";
+import { vitePluginVendorAlias } from "../vendor/vendor-alias.js";
+import { clientPackagesDiscoveryPlugin } from "../clientPackages/index.js";
+
+/**
+ * Per-side inputs for the orchestrator. The server- and client-first variants
+ * differ ONLY in which dev-server / react-static plugins they pull (.server vs
+ * .client) and the transformer's defaultEnvironment.
+ */
+export interface OrchestratorStrategy {
+  defaultEnvironment: "server" | "client";
+  devServerPlugin: (userOptions: any) => Plugin | Plugin[];
+  staticPlugin: (userOptions: any) => Plugin;
+}
+
+/**
+ * Shared body for the server- and client-first orchestrators. Everything except
+ * the per-side inputs above is identical: the plugin push order, the
+ * shared-userOptions-reference invariant, and the environment wiring.
+ *
+ * INVARIANT: every plugin below must receive the same `userOptions` *reference*.
+ * Spreading (`{...userOptions, foo}`) into a new object breaks the chain — the
+ * spread copy keeps the pre-discovery value of `clientPackages` and silently
+ * regresses node_modules `"use client"` handling. Mutate fields on userOptions
+ * directly instead.
+ */
+export const createPluginOrchestratorImpl = (
+  userOptions: any,
+  strategy: OrchestratorStrategy
+): Plugin[] => {
+  // Provide all environments for Environment API builds.
+  const availableEnvironments = ["client", "ssr", "server"];
+  const plugins: Plugin[] = [];
+
+  // Auto-discover packages that opt into the `"use client"` convention via
+  // `react` in peerDependencies, merged with any manual `clientPackages`.
+  // Mutates `userOptions.clientPackages` (see invariant above).
+  plugins.push(clientPackagesDiscoveryPlugin(userOptions));
+
+  // Alias react-server-dom-esm to our vendored copy.
+  plugins.push(vitePluginVendorAlias());
+
+  // Virtual module for RSC HMR utilities (dev and build).
+  plugins.push(virtualRscHmrPlugin());
+
+  // Redirect client-side imports of "use server" modules to a virtual client
+  // proxy (createServerReference). Must precede the transformer.
+  plugins.push(serverReferenceClientPlugin(userOptions));
+
+  // Transformer first, so it runs before the other plugins.
+  plugins.push(
+    createTransformerPlugin({
+      name: "dynamic",
+      defaultEnvironment: strategy.defaultEnvironment,
+      allowedEnvironments: ["client", "ssr", "server"],
+    })(userOptions)
+  );
+
+  // Core plugins. Mutating `availableEnvironments` on userOptions (rather than
+  // spreading) preserves the shared reference per the invariant above.
+  (userOptions as { availableEnvironments?: unknown }).availableEnvironments =
+    availableEnvironments;
+  plugins.push(createEnvironmentPlugin(userOptions));
+  plugins.push(createBuildEventPlugin(userOptions));
+
+  const devServerPlugins = strategy.devServerPlugin(userOptions);
+  if (Array.isArray(devServerPlugins)) {
+    plugins.push(...devServerPlugins);
+  } else {
+    plugins.push(devServerPlugins);
+  }
+
+  // SSG plugin (server-first gated on an always-true capability before; the
+  // client-first variant pushed it unconditionally — identical behavior).
+  plugins.push(strategy.staticPlugin(userOptions));
+
+  return plugins;
+};

--- a/plugin/orchestrator/createPluginOrchestrator.server.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.server.ts
@@ -1,82 +1,17 @@
 import type { Plugin } from "vite";
-import { createEnvironmentPlugin } from "../environments/createEnvironmentPlugin.js";
-import { createBuildEventPlugin } from "../environments/createBuildEventPlugin.js";
 import { vitePluginReactDevServer } from "../dev-server/plugin.server.js";
 import { reactStaticPlugin } from "../react-static/plugin.server.js";
-import { createTransformerPlugin } from "../transformer/createTransformerPlugin.js";
-import { serverReferenceClientPlugin } from "../transformer/serverReferenceClientPlugin.js";
-import { virtualRscHmrPlugin } from "../dev-server/virtualRscHmrPlugin.js";
-import { vitePluginVendorAlias } from "../vendor/vendor-alias.js";
-import { clientPackagesDiscoveryPlugin } from "../clientPackages/index.js";
+import { createPluginOrchestratorImpl } from "./createPluginOrchestrator.impl.js";
 
-// Server-first orchestrator - only imports server plugins
-export const createPluginOrchestrator = (
-  userOptions: any
-): Plugin[] => {
-  // Server-first logic - provide all environments for Environment API builds
-  const availableEnvironments = ["client", "ssr", "server"];
-  const capabilities = {
-    staticGeneration: true,
-    serverComponents: true,
-    clientBuilds: true,
-    ssrBuilds: true,
-  };
-
-  const plugins: Plugin[] = [];
-
-  // Auto-discover packages that opt into the `"use client"` convention via
-  // `react` in peerDependencies, and merge with any manual `clientPackages`
-  // the user supplied. Mutates `userOptions.clientPackages` so downstream
-  // plugins read the merged list when their own hooks fire.
-  //
-  // INVARIANT: every plugin below must receive the same `userOptions`
-  // *reference*. Spreading (`{...userOptions, foo}`) into a new object
-  // breaks the chain — the spread copy keeps the pre-discovery value of
-  // `clientPackages` and silently regresses node_modules `"use client"`
-  // handling. Mutate fields on userOptions directly instead.
-  plugins.push(clientPackagesDiscoveryPlugin(userOptions));
-
-  // Alias react-server-dom-esm to our vendored copy
-  plugins.push(vitePluginVendorAlias());
-
-  // Virtual module for RSC HMR utilities (works in both dev and build)
-  plugins.push(virtualRscHmrPlugin());
-
-  // Redirect client-side imports of "use server" modules to a virtual client
-  // proxy (createServerReference) so they resolve in dev (client/ssr envs are
-  // served here too in dev:rsc). Must precede the transformer.
-  plugins.push(serverReferenceClientPlugin(userOptions));
-
-  // Add transformer first so it runs before other plugins
-  plugins.push(
-    createTransformerPlugin({
-      name: "dynamic",
-      defaultEnvironment: "server",
-      allowedEnvironments: ["client", "ssr", "server"],
-    })(userOptions)
-  );
-  
-  // Core plugins. Mutating `availableEnvironments` on userOptions (rather
-  // than spreading into a new object) preserves the shared reference per
-  // the invariant above.
-  (userOptions as { availableEnvironments?: unknown }).availableEnvironments =
-    availableEnvironments;
-  plugins.push(createEnvironmentPlugin(userOptions));
-  plugins.push(createBuildEventPlugin(userOptions));
-  const devServerPlugins = vitePluginReactDevServer(userOptions);
-  if (Array.isArray(devServerPlugins)) {
-    plugins.push(...devServerPlugins);
-  } else {
-    plugins.push(devServerPlugins);
-  }
-
-  // SSG plugin for server
-  if (capabilities.staticGeneration) {
-    plugins.push(reactStaticPlugin(userOptions));
-  }
-
-  return plugins;
-};
+// Server-first orchestrator — pulls the .server dev-server / react-static plugins
+// and runs the transformer with a "server" default environment. The shared body
+// lives in createPluginOrchestrator.impl.ts.
+export const createPluginOrchestrator = (userOptions: any): Plugin[] =>
+  createPluginOrchestratorImpl(userOptions, {
+    defaultEnvironment: "server",
+    devServerPlugin: vitePluginReactDevServer,
+    staticPlugin: reactStaticPlugin,
+  });
 
 
 export interface Strategy {


### PR DESCRIPTION
Continues the 66g condition-split consolidation.

`createPluginOrchestrator.{server,client}.ts` had near-identical ~60-line bodies (same plugin push order, same shared-`userOptions`-reference invariant, same environment wiring) differing only in which dev-server / react-static plugin they pull (`.server` vs `.client`) and the transformer's `defaultEnvironment`.

## Changes
- **`createPluginOrchestrator.impl.ts`** — `createPluginOrchestratorImpl(userOptions, strategy)` holds the shared body; `OrchestratorStrategy` carries the per-side inputs `{ defaultEnvironment, devServerPlugin, staticPlugin }`.
- **server / client** shrink to a ~10-line binding each.
- The server-first variant gated the SSG plugin on an always-true `capabilities.staticGeneration` while the client-first pushed it unconditionally — identical behavior, so the impl pushes it unconditionally.

Left untouched: each file's exported `Strategy` interface. It differs from `orchestrator/types.ts`'s `Strategy` (this one has `legacyBuilder`; that one `environmentTargets`) and `plugin/types.ts` imports this one — consolidating the two `Strategy` types is a separate concern, deliberately out of scope.

## Testing
The orchestrator drives real builds, so the examples suites are the meaningful gate — both conditions exercised:
- build clean; package entrypoints 101 (`verify-package-entrypoints` + publint)
- `test:unit` 472; `test:server` 655 pass / 4 skip; `test:client` 182 pass / 7 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
