### PR TITLE
feat(stream): renderFlightToHtml — single-isolate flash-free HTML render

### DIFF
--- a/plugin/stream/index.client.ts
+++ b/plugin/stream/index.client.ts
@@ -18,6 +18,11 @@ export * from "./createFromNodeStream.client.js";
 // client-first / Web-runtime user decodes Flight with.
 export * from "./createFromReadableStream.client.js";
 
+// Single-isolate flash-free HTML: decode a Flight ReadableStream and render it
+// to an HTML ReadableStream in one process (no worker). The in-process twin of
+// plugin/worker/html, for edge / single-isolate builds.
+export * from "./renderFlightToHtml.client.js";
+
 // HTML stream creation
 export * from "./createHtmlStream.client.js";
 

--- a/plugin/stream/renderFlightToHtml.client.ts
+++ b/plugin/stream/renderFlightToHtml.client.ts
@@ -1,0 +1,69 @@
+import type { RenderFlightToHtmlFn } from "./renderFlightToHtml.types.js";
+import { React, ReactDOMHtmlServerEdge } from "../vendor/vendor.client.js";
+import { ReactDOMClientEdge } from "../vendor/vendorEdge.client.js";
+import { assertNonReactServer } from "../config/getCondition.js";
+
+assertNonReactServer();
+
+/**
+ * Single-isolate flash-free HTML: decode a Flight RSC `ReadableStream` and
+ * render it straight to an HTML `ReadableStream` in the SAME process — no
+ * worker_threads, no `--conditions` flip.
+ *
+ * This is the in-process counterpart of the worker-based HTML render
+ * (plugin/worker/html). It works because, in a single-isolate build, the rsc
+ * bundle bakes server React and the ssr bundle bakes client React, so the two
+ * graphs co-exist; client islands resolve via the client transport's native
+ * `import(moduleBaseURL + id)` into the ssr bundle (point `moduleBaseURL` there)
+ * with no condition-sensitive resolution. Web-streams only — edge-safe.
+ *
+ * Producing the Flight stays server-only (react-server condition); this is the
+ * consumption + HTML render half, so it runs under the client renderer and
+ * guards against being evaluated on the wrong side.
+ */
+export const renderFlightToHtml: RenderFlightToHtmlFn =
+  async function _renderFlightToHtml(options) {
+    const {
+      rscStream,
+      moduleBaseURL,
+      bootstrapModules,
+      bootstrapScriptContent,
+      nonce,
+      onError,
+      signal,
+      logger,
+      verbose = false,
+    } = options;
+
+    if (!rscStream) {
+      throw new Error("[renderFlightToHtml] rscStream is required");
+    }
+
+    // Decode the Flight payload ONCE into a stable promise. A Web ReadableStream
+    // can only be read by a single reader, and the streaming HTML render may
+    // re-invoke its component on retry — so the decode must NOT live inside the
+    // rendered component (that re-reads a locked stream). Decode here, React.use
+    // the stable promise inside Root.
+    const elementPromise = ReactDOMClientEdge.createFromReadableStream(rscStream, {
+      moduleBaseURL: moduleBaseURL || "/",
+    });
+
+    if (verbose) {
+      logger?.info(
+        `[renderFlightToHtml] rendering decoded Flight to HTML via react-dom/server.edge, moduleBaseURL: ${moduleBaseURL}`
+      );
+    }
+
+    function Root(): React.ReactNode {
+      return React.use(elementPromise);
+    }
+
+    return ReactDOMHtmlServerEdge.renderToReadableStream(
+      React.createElement(
+        React.Suspense,
+        null,
+        React.createElement(Root)
+      ),
+      { bootstrapModules, bootstrapScriptContent, nonce, onError, signal }
+    );
+  };

--- a/plugin/stream/renderFlightToHtml.types.ts
+++ b/plugin/stream/renderFlightToHtml.types.ts
@@ -1,0 +1,32 @@
+import type { Logger } from "vite";
+
+/**
+ * Options for {@link RenderFlightToHtmlFn}: render a Flight RSC payload to an
+ * HTML `ReadableStream` in a single isolate (no worker_threads), the edge /
+ * single-isolate counterpart of the worker-based HTML render.
+ */
+export type RenderFlightToHtmlOptions = {
+  /** The Flight RSC payload as a Web ReadableStream (the edge producer's output). */
+  rscStream: ReadableStream<Uint8Array>;
+  /**
+   * Base URL the client transport uses to resolve client-reference modules —
+   * point this at the client-React (ssr) bundle so islands resolve in-process.
+   */
+  moduleBaseURL?: string;
+  /** Client entry modules to bootstrap for hydration (react-dom bootstrapModules). */
+  bootstrapModules?: string[];
+  /** Inline bootstrap script content (react-dom bootstrapScriptContent). */
+  bootstrapScriptContent?: string;
+  /** Nonce forwarded to the HTML renderer. */
+  nonce?: string;
+  /** Called on a render error (forwarded to react-dom/server.edge onError). */
+  onError?: (error: unknown) => void;
+  /** Abort signal forwarded to the HTML renderer. */
+  signal?: AbortSignal;
+  logger?: Logger;
+  verbose?: boolean;
+};
+
+export type RenderFlightToHtmlFn = (
+  options: RenderFlightToHtmlOptions
+) => Promise<ReadableStream<Uint8Array>>;

--- a/plugin/types/react-dom-server-edge.d.ts
+++ b/plugin/types/react-dom-server-edge.d.ts
@@ -1,0 +1,7 @@
+// @types/react-dom ships types for "react-dom/server" (including
+// renderToReadableStream) but not for the "react-dom/server.edge" entry, which
+// exposes the same Web-streams surface. Re-export the server types so
+// vendor.client.ts's ReactDOMHtmlServerEdge is typed.
+declare module "react-dom/server.edge" {
+  export * from "react-dom/server";
+}

--- a/plugin/vendor/vendor.client.ts
+++ b/plugin/vendor/vendor.client.ts
@@ -31,6 +31,24 @@ const lazyReactDOMServer = createLazyVendorModule(
   reactPairedMode
 );
 const ReactDOMServer = lazyReactDOMServer.proxy;
+
+// Web-streams HTML renderer (react-dom/server.edge — renderToReadableStream).
+// The edge counterpart of ReactDOMServer's renderToPipeableStream: used by
+// renderFlightToHtml to render a decoded Flight tree to an HTML ReadableStream
+// in-process (no worker). Same consumer react-dom, edge entry; lazy for the
+// same settled-NODE_ENV reason as the others.
+// Named ...HtmlServerEdge (not ReactDOMServerEdge) deliberately: vendorEdge.
+// server.ts already exports a `ReactDOMServerEdge` that is the react-server-dom
+// FLIGHT renderer. This one is react-dom's HTML renderer — different module,
+// different signature — so it gets a distinct name to avoid confusion.
+const lazyReactDOMHtmlServerEdge = createLazyVendorModule(
+  () =>
+    projectRequire(
+      "react-dom/server.edge"
+    ) as typeof import("react-dom/server.edge"),
+  reactPairedMode
+);
+const ReactDOMHtmlServerEdge = lazyReactDOMHtmlServerEdge.proxy;
 const lazyReact = createLazyVendorModule(
   () => projectRequire("react") as typeof import("react"),
   reactPairedMode
@@ -49,5 +67,5 @@ if (hasReactServerCondition()) {
     .renderToPipeableStream;
 }
 
-export { ReactDOMServer, React, ReactDOMClient };
+export { ReactDOMServer, ReactDOMHtmlServerEdge, React, ReactDOMClient };
 export type React = typeof import("react");

--- a/test/streams/render-flight-to-html.test.ts
+++ b/test/streams/render-flight-to-html.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import * as streamApi from "vite-plugin-react-server/stream";
+
+// Companion to edge-from-readable-stream.test.ts. renderFlightToHtml is the
+// single-isolate HTML render: decode a Flight ReadableStream and render it to
+// an HTML ReadableStream in one process (react-dom/server.edge), no worker. It
+// is client-only — `vite-plugin-react-server/stream` exposes it under the
+// default condition and NOT under react-server — so skip on the react-server
+// leg of test-both, exactly like the decode test.
+const renderFlightToHtml = (streamApi as any).renderFlightToHtml as
+  | typeof import("../../plugin/stream/renderFlightToHtml.client.js").renderFlightToHtml
+  | undefined;
+
+function flightStream(text: string): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  return await new Response(stream).text();
+}
+
+describe.skipIf(!renderFlightToHtml)(
+  "single-isolate HTML render (renderFlightToHtml)",
+  () => {
+    it("renders a Flight ReadableStream to an HTML ReadableStream in-process", async () => {
+      // A host-element-only Flight (no client references) so the render needs
+      // no module resolution — it exercises the decode + react-dom/server.edge
+      // HTML render path end to end.
+      const html = await readAll(
+        await renderFlightToHtml!({
+          rscStream: flightStream(
+            '0:["$","div",null,{"id":"root","children":"hello-flight"}]\n'
+          ),
+          moduleBaseURL: "/",
+        })
+      );
+      expect(html).toContain("hello-flight");
+      expect(html).toContain('id="root"');
+    });
+
+    it("throws when given no rscStream", async () => {
+      await expect(renderFlightToHtml!({} as any)).rejects.toThrow(
+        /rscStream is required/
+      );
+    });
+  }
+);


### PR DESCRIPTION
## What

Adds `renderFlightToHtml` — decode a Flight RSC `ReadableStream` and render it to an HTML `ReadableStream` **in the same process**, with no `worker_threads` and no `--conditions` flip.

It's the in-process counterpart of the worker-based HTML render (`plugin/worker/html`). Today vprs renders HTML by running the opposite React condition (`react-client`) in a `worker_threads` html-worker, because the main isolate is pinned to `--conditions react-server`. That works in Node but not on edge runtimes (no `worker_threads`). `renderFlightToHtml` is the building block for single-isolate flash-free SSR: in a build where the rsc bundle bakes server React and the ssr bundle bakes client React, both graphs co-exist in one isolate, and client islands resolve via the client transport's native `import(moduleBaseURL + id)` into the ssr bundle — point `moduleBaseURL` there.

## Changes

- **`plugin/vendor/vendor.client.ts`** — expose `ReactDOMHtmlServerEdge` (`react-dom/server.edge`, the Web-streams `renderToReadableStream`). Named distinctly from `vendorEdge.server.ts`'s `ReactDOMServerEdge`, which is the react-server-dom **flight** renderer (different module, different signature — naming them alike would be a trap).
- **`plugin/stream/renderFlightToHtml.client.ts`** — decode the Flight **once** into a stable promise, `React.use` it inside a Suspense boundary, render via `react-dom/server.edge`. Decoding once matters: a Web `ReadableStream` has a single reader and the streaming render may re-invoke its component on retry, so decoding inside the rendered component re-reads a locked stream (`Invalid state: ReadableStream is locked`). Client-condition only — guards against `react-server` like the other client renderers.
- **`plugin/types/react-dom-server-edge.d.ts`** — `@types/react-dom` ships no `react-dom/server.edge` entry; re-export `react-dom/server`'s types.
- Web-streams only on this path — edge-safe (no `node:*`).

## Why now

This is the first, self-contained piece of single-isolate flash-free SSR. It's deliberately scoped to just the compose helper: it doesn't touch the build topology or the worker path, both of which are unchanged. The build-side work (baking React per environment so the rsc bundle runs without `--conditions`) is a separate follow-up.

## Verification

- New test renders a host-element Flight to HTML end to end (`test/streams/render-flight-to-html.test.ts`). It skips on the `react-server` leg of `test-both` (the helper is exported only under the client condition), mirroring `edge-from-readable-stream.test.ts`.
- `test:server` — 677 passed, 10 skipped
- `test:client` — 188 passed, 11 skipped
- `test:typecheck` — 20 passed · `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
