### PR TITLE
refactor(react-static): extract renderPage metrics topology (66g.5 slice)

### DIFF
--- a/plugin/react-static/renderPage.client.ts
+++ b/plugin/react-static/renderPage.client.ts
@@ -41,6 +41,7 @@
  */
 
 import { createRenderMetrics } from "../metrics/createRenderMetrics.js";
+import { createPageRenderMetrics } from "./renderPageMetrics.js";
 import type { RenderMetrics } from "../metrics/types.js";
 import { routeToURL } from "../utils/routeToURL.js";
 import type { RenderPageFn } from "./types.js";
@@ -49,8 +50,6 @@ import { assertNonReactServer } from "../config/getCondition.js";
 
 import { createRscStream } from "../stream/createRscStream.client.js";
 import { resolveComponents } from "../helpers/resolveComponents.client.js";
-
-import { join } from "node:path";
 
 import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
 import { performance } from "node:perf_hooks";
@@ -180,44 +179,14 @@ export const renderPage: RenderPageFn = async function* _renderPageClient(
     );
   }
 
-  const baseDir = join(
-    handlerOptions.build.outDir,
-    handlerOptions.build.static
-  );
-  const routePath = handlerOptions.route.replace(/^\//, "");
-
-  // Create metrics upfront with proper types - REVERSE from server
-  const htmlMetrics = createRenderMetrics({
-    route: handlerOptions.route,
-    type: "html",
-    fromMainThread: true, // Client: HTML rendered on main thread
-    fromRscWorker: false,
-    fromHtmlWorker: false,
-    baseDir,
-    routePath,
-    fileName: handlerOptions.build.htmlOutputPath,
-    outputPath: join(baseDir, routePath, handlerOptions.build.htmlOutputPath),
-  });
-  
-  const rscFullMetrics = createRenderMetrics({
-    route: handlerOptions.route,
-    type: "rsc-full",
-    fromMainThread: false,
-    fromRscWorker: true, // Client: RSC rendered on RSC worker
-    fromHtmlWorker: false,
-  });
-  
-  const rscHeadlessMetrics = createRenderMetrics({
-    route: handlerOptions.route,
-    type: "rsc-headless",
-    fromMainThread: false,
-    fromRscWorker: true, // Client: RSC rendered on RSC worker
-    fromHtmlWorker: false,
-    baseDir,
-    routePath,
-    fileName: handlerOptions.build.rscOutputPath,
-    outputPath: join(baseDir, routePath, handlerOptions.build.rscOutputPath),
-  });
+  // Metrics topology — client: RSC in the worker, HTML on the main thread
+  // (reverse of server).
+  const { htmlMetrics, rscFullMetrics, rscHeadlessMetrics } =
+    createPageRenderMetrics(handlerOptions, {
+      html: { fromMainThread: true, fromRscWorker: false, fromHtmlWorker: false },
+      rscFull: { fromMainThread: false, fromRscWorker: true, fromHtmlWorker: false },
+      rscHeadless: { fromMainThread: false, fromRscWorker: true, fromHtmlWorker: false },
+    });
 
   // Declare variables outside try block so they can be accessed in catch block
   let headlessRscStream: any = null;

--- a/plugin/react-static/renderPage.server.ts
+++ b/plugin/react-static/renderPage.server.ts
@@ -20,7 +20,7 @@
  * avoiding complex backpressure handling and race conditions.
  */
 
-import { createRenderMetrics } from "../metrics/createRenderMetrics.js";
+import { createPageRenderMetrics } from "./renderPageMetrics.js";
 import { routeToURL } from "../utils/routeToURL.js";
 import type { RenderPageFn } from "./types.js";
 import { handleError } from "../error/handleError.js";
@@ -32,7 +32,6 @@ import { createRscToHtmlStream } from "./rscToHtmlStream.server.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
 import { resolvePageAndProps } from "../helpers/resolvePageAndProps.js";
 import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
-import { join } from "node:path";
 import { createHeadlessStreamState, trackHeadlessStreamError, hasHeadlessStreamError } from "../helpers/headlessStreamState.js";
 
 export const renderPage: RenderPageFn = async function* renderPage(
@@ -41,44 +40,13 @@ export const renderPage: RenderPageFn = async function* renderPage(
   // Ensure we're in the correct environment
   assertReactServer();
 
-  // Create metrics upfront with proper types
-  const baseDir = join(
-    handlerOptions.build.outDir,
-    handlerOptions.build.static
-  );
-  const routePath = handlerOptions.route.replace(/^\//, "");
-
-  const htmlMetrics = createRenderMetrics({
-    route: handlerOptions.route,
-    type: "html",
-    fromMainThread: false, // Server: HTML rendered in worker
-    fromRscWorker: false,
-    fromHtmlWorker: true,
-    baseDir,
-    routePath,
-    fileName: handlerOptions.build.htmlOutputPath,
-    outputPath: join(baseDir, routePath, handlerOptions.build.htmlOutputPath),
-  });
-  
-  const rscFullMetrics = createRenderMetrics({
-    route: handlerOptions.route,
-    type: "rsc-full",
-    fromMainThread: true, // Server: RSC rendered on main thread
-    fromRscWorker: false,
-    fromHtmlWorker: false,
-  });
-  
-  const rscHeadlessMetrics = createRenderMetrics({
-    route: handlerOptions.route,
-    type: "rsc-headless",
-    fromMainThread: true, // Server: RSC rendered on main thread
-    fromRscWorker: false,
-    fromHtmlWorker: false,
-    baseDir,
-    routePath,
-    fileName: handlerOptions.build.rscOutputPath,
-    outputPath: join(baseDir, routePath, handlerOptions.build.rscOutputPath),
-  });
+  // Metrics topology — server: RSC on the main thread, HTML in the worker.
+  const { htmlMetrics, rscFullMetrics, rscHeadlessMetrics } =
+    createPageRenderMetrics(handlerOptions, {
+      html: { fromMainThread: false, fromRscWorker: false, fromHtmlWorker: true },
+      rscFull: { fromMainThread: true, fromRscWorker: false, fromHtmlWorker: false },
+      rscHeadless: { fromMainThread: true, fromRscWorker: false, fromHtmlWorker: false },
+    });
 
   // Declare variables outside try block
   let headlessRscHandler: any = null;

--- a/plugin/react-static/renderPageMetrics.ts
+++ b/plugin/react-static/renderPageMetrics.ts
@@ -1,0 +1,64 @@
+import { join } from "node:path";
+import { createRenderMetrics } from "../metrics/createRenderMetrics.js";
+
+/**
+ * Where each of the three render streams runs. This is the ONLY thing that
+ * differs between renderPage.server and renderPage.client's metrics: the server
+ * renders RSC on the main thread and HTML in a worker; the client renders RSC in
+ * a worker and HTML on the main thread. Everything else (route, output paths) is
+ * identical, so the two files pass an inverted topology to the same builder.
+ */
+export interface RenderStreamLocation {
+  fromMainThread: boolean;
+  fromRscWorker: boolean;
+  fromHtmlWorker: boolean;
+}
+
+export interface RenderMetricsTopology {
+  html: RenderStreamLocation;
+  rscFull: RenderStreamLocation;
+  rscHeadless: RenderStreamLocation;
+}
+
+/**
+ * Build the html / rsc-full / rsc-headless render metrics for a route. The
+ * html and rsc-headless metrics carry the on-disk output path (they are written
+ * to files); rsc-full is in-memory only. The return type is left to inference so
+ * each metric keeps the precise (per-`type`) shape createRenderMetrics produces —
+ * RenderPageFn's yields depend on those narrowed types.
+ */
+export function createPageRenderMetrics(
+  handlerOptions: any,
+  topology: RenderMetricsTopology
+) {
+  const baseDir = join(handlerOptions.build.outDir, handlerOptions.build.static);
+  const routePath = handlerOptions.route.replace(/^\//, "");
+
+  const htmlMetrics = createRenderMetrics({
+    route: handlerOptions.route,
+    type: "html",
+    ...topology.html,
+    baseDir,
+    routePath,
+    fileName: handlerOptions.build.htmlOutputPath,
+    outputPath: join(baseDir, routePath, handlerOptions.build.htmlOutputPath),
+  });
+
+  const rscFullMetrics = createRenderMetrics({
+    route: handlerOptions.route,
+    type: "rsc-full",
+    ...topology.rscFull,
+  });
+
+  const rscHeadlessMetrics = createRenderMetrics({
+    route: handlerOptions.route,
+    type: "rsc-headless",
+    ...topology.rscHeadless,
+    baseDir,
+    routePath,
+    fileName: handlerOptions.build.rscOutputPath,
+    outputPath: join(baseDir, routePath, handlerOptions.build.rscOutputPath),
+  });
+
+  return { htmlMetrics, rscFullMetrics, rscHeadlessMetrics };
+}


### PR DESCRIPTION
A safe, isolated slice of the `renderPage` consolidation (66g.5).

`renderPage.{server,client}.ts` built the same three render-metrics objects (`html`, `rsc-full`, `rsc-headless`); the **only** difference is where each stream runs — server renders RSC on the main thread + HTML in a worker; client is the reverse. Extract the construction to **`renderPageMetrics.createPageRenderMetrics(handlerOptions, topology)`**; each side passes its (inverted) topology.

Instrumentation only — **no change to rendered HTML/RSC output**. The return type is left to inference so each metric keeps the precise per-`type` shape `createRenderMetrics` produces (`RenderPageFn`'s yields depend on those narrowed types).

### Scope
This is deliberately *just* the metrics. The fragile core of `renderPage` — the dual RSC-stream creation, headless-stream reuse, `SafePageComponent`, and the HTML-completion wait — genuinely differs between the two files and is hydration-sensitive, so it stays per-file. Its full collapse is deferred to a reviewed pass with prod+basepath hydration verification (tracked on the bead).

### Testing
- build clean; package entrypoints 101 (`verify-package-entrypoints` + publint)
- `test:unit` 472; `test:server` 655 pass / 4 skip; `test:client` 182 pass / 7 skip (both conditions exercise renderPage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
