### PR TITLE
refactor(config): extract resolveHandlerContext (shared prelude)

### DIFF
--- a/plugin/config/createHandlerOptions.client.ts
+++ b/plugin/config/createHandlerOptions.client.ts
@@ -1,6 +1,4 @@
 import type { CreateHandlerOptions } from "../types.js";
-import { getRouteFiles } from "../helpers/getRouteFiles.js";
-import { routeToURL } from "../utils/routeToURL.js";
 import {
   serializedOptions,
   serializeResolvedConfig,
@@ -16,10 +14,9 @@ import { getNodeEnv } from "./getNodeEnv.js";
 import { createLogger } from "vite";
 import type { CreateHandlerOptionsParams } from "./createHandlerOptions.types.js";
 import {
-  createDefaultOptions,
-  resolveAutoDiscoveredFiles,
   buildSharedHandlerOptions,
   createConfiguredWorker,
+  resolveHandlerContext,
 } from "./createHandlerOptions.shared.js";
 import { getCondition } from "./getCondition.js";
 
@@ -79,34 +76,9 @@ export async function createHandlerOptions(
     );
   }
 
-  // Resolve defaults
-  const defaults = { ...createDefaultOptions(), ...options.defaults };
-
-  // Resolve auto-discovered files
-  const autoDiscoveredFiles = await resolveAutoDiscoveredFiles(
-    options,
-    userOptions,
-    logger
-  );
-
-  // Create URL
-  const url = routeToURL(
-    route,
-    userOptions.moduleBaseURL,
-    userOptions.build.rscOutputPath
-  );
-
-  // Get route files
-  const routeFilesResult = await getRouteFiles(
-    route,
-    autoDiscoveredFiles,
-    userOptions,
-    logger
-  );
-
-  if (routeFilesResult.type === "error") {
-    throw routeFilesResult.error || new Error("Failed to get route files");
-  }
+  // Resolve the shared prelude: defaults, auto-discovery, url, route files.
+  const { defaults, autoDiscoveredFiles, url, routeFiles: routeFilesResult } =
+    await resolveHandlerContext(route, options, userOptions, logger);
 
   // Create workers for client environment based on configuration and configEnv
   let rscWorker: any = undefined;

--- a/plugin/config/createHandlerOptions.server.ts
+++ b/plugin/config/createHandlerOptions.server.ts
@@ -1,6 +1,4 @@
 import type { CreateHandlerOptions, RootComponentType, HtmlComponentType } from "../types.js";
-import { getRouteFiles } from "../helpers/getRouteFiles.js";
-import { routeToURL } from "../utils/routeToURL.js";
 import {
   getStashedUserOptions,
   getStashedHandlerOptions,
@@ -12,10 +10,9 @@ import { getNodeEnv } from "./getNodeEnv.js";
 import { createLogger } from "vite";
 import type { CreateHandlerOptionsParams } from "./createHandlerOptions.types.js";
 import {
-  createDefaultOptions,
-  resolveAutoDiscoveredFiles,
   buildSharedHandlerOptions,
   createConfiguredWorker,
+  resolveHandlerContext,
 } from "./createHandlerOptions.shared.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
 import { serializedOptions } from "../helpers/serializeUserOptions.js";
@@ -73,34 +70,9 @@ export async function createHandlerOptions(
     );
   }
 
-  // Resolve defaults
-  const defaults = { ...createDefaultOptions(), ...options.defaults };
-
-  // Resolve auto-discovered files
-  const autoDiscoveredFiles = await resolveAutoDiscoveredFiles(
-    options,
-    userOptions,
-    logger
-  );
-
-  // Create URL
-  const url = routeToURL(
-    route,
-    userOptions.moduleBaseURL,
-    userOptions.build.rscOutputPath
-  );
-
-  // Get route files
-  const routeFilesResult = await getRouteFiles(
-    route,
-    autoDiscoveredFiles,
-    userOptions,
-    logger
-  );
-
-  if (routeFilesResult.type === "error") {
-    throw routeFilesResult.error || new Error("Failed to get route files");
-  }
+  // Resolve the shared prelude: defaults, auto-discovery, url, route files.
+  const { defaults, autoDiscoveredFiles, url, routeFiles: routeFilesResult } =
+    await resolveHandlerContext(route, options, userOptions, logger);
 
   // Load components from resolved file paths
   let PageComponent = userOptions.components?.Page;

--- a/plugin/config/createHandlerOptions.shared.ts
+++ b/plugin/config/createHandlerOptions.shared.ts
@@ -17,6 +17,8 @@ import type { AutoDiscoveredFiles, ResolvedUserOptions } from "../types.js";
 import { resolveAutoDiscover } from "./autoDiscover/resolveAutoDiscover.js";
 import { DEFAULT_CONFIG } from "./defaults.js";
 import { createWorker } from "../worker/createWorker.js";
+import { getRouteFiles } from "../helpers/getRouteFiles.js";
+import { routeToURL } from "../utils/routeToURL.js";
 import type {
   CreateHandlerOptionsParams,
   ResolvedDefaults,
@@ -185,4 +187,51 @@ export async function createConfiguredWorker(
     );
     return undefined;
   }
+}
+
+export interface HandlerContext {
+  defaults: ResolvedDefaults;
+  autoDiscoveredFiles: AutoDiscoveredFiles;
+  url: string;
+  routeFiles: SharedHandlerOptionsInput["routeFiles"];
+}
+
+/**
+ * The byte-identical prelude both variants ran before their per-side work: merge
+ * defaults, resolve auto-discovered files, build the route URL, and load the
+ * route's file paths (throwing on failure). Covered by the createHandlerOptions
+ * characterization test, which exercises this whole path.
+ */
+export async function resolveHandlerContext(
+  route: string,
+  options: CreateHandlerOptionsParams,
+  userOptions: ResolvedUserOptions,
+  logger: Logger
+): Promise<HandlerContext> {
+  const defaults = { ...createDefaultOptions(), ...options.defaults };
+
+  const autoDiscoveredFiles = await resolveAutoDiscoveredFiles(
+    options,
+    userOptions,
+    logger
+  );
+
+  const url = routeToURL(
+    route,
+    userOptions.moduleBaseURL,
+    userOptions.build.rscOutputPath
+  );
+
+  const routeFilesResult = await getRouteFiles(
+    route,
+    autoDiscoveredFiles,
+    userOptions,
+    logger
+  );
+
+  if (routeFilesResult.type === "error") {
+    throw routeFilesResult.error || new Error("Failed to get route files");
+  }
+
+  return { defaults, autoDiscoveredFiles, url, routeFiles: routeFilesResult };
 }


### PR DESCRIPTION
Continues the 66g `createHandlerOptions` consolidation (follows the worker-block dedup already merged).

`createHandlerOptions.{server,client}.ts` ran a byte-identical prelude before their per-side work: merge defaults, resolve auto-discovered files, build the route URL, and load the route's file paths (throwing on failure). Extract it to **`resolveHandlerContext`** in the shared module; each variant destructures the result.

## Testing
Covered by the existing `createHandlerOptions` characterization test (it exercises this whole prelude).
- build clean; package entrypoints 101 (`verify-package-entrypoints` + publint)
- `test:unit` 472; `test:server` 655 pass / 4 skip

The remaining `createHandlerOptions` divergence is the server-only component-loader (genuinely per-condition: the server loads components in-process, the client returns placeholders) — not a dedup opportunity, so 66g.4's productive consolidation is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
