### PR TITLE
refactor(worker): extract gracefulWorkerShutdown (share across static plugins)

### DIFF
--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -56,6 +56,7 @@ import {
 } from "../bundle/manifests.js";
 import { deferStaticGeneration } from "../bundle/deferredStaticGeneration.js";
 import type { Worker } from "node:worker_threads";
+import { gracefulWorkerShutdown } from "../worker/gracefulShutdown.js";
 import { resolveAutoDiscover } from "../config/autoDiscover/resolveAutoDiscover.js";
 import { join } from "node:path";
 
@@ -884,58 +885,17 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         throw finalError;
         }
       } finally {
-        // Graceful worker shutdown — runs on both success and error paths
+        // Graceful worker shutdown — runs on both success and error paths.
         if (rscWorker) {
-          try {
-            await Promise.race([
-              new Promise<void>((resolve, reject) => {
-                const timeout = setTimeout(() => {
-                  reject(new Error("Worker shutdown timeout"));
-                }, userOptions.workerShutdownTimeout);
-
-                const backupTimeout = setTimeout(() => {
-                  reject(new Error("Worker shutdown backup timeout"));
-                }, Math.floor(userOptions.workerShutdownTimeout * 0.6));
-
-                const shutdownMessageHandler = (message: any) => {
-                  if (message.type === "SHUTDOWN_COMPLETE") {
-                    clearTimeout(timeout);
-                    clearTimeout(backupTimeout);
-                    rscWorker?.removeListener(
-                      "message",
-                      shutdownMessageHandler
-                    );
-                    rscWorker?.removeAllListeners();
-                    resolve();
-                  }
-                };
-
-                rscWorker?.on("message", shutdownMessageHandler);
-                rscWorker?.postMessage({
-                  type: "SHUTDOWN",
-                  id: "*",
-                });
-              }),
-            ]);
-          } catch {
-            // Shutdown protocol failed — force terminate below
-          } finally {
-            if (rscWorker) {
-              try {
-                (rscWorker as Worker).removeAllListeners();
-                // Await full worker exit before letting the build's promise
-                // resolve. Without this, libuv-level handles in the worker
-                // (file reads/writes pending at exit) can fire AFTER doBuild
-                // has restored cwd, producing post-teardown ENOENT errors
-                // against relative paths the worker started while cwd was
-                // the test fixture root.
-                await (rscWorker as Worker).terminate();
-              } catch {
-                // Ignore termination errors
-              }
-              rscWorker = undefined;
-            }
-          }
+          await gracefulWorkerShutdown(rscWorker, {
+            timeoutMs: userOptions.workerShutdownTimeout,
+            // Await full worker exit before the build's promise resolves: libuv
+            // handles still pending in the worker (file reads/writes) can
+            // otherwise fire AFTER doBuild restores cwd, producing post-teardown
+            // ENOENT errors against relative paths. See bd-6pi.
+            awaitTerminate: true,
+          });
+          rscWorker = undefined;
         }
 
         // Reset any cached state to prevent issues in subsequent builds

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Worker } from "node:worker_threads";
+import { gracefulWorkerShutdown } from "../worker/gracefulShutdown.js";
 import {
   type ConfigEnv,
   type Logger,
@@ -667,73 +668,19 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
 
       // Graceful worker shutdown - only at the end of the entire build process
       if (worker) {
-        try {
-          await Promise.race([
-            new Promise<void>((resolve, reject) => {
-              const timeout = setTimeout(() => {
-                reject(new Error("Worker shutdown timeout"));
-              }, userOptions.workerShutdownTimeout);
-
-              const backupTimeout = setTimeout(() => {
-                reject(new Error("Worker shutdown backup timeout"));
-              }, Math.floor(userOptions.workerShutdownTimeout * 0.6)); // 60% of main timeout
-
-              const messageHandler = (message: any) => {
-                if (message.type === "SHUTDOWN_COMPLETE") {
-                  if (userOptions.verbose) {
-                    logger.info("Worker shutdown complete");
-                  }
-                  clearTimeout(timeout);
-                  clearTimeout(backupTimeout);
-                  worker?.removeListener("message", messageHandler);
-                  // Remove all other event listeners as well
-                  worker?.removeAllListeners();
-                  resolve();
-                } else if (message.type === "CLEANUP_COMPLETE") {
-                  // Handle cleanup complete messages during shutdown - this is normal
-                  if (userOptions.verbose) {
-                    logger.info("Worker cleanup completed during shutdown");
-                  }
-                  // Don't resolve here - wait for SHUTDOWN_COMPLETE
-                } else {
-                  if (userOptions.verbose) {
-                    logger.info(
-                      "Worker is still busy, received message " + message?.type
-                    );
-                  }
-                }
-              };
-
-              worker?.on("message", messageHandler);
-
-              // Send shutdown message
-              worker?.postMessage({
-                type: "SHUTDOWN",
-                id: "*",
-              });
-            }),
-          ]);
-        } catch (error) {
-          // If shutdown protocol fails, force terminate
-          this.warn(
-            "Worker shutdown protocol failed, forcing termination: " +
-              (error instanceof Error ? error.message : String(error))
-          );
-          // Don't try to clean up listeners in error case - just force terminate
-        } finally {
-          // Always force cleanup and termination
-          if (worker) {
-            try {
-              worker.removeAllListeners();
-              worker.terminate();
-            } catch (terminateError) {
-              // Ignore termination errors
-            }
-            worker = undefined;
-            // Reset global worker since it's been terminated
-            globalWorker = undefined;
-          }
-        }
+        await gracefulWorkerShutdown(worker, {
+          timeoutMs: userOptions.workerShutdownTimeout,
+          logger,
+          verbose: userOptions.verbose,
+          onProtocolFail: (error) =>
+            this.warn(
+              "Worker shutdown protocol failed, forcing termination: " +
+                (error instanceof Error ? error.message : String(error))
+            ),
+        });
+        worker = undefined;
+        // Reset global worker since it's been terminated
+        globalWorker = undefined;
       }
     },
   } as const;

--- a/plugin/worker/gracefulShutdown.ts
+++ b/plugin/worker/gracefulShutdown.ts
@@ -1,0 +1,81 @@
+import type { Worker } from "node:worker_threads";
+
+export interface GracefulShutdownOptions {
+  /** Main shutdown timeout (ms). A backup timeout fires at 60% of this. */
+  timeoutMs: number;
+  logger?: { info?: (msg: string) => void; warn?: (msg: string) => void };
+  verbose?: boolean;
+  /**
+   * Await `worker.terminate()` before resolving. The client static build needs
+   * this: libuv handles still pending in the worker at exit (file reads/writes)
+   * can otherwise fire AFTER doBuild restores cwd, producing post-teardown
+   * ENOENT errors against relative paths. See bd-6pi. Default false (the server
+   * build doesn't restore cwd under the worker, so a sync terminate is fine).
+   */
+  awaitTerminate?: boolean;
+  /** Called if the graceful protocol times out / errors, before force-terminate. */
+  onProtocolFail?: (error: unknown) => void;
+}
+
+/**
+ * Ask a worker to shut down gracefully, then force-terminate.
+ *
+ * Sends `{ type: "SHUTDOWN", id: "*" }` and waits for `SHUTDOWN_COMPLETE`; a
+ * main + 60%-backup timeout bounds the wait. On success or failure the worker's
+ * listeners are removed and it is terminated. Resolves once teardown is done.
+ *
+ * This consolidates the (near-)identical choreography that lived in the server-
+ * and client-static plugins' closeBundle/finally paths — the most fragile,
+ * race-prone code in the build, so it is worth having exactly once.
+ */
+export async function gracefulWorkerShutdown(
+  worker: Worker,
+  options: GracefulShutdownOptions
+): Promise<void> {
+  const { timeoutMs, logger, verbose, awaitTerminate, onProtocolFail } = options;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Worker shutdown timeout")),
+        timeoutMs
+      );
+      const backupTimeout = setTimeout(
+        () => reject(new Error("Worker shutdown backup timeout")),
+        Math.floor(timeoutMs * 0.6)
+      );
+
+      const messageHandler = (message: any) => {
+        if (message?.type === "SHUTDOWN_COMPLETE") {
+          if (verbose) logger?.info?.("Worker shutdown complete");
+          clearTimeout(timeout);
+          clearTimeout(backupTimeout);
+          worker.removeListener("message", messageHandler);
+          worker.removeAllListeners();
+          resolve();
+        } else if (message?.type === "CLEANUP_COMPLETE") {
+          // Normal during shutdown — keep waiting for SHUTDOWN_COMPLETE.
+          if (verbose) logger?.info?.("Worker cleanup completed during shutdown");
+        } else if (verbose) {
+          logger?.info?.("Worker is still busy, received message " + message?.type);
+        }
+      };
+
+      worker.on("message", messageHandler);
+      worker.postMessage({ type: "SHUTDOWN", id: "*" });
+    });
+  } catch (error) {
+    onProtocolFail?.(error);
+  } finally {
+    try {
+      worker.removeAllListeners();
+      if (awaitTerminate) {
+        await worker.terminate();
+      } else {
+        worker.terminate();
+      }
+    } catch {
+      // Ignore termination errors.
+    }
+  }
+}


### PR DESCRIPTION
The server- and client-static plugins' `closeBundle`/`finally` worker-teardown was near-identical: send `SHUTDOWN`, wait for `SHUTDOWN_COMPLETE` (bounded by a main + 60%-backup timeout), then force-terminate. Extract it to **`worker/gracefulWorkerShutdown`** so the most race-prone code in the build lives in exactly one place.

The one real difference is now an explicit, documented option:
- **client** static build → `awaitTerminate: true` (await full worker exit before `doBuild` restores cwd; otherwise libuv handles pending at exit fire post-teardown → ENOENT against relative paths — bd-6pi).
- **server** build → force-terminates synchronously, and passes `onProtocolFail` to warn via the rollup plugin context.

Previously that await-vs-sync difference was a *silent* divergence between two copy-pasted blocks; now it's a named option.

**Left as-is:** the client's separate error-path shutdown (a shorter, 1s-hardcoded protocol) — different semantics, not part of this dedup.

### Testing
Both conditions spawn **and** tear down workers in every examples build (the cwd-sensitive ENOENT path included), so the build suites are the real exercise:
- build clean; package entrypoints 101 (`verify-package-entrypoints` + publint)
- `test:unit` 472; `test:server` 655 pass / 4 skip; `test:client` 182 pass / 7 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
