### PR TITLE
feat(stream): edge (Web ReadableStream) RSC renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.10 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.11 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -5859,9 +5859,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.10",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.10.tgz",
-      "integrity": "sha512-5tjavvJvvijZmRXIBP+AxJPiKv8JdLa6EB/m4hqUyc8rg3kxPA6JIWtxh+n45VCj/f7JTrf2UuNSNw84RuNQ5g==",
+      "version": "19.2.11",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.11.tgz",
+      "integrity": "sha512-BPuj4ef8DAUkNdXhw4UNrJm5JRiWffVXjoS9WqYKasljy5bD5yVVscphurQmw8Hth/COAgnojVXDD7oAyCrI5w==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -419,7 +419,7 @@
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
-    "react-server-loader": "^19.2.10 || >=0.0.0-0 <0.0.1",
+    "react-server-loader": "^19.2.11 || >=0.0.0-0 <0.0.1",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }

--- a/plugin/helpers/createRequestHandler.server.ts
+++ b/plugin/helpers/createRequestHandler.server.ts
@@ -1,0 +1,139 @@
+import { readFile } from "node:fs/promises";
+import { join, extname } from "node:path";
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { MIME_TYPES } from "../config/mimeTypes.js";
+import { isPathWithin } from "./isPathWithin.js";
+import { handleServerActionRequest } from "./handleServerAction.server.js";
+import type { ServerActionHandlerOptions } from "./handleServerActionHelper.js";
+
+export interface CreateRequestHandlerOptions {
+  /**
+   * Directory of the prerendered build output to serve files from (typically
+   * `dist/static`). Routes map to files: `/` -> `index.html`, `/about/` or
+   * `/about` -> `about/index.html`, and `*.rsc` / hashed assets are served as-is.
+   */
+  staticDir: string;
+  /**
+   * Server-action handling. When provided, a POST carrying the action header is
+   * dispatched to {@link handleServerActionRequest} (same trust boundary as the
+   * Node handler). Omit to serve a read-only site.
+   */
+  action?: ServerActionHandlerOptions;
+  /**
+   * Optional per-request renderer for dynamic routes. Called on a GET before the
+   * static fallback; return a `Response` to handle the route dynamically (e.g.
+   * driving `createInlineFlightRenderer`), or `null` to fall through to the
+   * prerendered file.
+   */
+  render?: (
+    route: string,
+    request: Request
+  ) => Promise<Response | null> | Response | null;
+  /** Header that marks a POST as a server action. Default `x-rsc-action`. */
+  actionHeader?: string;
+}
+
+async function resolveStaticFile(
+  staticDir: string,
+  pathname: string
+): Promise<{ body: Uint8Array; contentType: string } | null> {
+  let rel = decodeURIComponent(pathname);
+  if (rel.endsWith("/")) rel += "index.html";
+  else if (!extname(rel)) rel += "/index.html";
+
+  const full = join(staticDir, rel.startsWith("/") ? `.${rel}` : rel);
+  // Traversal guard: a request path must not escape the static root.
+  if (!isPathWithin(staticDir, full)) return null;
+
+  try {
+    const body = await readFile(full);
+    const contentType =
+      MIME_TYPES[extname(full).toLowerCase()] ?? "application/octet-stream";
+    return { body: new Uint8Array(body), contentType };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A Web-standard `(Request) => Promise<Response>` server for a vprs build:
+ * dispatches server actions, optional dynamic routes, and prerendered files.
+ * Compose it with {@link toNodeListener} for `http.createServer`, or pass it
+ * straight to a Fetch-style runtime (Hono, Bun, Deno).
+ *
+ * Note: static file serving reads from disk (`node:fs`), so the handler as a
+ * whole is Node-first. The action surface is runtime-agnostic; on edge, serve
+ * prerendered files from the platform and use `render` for dynamic routes.
+ */
+export function createRequestHandler(
+  options: CreateRequestHandlerOptions
+): (request: Request) => Promise<Response> {
+  const { staticDir, action, render, actionHeader = "x-rsc-action" } = options;
+
+  return async function handler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "POST" && action && request.headers.get(actionHeader)) {
+      return handleServerActionRequest(request, action);
+    }
+
+    if (request.method === "GET" || request.method === "HEAD") {
+      if (render) {
+        const dynamic = await render(url.pathname, request);
+        if (dynamic) return dynamic;
+      }
+      const file = await resolveStaticFile(staticDir, url.pathname);
+      if (file) {
+        return new Response(request.method === "HEAD" ? null : file.body, {
+          headers: { "Content-Type": file.contentType },
+        });
+      }
+    }
+
+    return new Response("Not Found", { status: 404 });
+  };
+}
+
+/**
+ * Adapt a Web `(Request) => Promise<Response>` handler to a Node
+ * `http`/Connect request listener, so the same handler runs under
+ * `http.createServer(toNodeListener(handler))` or as Express middleware.
+ */
+export function toNodeListener(
+  handler: (request: Request) => Promise<Response>
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    const url = `http://${req.headers.host ?? "localhost"}${req.url ?? "/"}`;
+    const method = req.method ?? "GET";
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (Array.isArray(value)) value.forEach((v) => headers.append(key, v));
+      else if (value != null) headers.set(key, value);
+    }
+    const hasBody = method !== "GET" && method !== "HEAD";
+    const request = new Request(url, {
+      method,
+      headers,
+      body: hasBody ? (Readable.toWeb(req) as unknown as ReadableStream) : undefined,
+      // Required by undici when streaming a request body.
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    handler(request)
+      .then(async (response) => {
+        res.statusCode = response.status;
+        response.headers.forEach((value, key) => res.setHeader(key, value));
+        if (response.body) {
+          for await (const chunk of response.body as unknown as AsyncIterable<Uint8Array>) {
+            res.write(chunk);
+          }
+        }
+        res.end();
+      })
+      .catch((err) => {
+        res.statusCode = 500;
+        res.end(String(err instanceof Error ? err.message : err));
+      });
+  };
+}

--- a/plugin/helpers/index.server.ts
+++ b/plugin/helpers/index.server.ts
@@ -10,3 +10,7 @@ export * from "./index.shared.js";
 
 // Server action handling
 export { handleServerAction, handleServerActionRequest } from "./handleServerAction.server.js";
+
+// Web-standard request handler (dispatch actions / dynamic routes / static files)
+export { createRequestHandler, toNodeListener } from "./createRequestHandler.server.js";
+export type { CreateRequestHandlerOptions } from "./createRequestHandler.server.js";

--- a/plugin/stream/createFromReadableStream.client.ts
+++ b/plugin/stream/createFromReadableStream.client.ts
@@ -1,0 +1,93 @@
+import type {
+  CreateFromReadableStreamFn,
+  CreateFromFetchFn,
+} from "./createFromReadableStream.types.js";
+import { React } from "../vendor/vendor.client.js";
+import { ReactDOMClientEdge } from "../vendor/vendorEdge.client.js";
+import { assertNonReactServer } from "../config/getCondition.js";
+
+assertNonReactServer();
+
+/**
+ * Web-stream counterpart of {@link createFromNodeStream}: decode a Flight RSC
+ * payload delivered as a Web `ReadableStream<Uint8Array>` — from
+ * renderRscReadableStream / renderRscResponse, an RSC endpoint, an edge worker,
+ * or a static `.rsc` fetch — into React elements, via
+ * react-server-dom-esm/client.browser. Condition-free and runtime-agnostic
+ * (browser / workerd / Deno / Bun): the client transport runs in the consumer's
+ * normal React. This is the consumer half a client-first user reaches for —
+ * Flight production stays server-only (react-server condition), consumption
+ * does not.
+ */
+export const createFromReadableStream: CreateFromReadableStreamFn =
+  function _createFromReadableStreamClient(options) {
+    const { rscStream, children, logger, verbose = false } = options;
+    let { moduleBaseURL } = options;
+
+    if (children) {
+      return { type: "client", children: children as React.ReactElement };
+    }
+    if (!rscStream) {
+      throw new Error(
+        "[createFromReadableStream.client] no rscStream nor children provided"
+      );
+    }
+    if (typeof moduleBaseURL !== "string" || !moduleBaseURL) {
+      if (verbose) {
+        logger?.warn(
+          `[createFromReadableStream.client] moduleBaseURL is not a valid string (${JSON.stringify(
+            moduleBaseURL
+          )}); defaulting to "/"`
+        );
+      }
+      moduleBaseURL = "/";
+    }
+    if (verbose) {
+      logger?.info(
+        `[createFromReadableStream.client] decoding Flight ReadableStream via react-server-dom-esm/client.browser, moduleBaseURL: ${moduleBaseURL}`
+      );
+    }
+
+    // Capture as a non-let const for the closure below.
+    const baseURL = moduleBaseURL;
+    return {
+      type: "client",
+      children: React.createElement(() =>
+        React.use(
+          ReactDOMClientEdge.createFromReadableStream(rscStream, {
+            moduleBaseURL: baseURL,
+          })
+        )
+      ),
+    };
+  };
+
+/**
+ * Convenience over {@link createFromReadableStream}: decode a Flight `Response`
+ * directly (mirrors react-server-dom-esm/client's `createFromFetch`). Pass the
+ * `Response` (or a Promise of one) from fetching an RSC endpoint; the body's
+ * Flight stream becomes React elements without the caller touching `.body`.
+ */
+export const createFromFetch: CreateFromFetchFn =
+  function _createFromFetchClient(options) {
+    const { response, logger, verbose = false } = options;
+    const moduleBaseURL =
+      typeof options.moduleBaseURL === "string" && options.moduleBaseURL
+        ? options.moduleBaseURL
+        : "/";
+    if (verbose) {
+      logger?.info(
+        `[createFromFetch.client] decoding Flight Response via react-server-dom-esm/client.browser, moduleBaseURL: ${moduleBaseURL}`
+      );
+    }
+    return {
+      type: "client",
+      children: React.createElement(() =>
+        React.use(
+          ReactDOMClientEdge.createFromFetch(Promise.resolve(response), {
+            moduleBaseURL,
+          })
+        )
+      ),
+    };
+  };

--- a/plugin/stream/createFromReadableStream.types.ts
+++ b/plugin/stream/createFromReadableStream.types.ts
@@ -1,0 +1,43 @@
+// React types resolve from the vendor system at runtime; React.* is the global
+// namespace (mirrors createFromNodeStream.types.ts).
+import type { Logger } from "vite";
+
+/**
+ * Options for decoding a Flight RSC payload delivered as a Web stream into
+ * React elements (client-only: producing Flight stays server-only).
+ */
+export type CreateFromReadableStreamOptions = {
+  /** Pre-resolved elements: short-circuit decode (mirrors createFromNodeStream). */
+  children?: any;
+  /** The Flight RSC payload as a Web ReadableStream (the edge producer's output). */
+  rscStream?: ReadableStream<Uint8Array>;
+  /** Base URL the client transport uses to resolve client-reference modules. */
+  moduleBaseURL?: string;
+  logger?: Logger;
+  verbose?: boolean;
+};
+
+/**
+ * Options for {@link CreateFromFetchFn}: decode a Flight `Response` directly.
+ */
+export type CreateFromFetchOptions = {
+  /** A fetch Response (or a Promise of one) whose body is a Flight RSC payload. */
+  response: Response | Promise<Response>;
+  moduleBaseURL?: string;
+  logger?: Logger;
+  verbose?: boolean;
+};
+
+/** Result of decoding a Flight Web stream: a client-typed React element. */
+export interface FromReadableStreamResult {
+  type: "client";
+  children: React.ReactElement;
+}
+
+export type CreateFromReadableStreamFn = (
+  options: CreateFromReadableStreamOptions
+) => FromReadableStreamResult;
+
+export type CreateFromFetchFn = (
+  options: CreateFromFetchOptions
+) => FromReadableStreamResult;

--- a/plugin/stream/index.client.ts
+++ b/plugin/stream/index.client.ts
@@ -13,6 +13,11 @@ export * from "./createRenderToPipeableStreamHandler.client.js";
 // Node stream handling (RSC flight -> React elements)
 export * from "./createFromNodeStream.client.js";
 
+// Web-stream handling (RSC flight ReadableStream / Response -> React elements).
+// Consumer mirror of renderRscReadableStream (the edge producer): the half a
+// client-first / Web-runtime user decodes Flight with.
+export * from "./createFromReadableStream.client.js";
+
 // HTML stream creation
 export * from "./createHtmlStream.client.js";
 

--- a/plugin/stream/index.server.ts
+++ b/plugin/stream/index.server.ts
@@ -10,6 +10,9 @@ export * from "./createRscStream.server.js";
 // RSC -> pipeable stream
 export * from "./createRenderToPipeableStreamHandler.server.js";
 
+// RSC -> Web ReadableStream (edge / Web-streams runtimes)
+export * from "./renderRscReadableStream.server.js";
+
 // HTML stream creation
 export * from "./createHtmlStream.server.js";
 

--- a/plugin/stream/renderRscReadableStream.server.ts
+++ b/plugin/stream/renderRscReadableStream.server.ts
@@ -14,6 +14,16 @@ export const RSC_CONTENT_TYPE = "text/x-component";
 
 export type RscReadableStreamResult = {
   type: "server-edge";
+  /**
+   * Whether render setup succeeded. `false` means a SYNCHRONOUS failure
+   * (element creation, transport load, or render kickoff) — `rscStream` is then
+   * an empty closed stream and `error` holds the cause. Async errors that occur
+   * mid-stream surface via the `onError` handler, not here (the stream has
+   * already started by then).
+   */
+  ok: boolean;
+  /** The synchronous setup failure, when `ok` is false. */
+  error?: unknown;
   /** The RSC payload as a Web ReadableStream (Flight wire format). */
   rscStream: ReadableStream<Uint8Array>;
   /** Abort the in-flight render. */
@@ -41,7 +51,7 @@ const EMPTY_STREAM = (): ReadableStream<Uint8Array> =>
  */
 export function renderRscReadableStream(
   options: CreateHandlerOptions,
-  handlers?: Pick<StreamHandlers<"server">, "onError" | "onEnd" | "onData">
+  handlers?: Pick<StreamHandlers<"server">, "onError">
 ): RscReadableStreamResult {
   const id = options.id || "";
   const route = options.route;
@@ -53,7 +63,14 @@ export function renderRscReadableStream(
   const fail = (error: unknown, context: string): RscReadableStreamResult => {
     if (verbose) logger?.error(`[renderRscReadableStream:${route}] ${context}: ${error}`);
     handlers?.onError?.(id, error, { route, context });
-    return { type: "server-edge", rscStream: EMPTY_STREAM(), abort: () => {}, metrics };
+    return {
+      type: "server-edge",
+      ok: false,
+      error,
+      rscStream: EMPTY_STREAM(),
+      abort: () => {},
+      metrics,
+    };
   };
 
   let reactElement;
@@ -101,6 +118,7 @@ export function renderRscReadableStream(
 
     return {
       type: "server-edge",
+      ok: true,
       rscStream,
       abort: (reason?: unknown) => {
         handlers?.onError?.(
@@ -121,13 +139,25 @@ export function renderRscReadableStream(
  * Convenience wrapper: render an RSC tree and return a Web `Response` carrying
  * the Flight stream, ready to return from `createRequestHandler`'s `render`
  * hook or any Fetch-style runtime.
+ *
+ * A SYNCHRONOUS render-setup failure returns a `500` (not an empty `200`): the
+ * caller can't recover a half-built Flight stream, so surfacing it as a server
+ * error is the honest result. Errors that occur mid-stream can't change an
+ * already-sent status — handle those via {@link renderRscReadableStream}'s
+ * `onError`.
  */
 export function renderRscResponse(
   options: CreateHandlerOptions,
   init?: ResponseInit
 ): Response {
-  const { rscStream } = renderRscReadableStream(options);
+  const result = renderRscReadableStream(options);
+  if (!result.ok) {
+    return new Response("Internal Server Error", {
+      status: 500,
+      headers: { "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
   const headers = new Headers(init?.headers);
   if (!headers.has("Content-Type")) headers.set("Content-Type", RSC_CONTENT_TYPE);
-  return new Response(rscStream as unknown as BodyInit, { ...init, headers });
+  return new Response(result.rscStream as unknown as BodyInit, { ...init, headers });
 }

--- a/plugin/stream/renderRscReadableStream.server.ts
+++ b/plugin/stream/renderRscReadableStream.server.ts
@@ -1,0 +1,133 @@
+import type { CreateHandlerOptions, StreamMetrics } from "../types.js";
+import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
+import { createReactElement } from "../helpers/createRscRenderHelpers.server.js";
+import { checkReactVersion } from "../utils/checkReactVersion.js";
+import { assertRendererElementParity } from "../utils/assertRendererElementParity.js";
+import {
+  ReactDOMServerEdge,
+  getVendoredEdgeRendererMode,
+} from "../vendor/vendorEdge.server.js";
+import type { StreamHandlers } from "../worker/types.js";
+
+/** RSC content type the React Flight wire format is served as. */
+export const RSC_CONTENT_TYPE = "text/x-component";
+
+export type RscReadableStreamResult = {
+  type: "server-edge";
+  /** The RSC payload as a Web ReadableStream (Flight wire format). */
+  rscStream: ReadableStream<Uint8Array>;
+  /** Abort the in-flight render. */
+  abort: (reason?: unknown) => void;
+  metrics: StreamMetrics;
+};
+
+const EMPTY_STREAM = (): ReadableStream<Uint8Array> =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.close();
+    },
+  });
+
+/**
+ * Edge counterpart of {@link renderRscStream}: renders an RSC tree to a Web
+ * `ReadableStream` via the vendored react-server-dom-esm edge transport
+ * (`renderToReadableStream`). Returns a runtime-agnostic stream — pass it
+ * straight to a `Response` body (see {@link renderRscResponse}) on
+ * workerd/Deno/Bun or behind vprs's `createRequestHandler` `render` hook.
+ *
+ * Reference resolution is closed by react-server-loader's sealed reference gate
+ * in production (the edge transport cannot `import()` arbitrary file URLs), so
+ * `moduleBasePath` carries the build manifest base the gate was sealed against.
+ */
+export function renderRscReadableStream(
+  options: CreateHandlerOptions,
+  handlers?: Pick<StreamHandlers<"server">, "onError" | "onEnd" | "onData">
+): RscReadableStreamResult {
+  const id = options.id || "";
+  const route = options.route;
+  const verbose = options.verbose || false;
+  const logger = options.logger;
+  const metrics = createStreamMetrics();
+  const controller = new AbortController();
+
+  const fail = (error: unknown, context: string): RscReadableStreamResult => {
+    if (verbose) logger?.error(`[renderRscReadableStream:${route}] ${context}: ${error}`);
+    handlers?.onError?.(id, error, { route, context });
+    return { type: "server-edge", rscStream: EMPTY_STREAM(), abort: () => {}, metrics };
+  };
+
+  let reactElement;
+  try {
+    reactElement = createReactElement(options, {
+      id,
+      route,
+      verbose,
+      logger,
+      reuseHeadlessStreamId: (options as any).reuseHeadlessStreamId,
+      headlessStreamElements: (options as any).headlessStreamElements,
+      headlessStreamErrors: (options as any).headlessStreamErrors,
+    });
+  } catch (elementError) {
+    return fail(elementError, "React Element Creation Error");
+  }
+
+  try {
+    checkReactVersion();
+
+    // Touch the renderer BEFORE the parity check so the lazily-loaded vendored
+    // edge module resolves its dev/prod mode (mirrors renderRscStream).
+    const renderToReadableStream = ReactDOMServerEdge.renderToReadableStream;
+    assertRendererElementParity(
+      reactElement,
+      getVendoredEdgeRendererMode(),
+      `renderRscReadableStream:${route}`
+    );
+
+    const rscStream = renderToReadableStream(
+      reactElement,
+      options.moduleBasePath || "",
+      {
+        signal: controller.signal,
+        onError: (error: unknown) => {
+          if (verbose) logger?.error(`[renderRscReadableStream:${route}] React stream error: ${error}`);
+          handlers?.onError?.(id, error, { route, context: "React Stream Error" });
+          options.onEvent?.({
+            type: "route.error",
+            data: { error, route, panicThreshold: options.panicThreshold },
+          });
+        },
+      }
+    );
+
+    return {
+      type: "server-edge",
+      rscStream,
+      abort: (reason?: unknown) => {
+        handlers?.onError?.(
+          id,
+          reason instanceof Error ? reason : new Error(String(reason || "Stream aborted")),
+          { route, context: "Stream Aborted" }
+        );
+        controller.abort(reason);
+      },
+      metrics,
+    };
+  } catch (error) {
+    return fail(error, "RSC Render Error");
+  }
+}
+
+/**
+ * Convenience wrapper: render an RSC tree and return a Web `Response` carrying
+ * the Flight stream, ready to return from `createRequestHandler`'s `render`
+ * hook or any Fetch-style runtime.
+ */
+export function renderRscResponse(
+  options: CreateHandlerOptions,
+  init?: ResponseInit
+): Response {
+  const { rscStream } = renderRscReadableStream(options);
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Content-Type")) headers.set("Content-Type", RSC_CONTENT_TYPE);
+  return new Response(rscStream as unknown as BodyInit, { ...init, headers });
+}

--- a/plugin/stream/renderRscReadableStream.server.ts
+++ b/plugin/stream/renderRscReadableStream.server.ts
@@ -106,6 +106,12 @@ export function renderRscReadableStream(
       {
         signal: controller.signal,
         onError: (error: unknown) => {
+          // A deliberate abort() trips the renderer's onError with the abort
+          // reason — an intentional cancellation, not a route failure. abort()
+          // already raised its own ("Stream Aborted") onError, so swallow this
+          // one: no double-report, and no route.error that could spuriously
+          // trip panicThreshold on a normal cancellation.
+          if (controller.signal.aborted) return;
           if (verbose) logger?.error(`[renderRscReadableStream:${route}] React stream error: ${error}`);
           handlers?.onError?.(id, error, { route, context: "React Stream Error" });
           options.onEvent?.({

--- a/plugin/types/react-server-dom-esm.d.ts
+++ b/plugin/types/react-server-dom-esm.d.ts
@@ -258,11 +258,83 @@ declare module 'react-server-dom-esm/server' {
 }
 
 /**
+ * Server-side EDGE module for dynamic RSC rendering on Web-streams runtimes.
+ *
+ * The edge counterpart of 'react-server-dom-esm/server.node': it renders to a
+ * Web `ReadableStream` (`renderToReadableStream`) and prerenders to one
+ * (`prerender`) instead of Node pipeable streams, with no Busboy decoder. This
+ * is what runs under workerd/Deno/Bun and behind vprs's Web `(Request) =>
+ * Response` handler. Aborts via `options.signal` rather than a `.abort()` on a
+ * returned object.
+ */
+declare module 'react-server-dom-esm/server.edge' {
+  import type { ReactElement } from 'react';
+
+  export type RenderToReadableStreamOptions = {
+    onError?: (error: unknown) => void;
+    identifierPrefix?: string;
+    signal?: AbortSignal;
+    temporaryReferences?: WeakMap<any, any>;
+    environmentName?: string;
+    filterStackFrame?: (stackFrame: string) => string;
+  };
+
+  export function renderToReadableStream(
+    element: ReactElement,
+    moduleBasePath: string,
+    options?: RenderToReadableStreamOptions
+  ): ReadableStream<Uint8Array>;
+
+  export function prerender(
+    element: ReactElement,
+    moduleBasePath: string,
+    options?: RenderToReadableStreamOptions
+  ): Promise<{ prelude: ReadableStream<Uint8Array> }>;
+
+  export function createTemporaryReferenceSet(): WeakMap<any, any>;
+
+  export function decodeReply(
+    body: Uint8Array | string,
+    moduleBasePath: string,
+    options?: { temporaryReferences?: WeakMap<any, any> }
+  ): Promise<any>;
+
+  export function decodeReplyFromAsyncIterable(
+    iterable: AsyncIterable<Uint8Array>,
+    moduleBasePath: string,
+    options?: { temporaryReferences?: WeakMap<any, any> }
+  ): Promise<any>;
+
+  export function decodeAction(
+    body: FormData,
+    serverManifest: any
+  ): Promise<((formData: FormData) => Promise<any>) | null>;
+
+  export function decodeFormState(
+    actionResult: any,
+    body: FormData,
+    serverManifest: any
+  ): Promise<[any, string, string, number] | null>;
+
+  export function registerClientReference(
+    reference: any,
+    id: string,
+    exportName?: string
+  ): any;
+
+  export function registerServerReference(
+    reference: Function,
+    id: string,
+    exportName?: string
+  ): Function;
+}
+
+/**
  * Server-side Node.js module for dynamic RSC rendering
- * 
+ *
  * This module exports the same functionality as 'react-server-dom-esm/server'
  * but is specifically for Node.js environments with the 'react-server' condition.
- * 
+ *
  * Use case: Dynamic server-side rendering with real-time data and interactive features.
  */
 declare module 'react-server-dom-esm/server.node' {

--- a/plugin/vendor/vendorEdge.client.ts
+++ b/plugin/vendor/vendorEdge.client.ts
@@ -1,0 +1,31 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { transportPkgDir } from "./transportDir.js";
+import { createLazyVendorModule, reactPairedMode } from "./lazyVendorModule.js";
+
+// Edge counterpart of vendor.client.ts: the Web-streams CLIENT transport
+// (react-server-dom-esm/client.browser — createFromReadableStream /
+// createFromFetch), loaded from the vendored copy that ships inside
+// react-server-loader. Decodes a Flight ReadableStream into React elements in a
+// Web runtime (browser / workerd / Deno / Bun) — the consumer mirror of
+// vendorEdge.server.ts. Condition-free: the client transport runs in the
+// consumer's normal (client) React, so there is no wrong-side guard here.
+//
+// LAZY for the same NODE_ENV reason as vendor.client.ts: the vendored CJS picks
+// its dev/prod variant at require time, so the require is deferred to first
+// property access (by then build tooling has settled NODE_ENV). The React it
+// binds to still comes from the consumer's project (see vendor.client.ts).
+const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
+
+const lazyClientBrowser = createLazyVendorModule(
+  () =>
+    vendorRequire(
+      "react-server-dom-esm/client.browser"
+    ) as typeof import("react-server-dom-esm/client.browser"),
+  reactPairedMode
+);
+
+const ReactDOMClientEdge = lazyClientBrowser.proxy;
+
+export { ReactDOMClientEdge };
+export type * from "react-server-dom-esm/client.browser";

--- a/plugin/vendor/vendorEdge.server.ts
+++ b/plugin/vendor/vendorEdge.server.ts
@@ -1,0 +1,44 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { transportPkgDir } from "./transportDir.js";
+import {
+  createLazyVendorModule,
+  reactPairedMode,
+  vendoredTransportModeFromCache,
+} from "./lazyVendorModule.js";
+import { hasReactServerCondition } from "../config/getCondition.js";
+
+// Edge counterpart of vendor.server.ts. Loads react-server-dom-esm/server.edge
+// (Web-streams: renderToReadableStream / prerender) from the vendored copy that
+// ships inside react-server-loader, for rendering RSC behind a Web
+// `(Request) => Response` server (vprs createRequestHandler) or any
+// workerd/Deno/Bun runtime.
+//
+// LAZY for the same reason as the node server: the vendored CJS branches on
+// NODE_ENV at require time, so the require is deferred to first use. The React
+// it binds to still comes from the consumer's project (see vendor.server.ts).
+const vendorRequire = createRequire(join(transportPkgDir, "package.json"));
+
+const lazyServerEdge = createLazyVendorModule(
+  () =>
+    vendorRequire(
+      "react-server-dom-esm/server.edge"
+    ) as typeof import("react-server-dom-esm/server.edge"),
+  reactPairedMode,
+  () => vendoredTransportModeFromCache("react-server-dom-esm-server.edge")
+);
+const ReactDOMServerEdge = lazyServerEdge.proxy;
+
+// Wrong-side imports must stay LOUD, exactly like the node server module: the
+// vendored edge server demands a react-server React, so probe through the lazy
+// proxy at module init when the condition is absent.
+if (!hasReactServerCondition()) {
+  void (ReactDOMServerEdge as { renderToReadableStream?: unknown })
+    .renderToReadableStream;
+}
+
+/** dev/prod variant the vendored edge renderer resolved to (null until first use). */
+export const getVendoredEdgeRendererMode = lazyServerEdge.getLoadedMode;
+
+export { ReactDOMServerEdge };
+export type * from "react-server-dom-esm/server.edge";

--- a/test/streams/edge-from-readable-stream.test.ts
+++ b/test/streams/edge-from-readable-stream.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import * as streamApi from "vite-plugin-react-server/stream";
+
+// Consumer mirror of edge-stream.test.ts. The Web-stream consumer is
+// client-only: `vite-plugin-react-server/stream` resolves to index.client
+// (which exports createFromReadableStream / createFromFetch) under the default
+// condition, and to index.server (which does NOT) under react-server. So under
+// the react-server leg of test-both these are undefined — skip there, exactly
+// as the producer test skips on the client leg.
+const createFromReadableStream = (streamApi as any).createFromReadableStream as
+  | typeof import("../../plugin/stream/createFromReadableStream.client.js").createFromReadableStream
+  | undefined;
+const createFromFetch = (streamApi as any).createFromFetch as
+  | typeof import("../../plugin/stream/createFromReadableStream.client.js").createFromFetch
+  | undefined;
+
+function flightStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+const isReactElement = (v: unknown): boolean =>
+  typeof v === "object" && v !== null && "$$typeof" in (v as object);
+
+describe.skipIf(!createFromReadableStream)(
+  "edge RSC consumer (createFromReadableStream)",
+  () => {
+    it("wires a Flight ReadableStream into a client React element", () => {
+      const result = createFromReadableStream!({
+        rscStream: flightStream('0:"hello"\n'),
+        moduleBaseURL: "/",
+      });
+      expect(result.type).toBe("client");
+      // The decode is deferred to render (React.use), so we assert the wrapper
+      // produced a real, renderable client element rather than rendering here.
+      expect(isReactElement(result.children)).toBe(true);
+    });
+
+    it("short-circuits when children are already resolved", () => {
+      const el = { alreadyResolved: true } as any;
+      const result = createFromReadableStream!({ children: el } as any);
+      expect(result.type).toBe("client");
+      expect(result.children).toBe(el); // returned as-is, no decode
+    });
+
+    it("throws when given neither a stream nor children", () => {
+      expect(() => createFromReadableStream!({} as any)).toThrow(
+        /no rscStream nor children/
+      );
+    });
+
+    it("createFromFetch wires a Flight Response into a client React element", () => {
+      const res = new Response('0:"hi"\n', {
+        headers: { "Content-Type": "text/x-component" },
+      });
+      const result = createFromFetch!({ response: res, moduleBaseURL: "/" });
+      expect(result.type).toBe("client");
+      expect(isReactElement(result.children)).toBe(true);
+    });
+  }
+);

--- a/test/streams/edge-stream.test.ts
+++ b/test/streams/edge-stream.test.ts
@@ -83,4 +83,30 @@ describe.skipIf(!renderRscReadableStream)("edge RSC renderer (Web ReadableStream
     const res = renderRscResponse!(bad);
     expect(res.status).toBe(500);
   });
+
+  it("abort() reports a single Stream Aborted error and emits no route.error", async () => {
+    const config = await createHandlerOptions("/", {
+      configEnv: { command: "serve", mode: "development" },
+    });
+    const errors: Array<{ context?: string }> = [];
+    const events: Array<{ type?: string }> = [];
+    const result = renderRscReadableStream!(
+      { ...config, onEvent: (e: any) => events.push(e) } as any,
+      { onError: (_id: string, _err: unknown, ctx: any) => errors.push(ctx) }
+    );
+    expect(result.ok).toBe(true);
+
+    // Let the render begin, then abort it mid-flight.
+    await new Promise((r) => setTimeout(r, 0));
+    result.abort("test-abort");
+    // The renderer observes the aborted signal asynchronously — give it a tick.
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Exactly one explicit "Stream Aborted" report from abort()...
+    expect(errors.filter((c) => c?.context === "Stream Aborted")).toHaveLength(1);
+    // ...and the renderer's own onError must NOT also fire on a deliberate
+    // abort, nor emit a route.error (which would spuriously trip panicThreshold).
+    expect(errors.filter((c) => c?.context === "React Stream Error")).toHaveLength(0);
+    expect(events.filter((e) => e?.type === "route.error")).toHaveLength(0);
+  });
 });

--- a/test/streams/edge-stream.test.ts
+++ b/test/streams/edge-stream.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import * as streamApi from "vite-plugin-react-server/stream";
+import {
+  createHandlerOptions,
+  resolveOptions,
+} from "vite-plugin-react-server/config";
+
+// The edge renderer is react-server-only: `vite-plugin-react-server/stream`
+// resolves to index.server (which exports renderRscReadableStream) under the
+// react-server condition, and to index.client (which does NOT) otherwise. So
+// under the client leg of test-both these are undefined — skip there.
+const renderRscReadableStream = (streamApi as any).renderRscReadableStream as
+  | typeof import("../../plugin/stream/renderRscReadableStream.server.js").renderRscReadableStream
+  | undefined;
+const renderRscResponse = (streamApi as any).renderRscResponse as
+  | typeof import("../../plugin/stream/renderRscReadableStream.server.js").renderRscResponse
+  | undefined;
+const RSC_CONTENT_TYPE = (streamApi as any).RSC_CONTENT_TYPE as string | undefined;
+
+resolveOptions({
+  moduleBase: "test/streams",
+  Page: "test/streams/TestPage.tsx",
+  verbose: false,
+});
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Buffer[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+describe.skipIf(!renderRscReadableStream)("edge RSC renderer (Web ReadableStream)", () => {
+  it("renders a page to a non-empty Web ReadableStream", async () => {
+    const config = await createHandlerOptions("/", {
+      configEnv: { command: "serve", mode: "development" },
+    });
+
+    const result = renderRscReadableStream!(config);
+    expect(result.type).toBe("server-edge");
+    expect(result.ok).toBe(true);
+    expect(typeof result.rscStream.getReader).toBe("function"); // a real Web stream
+    expect(typeof result.abort).toBe("function");
+
+    const payload = await readAll(result.rscStream);
+    expect(payload.length).toBeGreaterThan(0); // a real Flight payload
+  });
+
+  it("renderRscResponse returns 200 with the RSC content type", async () => {
+    const config = await createHandlerOptions("/", {
+      configEnv: { command: "serve", mode: "development" },
+    });
+
+    const res = renderRscResponse!(config);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe(RSC_CONTENT_TYPE);
+    const body = await readAll(res.body as unknown as ReadableStream<Uint8Array>);
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("reports ok:false and renderRscResponse returns 500 on a synchronous render-setup failure", async () => {
+    // createReactElement reads options.htmlPath first; a throwing getter forces
+    // a synchronous setup failure (the branch the 500 path exists for).
+    const bad = {
+      id: "edge-fail",
+      route: "/",
+      verbose: false,
+      get htmlPath(): string {
+        throw new Error("boom: forced setup failure");
+      },
+    } as any;
+
+    const result = renderRscReadableStream!(bad);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+    // failed setup yields an empty, already-closed stream
+    expect(await readAll(result.rscStream)).toBe("");
+
+    const res = renderRscResponse!(bad);
+    expect(res.status).toBe(500);
+  });
+});

--- a/test/unit/createRequestHandler.test.ts
+++ b/test/unit/createRequestHandler.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequestHandler } from "../../dist/plugin/helpers/createRequestHandler.server.js";
+
+let staticDir: string;
+let handler: (request: Request) => Promise<Response>;
+
+beforeAll(async () => {
+  staticDir = await mkdtemp(join(tmpdir(), "vprs-req-"));
+  await writeFile(join(staticDir, "index.html"), "<!doctype html><title>home</title>");
+  await mkdir(join(staticDir, "about"), { recursive: true });
+  await writeFile(join(staticDir, "about", "index.html"), "<h1>about</h1>");
+  await writeFile(join(staticDir, "index.rsc"), "0:flight");
+
+  handler = createRequestHandler({
+    staticDir,
+    action: {
+      projectRoot: process.cwd(),
+      devOpen: true,
+      ssrLoadModule: async () => ({ go: async (x: string) => ({ got: x }) }),
+    },
+    render: (route) =>
+      route === "/dynamic"
+        ? new Response("<h1>dyn</h1>", { headers: { "Content-Type": "text/html" } })
+        : null,
+  });
+});
+
+afterAll(() => rm(staticDir, { recursive: true, force: true }));
+
+const get = (path: string) => handler(new Request(`https://example.test${path}`));
+
+describe("createRequestHandler", () => {
+  it("serves index.html for /", async () => {
+    const res = await get("/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("home");
+  });
+
+  it("serves a nested route's index.html for an extensionless path", async () => {
+    const res = await get("/about");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("about");
+  });
+
+  it("serves .rsc payloads as text/x-component", async () => {
+    const res = await get("/index.rsc");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+  });
+
+  it("uses the render hook for dynamic routes", async () => {
+    const res = await get("/dynamic");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("dyn");
+  });
+
+  it("falls through to the static file when render returns null", async () => {
+    const res = await get("/");
+    expect(await res.text()).toContain("home");
+  });
+
+  it("404s an unknown path", async () => {
+    expect((await get("/nope")).status).toBe(404);
+  });
+
+  it("blocks path traversal out of the static dir", async () => {
+    const res = await handler(
+      new Request("https://example.test/..%2f..%2f..%2fetc%2fpasswd")
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("dispatches a server-action POST to the action handler", async () => {
+    const res = await handler(
+      new Request("https://example.test/src/a.ts#go", {
+        method: "POST",
+        headers: { "x-rsc-action": "src/a.ts#go" },
+        body: JSON.stringify(["hi"]),
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    expect(await res.text()).toBe(`0:${JSON.stringify({ got: "hi" })}\n`);
+  });
+});


### PR DESCRIPTION
## What

Edge support for RSC, in two commits (both target `main`; `createRequestHandler` isn't on main yet):

1. `feat(helpers): createRequestHandler` (`4a4dbb2`) — a Web-standard `(Request) => Response` server over a vprs build (actions + optional dynamic `render` hook + prerendered files), with `toNodeListener` for `http.createServer`/Connect/Express.
2. `feat(stream): edge RSC renderer` (+ `fix`) — the Web-streams renderer the handler's `render` hook needs:
   - `renderRscReadableStream` — renders an RSC tree to a Web `ReadableStream` via the vendored `react-server-dom-esm` edge transport (`renderToReadableStream`)
   - `renderRscResponse` — wraps it in a `Response` (`text/x-component`); returns **500** on a synchronous render-setup failure (not an empty 200)
   - `vendorEdge.server.ts` (lazy `server.edge` load), `server.edge` ambient types, stream-barrel export
   - `test/streams/edge-stream.test.ts` — happy path + 500 path; `react-server`-only (skips on the client leg of test-both)

## Why

`createRequestHandler` is Web-standard, but the only RSC renderer was Node-pipeable. Together these let dynamic routes stream RSC on edge runtimes (workerd/Deno/Bun).

## Dependency

The edge renderer requires `react-server-loader` with the edge transport (`./server.edge`) — nicobrinkkemper/react-server-loader#11 (publishes as 19.2.11). A fresh CI install needs 19.2.11 on npm first. Verified locally against that build with React 19.2.7; `tsc --noEmit` clean.

## Notes

Reference resolution stays closed by rsl's sealed gate in production; `moduleBasePath` carries the manifest base (edge can't `import()` arbitrary file URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)