### PR TITLE
feat(helpers): Web-standard (Request)=>Response server-action handler

### DIFF
--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -7,6 +7,8 @@ import type {
 } from "./handleServerActionHelper.js";
 import {
   parseServerActionRequest as parseServerActionRequestHelper,
+  parseServerActionWebRequest,
+  assertOriginAllowed,
   createServerActionResponse,
   resolveServerAction,
   loadServerAction,
@@ -14,6 +16,7 @@ import {
   sendServerActionResponse,
   handleServerActionError as handleServerActionErrorHelper,
 } from "./handleServerActionHelper.js";
+import type { ServerActionRequest } from "./handleServerActionHelper.js";
 import { createSealedServerReferenceGate } from "../references/createSealedServerReferenceGate.server.js";
 import type { ReferenceGate } from "react-server-loader/references";
 import { readFile } from "node:fs/promises";
@@ -87,122 +90,159 @@ export function handleServerActionError(error: unknown, res: ServerResponse, log
 }
 
 /**
- * Server-side server action handler that uses ssrLoadModule
+ * I/O-agnostic core: resolve a parsed server-action request to its function (the
+ * devOpen dev resolver, or the sealed production gate) and execute it. Shared by
+ * the Node (req/res) and Web (Request/Response) entry points so the trust
+ * boundary lives in exactly one place. Returns the action's result.
+ */
+export async function resolveAndExecuteServerAction(
+  { id, args }: ServerActionRequest,
+  options: ServerActionHandlerOptions
+): Promise<unknown> {
+  const { projectRoot, verbose = false, logger, ssrLoadModule, base } = options;
+
+  let action: Function;
+  if (options.devOpen) {
+    // OPEN path — reachable ONLY when the Vite dev wrapper opts in. Dev serves
+    // live source, so there is no build manifest to seal against. NOT a trust
+    // boundary. Defense in depth: refuse it under NODE_ENV=production so a
+    // misconfigured prod deploy can never take the unsealed path even if the
+    // flag leaks in.
+    if (process.env.NODE_ENV === "production") {
+      throw new Error(
+        "[handleServerAction] devOpen (the unsealed dev resolver) was requested " +
+          "under NODE_ENV=production. Server actions must be sealed in production; refusing."
+      );
+    }
+    // Resolve against the project root with a traversal guard, then load on demand.
+    const { fullPath, exportName } = resolveServerAction(
+      id,
+      projectRoot,
+      verbose,
+      logger
+    );
+    if (!ssrLoadModule) {
+      throw new Error("ssrLoadModule is required for server action execution");
+    }
+    action = await loadServerAction(
+      fullPath,
+      exportName,
+      ssrLoadModule,
+      verbose,
+      logger
+    );
+  } else {
+    // SEALED path (production trust boundary). Resolve the client-supplied id
+    // through a gate built from the build's server manifest: an id the build
+    // never emitted is rejected before any import; the importer is bound to the
+    // manifest's real file, never to a path derived from the id.
+    const resolved = await resolveServerManifest(options);
+    if (!resolved) {
+      // FAIL CLOSED. A missing manifest in production must NOT silently fall back
+      // to the open resolver — that would reopen the boundary we are enforcing.
+      throw new Error(
+        `[handleServerAction] No server manifest found (looked for ` +
+          `${join(options.serverRoot ?? join(projectRoot, "dist", "server"), ".vite", "manifest.json")}). ` +
+          `Server actions resolve through a sealed allowlist; pass serverRoot for a ` +
+          `custom build.outDir, or serverManifest directly. Refusing unsealed resolution.`
+      );
+    }
+    let gate = sealedGates.get(resolved.serverManifest);
+    if (!gate) {
+      gate = createSealedServerReferenceGate({
+        serverManifest: resolved.serverManifest,
+        serverRoot: resolved.serverRoot,
+        base,
+      });
+      sealedGates.set(resolved.serverManifest, gate);
+    }
+    action = (await gate.resolveServerReference(id)) as Function;
+  }
+
+  return executeServerAction(action, args, verbose, logger);
+}
+
+/**
+ * Server-side server action handler (Node req/res). A thin shim over the shared
+ * core: CSRF guard, parse, resolve + execute, send.
  */
 export async function handleServerAction(
   req: IncomingMessage,
   res: ServerResponse,
   options: ServerActionHandlerOptions
 ): Promise<void> {
-  const { projectRoot, verbose = false, logger, ssrLoadModule, base } = options;
+  const { verbose = false, logger } = options;
 
   try {
     if (verbose) {
       logger?.info("[handleServerAction:server] Processing server action request");
     }
 
-    // CSRF / cross-origin guard (opt-in). When allowedOrigins is configured, a
-    // browser-driven cross-site POST carries an Origin header set to the calling
-    // site; reject anything not in the allowlist. A missing Origin is allowed: a
-    // page cannot suppress it on a cross-origin fetch, so its absence means
-    // same-origin or a non-browser client (not a CSRF vector).
-    if (options.allowedOrigins && options.allowedOrigins.length > 0) {
-      const origin = (req.headers.origin as string | undefined) ?? "";
-      if (origin && !options.allowedOrigins.includes(origin)) {
-        res.statusCode = 403;
-        res.setHeader("Content-Type", "application/json");
-        res.end(JSON.stringify({ success: false, error: "Origin not allowed" }));
-        return;
-      }
-    }
+    assertOriginAllowed(req.headers.origin as string | undefined, options.allowedOrigins);
 
-    // Parse the server action request
-    const { id, args } = await parseServerActionRequestHelper(
+    const parsed = await parseServerActionRequestHelper(
       req,
       verbose,
       logger,
       options.maxBodyBytes
     );
+    const result = await resolveAndExecuteServerAction(parsed, options);
 
-    let action: Function;
-    if (options.devOpen) {
-      // OPEN path — reachable ONLY when the Vite dev wrapper opts in. Dev serves
-      // live source, so there is no build manifest to seal against. NOT a trust
-      // boundary. Defense in depth: refuse it under NODE_ENV=production so a
-      // misconfigured prod deploy can never take the unsealed path even if the
-      // flag leaks in.
-      if (process.env.NODE_ENV === "production") {
-        throw new Error(
-          "[handleServerAction] devOpen (the unsealed dev resolver) was requested " +
-            "under NODE_ENV=production. Server actions must be sealed in production; refusing."
-        );
-      }
-      // Resolve against the project root with a traversal guard, then load on demand.
-      const { fullPath, exportName } = resolveServerAction(
-        id,
-        projectRoot,
-        verbose,
-        logger
-      );
-      if (!ssrLoadModule) {
-        throw new Error("ssrLoadModule is required for server action execution");
-      }
-      action = await loadServerAction(
-        fullPath,
-        exportName,
-        ssrLoadModule,
-        verbose,
-        logger
-      );
-    } else {
-      // SEALED path (production trust boundary). Resolve the client-supplied id
-      // through a gate built from the build's server manifest: an id the build
-      // never emitted is rejected before any import; the importer is bound to the
-      // manifest's real file, never to a path derived from the id.
-      const resolved = await resolveServerManifest(options);
-      if (!resolved) {
-        // FAIL CLOSED. A missing manifest in production must NOT silently fall back
-        // to the open resolver — that would reopen the boundary we are enforcing.
-        throw new Error(
-          `[handleServerAction] No server manifest found (looked for ` +
-            `${join(options.serverRoot ?? join(projectRoot, "dist", "server"), ".vite", "manifest.json")}). ` +
-            `Server actions resolve through a sealed allowlist; pass serverRoot for a ` +
-            `custom build.outDir, or serverManifest directly. Refusing unsealed resolution.`
-        );
-      }
-      let gate = sealedGates.get(resolved.serverManifest);
-      if (!gate) {
-        gate = createSealedServerReferenceGate({
-          serverManifest: resolved.serverManifest,
-          serverRoot: resolved.serverRoot,
-          base,
-        });
-        sealedGates.set(resolved.serverManifest, gate);
-      }
-      action = (await gate.resolveServerReference(id)) as Function;
-    }
-
-    // Execute the server action
-    const result = await executeServerAction(
-      action,
-      args,
-      verbose,
-      logger
-    );
-
-    // Send the response
-    sendServerActionResponse(
-      res,
-      result,
-      verbose,
-      logger
-    );
+    sendServerActionResponse(res, result, verbose, logger);
 
     if (verbose) {
       logger?.info("[handleServerAction:server] Server action completed successfully");
     }
   } catch (error: unknown) {
     handleServerActionErrorHelper(error, res, logger);
+  }
+}
+
+/**
+ * Web-standard server action handler: `(Request) => Promise<Response>`. The
+ * portable entry point for any Fetch-style runtime (Hono, Bun, Deno, edge
+ * functions). Same trust boundary as the Node handler — it shares
+ * `resolveAndExecuteServerAction` and the CSRF / body-cap guards — differing only
+ * in the request/response envelope. The Node `handleServerAction` is the req/res
+ * shim over the same core.
+ */
+export async function handleServerActionRequest(
+  request: Request,
+  options: ServerActionHandlerOptions
+): Promise<Response> {
+  const { verbose = false, logger } = options;
+  try {
+    if (verbose) {
+      logger?.info("[handleServerAction:web] Processing server action request");
+    }
+
+    assertOriginAllowed(request.headers.get("origin"), options.allowedOrigins);
+
+    const parsed = await parseServerActionWebRequest(
+      request,
+      verbose,
+      logger,
+      options.maxBodyBytes
+    );
+    const result = await resolveAndExecuteServerAction(parsed, options);
+
+    // RSC wire format, matching the Node sendServerActionResponse output.
+    return new Response(`0:${JSON.stringify(result)}\n`, {
+      headers: { "Content-Type": "text/x-component" },
+    });
+  } catch (error: unknown) {
+    const err = toError(error) as Error & { statusCode?: number };
+    logError(err, logger);
+    // Honor a tagged status (403 origin, 413 oversized) else 500. Never ship the
+    // stack to the client — it exposes absolute paths and internal module ids;
+    // the full error is logged above.
+    return new Response(
+      JSON.stringify({ success: false, error: err.message }),
+      {
+        status: typeof err.statusCode === "number" ? err.statusCode : 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
   }
 }
 

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -198,6 +198,92 @@ export async function parseServerActionRequest(
 }
 
 /**
+ * CSRF / cross-origin guard shared by the Node and Web entry points. When
+ * `allowedOrigins` is set, a request whose `Origin` is present and not in the
+ * allowlist is rejected (throws a 403-tagged error). A missing `Origin` is
+ * allowed: a browser cannot suppress it on a cross-origin POST, so its absence
+ * means same-origin or a non-browser client (not a CSRF vector).
+ */
+export function assertOriginAllowed(
+  origin: string | null | undefined,
+  allowedOrigins?: string[]
+): void {
+  if (!allowedOrigins || allowedOrigins.length === 0) return;
+  if (origin && !allowedOrigins.includes(origin)) {
+    const err = new Error("Origin not allowed") as Error & { statusCode?: number };
+    err.statusCode = 403;
+    throw err;
+  }
+}
+
+/**
+ * Web-standard counterpart to {@link parseServerActionRequest}: extract
+ * `{ id, args }` from a Fetch `Request`. Same id resolution (the `x-rsc-action`
+ * header, else the URL path) and body formats (a JSON args array, a `{id,args}`
+ * object, or a raw React-encoded body), and the same `maxBodyBytes` cap —
+ * rejected with a 413-tagged error before the whole body is buffered.
+ */
+export async function parseServerActionWebRequest(
+  request: Request,
+  verbose = false,
+  logger?: Logger,
+  maxBodyBytes?: number
+): Promise<ServerActionRequest> {
+  let id =
+    request.headers.get("x-rsc-action") ??
+    new URL(request.url).pathname ??
+    "";
+
+  let body = "";
+  if (request.body) {
+    const reader = request.body.getReader();
+    const decoder = new TextDecoder();
+    let received = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (maxBodyBytes !== undefined && received > maxBodyBytes) {
+        await reader.cancel();
+        const err = new Error(
+          `Server action request body exceeds maxBodyBytes (${maxBodyBytes})`
+        ) as Error & { statusCode?: number };
+        err.statusCode = 413;
+        throw err;
+      }
+      body += decoder.decode(value, { stream: true });
+    }
+    body += decoder.decode();
+  } else {
+    body = await request.text();
+  }
+
+  let args: unknown[];
+  try {
+    const parsed = JSON.parse(body);
+    if (Array.isArray(parsed)) {
+      args = parsed;
+    } else if (parsed && typeof parsed === "object" && "id" in parsed) {
+      id = (parsed as { id: string }).id;
+      args = (parsed as { args?: unknown[] }).args ?? [];
+    } else {
+      throw new Error("Invalid server action request format");
+    }
+  } catch {
+    // Not JSON — React's encoded format; pass the raw body for downstream decode.
+    args = [body];
+  }
+
+  if (!id) {
+    throw new Error("Server action ID is required");
+  }
+  if (verbose) {
+    logger?.info(`[handleServerActionHelper] Web server action request for ${id}`);
+  }
+  return { id, args };
+}
+
+/**
  * Resolves a server action ID to file path and export name
  */
 export function resolveServerAction(

--- a/plugin/helpers/index.server.ts
+++ b/plugin/helpers/index.server.ts
@@ -9,4 +9,4 @@
 export * from "./index.shared.js";
 
 // Server action handling
-export { handleServerAction } from "./handleServerAction.server.js";
+export { handleServerAction, handleServerActionRequest } from "./handleServerAction.server.js";

--- a/test/unit/handleServerActionWebRequest.test.ts
+++ b/test/unit/handleServerActionWebRequest.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleServerActionRequest } from "../../dist/plugin/helpers/handleServerAction.server.js";
+
+// Web-standard server-action entry: (Request) => Promise<Response>. It shares the
+// trust boundary (resolveAndExecuteServerAction) and the CSRF / body-cap guards
+// with the Node handler, so these mirror handleServerActionHardening.test.ts but
+// against the Fetch Request/Response envelope.
+
+function webReq(id: string, body = "[]", headers: Record<string, string> = {}) {
+  return new Request("https://example.test/__server-action", {
+    method: "POST",
+    headers: { "x-rsc-action": id, ...headers },
+    body,
+  });
+}
+
+const MANIFEST = {
+  "src/server/actions.server.ts": {
+    file: "assets/actions-abc.js",
+    src: "src/server/actions.server.ts",
+  },
+};
+
+describe("handleServerActionRequest (Web)", () => {
+  describe("allowedOrigins (CSRF guard)", () => {
+    it("rejects a request whose Origin is not in the allowlist (403), before resolving", async () => {
+      const ssrLoadModule = vi.fn();
+      const res = await handleServerActionRequest(
+        webReq("src/server/actions.server.ts#addTodo", "[]", {
+          origin: "https://evil.example",
+        }),
+        {
+          projectRoot: "/proj",
+          serverManifest: MANIFEST,
+          serverRoot: "/proj/dist/server",
+          allowedOrigins: ["https://app.example"],
+          ssrLoadModule,
+        }
+      );
+      expect(res.status).toBe(403);
+      expect(ssrLoadModule).not.toHaveBeenCalled();
+    });
+
+    it("allows a request with an allowed Origin", async () => {
+      const res = await handleServerActionRequest(
+        webReq("forged.server.ts#pwn", "[]", { origin: "https://app.example" }),
+        {
+          projectRoot: "/proj",
+          serverManifest: MANIFEST,
+          serverRoot: "/proj/dist/server",
+          allowedOrigins: ["https://app.example"],
+        }
+      );
+      // Origin passed the guard; it fails later on the unknown id, not 403.
+      expect(res.status).not.toBe(403);
+    });
+
+    it("allows a request with no Origin header (not a CSRF vector)", async () => {
+      const res = await handleServerActionRequest(webReq("forged.server.ts#pwn"), {
+        projectRoot: "/proj",
+        serverManifest: MANIFEST,
+        serverRoot: "/proj/dist/server",
+        allowedOrigins: ["https://app.example"],
+      });
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  describe("maxBodyBytes (DoS guard)", () => {
+    it("rejects an oversized body with 413 without resolving the action", async () => {
+      const ssrLoadModule = vi.fn();
+      const big = JSON.stringify(["x".repeat(1000)]);
+      const res = await handleServerActionRequest(
+        webReq("src/server/actions.server.ts#addTodo", big),
+        {
+          projectRoot: "/proj",
+          serverManifest: MANIFEST,
+          serverRoot: "/proj/dist/server",
+          maxBodyBytes: 16,
+          ssrLoadModule,
+        }
+      );
+      expect(res.status).toBe(413);
+      expect(ssrLoadModule).not.toHaveBeenCalled();
+    });
+
+    it("allows a body within the limit", async () => {
+      const res = await handleServerActionRequest(webReq("forged.server.ts#pwn", "[]"), {
+        projectRoot: "/proj",
+        serverManifest: MANIFEST,
+        serverRoot: "/proj/dist/server",
+        maxBodyBytes: 1024,
+      });
+      expect(res.status).not.toBe(413);
+    });
+  });
+
+  describe("responses", () => {
+    it("never includes a stack trace or file paths in the error response", async () => {
+      const res = await handleServerActionRequest(webReq("forged.server.ts#pwn"), {
+        projectRoot: "/proj",
+        serverManifest: MANIFEST,
+        serverRoot: "/proj/dist/server",
+      });
+      expect(res.status).toBe(500);
+      const body = await res.text();
+      expect(body).not.toContain("stack");
+      expect(body).not.toMatch(/\.ts:\d+|\/proj\//);
+    });
+
+    it("returns the action result in RSC wire format on success", async () => {
+      // devOpen path (not a trust boundary; used here to exercise the success
+      // envelope end-to-end without a built module on disk).
+      const ssrLoadModule = vi.fn(async () => ({
+        addTodo: async (t: string) => ({ ok: t }),
+      }));
+      const res = await handleServerActionRequest(
+        webReq("src/actions.ts#addTodo", JSON.stringify(["milk"])),
+        { projectRoot: process.cwd(), devOpen: true, ssrLoadModule }
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/x-component");
+      expect(await res.text()).toBe(`0:${JSON.stringify({ ok: "milk" })}\n`);
+      expect(ssrLoadModule).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Adds a Web-standard server-action entry point so a vprs server can run on any Fetch-style runtime (Hono, Fastify v5, Bun, Deno, edge functions), not just Node:

```ts
import { handleServerActionRequest } from "vite-plugin-react-server/helpers/handleServerAction";
// (request: Request) => Promise<Response>
```

The existing Node `handleServerAction(req, res)` becomes a thin shim over the same core.

## What changed
- **`handleServerActionRequest(request, options): Promise<Response>`** — the portable entry point.
- **`resolveAndExecuteServerAction(parsed, options)`** — the resolve+execute logic (devOpen dev resolver and the sealed production gate) extracted so the **trust boundary lives in exactly one place**; both entry points call it.
- **Shared guards** — `assertOriginAllowed` (CSRF) and a `Request`-based `parseServerActionWebRequest` that streams the body with the **same `maxBodyBytes` cap** and the same id resolution (`x-rsc-action` header, else URL) as the Node parser.

Only the request/response envelope differs between the two entries; the security checks and execution path are identical code.

## Scope
This is the headless-RSC/actions surface that's portable off Node. It does **not** include rendering the flash-free HTML document per request (that path uses a worker and stays Node-only). Making the bundle fully free of `node:*` built-ins (so it can be built for an edge runtime) is a follow-up; this PR establishes the Web signature, Node-verified.

## Testing
- New `test/unit/handleServerActionWebRequest.test.ts` mirrors the existing hardening suite against `Request`/`Response`: 403 on a disallowed `Origin`, 413 on an oversized body, no stack trace or file paths in error responses, and the RSC wire-format success envelope.
- The existing Node origin / body-cap / sealed-gate tests pass unchanged (behavior preserved).
- `build`, `test:unit` (479), `test:server` (662/4-skip), `test:typecheck` (no type errors) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
