### PR TITLE
refactor(dev-server): extract shared devPluginShared helpers

### DIFF
--- a/plugin/dev-server/devPluginShared.ts
+++ b/plugin/dev-server/devPluginShared.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { detectClientModule } from "react-server-loader/directives";
+import type { AutoDiscoveredFiles } from "../types.js";
+
+/**
+ * An empty AutoDiscoveredFiles. Both dev-server plugins (server + client) hand
+ * this to configureReactServer at configureServer time; the real auto-discovery
+ * happens later via configResolved. Kept in one place so the shape can't drift
+ * between the two plugins.
+ */
+export function emptyAutoDiscoveredFiles(): AutoDiscoveredFiles {
+  return {
+    propsMap: new Map(),
+    pageMap: new Map(),
+    rootMap: new Map(),
+    htmlMap: new Map(),
+    routeMap: new Map(),
+    urlMap: new Map(),
+    errors: [],
+    workerPaths: {},
+    serverEntry: null,
+    clientEntry: {},
+    clientInputs: {},
+    staticInputs: {},
+    serverInputs: {},
+    // staticManifest removed from AutoDiscoveredFiles
+    serverActions: {},
+  };
+}
+
+/**
+ * Is `file` a "use client" source module — a JS/TS source whose contents carry a
+ * client directive? Both dev plugins use this in `hotUpdate` to let Vite own
+ * client-side HMR (Fast Refresh / reload) for client components rather than
+ * routing the change through the RSC refetch / worker-invalidation path.
+ */
+export function isClientModuleFile(file: string): boolean {
+  if (
+    !(
+      file.endsWith(".tsx") ||
+      file.endsWith(".ts") ||
+      file.endsWith(".jsx") ||
+      file.endsWith(".js")
+    )
+  ) {
+    return false;
+  }
+  try {
+    const source = readFileSync(file, "utf-8");
+    return detectClientModule({ source, moduleId: file });
+  } catch {
+    return false;
+  }
+}

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -1,9 +1,8 @@
-import { readFileSync } from "node:fs";
 import type { VitePluginFn } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.client.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
-import { detectClientModule } from "react-server-loader/directives";
+import { emptyAutoDiscoveredFiles, isClientModuleFile } from "./devPluginShared.js";
 import type { ConfigEnv } from "vite";
 
 
@@ -50,23 +49,7 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       // This uses the existing configureReactServer.client.js implementation
       hmrHandler = configureReactServer({
         server,
-        autoDiscoveredFiles: {
-          propsMap: new Map(),
-          pageMap: new Map(),
-          rootMap: new Map(),
-          htmlMap: new Map(),
-          routeMap: new Map(),
-          urlMap: new Map(),
-          errors: [],
-          workerPaths: {},
-          serverEntry: null,
-          clientEntry: {},
-          clientInputs: {},
-          staticInputs: {},
-          serverInputs: {},
-          // staticManifest removed from AutoDiscoveredFiles
-          serverActions: {},
-        },
+        autoDiscoveredFiles: emptyAutoDiscoveredFiles(),
         userOptions,
         configEnv: configEnv!,
         serverManifest: {}, 
@@ -102,12 +85,7 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       // Skip client components — Vite owns client-side HMR (Fast Refresh
       // when `@vitejs/plugin-react` is installed, plain reload otherwise).
       // Worker invalidation is for the server tree.
-      const isClientFile = isSourceFile && (() => {
-        try {
-          const source = readFileSync(file, "utf-8");
-          return detectClientModule({ source, moduleId: file });
-        } catch { return false; }
-      })();
+      const isClientFile = isSourceFile && isClientModuleFile(file);
 
       // A CSS module imported transitively by a "use client" component lives
       // in the CLIENT module graph (the browser fetches it directly and Vite

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -2,9 +2,8 @@ import type { StreamPluginOptions } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.server.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
-import { detectClientModule } from "react-server-loader/directives";
 import type { Plugin, ViteDevServer } from "vite";
-import { readFileSync } from "node:fs";
+import { emptyAutoDiscoveredFiles, isClientModuleFile } from "./devPluginShared.js";
 
 /**
  * Dev server plugin for server environment.
@@ -45,12 +44,7 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
       // Client environment: Vite owns client-side HMR (Fast Refresh if
       // `@vitejs/plugin-react` is installed; plain reload otherwise).
       if (envName === 'client') {
-        const isClient = (file.endsWith('.tsx') || file.endsWith('.ts') || file.endsWith('.jsx') || file.endsWith('.js')) && (() => {
-          try {
-            const source = readFileSync(file, "utf-8");
-            return detectClientModule({ source, moduleId: file });
-          } catch { return false; }
-        })();
+        const isClient = isClientModuleFile(file);
 
         if (isClient) return; // Vite's client-side HMR owns this update
 
@@ -118,23 +112,7 @@ applyToEnvironment(partialEnvironment: any) {
       // This uses the existing configureReactServer.server.js implementation
       configureReactServer({
         server,
-        autoDiscoveredFiles: {
-          propsMap: new Map(),
-          pageMap: new Map(),
-          rootMap: new Map(),
-          htmlMap: new Map(),
-          routeMap: new Map(),
-          urlMap: new Map(),
-          errors: [],
-          workerPaths: {},
-          serverEntry: null,
-          clientEntry: {},
-          clientInputs: {},
-          staticInputs: {},
-          serverInputs: {},
-          // staticManifest removed from AutoDiscoveredFiles
-          serverActions: {},
-        },
+        autoDiscoveredFiles: emptyAutoDiscoveredFiles(),
         userOptions,
         serverManifest: {},
         resolvedConfig: server.config,


### PR DESCRIPTION
Continues the 66g condition-split consolidation.

`dev-server/plugin.{server,client}.ts` duplicated two things verbatim:
- the empty `AutoDiscoveredFiles` literal handed to `configureReactServer` at `configureServer` time, and
- the `JS/TS-extension + detectClientModule` "is this a `use client` source file?" IIFE inside `hotUpdate`.

Extract both to **`devPluginShared.ts`** (`emptyAutoDiscoveredFiles`, `isClientModuleFile`).

Scoped to the genuinely-identical pieces. The broader `hotUpdate` orchestration legitimately differs per side (server branches on environment and sends the RSC-refetch WS event; client does worker invalidation behind an `isProcessingHmr` guard), so it stays in place.

## Testing
- build clean; package entrypoints 101 (`verify-package-entrypoints` + publint)
- `test:unit` 472; `test:dev` 37 (HMR); `test:server` 655 pass / 4 skip; `test:client` 182 pass / 7 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
