### PR TITLE
refactor(config): unify createHandlerOptions worker creation + name React conditions

### DIFF
--- a/plugin/config/createHandlerOptions.client.ts
+++ b/plugin/config/createHandlerOptions.client.ts
@@ -18,7 +18,7 @@ import {
   createHandlerWorkers,
   resolveHandlerContext,
 } from "./createHandlerOptions.shared.js";
-import { getCondition } from "./getCondition.js";
+import { getCondition, REACT_CONDITION } from "./getCondition.js";
 
 /**
  * Client-specific handler options creation for HTML generation.
@@ -81,10 +81,12 @@ export async function createHandlerOptions(
     await resolveHandlerContext(route, options, userOptions, logger);
 
   // Create workers for the client environment. The gate + run loop is shared;
-  // only the per-kind createWorker args are client-specific. The client always
-  // threads a top-level configEnv into workerData and serializes resolvedConfig
-  // (with a kind-specific fallback when no `config` was supplied: undefined for
-  // the RSC worker, a synthesized ResolvedConfig literal for the HTML worker).
+  // only the per-worker createWorker args are client-specific. The client always
+  // threads a top-level configEnv into workerData and serializes resolvedConfig.
+  // We are in a .client file, so currentCondition is react-client for both.
+  const serializedClientUserOptions = () =>
+    serializedOptions(userOptions, autoDiscoveredFiles);
+
   const { rscWorker, htmlWorker } = await createHandlerWorkers({
     route,
     userOptions,
@@ -92,16 +94,34 @@ export async function createHandlerOptions(
     mode,
     logger,
     labelPrefix: "[createHandlerOptions.client]",
-    buildWorkerArgs: (kind) => {
-      const serializedUserOptions = serializedOptions(
-        userOptions,
-        autoDiscoveredFiles
-      );
-
-      const serializedResolvedConfig = config
-        ? serializeResolvedConfig(config)
-        : kind === "html"
-          ? {
+    rscWorkerArgs: () => ({
+      currentCondition: REACT_CONDITION.client,
+      // RSC worker omits reverseCondition (createWorker derives react-server).
+      workerPath: userOptions.rscWorkerPath,
+      verbose: userOptions.verbose,
+      logger,
+      workerData: {
+        id: route,
+        userOptions: serializedClientUserOptions(),
+        // No config supplied -> RSC resolvedConfig stays undefined.
+        resolvedConfig: config ? serializeResolvedConfig(config) : undefined,
+        configEnv,
+      },
+    }),
+    htmlWorkerArgs: () => ({
+      currentCondition: REACT_CONDITION.client,
+      // The user requested a worker, which uses the same (react-client) condition.
+      reverseCondition: REACT_CONDITION.client,
+      workerPath: userOptions.htmlWorkerPath,
+      verbose: userOptions.verbose,
+      logger,
+      workerData: {
+        id: route,
+        userOptions: serializedClientUserOptions(),
+        // No config supplied -> synthesize a ResolvedConfig-shaped fallback.
+        resolvedConfig: (config
+          ? serializeResolvedConfig(config)
+          : {
               mode: configEnv?.mode || mode || "development",
               root: process.cwd(),
               logLevel: "info",
@@ -113,28 +133,10 @@ export async function createHandlerOptions(
               command: configEnv?.command || "serve",
               isSsrBuild: configEnv?.command === "build",
               isPreview: false,
-            }
-          : undefined;
-
-      return {
-        // We are in a .client file. The RSC worker omits reverseCondition
-        // (createWorker derives react-server); the HTML worker stays react-client.
-        currentCondition: "react-client",
-        ...(kind === "html" ? { reverseCondition: "react-client" } : {}),
-        workerPath:
-          kind === "rsc"
-            ? userOptions.rscWorkerPath
-            : userOptions.htmlWorkerPath,
-        verbose: userOptions.verbose,
-        logger,
-        workerData: {
-          id: route,
-          userOptions: serializedUserOptions,
-          resolvedConfig: serializedResolvedConfig as any,
-          configEnv,
-        },
-      };
-    },
+            }) as any,
+        configEnv,
+      },
+    }),
   });
 
   // Create client-specific handler options. The shared fields are assembled by
@@ -166,7 +168,7 @@ export async function createHandlerOptions(
     RootComponent: undefined,
 
     // Backward compatibility: prefer the condition-appropriate worker
-    worker: condition === "react-server" ? rscWorker : htmlWorker,
+    worker: condition === REACT_CONDITION.server ? rscWorker : htmlWorker,
 
     // Children provided directly via options
     children,

--- a/plugin/config/createHandlerOptions.client.ts
+++ b/plugin/config/createHandlerOptions.client.ts
@@ -15,7 +15,7 @@ import { createLogger } from "vite";
 import type { CreateHandlerOptionsParams } from "./createHandlerOptions.types.js";
 import {
   buildSharedHandlerOptions,
-  createConfiguredWorker,
+  createHandlerWorkers,
   resolveHandlerContext,
 } from "./createHandlerOptions.shared.js";
 import { getCondition } from "./getCondition.js";
@@ -80,121 +80,62 @@ export async function createHandlerOptions(
   const { defaults, autoDiscoveredFiles, url, routeFiles: routeFilesResult } =
     await resolveHandlerContext(route, options, userOptions, logger);
 
-  // Create workers for client environment based on configuration and configEnv
-  let rscWorker: any = undefined;
-  let htmlWorker: any = undefined;
+  // Create workers for the client environment. The gate + run loop is shared;
+  // only the per-kind createWorker args are client-specific. The client always
+  // threads a top-level configEnv into workerData and serializes resolvedConfig
+  // (with a kind-specific fallback when no `config` was supplied: undefined for
+  // the RSC worker, a synthesized ResolvedConfig literal for the HTML worker).
+  const { rscWorker, htmlWorker } = await createHandlerWorkers({
+    route,
+    userOptions,
+    configEnv,
+    mode,
+    logger,
+    labelPrefix: "[createHandlerOptions.client]",
+    buildWorkerArgs: (kind) => {
+      const serializedUserOptions = serializedOptions(
+        userOptions,
+        autoDiscoveredFiles
+      );
 
-  // Determine if we need workers based on configEnv and dev config
-  const isServeMode =
-    configEnv?.command === "serve" ||
-    configEnv?.mode === "development" ||
-    mode === "development";
-  const isBuildMode = configEnv?.command === "build";
+      const serializedResolvedConfig = config
+        ? serializeResolvedConfig(config)
+        : kind === "html"
+          ? {
+              mode: configEnv?.mode || mode || "development",
+              root: process.cwd(),
+              logLevel: "info",
+              env: {},
+              envPrefix: "VITE_",
+              base: "/",
+              publicDir: "public",
+              cacheDir: "node_modules/.vite",
+              command: configEnv?.command || "serve",
+              isSsrBuild: configEnv?.command === "build",
+              isPreview: false,
+            }
+          : undefined;
 
-  // Create RSC worker if:
-  // 1. useRscWorker is enabled in dev config AND we're in serve mode, OR
-  // 2. useRscWorker is enabled in build config AND we're in build mode
-  const shouldCreateRscWorker =
-    (userOptions.dev?.useRscWorker && isServeMode) ||
-    (userOptions.build?.useRscWorker && isBuildMode);
-
-  if (shouldCreateRscWorker) {
-    const serializedUserOptions = userOptions
-      ? serializedOptions(userOptions, autoDiscoveredFiles)
-      : undefined;
-
-    const serializedResolvedConfig = config
-      ? serializeResolvedConfig(config)
-      : undefined;
-
-    rscWorker = await createConfiguredWorker(
-      `[createHandlerOptions.client] RSC worker (route ${route})`,
-      {
+      return {
+        // We are in a .client file. The RSC worker omits reverseCondition
+        // (createWorker derives react-server); the HTML worker stays react-client.
         currentCondition: "react-client",
-        workerPath: userOptions.rscWorkerPath,
+        ...(kind === "html" ? { reverseCondition: "react-client" } : {}),
+        workerPath:
+          kind === "rsc"
+            ? userOptions.rscWorkerPath
+            : userOptions.htmlWorkerPath,
         verbose: userOptions.verbose,
         logger,
         workerData: {
           id: route,
           userOptions: serializedUserOptions,
-          resolvedConfig: serializedResolvedConfig,
+          resolvedConfig: serializedResolvedConfig as any,
           configEnv,
         },
-      },
-      logger,
-      userOptions.verbose
-    );
-  }
-
-  // Create HTML worker if:
-  // 1. useHtmlWorker is enabled in dev config AND we're in serve mode, OR
-  // 2. useHtmlWorker is enabled in build config AND we're in build mode
-  const shouldCreateHtmlWorker =
-    (userOptions.dev?.useHtmlWorker && isServeMode) ||
-    (userOptions.build?.useHtmlWorker && isBuildMode);
-
-  if (shouldCreateHtmlWorker) {
-    // Create fallback defaults based on configEnv
-    const fallbackDefaults = {
-      verbose: false,
-      panicThreshold: 1000,
-      moduleRootPath: "",
-      moduleBaseURL: "",
-      moduleBasePath: "",
-      projectRoot: process.cwd(),
-      htmlTimeout: 30000,
-      serverPipeableStreamOptions: {},
-      clientPipeableStreamOptions: {},
-      build: {
-        useHtmlWorker: isBuildMode,
-        useRscWorker: isBuildMode,
-        pages: [],
-      },
-      dev: {
-        useHtmlWorker: false,
-        useRscWorker: true,
-      },
-    };
-
-    const serializedUserOptions = userOptions
-      ? serializedOptions(userOptions, autoDiscoveredFiles)
-      : serializedOptions(fallbackDefaults as any, autoDiscoveredFiles);
-
-    const serializedResolvedConfig = config
-      ? serializeResolvedConfig(config)
-      : {
-          mode: configEnv?.mode || mode || "development",
-          root: process.cwd(),
-          logLevel: "info",
-          env: {},
-          envPrefix: "VITE_",
-          base: "/",
-          publicDir: "public",
-          cacheDir: "node_modules/.vite",
-          command: configEnv?.command || "serve",
-          isSsrBuild: configEnv?.command === "build",
-          isPreview: false,
-        };
-
-    htmlWorker = await createConfiguredWorker(
-      `[createHandlerOptions.client] HTML worker (route ${route})`,
-      {
-        currentCondition: "react-client", // We are in a .client file
-        reverseCondition: "react-client", // The user still requested a worker, which uses the same condition
-        workerPath: userOptions.htmlWorkerPath,
-        verbose: userOptions.verbose,
-        logger,
-        workerData: {
-          id: route,
-          userOptions: serializedUserOptions,
-          resolvedConfig: serializedResolvedConfig,
-          configEnv,
-        },
-      },
-      logger,
-      userOptions.verbose
-    );
-  }
+      };
+    },
+  });
 
   // Create client-specific handler options. The shared fields are assembled by
   // buildSharedHandlerOptions; only the client-specific tail lives here.

--- a/plugin/config/createHandlerOptions.server.ts
+++ b/plugin/config/createHandlerOptions.server.ts
@@ -11,7 +11,7 @@ import { createLogger } from "vite";
 import type { CreateHandlerOptionsParams } from "./createHandlerOptions.types.js";
 import {
   buildSharedHandlerOptions,
-  createConfiguredWorker,
+  createHandlerWorkers,
   resolveHandlerContext,
 } from "./createHandlerOptions.shared.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
@@ -227,67 +227,33 @@ export async function createHandlerOptions(
     }
   }
 
-  // Create workers for server environment based on configuration and configEnv
-  let rscWorker: any = undefined;
-  let htmlWorker: any = undefined;
-  
-  // Determine if we need workers based on configEnv and dev config
-  const isServeMode = configEnv?.command === "serve" || configEnv?.mode === "development" || mode === "development";
-  const isBuildMode = configEnv?.command === "build";
-  
-  // Create RSC worker if:
-  // 1. useRscWorker is enabled in dev config AND we're in serve mode, OR
-  // 2. useRscWorker is enabled in build config AND we're in build mode
-  const shouldCreateRscWorker = (userOptions.dev?.useRscWorker && isServeMode) || 
-                               (userOptions.build?.useRscWorker && isBuildMode);
-  
-  if (shouldCreateRscWorker) {
-    rscWorker = await createConfiguredWorker(
-      `[createHandlerOptions.server] RSC worker (route ${route})`,
-      {
-        currentCondition: "react-server",
-        // same CONDITION as the current one (this worker may be redundant)
-        reverseCondition: "react-server",
-        workerPath: userOptions.rscWorkerPath,
-        verbose: userOptions.verbose,
-        logger,
-        workerData: {
-          id: route,
-          userOptions: serializedOptions(userOptions, autoDiscoveredFiles),
-          resolvedConfig: { configEnv, mode },
-        },
-      },
+  // Create workers for the server environment. The gate + run loop is shared;
+  // only the per-kind createWorker args (conditions, worker path, workerData)
+  // are server-specific. Server passes the RAW { configEnv, mode } as
+  // resolvedConfig and omits a top-level configEnv (vs client).
+  const { rscWorker, htmlWorker } = await createHandlerWorkers({
+    route,
+    userOptions,
+    configEnv,
+    mode,
+    logger,
+    labelPrefix: "[createHandlerOptions.server]",
+    buildWorkerArgs: (kind) => ({
+      currentCondition: "react-server",
+      // RSC worker keeps the current condition (it may be redundant); HTML
+      // worker needs the react-client condition.
+      reverseCondition: kind === "rsc" ? "react-server" : "react-client",
+      workerPath:
+        kind === "rsc" ? userOptions.rscWorkerPath : userOptions.htmlWorkerPath,
+      verbose: userOptions.verbose,
       logger,
-      userOptions.verbose
-    );
-  }
-
-  // Create HTML worker if:
-  // Create HTML worker if:
-  // 1. useHtmlWorker is enabled in dev config AND we're in serve mode, OR
-  // 2. useHtmlWorker is enabled in build config AND we're in build mode
-  const shouldCreateHtmlWorker = (userOptions.dev?.useHtmlWorker && isServeMode) || 
-                                (userOptions.build?.useHtmlWorker && isBuildMode);
-  
-  if (shouldCreateHtmlWorker) {
-    htmlWorker = await createConfiguredWorker(
-      `[createHandlerOptions.server] HTML worker (route ${route})`,
-      {
-        currentCondition: "react-server",
-        reverseCondition: "react-client", // HTML worker needs react-client condition
-        workerPath: userOptions.htmlWorkerPath,
-        verbose: userOptions.verbose,
-        logger,
-        workerData: {
-          id: route,
-          userOptions: serializedOptions(userOptions, autoDiscoveredFiles),
-          resolvedConfig: { configEnv, mode },
-        },
+      workerData: {
+        id: route,
+        userOptions: serializedOptions(userOptions, autoDiscoveredFiles),
+        resolvedConfig: { configEnv, mode } as any,
       },
-      logger,
-      userOptions.verbose
-    );
-  }
+    }),
+  });
 
   // Create server-specific handler options. The shared fields are assembled by
   // buildSharedHandlerOptions; only the server-specific tail lives here.

--- a/plugin/config/createHandlerOptions.server.ts
+++ b/plugin/config/createHandlerOptions.server.ts
@@ -16,6 +16,7 @@ import {
 } from "./createHandlerOptions.shared.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
 import { serializedOptions } from "../helpers/serializeUserOptions.js";
+import { REACT_CONDITION } from "./getCondition.js";
 
 /**
  * Server-specific handler options creation for React Server Components (RSC).
@@ -53,7 +54,7 @@ export async function createHandlerOptions(
     id = `${route}-${Date.now()}-${Math.random()
       .toString(36)
       .substring(2, 11)}`,
-    envId = getEnvironmentId("react-server", mode),
+    envId = getEnvironmentId(REACT_CONDITION.server, mode),
     userOptions = getStashedUserOptions(envId),
   } = options;
 
@@ -228,9 +229,14 @@ export async function createHandlerOptions(
   }
 
   // Create workers for the server environment. The gate + run loop is shared;
-  // only the per-kind createWorker args (conditions, worker path, workerData)
+  // only the per-worker createWorker args (conditions, worker path, workerData)
   // are server-specific. Server passes the RAW { configEnv, mode } as
   // resolvedConfig and omits a top-level configEnv (vs client).
+  const serverWorkerData = () => ({
+    id: route,
+    userOptions: serializedOptions(userOptions, autoDiscoveredFiles),
+    resolvedConfig: { configEnv, mode } as any,
+  });
   const { rscWorker, htmlWorker } = await createHandlerWorkers({
     route,
     userOptions,
@@ -238,20 +244,23 @@ export async function createHandlerOptions(
     mode,
     logger,
     labelPrefix: "[createHandlerOptions.server]",
-    buildWorkerArgs: (kind) => ({
-      currentCondition: "react-server",
-      // RSC worker keeps the current condition (it may be redundant); HTML
-      // worker needs the react-client condition.
-      reverseCondition: kind === "rsc" ? "react-server" : "react-client",
-      workerPath:
-        kind === "rsc" ? userOptions.rscWorkerPath : userOptions.htmlWorkerPath,
+    rscWorkerArgs: () => ({
+      currentCondition: REACT_CONDITION.server,
+      // RSC worker keeps the current condition (it may be redundant).
+      reverseCondition: REACT_CONDITION.server,
+      workerPath: userOptions.rscWorkerPath,
       verbose: userOptions.verbose,
       logger,
-      workerData: {
-        id: route,
-        userOptions: serializedOptions(userOptions, autoDiscoveredFiles),
-        resolvedConfig: { configEnv, mode } as any,
-      },
+      workerData: serverWorkerData(),
+    }),
+    htmlWorkerArgs: () => ({
+      currentCondition: REACT_CONDITION.server,
+      // HTML worker needs the react-client condition.
+      reverseCondition: REACT_CONDITION.client,
+      workerPath: userOptions.htmlWorkerPath,
+      verbose: userOptions.verbose,
+      logger,
+      workerData: serverWorkerData(),
     }),
   });
 

--- a/plugin/config/createHandlerOptions.shared.ts
+++ b/plugin/config/createHandlerOptions.shared.ts
@@ -3,14 +3,16 @@
  *
  * Logic shared verbatim by createHandlerOptions.server.ts and .client.ts.
  *
- * Scope note: this intentionally covers only the parts that are byte-identical
- * across the two variants AND guarded by test/unit/createHandlerOptions.test.ts
- * — the default options, the auto-discovery resolution, and the assembly of the
- * fields that are the same in both. The worker-creation blocks and the
- * variant-specific tail (components vs placeholders, clientPipeableStreamOptions
- * coercion, worker selection, children) deliberately stay in each variant; the
- * characterization test runs with workers disabled, so unifying the worker
- * blocks needs its own coverage first.
+ * Scope note: this covers the parts shared across the two variants — the
+ * default options, the auto-discovery resolution, the assembly of the fields
+ * that are the same in both, and the worker-creation gate + run loop
+ * (createHandlerWorkers). The per-kind createWorker args stay at each call site
+ * (they genuinely diverge: server passes raw { configEnv, mode }, client
+ * serializes + threads configEnv), as does the variant-specific tail
+ * (components vs placeholders, clientPipeableStreamOptions coercion, worker
+ * selection, children). Coverage: createHandlerOptions.test.ts pins the shared
+ * output (workers disabled); createHandlerOptionsWorkers.test.ts pins the
+ * per-variant createWorker call shape (workers enabled).
  */
 import type { Logger, ConfigEnv, ResolvedConfig } from "vite";
 import type { AutoDiscoveredFiles, ResolvedUserOptions } from "../types.js";
@@ -187,6 +189,90 @@ export async function createConfiguredWorker(
     );
     return undefined;
   }
+}
+
+/**
+ * Decide whether the RSC / HTML workers should be created. Both variants used
+ * the identical gate: a worker is created when its flag is on for the current
+ * command (dev flag in serve mode, build flag in build mode).
+ */
+export function resolveWorkerGate(
+  userOptions: ResolvedUserOptions,
+  configEnv: ConfigEnv | undefined,
+  mode: string | undefined
+): { isServeMode: boolean; isBuildMode: boolean; rsc: boolean; html: boolean } {
+  const isServeMode =
+    configEnv?.command === "serve" ||
+    configEnv?.mode === "development" ||
+    mode === "development";
+  const isBuildMode = configEnv?.command === "build";
+
+  const rsc =
+    (!!userOptions.dev?.useRscWorker && isServeMode) ||
+    (!!userOptions.build?.useRscWorker && isBuildMode);
+  const html =
+    (!!userOptions.dev?.useHtmlWorker && isServeMode) ||
+    (!!userOptions.build?.useHtmlWorker && isBuildMode);
+
+  return { isServeMode, isBuildMode, rsc, html };
+}
+
+export interface CreateHandlerWorkersInput {
+  route: string;
+  userOptions: ResolvedUserOptions;
+  configEnv: ConfigEnv | undefined;
+  mode: string | undefined;
+  logger: Logger;
+  /** Label prefix for log lines, e.g. "[createHandlerOptions.server]". */
+  labelPrefix: string;
+  /**
+   * Per-variant createWorker args. Called once per enabled worker kind; the
+   * divergent bits (conditions, workerPath, workerData shape) live here so the
+   * gate + run loop can stay shared. See createHandlerOptions.{server,client}.ts.
+   */
+  buildWorkerArgs: (kind: "rsc" | "html") => Parameters<typeof createWorker>[0];
+}
+
+/**
+ * The shared worker-creation driver: run the (identical) gate, then run each
+ * enabled worker through createConfiguredWorker with the variant's args. Returns
+ * the worker-or-undefined pair both variants assemble into their handler options.
+ *
+ * Covered by test/unit/createHandlerOptionsWorkers.test.ts (the createHandlerOptions
+ * characterization test runs workers-disabled, so this carries its own coverage).
+ */
+export async function createHandlerWorkers(
+  input: CreateHandlerWorkersInput
+  // The worker fields on CreateHandlerOptions are loosely typed; both variants
+  // previously held these in `any` locals. Preserve that to avoid churn here.
+): Promise<{ rscWorker: any; htmlWorker: any }> {
+  const { route, userOptions, configEnv, mode, logger, labelPrefix, buildWorkerArgs } =
+    input;
+
+  const gate = resolveWorkerGate(userOptions, configEnv, mode);
+
+  let rscWorker: any = undefined;
+  let htmlWorker: any = undefined;
+
+  if (gate.rsc) {
+    rscWorker = await createConfiguredWorker(
+      `${labelPrefix} RSC worker (route ${route})`,
+      buildWorkerArgs("rsc"),
+      logger,
+      userOptions.verbose
+    );
+  }
+
+  if (gate.html) {
+    htmlWorker = await createConfiguredWorker(
+      `${labelPrefix} HTML worker (route ${route})`,
+      buildWorkerArgs("html"),
+      logger,
+      userOptions.verbose
+    );
+  }
+
+  return { rscWorker, htmlWorker };
 }
 
 export interface HandlerContext {

--- a/plugin/config/createHandlerOptions.shared.ts
+++ b/plugin/config/createHandlerOptions.shared.ts
@@ -217,6 +217,8 @@ export function resolveWorkerGate(
   return { isServeMode, isBuildMode, rsc, html };
 }
 
+type CreateWorkerArgs = Parameters<typeof createWorker>[0];
+
 export interface CreateHandlerWorkersInput {
   route: string;
   userOptions: ResolvedUserOptions;
@@ -226,11 +228,13 @@ export interface CreateHandlerWorkersInput {
   /** Label prefix for log lines, e.g. "[createHandlerOptions.server]". */
   labelPrefix: string;
   /**
-   * Per-variant createWorker args. Called once per enabled worker kind; the
-   * divergent bits (conditions, workerPath, workerData shape) live here so the
-   * gate + run loop can stay shared. See createHandlerOptions.{server,client}.ts.
+   * Per-variant createWorker args, evaluated only when the gate enables that
+   * worker. The divergent bits (conditions, workerPath, workerData shape) live
+   * in these thunks so the gate + run loop stay shared. See
+   * createHandlerOptions.{server,client}.ts.
    */
-  buildWorkerArgs: (kind: "rsc" | "html") => Parameters<typeof createWorker>[0];
+  rscWorkerArgs: () => CreateWorkerArgs;
+  htmlWorkerArgs: () => CreateWorkerArgs;
 }
 
 /**
@@ -246,31 +250,27 @@ export async function createHandlerWorkers(
   // The worker fields on CreateHandlerOptions are loosely typed; both variants
   // previously held these in `any` locals. Preserve that to avoid churn here.
 ): Promise<{ rscWorker: any; htmlWorker: any }> {
-  const { route, userOptions, configEnv, mode, logger, labelPrefix, buildWorkerArgs } =
-    input;
+  const { route, userOptions, configEnv, mode, logger, labelPrefix } = input;
 
   const gate = resolveWorkerGate(userOptions, configEnv, mode);
 
-  let rscWorker: any = undefined;
-  let htmlWorker: any = undefined;
+  const rscWorker = gate.rsc
+    ? await createConfiguredWorker(
+        `${labelPrefix} RSC worker (route ${route})`,
+        input.rscWorkerArgs(),
+        logger,
+        userOptions.verbose
+      )
+    : undefined;
 
-  if (gate.rsc) {
-    rscWorker = await createConfiguredWorker(
-      `${labelPrefix} RSC worker (route ${route})`,
-      buildWorkerArgs("rsc"),
-      logger,
-      userOptions.verbose
-    );
-  }
-
-  if (gate.html) {
-    htmlWorker = await createConfiguredWorker(
-      `${labelPrefix} HTML worker (route ${route})`,
-      buildWorkerArgs("html"),
-      logger,
-      userOptions.verbose
-    );
-  }
+  const htmlWorker = gate.html
+    ? await createConfiguredWorker(
+        `${labelPrefix} HTML worker (route ${route})`,
+        input.htmlWorkerArgs(),
+        logger,
+        userOptions.verbose
+      )
+    : undefined;
 
   return { rscWorker, htmlWorker };
 }

--- a/plugin/config/getCondition.ts
+++ b/plugin/config/getCondition.ts
@@ -2,6 +2,19 @@
 // This file is consumed in both server and client plugin contexts.
 
 /**
+ * The two React resolution conditions vprs cares about. Named so call sites can
+ * reference REACT_CONDITION.server / .client instead of the bare string
+ * literals scattered across the codebase.
+ */
+export const REACT_CONDITION = {
+  server: "react-server",
+  client: "react-client",
+} as const;
+
+export type ReactCondition =
+  (typeof REACT_CONDITION)[keyof typeof REACT_CONDITION];
+
+/**
  * Tokenizes NODE_OPTIONS string into individual arguments.
  * Tokens split on unquoted whitespace only; a quoted segment stays attached
  * to the token it appears in (Node semantics: quotes protect spaces, so
@@ -115,7 +128,10 @@ export const getAllConditions = (): string[] => {
 // ----------------------------------------------------------------------------
 let didWarnAmbiguousConditions = false;
 // react-static does not exists, because you still need condition react-server for the .static imports to work.
-const reactConditionSet = new Set(["react-server", "react-client"]);
+const reactConditionSet = new Set<string>([
+  REACT_CONDITION.server,
+  REACT_CONDITION.client,
+]);
 
 export const detectReactConditionAmbiguity = (): string[] => {
   const conditions = getAllConditions();

--- a/test/unit/createHandlerOptionsWorkers.test.ts
+++ b/test/unit/createHandlerOptionsWorkers.test.ts
@@ -6,7 +6,7 @@
  * ENABLES the worker flags, mocks createWorker, and pins the EXACT createWorker
  * call shape each of the four blocks (server/client × rsc/html) produces for
  * identical input. That is the safety net that makes folding the four blocks
- * onto one shared helper safe (bd-3ly) — assert-the-call-shape, then unify.
+ * onto one shared helper safe: assert-the-call-shape, then unify.
  *
  * Pinned divergences (must survive consolidation):
  *  - currentCondition: server="react-server", client="react-client".

--- a/test/unit/createHandlerOptionsWorkers.test.ts
+++ b/test/unit/createHandlerOptionsWorkers.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Worker-creation characterization tests for createHandlerOptions.server / .client.
+ *
+ * The sibling test (createHandlerOptions.test.ts) runs with workers DISABLED, so
+ * it cannot guard the worker-creation blocks. This file does the opposite: it
+ * ENABLES the worker flags, mocks createWorker, and pins the EXACT createWorker
+ * call shape each of the four blocks (server/client × rsc/html) produces for
+ * identical input. That is the safety net that makes folding the four blocks
+ * onto one shared helper safe (bd-3ly) — assert-the-call-shape, then unify.
+ *
+ * Pinned divergences (must survive consolidation):
+ *  - currentCondition: server="react-server", client="react-client".
+ *  - reverseCondition: server-rsc="react-server", server-html="react-client",
+ *    client-rsc=OMITTED (createWorker defaults it), client-html="react-client".
+ *  - workerData.resolvedConfig: server passes the RAW { configEnv, mode };
+ *    client passes serializeResolvedConfig(config) or, with no config,
+ *    undefined (rsc) / a synthesized ResolvedConfig literal (html).
+ *  - workerData.configEnv: client includes it, server omits it.
+ *  - workerData.userOptions: both pass serializedOptions(userOptions, files).
+ *  - workerPath: rsc uses userOptions.rscWorkerPath, html uses htmlWorkerPath.
+ *
+ * Runs under the react-server condition only (test/unit/** is gated to it).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { createWorkerMock } = vi.hoisted(() => ({ createWorkerMock: vi.fn() }));
+vi.mock("../../plugin/worker/createWorker.js", () => ({
+  createWorker: createWorkerMock,
+}));
+
+import { createLogger } from "vite";
+import { resolveOptions } from "vite-plugin-react-server/config";
+import { testUserOptions } from "../test-config.js";
+import { createHandlerOptions as createServerHandlerOptions } from "../../plugin/config/createHandlerOptions.server.js";
+import { createHandlerOptions as createClientHandlerOptions } from "../../plugin/config/createHandlerOptions.client.js";
+
+const PageStub = () => null;
+const RootStub = () => null;
+const HtmlStub = () => null;
+
+function emptyAutoDiscoveredFiles(): any {
+  return {
+    clientInputs: {},
+    serverInputs: {},
+    staticManifest: {},
+    staticInputs: {},
+    workerPaths: {},
+    serverEntry: null,
+    clientEntry: {},
+    serverActions: {},
+    propsMap: new Map(),
+    pageMap: new Map(),
+    rootMap: new Map(),
+    htmlMap: new Map(),
+    routeMap: new Map(),
+    urlMap: new Map(),
+    errors: [],
+  };
+}
+
+function buildUserOptions() {
+  const userOptions: any = resolveOptions(testUserOptions).userOptions!;
+  // Pre-supply components so the server variant skips component loading.
+  userOptions.components = { Page: PageStub, Root: RootStub, Html: HtmlStub };
+  // Enable BOTH workers under build mode so each block runs exactly once.
+  userOptions.dev = { ...userOptions.dev, useRscWorker: true, useHtmlWorker: true };
+  userOptions.build = { ...userOptions.build, useRscWorker: true, useHtmlWorker: true };
+  return userOptions;
+}
+
+function seededFiles() {
+  const autoDiscoveredFiles = emptyAutoDiscoveredFiles();
+  autoDiscoveredFiles.urlMap.set("/", {
+    page: "src/page/page.tsx",
+    props: undefined,
+    root: "",
+    html: "",
+  });
+  return autoDiscoveredFiles;
+}
+
+const CONFIG_ENV = { mode: "production", command: "build" } as const;
+
+/** Pull the createWorker call for a given workerPath (rsc vs html). */
+function callFor(workerPath: string) {
+  const call = createWorkerMock.mock.calls.find(
+    ([args]) => args.workerPath === workerPath
+  );
+  if (!call) throw new Error(`no createWorker call for workerPath ${workerPath}`);
+  return call[0];
+}
+
+beforeEach(() => {
+  createWorkerMock.mockReset();
+  // Every block runs createConfiguredWorker, which needs a tagged result.
+  createWorkerMock.mockResolvedValue({ type: "success", worker: { kind: "stub" } });
+});
+
+describe("createHandlerOptions.server: worker call shape", () => {
+  it("spawns one RSC and one HTML worker with the server-side args", async () => {
+    const userOptions = buildUserOptions();
+    await createServerHandlerOptions("/", {
+      userOptions,
+      autoDiscoveredFiles: seededFiles(),
+      configEnv: CONFIG_ENV,
+      mode: "production",
+      logger: createLogger("silent"),
+      id: "char-server-workers",
+    });
+
+    expect(createWorkerMock).toHaveBeenCalledTimes(2);
+
+    const rsc = callFor(userOptions.rscWorkerPath);
+    expect(rsc.currentCondition).toBe("react-server");
+    expect(rsc.reverseCondition).toBe("react-server");
+    expect(rsc.workerData.id).toBe("/");
+    expect(rsc.workerData.userOptions).toBeDefined();
+    // Server passes the raw { configEnv, mode } as resolvedConfig, no top-level configEnv.
+    expect(rsc.workerData.resolvedConfig).toEqual({ configEnv: CONFIG_ENV, mode: "production" });
+    expect("configEnv" in rsc.workerData).toBe(false);
+
+    const html = callFor(userOptions.htmlWorkerPath);
+    expect(html.currentCondition).toBe("react-server");
+    expect(html.reverseCondition).toBe("react-client");
+    expect(html.workerData.resolvedConfig).toEqual({ configEnv: CONFIG_ENV, mode: "production" });
+    expect("configEnv" in html.workerData).toBe(false);
+  });
+});
+
+describe("createHandlerOptions.client: worker call shape", () => {
+  it("spawns one RSC and one HTML worker with the client-side args", async () => {
+    const userOptions = buildUserOptions();
+    await createClientHandlerOptions("/", {
+      userOptions,
+      autoDiscoveredFiles: seededFiles(),
+      configEnv: CONFIG_ENV,
+      mode: "production",
+      logger: createLogger("silent"),
+      id: "char-client-workers",
+    });
+
+    expect(createWorkerMock).toHaveBeenCalledTimes(2);
+
+    const rsc = callFor(userOptions.rscWorkerPath);
+    expect(rsc.currentCondition).toBe("react-client");
+    // client RSC omits reverseCondition (createWorker derives it).
+    expect("reverseCondition" in rsc).toBe(false);
+    expect(rsc.workerData.id).toBe("/");
+    expect(rsc.workerData.userOptions).toBeDefined();
+    // No config passed -> RSC resolvedConfig is undefined; configEnv is threaded.
+    expect(rsc.workerData.resolvedConfig).toBeUndefined();
+    expect(rsc.workerData.configEnv).toEqual(CONFIG_ENV);
+
+    const html = callFor(userOptions.htmlWorkerPath);
+    expect(html.currentCondition).toBe("react-client");
+    expect(html.reverseCondition).toBe("react-client");
+    expect(html.workerData.configEnv).toEqual(CONFIG_ENV);
+    // No config passed -> HTML synthesizes a ResolvedConfig-shaped fallback.
+    expect(html.workerData.resolvedConfig).toEqual(
+      expect.objectContaining({
+        mode: "production",
+        command: "build",
+        isSsrBuild: true,
+        base: "/",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## What

Unify the worker-creation logic that `createHandlerOptions.server.ts` and `.client.ts` duplicated, and replace the magic-string condition/discriminator literals with named constants.

### Worker creation (`812f7bd`)
Both variants duplicated the worker gate (dev flag in serve mode / build flag in build mode) and the run loop wrapping each `createWorker` call. Extracted into `createHandlerOptions.shared.ts`:

- `resolveWorkerGate()` — the identical gate deciding whether the RSC / HTML workers are created.
- `createHandlerWorkers()` — the shared run loop; each variant supplies only its divergent per-kind `createWorker` args via thunks.

The real divergences are preserved verbatim: server passes raw `{ configEnv, mode }` as `resolvedConfig` and omits a top-level `configEnv`; client serializes `resolvedConfig` (with a kind-specific fallback when no config is supplied) and threads `configEnv` into `workerData`; conditions and worker paths differ per side/kind.

Net ~93 fewer lines across the two variants.

### Named React conditions (`6ffd8aa`)
The worker unification leaned on bare `"react-server"` / `"react-client"` string literals. Added `REACT_CONDITION` + `ReactCondition` in `getCondition.ts` (the canonical condition module) and adopted them in both variants and in `getCondition`'s own ambiguity set. Replaced `createHandlerWorkers`' `buildWorkerArgs(kind)` closure (which branched on the `"rsc"`/`"html"` discriminator) with explicit `rscWorkerArgs`/`htmlWorkerArgs` thunks — no discriminator, no per-kind ternaries. Other call sites still use the bare literals and can be swept separately.

## Coverage

Adds `test/unit/createHandlerOptionsWorkers.test.ts`, which mocks `createWorker` and pins the exact call shape of all four blocks (server/client × rsc/html) with workers enabled. The sibling `createHandlerOptions.test.ts` runs with workers disabled and could not guard them.

## Verification

Behavior unchanged. Full gate green:

- `test:server` — 677 passed, 8 skipped
- `test:client` — 186 passed, 11 skipped
- `test:typecheck` — 20 passed
- `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
