### PR TITLE
fix(references): dispatch bare server-action ids (2.9.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/references/createSealedServerReferenceGate.server.ts
+++ b/plugin/references/createSealedServerReferenceGate.server.ts
@@ -30,7 +30,9 @@ export interface SealedServerReferenceGateOptions {
  * deploy.
  *
  * A server action POST carries a client-supplied id of the form
- * `<base><srcPath>#<exportName>`. The vendored transport would `import()` a path
+ * `<srcPath>#<exportName>` (the directive transform bakes the bare manifest key),
+ * or `<base><srcPath>#<exportName>` from a base-prefixed transport. The vendored
+ * transport would `import()` a path
  * derived from that id (an open allowlist); this gate instead resolves it as a
  * dictionary lookup against the modules the build actually emitted, with each
  * importer bound to the manifest's real built file — never to anything derived
@@ -57,15 +59,19 @@ export function createSealedServerReferenceGate({
 
   for (const [key, entry] of Object.entries(serverManifest)) {
     if (!entry?.file) continue;
-    // Hosted id = base + source key, matching what the client sends. The
-    // importer is bound to the built file from the manifest, not the id.
-    const id = prefix + key.replace(/^\//, "");
     const file = entry.file;
-    gate.register({
-      id,
-      kind: "server",
-      load: () => import(join(serverRoot, file)) as Promise<Record<string, unknown>>,
-    });
+    const load = () =>
+      import(join(serverRoot, file)) as Promise<Record<string, unknown>>;
+    // The directive transform bakes a BARE manifest-key id (`<srcKey>#<export>`);
+    // a base-prefixed transport sends `<base><srcKey>#<export>`. Register both
+    // shapes so resolution is an exact-key lookup either way. This does not widen
+    // the allowlist: only modules the build enumerated are registered, and every
+    // importer is bound to the manifest's built file, never to anything derived
+    // from the incoming id — so a forged id still has no entry to resolve.
+    const bareKey = key.replace(/^\//, "");
+    for (const id of new Set([bareKey, prefix + bareKey])) {
+      gate.register({ id, kind: "server", load });
+    }
   }
 
   gate.seal();

--- a/test/unit/sealedServerReferenceGate.test.ts
+++ b/test/unit/sealedServerReferenceGate.test.ts
@@ -46,7 +46,19 @@ export const notAnAction = 42;
     expect(makeGate().sealed).toBe(true);
   });
 
-  it("resolves a manifest-registered action by its client-sent id", async () => {
+  it("resolves a manifest-registered action by its bare client-sent id", async () => {
+    // The directive transform bakes a BARE id (no base prefix) — this is what the
+    // real client sends, and what createRequestHandler must dispatch.
+    const gate = makeGate();
+    const ref = await gate.resolveServerReference(
+      "src/server/actions.server.ts#addItem"
+    );
+    expect(await (ref as (t: string) => Promise<{ ok: boolean }>)("x")).toEqual({
+      ok: true,
+    });
+  });
+
+  it("also resolves the base-prefixed id shape", async () => {
     const gate = makeGate();
     const ref = await gate.resolveServerReference(
       "/src/server/actions.server.ts#addItem"


### PR DESCRIPTION
## What

`createRequestHandler` (the 2.9.0 Web-standard server) dispatches "use server" actions through the sealed reference gate. The gate registered each action **only** under the base-prefixed id (`<base><srcKey>#<export>`), but the directive transform bakes a **bare** id (`<srcKey>#<export>`) — which is what the client actually sends. So every server action on a `createRequestHandler` deploy 500'd with `Unknown server reference`.

The existing unit test masked this by asserting the prefixed shape (`/src/...`) the real client never sends.

## Fix

Register both the bare and base-prefixed id shapes, so resolution is an exact-key lookup either way. The bare form matches the client; the prefixed form preserves any base-prefixed transport.

**The allowlist is not widened:** only modules the build enumerated are registered, every importer stays bound to the manifest's built `entry.file` (never anything derived from the incoming id), and a forged id whose module the build never emitted still has no entry to resolve. The sealed-rejection tests are unchanged.

## Test

- New unit case asserting the **bare** client id resolves (the real-world path); the prefixed shape kept as a second case.
- Forged-id and non-reference-export rejections unchanged → allowlist semantics intact.
- Verified end-to-end against the bidoof-template demo driven entirely by `createRequestHandler` + `handleServerAction`: prod-build e2e (add/delete persist across reload, client-imported server fn, flash-free SSR) **3/3 passing**, where the same demo 500'd on every action before the fix.
- Server + client suites green (113 passed / 3 skipped), no regression.

Bumps to **2.9.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)