### PR TITLE
refactor(config): adopt ReactCondition type + REACT_CONDITION across the codebase

### DIFF
--- a/plugin/config/getCondition.ts
+++ b/plugin/config/getCondition.ts
@@ -195,10 +195,10 @@ export const getCondition = <Prefix extends string = "react-", DefaultCondition 
     | `${Prefix}client` = `${prefix}client` as `${Prefix}client`
 ): `${Prefix}client` | `${Prefix}server` | DefaultCondition => {
   const condition = getCurrentCondition();
-  if (condition === "react-server") {
+  if (condition === REACT_CONDITION.server) {
     return `${prefix}server` as `${Prefix}server`;
   }
-  if (condition === "react-client") {
+  if (condition === REACT_CONDITION.client) {
     return `${prefix}client` as `${Prefix}client`;
   }
   return defaultReturn;
@@ -212,7 +212,7 @@ export function assertReactServer(): asserts this is {
   condition: "react-server";
 } {
   const currentCondition = getCurrentCondition();
-  if (currentCondition !== "react-server") {
+  if (currentCondition !== REACT_CONDITION.server) {
     // Debug-only: avoid Node-only APIs to keep this file browser-safe
     console.warn(
       `[vite-plugin-react-server] Condition mismatch: expected react-server. Set NODE_OPTIONS="--conditions=react-server"`
@@ -225,7 +225,7 @@ export function assertNonReactServer(): asserts this is {
   condition: "react-client";
 } {
   const currentCondition = getCurrentCondition();
-  if (currentCondition === "react-server") {
+  if (currentCondition === REACT_CONDITION.server) {
     // Debug-only: avoid Node-only APIs to keep this file browser-safe
     console.warn(
       `[vite-plugin-react-server] Condition mismatch: unexpected react-server condition on this module.`
@@ -239,14 +239,14 @@ export function assertNonReactServer(): asserts this is {
  * Use this for React Server DOM compatibility checks
  */
 export const isReactServerCondition = (): boolean =>
-  getCurrentCondition() === "react-server";
+  getCurrentCondition() === REACT_CONDITION.server;
 
 /**
  * Checks if the current condition is react-client (strict - requires both NODE_OPTIONS and execArgv)
  * Use this for React Server DOM compatibility checks
  */
 export const isReactClientCondition = (): boolean =>
-  getCurrentCondition() === "react-client";
+  getCurrentCondition() === REACT_CONDITION.client;
 
 /**
  * Checks if react-server condition is present in either NODE_OPTIONS OR execArgv (lenient)

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -15,6 +15,7 @@ import { readFileSync, existsSync } from "node:fs";
 import type { OutputOptions, PreRenderedAsset, PreRenderedChunk } from "rollup";
 import { DEFAULT_CONFIG } from "./defaults.js";
 import { getNodeEnv } from "./getNodeEnv.js";
+import { REACT_CONDITION, type ReactCondition } from "./getCondition.js";
 import { getEnvValue, setEnvValue } from "../env/getEnvKey.js";
 import {
   mergeClientPackagesNoExternal,
@@ -25,7 +26,7 @@ import { createRollupLikeHash } from "./createRollupLikeHash.js";
 const stashedUserConfig: Record<string, ResolvedUserConfig | null> = {};
 let originalConfig: UserConfig | null = null;
 export type ResolveUserConfigProps = {
-  condition: "react-client" | "react-server";
+  condition: ReactCondition;
   config: UserConfig;
   configEnv: ConfigEnv;
   userOptions: ResolvedUserOptions;
@@ -63,22 +64,22 @@ export const resolveUserConfig: ResolveUserConfigFn =
         ? ssr
         : typeof config.build?.ssr === "boolean"
         ? config.build?.ssr
-        : condition === "react-server"
+        : condition === REACT_CONDITION.server
         ? true
         : typeof configEnv.isSsrBuild === "boolean"
         ? configEnv.isSsrBuild
         : false;
 
-    if (condition === "react-server" && !ssr) {
+    if (condition === REACT_CONDITION.server && !ssr) {
       const logger = config.customLogger ?? createLogger();
       logger.warn(
         "react-server build should be ssr, but is was manually set to false. This may not work as expected."
       );
     }
     const envDir =
-      condition === "react-client" && ssr
+      condition === REACT_CONDITION.client && ssr
         ? userOptions.build.client
-        : condition === "react-client"
+        : condition === REACT_CONDITION.client
         ? userOptions.build.static
         : userOptions.build.server;
     const envId = `${envDir}${ssr ? "-ssr" : ""}`;
@@ -215,7 +216,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
     // For static builds (browser/ESM): bundle everything - no need to preserve modules or node_modules structure
     // For client/server environments (SSR): preserve modules to maintain module structure for server-side rendering
     // Use preserveModules: true for SSR, but for static builds use false to prevent _virtual files
-    const shouldPreserveModules = ssr || condition === "react-server";
+    const shouldPreserveModules = ssr || condition === REACT_CONDITION.server;
     
     const pluginOutput = {
       // For static builds: false to bundle everything and prevent _virtual files
@@ -487,7 +488,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
       setEnvValue("PUBLIC_ORIGIN", publicOrigin, primaryPrefix);
     }
 
-    if (condition === "react-client") {
+    if (condition === REACT_CONDITION.client) {
       // client plugin build options (client plugin still outputs server files)
       const clientConfig = {
         ...config,

--- a/plugin/dev-server/restartWorker.client.ts
+++ b/plugin/dev-server/restartWorker.client.ts
@@ -6,6 +6,7 @@ import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
 import { React } from "../vendor/vendor.client.js";
 import type { RestartWorkerFn } from "../react-client/types.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
+import { REACT_CONDITION } from "../config/getCondition.js";
 import { handleError } from "../error/handleError.js";
 import { setMaxListenersOnPort, unrefPort } from "../stream/setMaxListeners.js";
 import { attachRunnerFetchHandler } from "./handleRunnerFetch.server.js";
@@ -139,8 +140,8 @@ export const restartWorker: RestartWorkerFn = async function _restartWorker({
     const workerResult = await createWorker({
       projectRoot: userOptions.projectRoot || server.config.root,
       workerPath: userOptions.rscWorkerPath,
-      reverseCondition: "react-server",
-      currentCondition: "react-client",
+      reverseCondition: REACT_CONDITION.server,
+      currentCondition: REACT_CONDITION.client,
       maxListeners: maxListeners,
       envPrefix: envPrefixFromConfig(server.config),
       workerData: {

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -9,6 +9,7 @@ import { createDefaultModuleID } from "../config/createModuleID.js";
 import { createLogger } from "vite";
 import { join } from "node:path";
 import { DEFAULT_LOADER_CONFIG } from "../config/defaults.js";
+import { REACT_CONDITION } from "../config/getCondition.js";
 import { runDeferredStaticGeneration } from "../bundle/deferredStaticGeneration.js";
 
 /**
@@ -212,7 +213,7 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
         // detect if legacy build or not
         const legacyBuild = userOptions.strategy?.legacyBuilder && !config?.builder;
         const implicitSsr =
-          userOptions.strategy?.mainThreadCondition === "react-server" &&
+          userOptions.strategy?.mainThreadCondition === REACT_CONDITION.server &&
           userOptions.strategy?.legacyBuilder;
         // this follows vite's logic for legacy builds
         const implicitViteBuildName =

--- a/plugin/environments/resolveEnvironmentConfig.ts
+++ b/plugin/environments/resolveEnvironmentConfig.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { createLogger } from "vite";
 import { getEnvValue, setEnvValue } from "../env/getEnvKey.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { REACT_CONDITION, type ReactCondition } from "../config/getCondition.js";
 
 
 // Cache for resolved environment configs to avoid recomputation
@@ -33,7 +34,7 @@ let originalConfig: UserConfig | null = null;
  */
 
 export type ResolveEnvironmentConfigProps = {
-  condition: "react-client" | "react-server";
+  condition: ReactCondition;
   config: UserConfig;
   userOptions: ResolvedUserOptions;
   autoDiscoveredFiles: AutoDiscoveredFiles;
@@ -76,11 +77,11 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
         ? ssr
         : typeof config.build?.ssr === "boolean"
         ? config.build?.ssr
-        : condition === "react-server"
+        : condition === REACT_CONDITION.server
         ? true
         : false;
 
-    if (condition === "react-server" && !ssr) {
+    if (condition === REACT_CONDITION.server && !ssr) {
       const logger = config.customLogger ?? createLogger();
       logger.warn(
         "react-server build should be ssr, but it was manually set to false. This may not work as expected."
@@ -89,9 +90,9 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
 
     // Determine environment-specific directory
     const envDir =
-      condition === "react-client" && ssr
+      condition === REACT_CONDITION.client && ssr
         ? userOptions.build.client
-        : condition === "react-client"
+        : condition === REACT_CONDITION.client
         ? userOptions.build.static
         : userOptions.build.server;
     
@@ -131,7 +132,7 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
 
       // Determine inputs based on condition and SSR with better normalization
       let inputs: Record<string, string>;
-      if (condition === "react-client") {
+      if (condition === REACT_CONDITION.client) {
         if (ssr) {
           // For SSR builds, exclude HTML files and use only client inputs
           inputs = Object.fromEntries(
@@ -212,7 +213,7 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
         },
       };
 
-      if (condition === "react-client") {
+      if (condition === REACT_CONDITION.client) {
         // Client environment configuration
         const clientEnvironmentConfig: BuildEnvironmentOptions = {
           outDir: join(userOptions.build.outDir, envDir),
@@ -296,7 +297,7 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
                 name: "react-server-conditions",
                 buildStart() {
                   // Ensure react-server condition is available during server builds
-                  if (condition === "react-server") {
+                  if (condition === REACT_CONDITION.server) {
                    // process.env.NODE_OPTIONS = (process.env.NODE_OPTIONS || "") + " --conditions react-server";
                   }
                 },

--- a/plugin/orchestrator/createPluginOrchestrator.client.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.client.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "vite";
 import { vitePluginReactDevServer } from "../dev-server/plugin.client.js";
 import { reactStaticPlugin } from "../react-static/plugin.client.js";
 import { createPluginOrchestratorImpl } from "./createPluginOrchestrator.impl.js";
+import type { ReactCondition } from "../config/getCondition.js";
 
 // Client-first orchestrator — pulls the .client dev-server / react-static plugins
 // and runs the transformer with a "client" default environment. The shared body
@@ -17,8 +18,8 @@ export const createPluginOrchestrator = (userOptions: any): Plugin[] =>
 export interface Strategy {
   mode?: "auto" | "server" | "client";
   bundleTarget?: "server" | "client" | "ssr";
-  importContext?: "react-server" | "react-client";
-  mainThreadCondition?: "react-server" | "react-client";
+  importContext?: ReactCondition;
+  mainThreadCondition?: ReactCondition;
   legacyBuilder?: boolean;
   staticBuild?: boolean;
   ssg?: boolean;

--- a/plugin/orchestrator/createPluginOrchestrator.server.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.server.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "vite";
 import { vitePluginReactDevServer } from "../dev-server/plugin.server.js";
 import { reactStaticPlugin } from "../react-static/plugin.server.js";
 import { createPluginOrchestratorImpl } from "./createPluginOrchestrator.impl.js";
+import type { ReactCondition } from "../config/getCondition.js";
 
 // Server-first orchestrator — pulls the .server dev-server / react-static plugins
 // and runs the transformer with a "server" default environment. The shared body
@@ -17,8 +18,8 @@ export const createPluginOrchestrator = (userOptions: any): Plugin[] =>
 export interface Strategy {
   mode?: "auto" | "server" | "client";
   bundleTarget?: "server" | "client" | "ssr";
-  importContext?: "react-server" | "react-client";
-  mainThreadCondition?: "react-server" | "react-client";
+  importContext?: ReactCondition;
+  mainThreadCondition?: ReactCondition;
   legacyBuilder?: boolean;
   staticBuild?: boolean;
   ssg?: boolean;

--- a/plugin/orchestrator/createPluginOrchestrator.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.ts
@@ -29,14 +29,14 @@
 // without honoring them; bd-6pi tracks the resulting bidoof regression.
 
 import type { Plugin } from "vite";
-import { getCondition } from "../config/getCondition.js";
+import { getCondition, REACT_CONDITION } from "../config/getCondition.js";
 import type { UserOptions } from "./types.js";
 
 const condition = getCondition();
 const dirpath = new URL("./", import.meta.url).pathname.replace(/\/$/, "");
 
 const mod = (await import(
-  `${dirpath}/createPluginOrchestrator.${condition === "react-server" ? "server" : "client"}.js`
+  `${dirpath}/createPluginOrchestrator.${condition === REACT_CONDITION.server ? "server" : "client"}.js`
 )) as {
   createPluginOrchestrator: (userOptions: UserOptions) => Plugin[];
 };

--- a/plugin/orchestrator/resolveStrategy.ts
+++ b/plugin/orchestrator/resolveStrategy.ts
@@ -1,9 +1,10 @@
 import type { Strategy } from "./types.js";
+import { REACT_CONDITION, type ReactCondition } from "../config/getCondition.js";
 
 export interface ResolveStrategyOptions {
   userStrategy?: Partial<Strategy>;
-  mainThreadCondition: "react-client" | "react-server";
-  importContext: "react-client" | "react-server";
+  mainThreadCondition: ReactCondition;
+  importContext: ReactCondition;
   functionName: "vitePluginReactClient" | "vitePluginReactServer";
 }
 
@@ -35,14 +36,14 @@ export function resolveStrategy(options: ResolveStrategyOptions): Strategy {
   };
 
   // Validate bundleTarget compatibility with mainThreadCondition
-  if (strategy.bundleTarget === "server" && mainThreadCondition === "react-client") {
+  if (strategy.bundleTarget === "server" && mainThreadCondition === REACT_CONDITION.client) {
     throw new Error(
       `Invalid strategy: bundleTarget "server" is not compatible with mainThreadCondition "react-client". ` +
       `Use vitePluginReactServer for server builds or set mainThreadCondition to "react-server".`
     );
   }
 
-  if (strategy.bundleTarget === "client" && mainThreadCondition === "react-server") {
+  if (strategy.bundleTarget === "client" && mainThreadCondition === REACT_CONDITION.server) {
     throw new Error(
       `Invalid strategy: bundleTarget "client" is not compatible with mainThreadCondition "react-server". ` +
       `Use vitePluginReactServer for client builds or set mainThreadCondition to "react-client".`

--- a/plugin/orchestrator/types.ts
+++ b/plugin/orchestrator/types.ts
@@ -1,11 +1,12 @@
 import type { StreamPluginOptions } from "../types.js";
+import type { ReactCondition } from "../config/getCondition.js";
 
 // Strategy types
 export interface Strategy {
     mode?: "auto" | "client" | "server";
     bundleTarget?: "server" | "client" | "ssr";
-    importContext?: "react-server" | "react-client";
-    mainThreadCondition?: "react-server" | "react-client";
+    importContext?: ReactCondition;
+    mainThreadCondition?: ReactCondition;
     staticBuild?: boolean;
     ssg?: boolean;
     environmentTargets?: Map<string, string>;

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -41,7 +41,7 @@ import { getBundleManifest } from "../helpers/getBundleManifest.js";
 import { handleError } from "../error/handleError.js";
 import { shouldCausePanic } from "../error/panicThresholdHandler.js";
 import { configurePreviewServer } from "./configurePreviewServer.js";
-import { assertNonReactServer } from "../config/getCondition.js";
+import { assertNonReactServer, REACT_CONDITION } from "../config/getCondition.js";
 import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
 import { createWorkerStartupMetrics } from "../metrics/createWorkerStartupMetrics.js";
 import { processCssFilesForPages } from "./processCssFilesForPages.js";
@@ -546,8 +546,8 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
           rscWorkerResult = await createWorker({
             projectRoot: userOptions.projectRoot,
             workerPath: userOptions.rscWorkerPath,
-            currentCondition: "react-client",
-            reverseCondition: "react-server",
+            currentCondition: REACT_CONDITION.client,
+            reverseCondition: REACT_CONDITION.server,
             maxListeners: Math.max(routes.length * 3, 10), // Account for multiple listeners per route
             envPrefix: envPrefixFromConfig(resolvedConfig as any),
             logger: logger,

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -55,7 +55,7 @@ import { createWorkerStartupMetrics } from "../metrics/createWorkerStartupMetric
 import { tryManifest } from "../helpers/tryManifest.js";
 import { join } from "node:path";
 import { resolveAutoDiscover } from "../config/autoDiscover/resolveAutoDiscover.js";
-import { assertReactServer } from "../config/getCondition.js";
+import { assertReactServer, REACT_CONDITION } from "../config/getCondition.js";
 import { toError } from "../error/toError.js";
 
 assertReactServer();
@@ -372,8 +372,8 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
           const workerResult = await createWorker({
             projectRoot: userOptions.projectRoot,
             workerPath: userOptions.htmlWorkerPath,
-            currentCondition: "react-server",
-            reverseCondition: "react-client", // HTML worker needs react-client for react-dom/server
+            currentCondition: REACT_CONDITION.server,
+            reverseCondition: REACT_CONDITION.client, // HTML worker needs react-client for react-dom/server
             maxListeners: maxListeners,
             envPrefix: viteEnvPrefix,
             logger: logger,

--- a/plugin/stream/createInlineFlightRenderer.server.ts
+++ b/plugin/stream/createInlineFlightRenderer.server.ts
@@ -25,7 +25,7 @@ import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import type { Readable } from "node:stream";
 import { React } from "../vendor/vendor.server.js";
-import { assertReactServer } from "../config/getCondition.js";
+import { assertReactServer, REACT_CONDITION } from "../config/getCondition.js";
 import { createRenderToPipeableStreamHandler } from "./createRenderToPipeableStreamHandler.server.js";
 import { createHtmlStreamWithInlineFlight } from "./createHtmlStreamWithInlineFlight.server.js";
 import { createWorker } from "../worker/createWorker.js";
@@ -99,8 +99,8 @@ export const createInlineFlightRenderer: CreateInlineFlightRendererFn = function
       workerPromise = createWorker({
         projectRoot,
         ...(config.htmlWorkerPath ? { workerPath: config.htmlWorkerPath } : {}),
-        currentCondition: "react-server",
-        reverseCondition: "react-client",
+        currentCondition: REACT_CONDITION.server,
+        reverseCondition: REACT_CONDITION.client,
         mode: "production",
         verbose,
         workerData: {

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -6,7 +6,11 @@ import {
 } from "node:worker_threads";
 import type { ConfigEnv } from "vite";
 import { getMode, getNodePath } from "../config/getPaths.js";
-import { getCondition } from "../config/getCondition.js";
+import {
+  getCondition,
+  REACT_CONDITION,
+  type ReactCondition,
+} from "../config/getCondition.js";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { pluginRoot } from "../root.js";
@@ -126,7 +130,7 @@ export type CreateWorkerReturn =
 
 export type CreateWorkerOptions = {
   projectRoot?: string;
-  currentCondition?: "react-server" | "react-client";
+  currentCondition?: ReactCondition;
   nodePath?: string;
   nodeOptions?: string[];
   envPrefix?: string;
@@ -168,9 +172,9 @@ export const createWorker: CreateWorkerFn = async function _createWorker(
     nodePath = getNodePath(projectRoot),
     currentCondition = getCondition(),
     envPrefix = DEFAULT_CONFIG.ENV_PREFIX,
-    reverseCondition = currentCondition === "react-server"
-      ? "react-client"
-      : "react-server",
+    reverseCondition = currentCondition === REACT_CONDITION.server
+      ? REACT_CONDITION.client
+      : REACT_CONDITION.server,
     maxListeners = 100,
     mode = getMode(),
     workerPath,
@@ -183,14 +187,14 @@ export const createWorker: CreateWorkerFn = async function _createWorker(
     logger = createLogger(),
     verbose = false,
   } = options;
-  const id = reverseCondition === "react-server" ? "worker/rsc" : "worker/html";
+  const id = reverseCondition === REACT_CONDITION.server ? "worker/rsc" : "worker/html";
   let workerPathWithDefault =
     typeof workerPath === "string" ? workerPath : undefined;
   if (!workerPathWithDefault) {
     // Use the default worker paths that include the full filename
     const isProduction = mode === "production";
     const workerFileName =
-      reverseCondition === "react-server"
+      reverseCondition === REACT_CONDITION.server
         ? `rsc-worker.${isProduction ? "production" : "development"}.js`
         : `html-worker.${isProduction ? "production" : "development"}.js`;
 
@@ -364,7 +368,7 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
         // is a public entry (exported as `vite-plugin-react-server/worker`), and
         // an undefined timeout makes `setTimeout(reject, undefined)` fire on the
         // next tick, so the worker "times out" before it can even start.
-        const workerType = reverseCondition === "react-server" ? "rsc" : "html";
+        const workerType = reverseCondition === REACT_CONDITION.server ? "rsc" : "html";
         const startupTimeout =
           (workerType === "rsc"
             ? options.workerData.userOptions?.rscWorkerStartupTimeout


### PR DESCRIPTION
## What

Follow-up to #199, which introduced `REACT_CONDITION` / `ReactCondition` in `getCondition.ts` but only adopted them in the two `createHandlerOptions` variants — leaving the rest of the codebase on bare `"react-server"` / `"react-client"` literals. This sweeps the rest so the constant earns its place and the tree isn't split between two styles.

This is the **type-focused** sweep (high signal-to-noise), not a blanket find-and-replace:

- **Type unions** — every hand-written `"react-server" | "react-client"` annotation now uses the `ReactCondition` type: `createWorker`, both orchestrator wrappers + `orchestrator/types`, `resolveStrategy`, `resolveUserConfig`, `resolveEnvironmentConfig`.
- **Logic / comparison sites** — equality checks and ternaries against a condition literal now compare against `REACT_CONDITION.*`, where a typo would otherwise be a silent runtime bug rather than a type error: `createWorker`'s `reverseCondition`/`id`/`workerType` derivation, the condition branches in `resolveUserConfig` / `resolveEnvironmentConfig` / `getCondition` itself, the orchestrator dispatch, `resolveStrategy`'s validation, `createEnvironmentPlugin`'s `implicitSsr`.
- **Worker-arg assignments** — `currentCondition` / `reverseCondition` object fields in `react-static.{server,client}`, `createInlineFlightRenderer`, and `restartWorker` use `REACT_CONDITION.*`, matching what #199 already did in `createHandlerOptions`.

## Deliberately left as literals

Self-describing external-protocol values, not condition logic — converting these adds noise without safety:

- Top-level factory entry points (`makeVitePluginReactServer(...)` / `createEnvPlugin(...)` args).
- Vite `conditions: [...]` arrays.
- `importContext` identity assignments.
- The mixed env-name heuristic in `createTransformerPlugin` (`envName === "server" || "rsc" || "react-server"`) — converting one of three sibling literals would add asymmetry without a safety gain.

## Verification

Behavior unchanged; test counts identical to main.

- `test:server` — 677 passed, 8 skipped
- `test:client` — 186 passed, 11 skipped
- `test:typecheck` — 20 passed
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
