### PR TITLE
feat(helpers): createRequestHandler — Web request handler for a build

### DIFF
--- a/plugin/helpers/createRequestHandler.server.ts
+++ b/plugin/helpers/createRequestHandler.server.ts
@@ -1,0 +1,139 @@
+import { readFile } from "node:fs/promises";
+import { join, extname } from "node:path";
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { MIME_TYPES } from "../config/mimeTypes.js";
+import { isPathWithin } from "./isPathWithin.js";
+import { handleServerActionRequest } from "./handleServerAction.server.js";
+import type { ServerActionHandlerOptions } from "./handleServerActionHelper.js";
+
+export interface CreateRequestHandlerOptions {
+  /**
+   * Directory of the prerendered build output to serve files from (typically
+   * `dist/static`). Routes map to files: `/` -> `index.html`, `/about/` or
+   * `/about` -> `about/index.html`, and `*.rsc` / hashed assets are served as-is.
+   */
+  staticDir: string;
+  /**
+   * Server-action handling. When provided, a POST carrying the action header is
+   * dispatched to {@link handleServerActionRequest} (same trust boundary as the
+   * Node handler). Omit to serve a read-only site.
+   */
+  action?: ServerActionHandlerOptions;
+  /**
+   * Optional per-request renderer for dynamic routes. Called on a GET before the
+   * static fallback; return a `Response` to handle the route dynamically (e.g.
+   * driving `createInlineFlightRenderer`), or `null` to fall through to the
+   * prerendered file.
+   */
+  render?: (
+    route: string,
+    request: Request
+  ) => Promise<Response | null> | Response | null;
+  /** Header that marks a POST as a server action. Default `x-rsc-action`. */
+  actionHeader?: string;
+}
+
+async function resolveStaticFile(
+  staticDir: string,
+  pathname: string
+): Promise<{ body: Uint8Array; contentType: string } | null> {
+  let rel = decodeURIComponent(pathname);
+  if (rel.endsWith("/")) rel += "index.html";
+  else if (!extname(rel)) rel += "/index.html";
+
+  const full = join(staticDir, rel.startsWith("/") ? `.${rel}` : rel);
+  // Traversal guard: a request path must not escape the static root.
+  if (!isPathWithin(staticDir, full)) return null;
+
+  try {
+    const body = await readFile(full);
+    const contentType =
+      MIME_TYPES[extname(full).toLowerCase()] ?? "application/octet-stream";
+    return { body: new Uint8Array(body), contentType };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A Web-standard `(Request) => Promise<Response>` server for a vprs build:
+ * dispatches server actions, optional dynamic routes, and prerendered files.
+ * Compose it with {@link toNodeListener} for `http.createServer`, or pass it
+ * straight to a Fetch-style runtime (Hono, Bun, Deno).
+ *
+ * Note: static file serving reads from disk (`node:fs`), so the handler as a
+ * whole is Node-first. The action surface is runtime-agnostic; on edge, serve
+ * prerendered files from the platform and use `render` for dynamic routes.
+ */
+export function createRequestHandler(
+  options: CreateRequestHandlerOptions
+): (request: Request) => Promise<Response> {
+  const { staticDir, action, render, actionHeader = "x-rsc-action" } = options;
+
+  return async function handler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "POST" && action && request.headers.get(actionHeader)) {
+      return handleServerActionRequest(request, action);
+    }
+
+    if (request.method === "GET" || request.method === "HEAD") {
+      if (render) {
+        const dynamic = await render(url.pathname, request);
+        if (dynamic) return dynamic;
+      }
+      const file = await resolveStaticFile(staticDir, url.pathname);
+      if (file) {
+        return new Response(request.method === "HEAD" ? null : file.body, {
+          headers: { "Content-Type": file.contentType },
+        });
+      }
+    }
+
+    return new Response("Not Found", { status: 404 });
+  };
+}
+
+/**
+ * Adapt a Web `(Request) => Promise<Response>` handler to a Node
+ * `http`/Connect request listener, so the same handler runs under
+ * `http.createServer(toNodeListener(handler))` or as Express middleware.
+ */
+export function toNodeListener(
+  handler: (request: Request) => Promise<Response>
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    const url = `http://${req.headers.host ?? "localhost"}${req.url ?? "/"}`;
+    const method = req.method ?? "GET";
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (Array.isArray(value)) value.forEach((v) => headers.append(key, v));
+      else if (value != null) headers.set(key, value);
+    }
+    const hasBody = method !== "GET" && method !== "HEAD";
+    const request = new Request(url, {
+      method,
+      headers,
+      body: hasBody ? (Readable.toWeb(req) as unknown as ReadableStream) : undefined,
+      // Required by undici when streaming a request body.
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    handler(request)
+      .then(async (response) => {
+        res.statusCode = response.status;
+        response.headers.forEach((value, key) => res.setHeader(key, value));
+        if (response.body) {
+          for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
+            res.write(chunk);
+          }
+        }
+        res.end();
+      })
+      .catch((err) => {
+        res.statusCode = 500;
+        res.end(String(err instanceof Error ? err.message : err));
+      });
+  };
+}

--- a/plugin/helpers/index.server.ts
+++ b/plugin/helpers/index.server.ts
@@ -10,3 +10,7 @@ export * from "./index.shared.js";
 
 // Server action handling
 export { handleServerAction, handleServerActionRequest } from "./handleServerAction.server.js";
+
+// Web-standard request handler (dispatch actions / dynamic routes / static files)
+export { createRequestHandler, toNodeListener } from "./createRequestHandler.server.js";
+export type { CreateRequestHandlerOptions } from "./createRequestHandler.server.js";

--- a/test/unit/createRequestHandler.test.ts
+++ b/test/unit/createRequestHandler.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequestHandler } from "../../dist/plugin/helpers/createRequestHandler.server.js";
+
+let staticDir: string;
+let handler: (request: Request) => Promise<Response>;
+
+beforeAll(async () => {
+  staticDir = await mkdtemp(join(tmpdir(), "vprs-req-"));
+  await writeFile(join(staticDir, "index.html"), "<!doctype html><title>home</title>");
+  await mkdir(join(staticDir, "about"), { recursive: true });
+  await writeFile(join(staticDir, "about", "index.html"), "<h1>about</h1>");
+  await writeFile(join(staticDir, "index.rsc"), "0:flight");
+
+  handler = createRequestHandler({
+    staticDir,
+    action: {
+      projectRoot: process.cwd(),
+      devOpen: true,
+      ssrLoadModule: async () => ({ go: async (x: string) => ({ got: x }) }),
+    },
+    render: (route) =>
+      route === "/dynamic"
+        ? new Response("<h1>dyn</h1>", { headers: { "Content-Type": "text/html" } })
+        : null,
+  });
+});
+
+afterAll(() => rm(staticDir, { recursive: true, force: true }));
+
+const get = (path: string) => handler(new Request(`https://example.test${path}`));
+
+describe("createRequestHandler", () => {
+  it("serves index.html for /", async () => {
+    const res = await get("/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("home");
+  });
+
+  it("serves a nested route's index.html for an extensionless path", async () => {
+    const res = await get("/about");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("about");
+  });
+
+  it("serves .rsc payloads as text/x-component", async () => {
+    const res = await get("/index.rsc");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+  });
+
+  it("uses the render hook for dynamic routes", async () => {
+    const res = await get("/dynamic");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("dyn");
+  });
+
+  it("falls through to the static file when render returns null", async () => {
+    const res = await get("/");
+    expect(await res.text()).toContain("home");
+  });
+
+  it("404s an unknown path", async () => {
+    expect((await get("/nope")).status).toBe(404);
+  });
+
+  it("blocks path traversal out of the static dir", async () => {
+    const res = await handler(
+      new Request("https://example.test/..%2f..%2f..%2fetc%2fpasswd")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("dispatches a server-action POST to the action handler", async () => {
+    const res = await handler(
+      new Request("https://example.test/src/a.ts#go", {
+        method: "POST",
+        headers: { "x-rsc-action": "src/a.ts#go" },
+        body: JSON.stringify(["hi"]),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    expect(await res.text()).toBe(`0:${JSON.stringify({ got: "hi" })}\n`);
+  });
+});


### PR DESCRIPTION
Makes standing up a server over a vprs build a few lines instead of a hand-rolled Express recipe:

```ts
import { createRequestHandler, toNodeListener } from "vite-plugin-react-server/helpers";
import { createServer } from "node:http";

const handler = createRequestHandler({
  staticDir: "dist/static",
  action: { projectRoot: process.cwd() },        // server actions (sealed in prod)
  // render: (route, req) => …                    // optional dynamic routes
});

createServer(toNodeListener(handler)).listen(3000);
```

## What's here
- **`createRequestHandler(options) => (Request) => Promise<Response>`** — dispatches:
  - a POST carrying the action header → `handleServerActionRequest` (the shared trust boundary);
  - a GET → an optional `render(route, request)` hook for dynamic routes, then the prerendered file (`/` → `index.html`, `/about` → `about/index.html`, `*.rsc` and assets as-is) with a path-traversal guard, then `404`.
- **`toNodeListener(handler)`** — adapts the Web handler to a Node `http`/Connect/Express request listener.

## Notes
- Static serving reads from disk (`node:fs`), so the handler is Node-first. The action surface is runtime-agnostic, and `render` lets a consumer own dynamic rendering — so the same handler also drops into a Fetch-style runtime where static is served by the platform.
- Per-request RSC flight generation off Node is not included here: the vendored transport currently exposes only the Node (pipeable) flight renderer, so a Web-stream flight renderer has to land in `react-server-loader` first.

## Testing
New `test/unit/createRequestHandler.test.ts`: static index, extensionless nested route, `.rsc` content-type, the render hook (hit + fall-through), `404`, path-traversal block, and server-action dispatch. `build`, `test:unit` (487), `test:server` (670/4-skip), `test:typecheck` (no type errors) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
