### PR TITLE
feat(build): build.edge single-isolate rsc bake (dist/server-edge)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,21 +8,22 @@
 4. [CSS Handling](./css-handling.md) — inline/linked CSS, CSS modules
 5. [Server Actions](./server-actions.md) — `"use server"` directives, form actions
 6. [Storybook](./storybook.md) — the `vite-plugin-react-server/storybook` preset for rendering your RSC components in stories
-7. [Examples](./examples.md) — static site, dynamic server, custom routing
-8. [Troubleshooting](./troubleshooting.md) — common errors and fixes
-9. [API Reference](./api-reference.md) — exported functions, types, components
+7. [Edge / Single-Isolate](./edge.md) — flash-free SSR from one Web `fetch` handler, no workers or `--conditions` (Cloudflare/Deno/Vercel/Bun)
+8. [Examples](./examples.md) — static site, dynamic server, custom routing
+9. [Troubleshooting](./troubleshooting.md) — common errors and fixes
+10. [API Reference](./api-reference.md) — exported functions, types, components
 
 ## Internals (contributors)
 
-10. [Architecture](./internals/architecture.md) — condition system, module structure, plugin composition
-11. [Transformer](./internals/transformer.md) — directive handling and code transforms
-12. [Workers](./internals/workers.md) — RSC and HTML worker threads
-13. [Module-resolution escape hatches](./internals/module-resolution-escape-hatches.md) — when to reach for `external`, `noExternal`, `optimizeDeps`, virtual stubs, vendor aliases (and how to pick the right one)
+11. [Architecture](./internals/architecture.md) — condition system, module structure, plugin composition
+12. [Transformer](./internals/transformer.md) — directive handling and code transforms
+13. [Workers](./internals/workers.md) — RSC and HTML worker threads
+14. [Module-resolution escape hatches](./internals/module-resolution-escape-hatches.md) — when to reach for `external`, `noExternal`, `optimizeDeps`, virtual stubs, vendor aliases (and how to pick the right one)
 
 ## Maintenance
 
-14. [Releasing](./releasing.md) — version bumps, publishing, demo updates
-15. [React Compatibility](./react-type-compatibility.md) — vendored ESM transport, type system
+15. [Releasing](./releasing.md) — version bumps, publishing, demo updates
+16. [React Compatibility](./react-type-compatibility.md) — vendored ESM transport, type system
 
 ## Links
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -190,20 +190,25 @@ interface BuildConfig {
 }
 ```
 
-### EdgeBuildConfig
+### `build.edge`
 
-Single-isolate edge bundle (additive; off by default). See [Edge / Single-Isolate](./edge.md).
+Single-isolate edge bundle (additive; **ON by default**). See [Edge / Single-Isolate](./edge.md).
 
 ```typescript
+// build.edge?: boolean | EdgeBuildConfig   (default: true)
+//   true / omitted  → emit with defaults
+//   false           → opt out
+//   { … }           → emit, with overrides
 interface EdgeBuildConfig {
-  singleIsolate?: boolean; // Default: false — emit dist/server-edge/render.js
-  outDir?: string;         // Default: "server-edge" (under build.outDir)
-  minify?: boolean;        // Default: true — edge runtimes cap bundle size
+  outDir?: string;  // Default: "server-edge" (under build.outDir)
+  minify?: boolean; // Default: true — edge runtimes cap bundle size
 }
 ```
 
-Pair the baked `render.js` (`renderRouteToFlight`) with `createEdgeHandler` from
-`vite-plugin-react-server/stream` to get a Web `(Request) => Response` handler.
+Drive the baked `render.js` with `createEdgeHandler` from
+`vite-plugin-react-server/stream`: `renderRouteToDocument` for a flash-free
+inline-flight document, `handleRouteAction` for the baked server-action gate, or
+the low-level `renderRouteToFlight` producer.
 
 ### CssConfig
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -186,8 +186,24 @@ interface BuildConfig {
   htmlOutputPath?: string; // Default: "index.html"
   preserveModulesRoot?: boolean;
   hash?: string;
+  edge?: EdgeBuildConfig;
 }
 ```
+
+### EdgeBuildConfig
+
+Single-isolate edge bundle (additive; off by default). See [Edge / Single-Isolate](./edge.md).
+
+```typescript
+interface EdgeBuildConfig {
+  singleIsolate?: boolean; // Default: false — emit dist/server-edge/render.js
+  outDir?: string;         // Default: "server-edge" (under build.outDir)
+  minify?: boolean;        // Default: true — edge runtimes cap bundle size
+}
+```
+
+Pair the baked `render.js` (`renderRouteToFlight`) with `createEdgeHandler` from
+`vite-plugin-react-server/stream` to get a Web `(Request) => Response` handler.
 
 ### CssConfig
 

--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -209,6 +209,21 @@ build: {
 
 Use `renderMode: "sequential"` for debugging or low-memory environments.
 
+## Optional: `dist/server-edge/` (single-isolate edge bundle)
+
+With `build.edge.singleIsolate: true`, the build emits one extra artifact:
+
+```
+dist/
+└── server-edge/
+    └── render.js      # baked Flight producer, React inlined (server condition)
+```
+
+This is **additive** — the three directories above are untouched. `render.js`
+exports `renderRouteToFlight(url)` and runs in a single isolate with no
+`worker_threads` and no runtime `--conditions`, for edge runtimes. Pair it with
+`createEdgeHandler` to get a Web `fetch` handler. See [Edge / Single-Isolate](./edge.md).
+
 ## Environment Variables
 
 The plugin sets these automatically if not provided:

--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -209,9 +209,10 @@ build: {
 
 Use `renderMode: "sequential"` for debugging or low-memory environments.
 
-## Optional: `dist/server-edge/` (single-isolate edge bundle)
+## `dist/server-edge/` (single-isolate edge bundle)
 
-With `build.edge.singleIsolate: true`, the build emits one extra artifact:
+`build.edge` is **on by default** (pass `build.edge: false` to opt out), so the
+build also emits:
 
 ```
 dist/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,13 +53,11 @@ export default defineConfig({
       rscOutputPath: "index.rsc",
       htmlOutputPath: "index.html",
 
-      // Optional — single-isolate edge bundle (additive; default off).
-      // See docs/edge.md.
-      edge: {
-        singleIsolate: false,          // emit dist/server-edge/render.js
-        outDir: "server-edge",         // under build.dir
-        minify: true,                  // edge runtimes enforce size limits
-      },
+      // Optional — single-isolate edge bundle (additive; ON by default).
+      // `boolean | { outDir?, minify? }`. See docs/edge.md.
+      //   edge: false             — opt out
+      //   edge: { minify: false } — keep on, tune a default
+      edge: true,
     },
 
     // Optional — workers

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,14 @@ export default defineConfig({
       batchSize: 8,                    // pages per batch in parallel mode
       rscOutputPath: "index.rsc",
       htmlOutputPath: "index.html",
+
+      // Optional — single-isolate edge bundle (additive; default off).
+      // See docs/edge.md.
+      edge: {
+        singleIsolate: false,          // emit dist/server-edge/render.js
+        outDir: "server-edge",         // under build.dir
+        minify: true,                  // edge runtimes enforce size limits
+      },
     },
 
     // Optional — workers

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -142,6 +142,68 @@ npm run build        # emits dist/server-edge/render.js + dist/client
 npm run edge         # node edge-server.mjs → http://localhost:8787
 ```
 
+## Flash-free documents (`renderRouteToDocument`)
+
+`renderRouteToFlight` renders partial markup. For a **full flash-free document** —
+one whose initial HTML carries the live data and hydrates with no `.rsc` refetch —
+the bundle also exports `renderRouteToDocument`:
+
+```ts
+renderRouteToDocument(url, { cssFiles, globalCss }): Promise<{
+  full: ReadableStream;      // Html/Root-wrapped document flight
+  headless: ReadableStream;  // Root-only #root contents, for the inline payload
+}>
+```
+
+`createEdgeHandler`'s **document mode** drives it: it renders `full` to a complete
+HTML document and inlines `headless` as `<script id="vprs-flight">`, so the browser
+hydrates in place.
+
+```ts
+const handler = createEdgeHandler({
+  renderDocument: (url) => renderRouteToDocument(url, { cssFiles }),
+  moduleBaseURL: pathToFileURL(join(buildDir, "client")).href + "/", // ssr bundle, on disk
+  bootstrapModules: ["/" + clientEntry],
+});
+```
+
+> The in-process render decodes the flight under client React and resolves
+> client-component references by importing them from the **ssr bundle**
+> (`dist/client`) — so `moduleBaseURL` here is that directory as a **file URL**,
+> not the browser's HTTP base. The browser hydrates from its own base separately;
+> the client-component filenames are hash-identical across `dist/client` and
+> `dist/static`, so the same refs resolve on both sides.
+
+Pass live `cssFiles`/`globalCss` (a `Map<string, CssContent>`, e.g. via
+`collectManifestCss`) so the document and the inline payload carry the same styles.
+
+## Server actions, no `--conditions` (`handleRouteAction`)
+
+A `"use server"` app needs the server RSC transport to decode/dispatch actions —
+which normally forces `--conditions react-server` and so conflicts with the
+client-React document render above. The bundle resolves this by **baking the
+action gate** too: it exports `handleRouteAction`, a sealed gate over the action
+modules (the `*.server.*` allowlist) baked in with server React, so the action
+path never disk-imports the transport.
+
+```ts
+import { createRequestHandler } from "vite-plugin-react-server/request-handler";
+
+const { renderRouteToDocument, handleRouteAction } = await import(edgeBundleUrl);
+
+const handler = createRequestHandler({
+  staticDir,
+  action: (request) => handleRouteAction(request, { projectRoot }), // baked gate (a function)
+  render: async (pathname, request) => { /* renderDocument for dynamic routes */ },
+});
+```
+
+`createRequestHandler` lazy-imports its built-in (disk) gate, so passing the baked
+**function** keeps the whole server condition-neutral. The baked gate is still a
+sealed allowlist — an id the build did not enumerate is rejected. This is the
+shape that runs a full server-actions app (live data + flash-free SSR) in one
+isolate with `NODE_OPTIONS` unset; see the bidoof-template demo's `start.tsx`.
+
 ## When to use it
 
 - **Use it** for edge runtimes, or any single-process deploy where you want
@@ -159,3 +221,6 @@ npm run edge         # node edge-server.mjs → http://localhost:8787
 - `createEdgeHandler` / `renderFlightToHtml` are client-condition exports (they
   run client React); import them from `vite-plugin-react-server/stream` **without**
   the `react-server` condition. Only the baked `render.js` is server React.
+- The baked action gate (`handleRouteAction`) enumerates `*.server.*` modules as
+  the allowlist — a `"use server"` action must live in such a module (the common
+  convention). Inline `"use server"` in a non-`.server.` file is not baked.

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -1,0 +1,161 @@
+# Edge / Single-Isolate Rendering
+
+The default build renders HTML through worker threads under a `--conditions
+react-server` process flag. That model is great on Node, but it does not fit
+edge runtimes (Cloudflare Workers, Deno Deploy, Vercel Edge, Bun), which have no
+`worker_threads` and no process-level export conditions.
+
+The **single-isolate edge build** removes both requirements. It bakes a second,
+self-contained bundle in which React is **inlined** under the `react-server`
+condition at build time, so the running isolate needs no `worker_threads` and no
+runtime `--conditions`. You get flash-free streaming SSR from one Web `fetch`
+handler.
+
+It is **additive**: the normal `dist/server` / `dist/static` output is untouched.
+Dev is unaffected.
+
+## How it works
+
+Two bundles co-exist in one isolate:
+
+- **`dist/server-edge/render.js`** — the Flight *producer*. React is baked under
+  the `react-server` condition (server components), so this is where your Page
+  renders to an RSC Flight stream. It exports one function:
+
+  ```ts
+  export function renderRouteToFlight(url: string): Promise<ReadableStream<Uint8Array>>;
+  ```
+
+  It is a **closed manifest** over `build.pages`: every prerendered route is
+  baked in by static import, so there is no runtime `import()`. An unknown url
+  throws.
+
+- **`dist/client`** — the client (ssr) bundle. React is the normal client build.
+  The HTML render and client islands live here.
+
+`renderFlightToHtml` decodes the Flight stream and renders HTML in the **same
+process** under client React. Client islands resolve through the client
+transport's native `import(moduleBaseURL + id)` into `dist/client` — no
+condition-sensitive resolution. The two React copies never collide because each
+was baked into its own graph.
+
+```
+Request ──▶ renderRouteToFlight(url)  ──▶ Flight stream   (dist/server-edge, server React)
+                                            │
+                                            ▼
+            renderFlightToHtml(...)   ──▶ HTML stream     (dist/client,     client React)
+                                            │
+                                            ▼
+                                         Response
+```
+
+## Enable it
+
+```ts
+// vite.config.ts
+vitePluginReactServer({
+  moduleBase: "src",
+  Page: "src/page.tsx",
+  props: "src/props.ts",
+  build: {
+    pages: ["/"],
+    edge: {
+      singleIsolate: true,   // emit dist/server-edge/render.js
+      // outDir: "server-edge",
+      // minify: true,        // default; turn off to inspect the bundle
+    },
+  },
+});
+```
+
+| option         | default        | meaning |
+| -------------- | -------------- | ------- |
+| `singleIsolate`| `false`        | emit the baked edge bundle |
+| `outDir`       | `"server-edge"`| output dir, under `build.dir` |
+| `minify`       | `true`         | minify the bundle. It bakes React in, so it is large; edge platforms cap bundle size. Set `false` for readable output. |
+
+## Serve it: `createEdgeHandler`
+
+`createEdgeHandler` composes the producer and the HTML render into a standard
+Web `(Request) => Response` handler — the native entrypoint shape for edge
+runtimes:
+
+```ts
+import { renderRouteToFlight } from "./dist/server-edge/render.js";
+import { createEdgeHandler } from "vite-plugin-react-server/stream";
+
+const handler = createEdgeHandler({
+  render: renderRouteToFlight,
+  moduleBaseURL: "/",                       // where dist/client is served
+  bootstrapModules: ["/client-abc123.js"],  // your client entry (for hydration)
+});
+
+export default { fetch: handler };          // Cloudflare / Deno / Bun
+```
+
+The handler **streams** (responds when the HTML shell is ready), returns **404**
+for a url the bundle was not baked with (override via `onNotFound`), and
+propagates other render errors after `onError`.
+
+### Options
+
+| option                  | default                          | meaning |
+| ----------------------- | -------------------------------- | ------- |
+| `render`                | —                                | the baked `renderRouteToFlight` |
+| `moduleBaseURL`         | `"/"`                            | base url where `dist/client` is served; client islands resolve against it. Mind a non-root deploy base. |
+| `bootstrapModules`      | `[]`                             | client entry module(s) to bootstrap hydration |
+| `bootstrapScriptContent`| —                                | inline bootstrap script |
+| `nonce`                 | —                                | CSP nonce |
+| `getURL`                | `req => new URL(req.url).pathname` | map a Request to a baked route url |
+| `headers`               | —                                | merged over the default `content-type: text/html` |
+| `onError`               | —                                | render-error hook |
+| `onNotFound`            | 404 `text/plain`                 | response for an unbaked route |
+
+### Finding `bootstrapModules`
+
+The bootstrap entry is your client entry's hashed filename, read from the client
+build manifest (`dist/client/.vite/manifest.json`) — the same mapping the static
+build uses:
+
+```ts
+import { readFileSync } from "node:fs";
+
+const manifest = JSON.parse(readFileSync("dist/client/.vite/manifest.json", "utf8"));
+const entry = manifest["src/client.tsx"]?.file;      // e.g. "client-abc123.js"
+const bootstrapModules = entry ? ["/" + entry] : [];
+```
+
+> Keep `moduleBaseURL` and the `bootstrapModules` prefix in sync with where you
+> actually host `dist/client`. A non-root deploy base (e.g. GitHub Pages) is the
+> usual reason hydration breaks — verify in a real prod build at the real base.
+
+## Run it on Node
+
+On a real edge platform you export the handler directly. On Node, wrap it in a
+tiny adapter that serves `dist/client` and routes the rest through the handler.
+The `examples/hello-world` example ships a complete one — see
+[`edge-server.mjs`](../examples/hello-world/edge-server.mjs):
+
+```bash
+cd examples/hello-world
+npm run build        # emits dist/server-edge/render.js + dist/client
+npm run edge         # node edge-server.mjs → http://localhost:8787
+```
+
+## When to use it
+
+- **Use it** for edge runtimes, or any single-process deploy where you want
+  flash-free streaming SSR without `worker_threads` or a `--conditions` flag.
+- **Stick with the default** worker-based build for Node servers that already
+  run under `--conditions react-server`, or for purely static (SSG) hosting —
+  the edge bundle is an extra artifact you do not need there.
+
+## Limitations
+
+- The producer is a closed enumeration of `build.pages`; it is not a dynamic
+  router. Unbaked urls 404.
+- The bundle inlines React, so it is large — keep `minify: true` for deploys and
+  watch your platform's size limit.
+- `createEdgeHandler` / `renderFlightToHtml` are client-condition exports (they
+  run client React); import them from `vite-plugin-react-server/stream` **without**
+  the `react-server` condition. Only the baked `render.js` is server React.

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -59,20 +59,27 @@ vitePluginReactServer({
   props: "src/props.ts",
   build: {
     pages: ["/"],
-    edge: {
-      singleIsolate: true,   // emit dist/server-edge/render.js
-      // outDir: "server-edge",
-      // minify: true,        // default; turn off to inspect the bundle
-    },
+    // edge is ON by default. Omit it entirely to get the defaults, or:
+    //   edge: false             — opt out (no dist/server-edge artifact)
+    //   edge: { minify: false } — keep on, tune a default
   },
 });
 ```
 
-| option         | default        | meaning |
-| -------------- | -------------- | ------- |
-| `singleIsolate`| `false`        | emit the baked edge bundle |
-| `outDir`       | `"server-edge"`| output dir, under `build.dir` |
-| `minify`       | `true`         | minify the bundle. It bakes React in, so it is large; edge platforms cap bundle size. Set `false` for readable output. |
+`build.edge` is `boolean | { outDir?, minify? }`, default **`true`** (the bundle
+is additive — the worker-based `dist/server` build is untouched — and a bake
+failure is a warning, never a build failure).
+
+| form                     | meaning |
+| ------------------------ | ------- |
+| `edge: true` / omitted   | emit the baked edge bundle with defaults |
+| `edge: false`            | opt out — no `dist/server-edge` artifact |
+| `edge: { … }`            | emit, with overrides (presence means enabled) |
+
+| option    | default        | meaning |
+| --------- | -------------- | ------- |
+| `outDir`  | `"server-edge"`| output dir, under `build.dir` |
+| `minify`  | `true`         | minify the bundle. It bakes React in, so it is large; edge platforms cap bundle size. Set `false` for readable output. |
 
 ## Serve it: `createEdgeHandler`
 

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -44,9 +44,10 @@ This example focuses on dev. For production-build flags see [docs/getting-starte
 
 ## Edge / single-isolate
 
-This example also enables the single-isolate edge build (`build.edge.singleIsolate`
-in `vite.config.ts`), which bakes `dist/server-edge/render.js` — flash-free SSR
-from one Web `fetch` handler, no `worker_threads` and no `--conditions`.
+The single-isolate edge build (`build.edge`, on by default) bakes
+`dist/server-edge/render.js` — flash-free SSR from one Web `fetch` handler, no
+`worker_threads` and no `--conditions`. This example only sets `edge: { minify:
+false }` in `vite.config.ts` to keep the baked bundle readable.
 
 ```bash
 npm run build     # emits dist/server-edge/render.js + dist/client

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -41,3 +41,20 @@ This example is the smallest config that ships all four. Use it as a reference w
 ## Build
 
 This example focuses on dev. For production-build flags see [docs/getting-started.md](../../docs/getting-started.md) and the larger [bidoof-template](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official).
+
+## Edge / single-isolate
+
+This example also enables the single-isolate edge build (`build.edge.singleIsolate`
+in `vite.config.ts`), which bakes `dist/server-edge/render.js` — flash-free SSR
+from one Web `fetch` handler, no `worker_threads` and no `--conditions`.
+
+```bash
+npm run build     # emits dist/server-edge/render.js + dist/client
+npm run edge      # node edge-server.mjs → http://localhost:8787
+```
+
+[`edge-server.mjs`](./edge-server.mjs) is a small Node adapter around
+`createEdgeHandler`; on a real edge platform (Cloudflare/Deno/Bun) you export the
+handler directly. `minify` is set to `false` here so the baked bundle stays
+readable — leave it on (the default) for real deploys. See
+[docs/edge.md](../../docs/edge.md).

--- a/examples/hello-world/edge-server.mjs
+++ b/examples/hello-world/edge-server.mjs
@@ -1,0 +1,88 @@
+// Runnable demo of the single-isolate edge build (`build.edge.singleIsolate`).
+//
+// The deployable artifact is a Web `fetch` handler — exactly what Cloudflare
+// Workers, Deno Deploy, Vercel Edge and Bun call. This file is the thin Node
+// adapter around that handler: it serves the built client bundle (dist/client)
+// and routes everything else through `createEdgeHandler`. On a real edge
+// platform you would export the handler directly and drop this adapter.
+//
+//   1. npm run build      # emits dist/server-edge/render.js + dist/client
+//   2. node edge-server.mjs
+//   3. open http://localhost:8787
+
+import { createServer } from "node:http";
+import { Readable } from "node:stream";
+import { readFileSync, existsSync, statSync } from "node:fs";
+import { join, extname, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderRouteToFlight } from "./dist/server-edge/render.js";
+import { createEdgeHandler } from "vite-plugin-react-server/stream";
+
+const root = fileURLToPath(new URL(".", import.meta.url));
+const clientDir = join(root, "dist", "client");
+
+// Derive the hydration bootstrap entry from the client build manifest — the
+// same `src/client.tsx -> <hashed>.js` mapping the SSG path reads. Served from
+// the root, so the bootstrap url is `/<file>` and moduleBaseURL is `/`.
+const clientManifest = JSON.parse(
+  readFileSync(join(clientDir, ".vite", "manifest.json"), "utf8")
+);
+const clientEntry = clientManifest["src/client.tsx"]?.file;
+const bootstrapModules = clientEntry ? ["/" + clientEntry] : [];
+
+const handler = createEdgeHandler({
+  render: renderRouteToFlight,
+  moduleBaseURL: "/", // dist/client is served at the root below
+  bootstrapModules,
+});
+
+const MIME = {
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".map": "application/json; charset=utf-8",
+};
+
+createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, "http://localhost");
+
+    // Serve a built client asset straight from dist/client if it exists.
+    // normalize + prefix-check guards against path traversal.
+    const assetPath = normalize(join(clientDir, url.pathname));
+    if (
+      url.pathname !== "/" &&
+      assetPath.startsWith(clientDir) &&
+      existsSync(assetPath) &&
+      statSync(assetPath).isFile()
+    ) {
+      res.setHeader(
+        "content-type",
+        MIME[extname(assetPath)] ?? "application/octet-stream"
+      );
+      res.end(readFileSync(assetPath));
+      return;
+    }
+
+    // Otherwise render through the edge fetch handler.
+    const response = await handler(
+      new Request(url, { method: req.method, headers: req.headers })
+    );
+    res.statusCode = response.status;
+    response.headers.forEach((value, key) => res.setHeader(key, value));
+    if (response.body) {
+      Readable.fromWeb(response.body).pipe(res);
+    } else {
+      res.end(await response.text());
+    }
+  } catch (error) {
+    console.error(error);
+    res.statusCode = 500;
+    res.end("Internal Server Error");
+  }
+}).listen(8787, () => {
+  console.log("edge demo running on http://localhost:8787");
+});

--- a/examples/hello-world/edge-server.mjs
+++ b/examples/hello-world/edge-server.mjs
@@ -1,4 +1,4 @@
-// Runnable demo of the single-isolate edge build (`build.edge.singleIsolate`).
+// Runnable demo of the single-isolate edge build (`build.edge`, on by default).
 //
 // The deployable artifact is a Web `fetch` handler — exactly what Cloudflare
 // Workers, Deno Deploy, Vercel Edge and Bun call. This file is the thin Node

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "build": "vite build --app",
+    "edge": "node edge-server.mjs"
   },
   "dependencies": {
     "react": "0.0.0-experimental-f93b9fd4-20251217",

--- a/examples/hello-world/src/client.tsx
+++ b/examples/hello-world/src/client.tsx
@@ -5,7 +5,7 @@ import { useRscHmr } from "virtual:react-server/hmr";
 
 const Shell = ({ data }: { data: React.Usable<React.ReactNode> }) => {
   const [, startTransition] = useTransition();
-  const [stream, setStream] = useState(data);
+  const [stream, setStream] = useState<React.Usable<React.ReactNode>>(data);
   const refetch = useCallback(() => {
     startTransition(() => setStream(createReactFetcher()));
   }, []);

--- a/examples/hello-world/vite.config.ts
+++ b/examples/hello-world/vite.config.ts
@@ -1,13 +1,21 @@
-import { defineConfig } from "vite";
-import { vitePluginReactServer } from "vite-plugin-react-server";
+import { defineConfig, PluginOption } from "vite";
+import { StreamPluginOptions, vitePluginReactServer } from "vite-plugin-react-server";
 
 export default defineConfig({
-  plugins: vitePluginReactServer({
+  plugins: [vitePluginReactServer({
     moduleBase: "src",
     Page: "src/page.tsx",
     props: "src/props.ts",
-    build: { pages: ["/"] },
-  }),
+    build: {
+      pages: ["/"],
+      edge: {
+        singleIsolate: true,
+        // Keep the baked dist/server-edge/render.js readable for learning.
+        // Defaults to true — leave it on for real edge deploys (size limits).
+        minify: false,
+      },
+    },
+  } satisfies StreamPluginOptions) as PluginOption],
   optimizeDeps: {
     include: ["react-server-dom-esm/client.browser"],
   },

--- a/examples/hello-world/vite.config.ts
+++ b/examples/hello-world/vite.config.ts
@@ -8,12 +8,10 @@ export default defineConfig({
     props: "src/props.ts",
     build: {
       pages: ["/"],
-      edge: {
-        singleIsolate: true,
-        // Keep the baked dist/server-edge/render.js readable for learning.
-        // Defaults to true — leave it on for real edge deploys (size limits).
-        minify: false,
-      },
+      // The single-isolate edge bundle is ON by default; the object form just
+      // tunes it. Here: keep dist/server-edge/render.js unminified for learning
+      // (minify defaults to true for real edge deploys). `edge: false` opts out.
+      edge: { minify: false },
     },
   } satisfies StreamPluginOptions) as PluginOption],
   optimizeDeps: {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
       "default": "./dist/plugin/storybook/preset.js"
     },
     "./metrics": "./dist/plugin/metrics/index.js",
+    "./request-handler": "./dist/plugin/helpers/createRequestHandler.server.js",
     "./stream": {
       "react-server": "./dist/plugin/stream/index.server.js",
       "default": "./dist/plugin/stream/index.client.js"

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -90,14 +90,32 @@ export async function buildEdgeBundle(opts: {
     return;
   }
   const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
-  const pageFile = manifestFileFor(manifest, userOptions.Page);
-  const propsFile = manifestFileFor(manifest, userOptions.props);
-  if (!pageFile || !propsFile) {
-    logger.warn(
-      `${tag} could not resolve built Page/props from the manifest (Page=${String(
-        userOptions.Page
-      )}, props=${String(userOptions.props)}); skipping`
-    );
+
+  // Enumerate every prerendered route. Post-build, build.pages already lists
+  // all URLs (the SSG just rendered them) and every page module is in
+  // dist/server — so we CALL the (possibly functional) Page/props router for
+  // each URL to map the route to its built module. No need to understand the
+  // router: a closed enumeration over what the build already produced.
+  const rawPages = userOptions.build.pages;
+  const urls: string[] = Array.isArray(rawPages)
+    ? rawPages
+    : typeof rawPages === "function"
+    ? await rawPages()
+    : await rawPages;
+
+  const routeSource = (opt: unknown, url: string): unknown =>
+    typeof opt === "function" ? (opt as (u: string) => unknown)(url) : opt;
+
+  const routes: { url: string; pageFile: string; propsFile: string }[] = [];
+  for (const url of urls ?? []) {
+    const pageFile = manifestFileFor(manifest, routeSource(userOptions.Page, url));
+    const propsFile = manifestFileFor(manifest, routeSource(userOptions.props, url));
+    if (pageFile && propsFile) routes.push({ url, pageFile, propsFile });
+    else
+      logger.warn(`${tag} could not resolve built Page/props for route ${url}; omitting`);
+  }
+  if (routes.length === 0) {
+    logger.warn(`${tag} no routes resolved from build.pages; skipping`);
     return;
   }
 
@@ -122,17 +140,57 @@ export async function buildEdgeBundle(opts: {
     alias[key] = target;
   }
 
-  // Generate the flight-producer entry: (url) => Web ReadableStream Flight.
-  // moduleBasePath "" mirrors renderRscReadableStream's default.
+  // Generate a router-aware flight-producer entry: renderRouteToFlight(url) maps
+  // a known route to its baked Page/props and renders the Flight. moduleBasePath
+  // comes from the user config (the SSG used the same), so client-reference ids
+  // align with the ssr bundle the runtime points moduleBaseURL at.
   const { entryFileName, flightExport } = DEFAULT_CONFIG.EDGE;
+  const pageExport = userOptions.pageExportName ?? "Page";
+  const propsExport = userOptions.propsExportName ?? "props";
+  const moduleBasePath = userOptions.moduleBasePath ?? "";
+
+  // Dedup imports by built file (distinct routes can share a module).
+  const importLines: string[] = [];
+  const idByKey = new Map<string, string>();
+  const idFor = (file: string, kind: "P" | "Q", exportName: string): string => {
+    const key = `${kind}:${file}`;
+    let id = idByKey.get(key);
+    if (!id) {
+      id = `${kind}${idByKey.size}`;
+      idByKey.set(key, id);
+      importLines.push(
+        `import { ${exportName} as ${id} } from ${JSON.stringify(
+          join(serverDir, file)
+        )};`
+      );
+    }
+    return id;
+  };
+  const routeLines = routes.map(
+    (r) =>
+      `  ${JSON.stringify(r.url)}: { Page: ${idFor(
+        r.pageFile,
+        "P",
+        pageExport
+      )}, props: ${idFor(r.propsFile, "Q", propsExport)} },`
+  );
+
   const entryPath = join(serverDir, `.vprs-${entryFileName}`);
   const entrySource = `import { createElement } from "react";
 import { renderToReadableStream } from ${JSON.stringify(serverEdge)};
-import { Page } from ${JSON.stringify(join(serverDir, pageFile))};
-import { props } from ${JSON.stringify(join(serverDir, propsFile))};
+${importLines.join("\n")}
 
-export function ${flightExport}(url) {
-  return renderToReadableStream(createElement(Page, props(url)), "");
+const routes = {
+${routeLines.join("\n")}
+};
+
+export async function ${flightExport}(url) {
+  const route = routes[url];
+  if (!route) throw new Error("[edge] unknown route: " + url);
+  const props = await route.props(url);
+  return renderToReadableStream(createElement(route.Page, props), ${JSON.stringify(
+    moduleBasePath
+  )});
 }
 `;
   writeFileSync(entryPath, entrySource, "utf8");

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -262,7 +262,7 @@ export async function ${flightExport}(url) {
         ssr: true,
         outDir: edgeDir,
         emptyOutDir: true,
-        minify: false,
+        minify: userOptions.build.edge.minify ?? true,
         rollupOptions: {
           input: { [entryFileName.replace(/\.js$/, "")]: entryPath },
           output: { preserveModules: false, format: "es" },

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -172,16 +172,47 @@ export async function buildEdgeBundle(opts: {
   // render does not diverge. moduleBasePath/URL come from the user config (the
   // SSG used the same), so client-reference ids align with the ssr bundle the
   // runtime points moduleBaseURL at.
-  const { entryFileName, flightExport } = DEFAULT_CONFIG.EDGE;
+  const { entryFileName, flightExport, documentExport, actionExport } =
+    DEFAULT_CONFIG.EDGE;
   const pageExport = userOptions.pageExportName ?? "Page";
   const propsExport = userOptions.propsExportName ?? "props";
+  const moduleBase = userOptions.moduleBase ?? "";
   const moduleBasePath = userOptions.moduleBasePath ?? "";
   const moduleBaseURL = userOptions.moduleBaseURL ?? "/";
-  // resolvePageAndProps lives beside this module in the SAME installed vprs.
-  const resolveHelper = join(
-    dirname(fileURLToPath(import.meta.url)),
-    "../helpers/resolvePageAndProps.js"
-  );
+  // resolvePageAndProps + createElementWithReact live beside this module in the
+  // SAME installed vprs. createElementWithReact is the canonical composer the
+  // static build uses — reusing it keeps the edge document tree byte-identical
+  // (no hydration mismatch).
+  const here = dirname(fileURLToPath(import.meta.url));
+  const resolveHelper = join(here, "../helpers/resolvePageAndProps.js");
+  const elementHelper = join(here, "../helpers/createElementWithReact.js");
+  const actionHelper = join(here, "../helpers/handleServerAction.server.js");
+  const gateHelper = join(here, "../references/createSealedServerReferenceGate.server.js");
+
+  // Resolve the Html + Root components for the full-document flight. A configured
+  // `Html`/`Root` string resolves to its built module (export named by
+  // html/rootExportName); otherwise the bundled defaults. A functional
+  // Html/Root (per-url) is uncommon here and falls back to the default with a
+  // warning — document mode wants one document shell.
+  const htmlExport = userOptions.htmlExportName ?? "Html";
+  const rootExport = userOptions.rootExportName ?? "Root";
+  const resolveComponent = (
+    opt: unknown,
+    exportName: string,
+    defaultFile: string,
+    defaultExport: string
+  ): { abs: string; exportName: string } => {
+    if (typeof opt === "string") {
+      const abs = resolveBuilt(opt);
+      if (abs) return { abs, exportName };
+      logger.warn(`${tag} could not resolve built component "${opt}"; using default`);
+    } else if (typeof opt === "function") {
+      logger.warn(`${tag} functional Html/Root not supported in document mode; using default`);
+    }
+    return { abs: join(here, defaultFile), exportName: defaultExport };
+  };
+  const htmlComp = resolveComponent(userOptions.Html, htmlExport, "../components/html.js", "Html");
+  const rootComp = resolveComponent(userOptions.Root, rootExport, "../components/root.js", "Root");
 
   // Static namespace imports of each built module, deduped by file. The loader
   // resolvePageAndProps calls is a dictionary lookup over these — a closed
@@ -207,22 +238,60 @@ export async function buildEdgeBundle(opts: {
     )}: ${pageNs}, ${JSON.stringify(r.propsSrc)}: ${propsNs} } },`;
   });
 
+  const htmlNs = nsFor(htmlComp.abs);
+  const rootNs = nsFor(rootComp.abs);
+
+  // Enumerate server-action modules from the server manifest (the sealed-gate
+  // allowlist): keys matching the action pattern, baked so the gate resolves
+  // them without a disk import (and thus no `react-server` condition at runtime).
+  const actionKeyRe = new RegExp(DEFAULT_CONFIG.EDGE.actionKeyPattern);
+  const actionEntries: { key: string; file: string; ns: string }[] = [];
+  for (const [key, entry] of Object.entries(
+    manifest as Record<string, { file?: string } | undefined>
+  )) {
+    if (!entry?.file || !actionKeyRe.test(key)) continue;
+    const abs = join(serverDir, entry.file);
+    if (!existsSync(abs)) continue;
+    actionEntries.push({ key, file: entry.file, ns: nsFor(abs) });
+  }
+  const actionDictLines = actionEntries.map(
+    (a) => `  ${JSON.stringify(a.key)}: ${a.ns},`
+  );
+  const actionManifestLines = actionEntries.map(
+    (a) => `  ${JSON.stringify(a.key)}: { file: ${JSON.stringify(a.file)} },`
+  );
+  if (actionEntries.length > 0) {
+    logger.info(
+      `${tag} baking server-action gate over ${actionEntries.length} module(s): ${actionEntries
+        .map((a) => a.key)
+        .join(", ")}`
+    );
+  }
+
   const entryPath = join(serverDir, `.vprs-${entryFileName}`);
-  const entrySource = `import { createElement } from "react";
+  const entrySource = `import * as React from "react";
+import { createElement } from "react";
 import { renderToReadableStream } from ${JSON.stringify(serverEdge)};
 import { resolvePageAndProps } from ${JSON.stringify(resolveHelper)};
+import { createElementWithReact } from ${JSON.stringify(elementHelper)};
+import { handleServerActionRequest } from ${JSON.stringify(actionHelper)};
+import { createSealedServerReferenceGate } from ${JSON.stringify(gateHelper)};
 ${importLines.join("\n")}
 
 const PAGE_EXPORT = ${JSON.stringify(pageExport)};
 const PROPS_EXPORT = ${JSON.stringify(propsExport)};
+const MODULE_BASE = ${JSON.stringify(moduleBase)};
 const MODULE_BASE_PATH = ${JSON.stringify(moduleBasePath)};
 const MODULE_BASE_URL = ${JSON.stringify(moduleBaseURL)};
+const HtmlComponent = ${htmlNs}[${JSON.stringify(htmlComp.exportName)}];
+const RootComponent = ${rootNs}[${JSON.stringify(rootComp.exportName)}];
 
 const routes = {
 ${routeLines.join("\n")}
 };
 
-export async function ${flightExport}(url) {
+/** Resolve a route's Page component + live props through the canonical helper. */
+async function resolveRoute(url) {
   const route = routes[url];
   if (!route) throw new Error("[edge] unknown route: " + url);
   const resolved = await resolvePageAndProps({
@@ -243,10 +312,84 @@ export async function ${flightExport}(url) {
   if (resolved.type !== "success") {
     throw resolved.error ?? new Error("[edge] failed to resolve route: " + url);
   }
+  return resolved;
+}
+
+/** Headless page flight (Page only) — the simple producer. */
+export async function ${flightExport}(url) {
+  const resolved = await resolveRoute(url);
   return renderToReadableStream(
     createElement(resolved.PageComponent, resolved.pageProps),
     MODULE_BASE_PATH
   );
+}
+
+/**
+ * Full-document flights for the flash-free inline-flight path: two flights from
+ * the SAME live props (so markup and inline payload agree). \`full\` is the
+ * Html/Root-wrapped document; \`headless\` is the Root-only #root contents the
+ * client decodes from the inline payload. Pass live \`cssFiles\`/\`globalCss\`
+ * (Map<string, CssContent>) so both carry the page styles.
+ */
+export async function ${documentExport}(url, opts = {}) {
+  const resolved = await resolveRoute(url);
+  const base = {
+    PageComponent: resolved.PageComponent,
+    RootComponent,
+    pageProps: resolved.pageProps,
+    cssFiles: opts.cssFiles ?? new Map(),
+    globalCss: opts.globalCss ?? new Map(),
+    moduleBase: MODULE_BASE,
+    moduleBaseURL: MODULE_BASE_URL,
+    moduleBasePath: MODULE_BASE_PATH,
+    route: url,
+    url,
+    as: "div",
+  };
+  const full = renderToReadableStream(
+    createElementWithReact(React, { ...base, HtmlComponent }),
+    MODULE_BASE_PATH
+  );
+  const headless = renderToReadableStream(
+    createElementWithReact(React, { ...base, HtmlComponent: React.Fragment }),
+    MODULE_BASE_PATH
+  );
+  return { full, headless };
+}
+
+// Server-action modules baked into this bundle (server React inlined), keyed by
+// their server-manifest key. The sealed gate loads from here instead of disk, so
+// dispatching an action needs no \`react-server\` condition at runtime.
+const ACTION_MODULES = {
+${actionDictLines.join("\n")}
+};
+const ACTION_MANIFEST = {
+${actionManifestLines.join("\n")}
+};
+const actionGate = createSealedServerReferenceGate({
+  serverManifest: ACTION_MANIFEST,
+  serverRoot: "",
+  base: MODULE_BASE_URL,
+  loadModule: async (key) => {
+    const mod = ACTION_MODULES[key];
+    if (!mod) throw new Error("[edge] no baked action module for: " + key);
+    return mod;
+  },
+});
+
+/**
+ * Baked server-action handler: a sealed gate over the action modules above,
+ * dispatched through the same trust boundary as the on-disk handler (CSRF /
+ * body-cap guards, post-import server-reference check) — but with no disk import
+ * and no \`react-server\` condition. \`(Request, { projectRoot? }) => Response\`.
+ */
+export async function ${actionExport}(request, opts = {}) {
+  return handleServerActionRequest(request, {
+    projectRoot: opts.projectRoot ?? "",
+    base: MODULE_BASE_URL,
+    resolveServerReference: (id) => actionGate.resolveServerReference(id),
+    ...opts,
+  });
 }
 `;
   writeFileSync(entryPath, entrySource, "utf8");

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -31,7 +31,7 @@ function reactServerExportTarget(
 
 
 /**
- * Single-isolate edge bake (build.edge.singleIsolate). Generates a flight-
+ * Single-isolate edge bake (build.edge, on by default). Generates a flight-
  * producer entry over the already-transformed server build (`dist/server`) and
  * bundles it into a single-isolate rsc bundle (`dist/server-edge`) with React
  * INLINED, so it runs on an edge runtime with no worker_threads and no runtime
@@ -58,7 +58,7 @@ export async function buildEdgeBundle(opts: {
   logger: Logger;
 }): Promise<void> {
   const { userOptions, projectRoot, logger } = opts;
-  if (!userOptions.build.edge.singleIsolate) return;
+  if (!userOptions.build.edge.enabled) return;
 
   const tag = "[build.edge]";
   const outRoot = join(projectRoot, userOptions.build.outDir);
@@ -405,7 +405,7 @@ export async function ${actionExport}(request, opts = {}) {
         ssr: true,
         outDir: edgeDir,
         emptyOutDir: true,
-        minify: userOptions.build.edge.minify ?? true,
+        minify: userOptions.build.edge.minify,
         rollupOptions: {
           input: { [entryFileName.replace(/\.js$/, "")]: entryPath },
           output: { preserveModules: false, format: "es" },
@@ -413,6 +413,17 @@ export async function ${actionExport}(request, opts = {}) {
       },
     });
     logger.info(`${tag} baked single-isolate rsc bundle → ${edgeDir}`);
+  } catch (error) {
+    // The edge bundle is ADDITIVE and on by default — a bake failure must not
+    // fail an otherwise-good build. Warn loudly and skip the artifact; the
+    // worker-based dist/server build stands on its own. Opt out with
+    // `build.edge: false` if the bake is not wanted.
+    logger.warn(
+      `${tag} skipped — edge bundle bake failed (the main build is unaffected; ` +
+        `set build.edge:false to silence): ${
+          error instanceof Error ? error.message : String(error)
+        }`
+    );
   } finally {
     rmSync(entryPath, { force: true });
   }

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -1,0 +1,162 @@
+import { build as viteBuild, type Logger } from "vite";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import type { ResolvedUserOptions } from "../types.js";
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+
+/** Resolve a package subpath's `react-server` export target to an absolute path. */
+function reactServerExportTarget(
+  reactDir: string,
+  subpath: string
+): string | null {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(reactDir, "package.json"), "utf8")
+    ) as { exports?: Record<string, unknown> };
+    const entry = pkg.exports?.[subpath];
+    const rel =
+      typeof entry === "string"
+        ? entry
+        : entry && typeof entry === "object"
+        ? (entry as Record<string, string>)["react-server"]
+        : undefined;
+    return rel ? join(reactDir, rel) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Look up a source module's built output file in a Vite manifest. */
+function manifestFileFor(
+  manifest: Record<string, { file: string; src?: string }>,
+  source: unknown
+): string | null {
+  if (typeof source !== "string") return null;
+  if (manifest[source]?.file) return manifest[source].file;
+  // Fallback: match by source basename (handles minor key normalization).
+  const base = source.split("/").pop();
+  const hit = Object.values(manifest).find((e) => e.src?.split("/").pop() === base);
+  return hit?.file ?? null;
+}
+
+/**
+ * Single-isolate edge bake (build.edge.singleIsolate). Generates a flight-
+ * producer entry over the already-transformed server build (`dist/server`) and
+ * bundles it into a single-isolate rsc bundle (`dist/server-edge`) with React
+ * INLINED, so it runs on an edge runtime with no worker_threads and no runtime
+ * `--conditions`.
+ *
+ * Two resolve.alias redirects do the work (alias redirects the PATH before
+ * export-condition matching, so even the vendored CJS `require('react')` — which
+ * ignores Vite's resolve.conditions — is caught):
+ *   - the react-server subpaths ({@link DEFAULT_CONFIG.EDGE.reactServerSubpaths})
+ *     → their `react-server` export targets (derived from react's own package
+ *     `exports`), so the bundle bakes SERVER React without a process-level
+ *     `--conditions react-server` (which would break the client render that runs
+ *     in the same isolate).
+ *   - the vendored `server.node` transport → `server.edge` (Web streams), so the
+ *     edge bundle carries no `node:*` from the Node transport.
+ *
+ * Bundles through Vite's own `build()` — not a separate bundler — so it rides
+ * Vite's internal transformer (esbuild today, Oxc/Rolldown later). The default
+ * worker-based `dist/server` build is untouched; this is additive.
+ */
+export async function buildEdgeBundle(opts: {
+  userOptions: ResolvedUserOptions;
+  projectRoot: string;
+  logger: Logger;
+}): Promise<void> {
+  const { userOptions, projectRoot, logger } = opts;
+  if (!userOptions.build.edge.singleIsolate) return;
+
+  const tag = "[build.edge]";
+  const outRoot = join(projectRoot, userOptions.build.outDir);
+  const serverDir = join(outRoot, userOptions.build.server);
+  const edgeDir = join(
+    outRoot,
+    userOptions.build.edge.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir
+  );
+
+  if (!existsSync(serverDir)) {
+    logger.warn(`${tag} server build dir not found at ${serverDir}; skipping`);
+    return;
+  }
+
+  // Resolve the page + props built files from the server manifest.
+  const manifestPath = join(serverDir, ".vite/manifest.json");
+  if (!existsSync(manifestPath)) {
+    logger.warn(`${tag} no server manifest at ${manifestPath}; skipping`);
+    return;
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const pageFile = manifestFileFor(manifest, userOptions.Page);
+  const propsFile = manifestFileFor(manifest, userOptions.props);
+  if (!pageFile || !propsFile) {
+    logger.warn(
+      `${tag} could not resolve built Page/props from the manifest (Page=${String(
+        userOptions.Page
+      )}, props=${String(userOptions.props)}); skipping`
+    );
+    return;
+  }
+
+  // Resolve React's react-server entries + the vendored Web transport, relative
+  // to the consumer project (the same react the build used).
+  const projectRequire = createRequire(join(projectRoot, "package.json"));
+  const reactDir = dirname(projectRequire.resolve("react/package.json"));
+  const serverEdge = projectRequire.resolve("react-server-loader/server.edge");
+  const serverNode = projectRequire.resolve("react-server-loader/server.node");
+
+  const alias: Record<string, string> = { [serverNode]: serverEdge };
+  for (const subpath of DEFAULT_CONFIG.EDGE.reactServerSubpaths) {
+    const target = reactServerExportTarget(reactDir, subpath);
+    if (!target) {
+      logger.warn(
+        `${tag} react has no 'react-server' export for "${subpath}"; skipping`
+      );
+      return;
+    }
+    // alias key: "." → "react", "./jsx-runtime" → "react/jsx-runtime"
+    const key = subpath === "." ? "react" : `react/${subpath.slice(2)}`;
+    alias[key] = target;
+  }
+
+  // Generate the flight-producer entry: (url) => Web ReadableStream Flight.
+  // moduleBasePath "" mirrors renderRscReadableStream's default.
+  const { entryFileName, flightExport } = DEFAULT_CONFIG.EDGE;
+  const entryPath = join(serverDir, `.vprs-${entryFileName}`);
+  const entrySource = `import { createElement } from "react";
+import { renderToReadableStream } from ${JSON.stringify(serverEdge)};
+import { Page } from ${JSON.stringify(join(serverDir, pageFile))};
+import { props } from ${JSON.stringify(join(serverDir, propsFile))};
+
+export function ${flightExport}(url) {
+  return renderToReadableStream(createElement(Page, props(url)), "");
+}
+`;
+  writeFileSync(entryPath, entrySource, "utf8");
+
+  try {
+    await viteBuild({
+      root: serverDir,
+      logLevel: "warn",
+      configFile: false,
+      resolve: { alias },
+      ssr: { target: "node", noExternal: true },
+      build: {
+        ssr: true,
+        outDir: edgeDir,
+        emptyOutDir: true,
+        minify: false,
+        rollupOptions: {
+          input: { [entryFileName.replace(/\.js$/, "")]: entryPath },
+          output: { preserveModules: false, format: "es" },
+        },
+      },
+    });
+    logger.info(`${tag} baked single-isolate rsc bundle → ${edgeDir}`);
+  } finally {
+    rmSync(entryPath, { force: true });
+  }
+}

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -1,6 +1,7 @@
 import { build as viteBuild, type Logger } from "vite";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import type { ResolvedUserOptions } from "../types.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
@@ -106,13 +107,28 @@ export async function buildEdgeBundle(opts: {
   const routeSource = (opt: unknown, url: string): unknown =>
     typeof opt === "function" ? (opt as (u: string) => unknown)(url) : opt;
 
-  const routes: { url: string; pageFile: string; propsFile: string }[] = [];
+  const routes: {
+    url: string;
+    pageSrc: string;
+    pageFile: string;
+    propsSrc: string;
+    propsFile: string;
+  }[] = [];
   for (const url of urls ?? []) {
-    const pageFile = manifestFileFor(manifest, routeSource(userOptions.Page, url));
-    const propsFile = manifestFileFor(manifest, routeSource(userOptions.props, url));
-    if (pageFile && propsFile) routes.push({ url, pageFile, propsFile });
-    else
+    const pageSrc = routeSource(userOptions.Page, url);
+    const propsSrc = routeSource(userOptions.props, url);
+    const pageFile = manifestFileFor(manifest, pageSrc);
+    const propsFile = manifestFileFor(manifest, propsSrc);
+    if (
+      typeof pageSrc === "string" &&
+      typeof propsSrc === "string" &&
+      pageFile &&
+      propsFile
+    ) {
+      routes.push({ url, pageSrc, pageFile, propsSrc, propsFile });
+    } else {
       logger.warn(`${tag} could not resolve built Page/props for route ${url}; omitting`);
+    }
   }
   if (routes.length === 0) {
     logger.warn(`${tag} no routes resolved from build.pages; skipping`);
@@ -140,45 +156,60 @@ export async function buildEdgeBundle(opts: {
     alias[key] = target;
   }
 
-  // Generate a router-aware flight-producer entry: renderRouteToFlight(url) maps
-  // a known route to its baked Page/props and renders the Flight. moduleBasePath
-  // comes from the user config (the SSG used the same), so client-reference ids
-  // align with the ssr bundle the runtime points moduleBaseURL at.
+  // Generate a router-aware flight-producer entry. Rather than re-implement
+  // props resolution, it routes through vprs's canonical resolvePageAndProps
+  // (the same helper dev/SSG use — handles props-as-function/class/async, the
+  // props-in-page-module fallback, the {url} default, errors), so the edge
+  // render does not diverge. moduleBasePath/URL come from the user config (the
+  // SSG used the same), so client-reference ids align with the ssr bundle the
+  // runtime points moduleBaseURL at.
   const { entryFileName, flightExport } = DEFAULT_CONFIG.EDGE;
   const pageExport = userOptions.pageExportName ?? "Page";
   const propsExport = userOptions.propsExportName ?? "props";
   const moduleBasePath = userOptions.moduleBasePath ?? "";
+  const moduleBaseURL = userOptions.moduleBaseURL ?? "/";
+  // resolvePageAndProps lives beside this module in the SAME installed vprs.
+  const resolveHelper = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../helpers/resolvePageAndProps.js"
+  );
 
-  // Dedup imports by built file (distinct routes can share a module).
+  // Static namespace imports of each built module, deduped by file. The loader
+  // resolvePageAndProps calls is a dictionary lookup over these — a closed
+  // manifest, no runtime import().
   const importLines: string[] = [];
-  const idByKey = new Map<string, string>();
-  const idFor = (file: string, kind: "P" | "Q", exportName: string): string => {
-    const key = `${kind}:${file}`;
-    let id = idByKey.get(key);
+  const idByFile = new Map<string, string>();
+  const nsFor = (file: string): string => {
+    let id = idByFile.get(file);
     if (!id) {
-      id = `${kind}${idByKey.size}`;
-      idByKey.set(key, id);
+      id = `M${idByFile.size}`;
+      idByFile.set(file, id);
       importLines.push(
-        `import { ${exportName} as ${id} } from ${JSON.stringify(
-          join(serverDir, file)
-        )};`
+        `import * as ${id} from ${JSON.stringify(join(serverDir, file))};`
       );
     }
     return id;
   };
-  const routeLines = routes.map(
-    (r) =>
-      `  ${JSON.stringify(r.url)}: { Page: ${idFor(
-        r.pageFile,
-        "P",
-        pageExport
-      )}, props: ${idFor(r.propsFile, "Q", propsExport)} },`
-  );
+  const routeLines = routes.map((r) => {
+    const pageNs = nsFor(r.pageFile);
+    const propsNs = nsFor(r.propsFile);
+    return `  ${JSON.stringify(r.url)}: { pagePath: ${JSON.stringify(
+      r.pageSrc
+    )}, propsPath: ${JSON.stringify(r.propsSrc)}, modules: { ${JSON.stringify(
+      r.pageSrc
+    )}: ${pageNs}, ${JSON.stringify(r.propsSrc)}: ${propsNs} } },`;
+  });
 
   const entryPath = join(serverDir, `.vprs-${entryFileName}`);
   const entrySource = `import { createElement } from "react";
 import { renderToReadableStream } from ${JSON.stringify(serverEdge)};
+import { resolvePageAndProps } from ${JSON.stringify(resolveHelper)};
 ${importLines.join("\n")}
+
+const PAGE_EXPORT = ${JSON.stringify(pageExport)};
+const PROPS_EXPORT = ${JSON.stringify(propsExport)};
+const MODULE_BASE_PATH = ${JSON.stringify(moduleBasePath)};
+const MODULE_BASE_URL = ${JSON.stringify(moduleBaseURL)};
 
 const routes = {
 ${routeLines.join("\n")}
@@ -187,10 +218,28 @@ ${routeLines.join("\n")}
 export async function ${flightExport}(url) {
   const route = routes[url];
   if (!route) throw new Error("[edge] unknown route: " + url);
-  const props = await route.props(url);
-  return renderToReadableStream(createElement(route.Page, props), ${JSON.stringify(
-    moduleBasePath
-  )});
+  const resolved = await resolvePageAndProps({
+    pagePath: route.pagePath,
+    propsPath: route.propsPath,
+    pageExportName: PAGE_EXPORT,
+    propsExportName: PROPS_EXPORT,
+    moduleBaseURL: MODULE_BASE_URL,
+    url,
+    loader: async (id) => {
+      // resolvePage/resolveProps may pass "<path>#<export>"; key by the path.
+      const path = String(id).split("#")[0];
+      const mod = route.modules[path];
+      if (!mod) throw new Error("[edge] no baked module for id: " + id);
+      return mod;
+    },
+  });
+  if (resolved.type !== "success") {
+    throw resolved.error ?? new Error("[edge] failed to resolve route: " + url);
+  }
+  return renderToReadableStream(
+    createElement(resolved.PageComponent, resolved.pageProps),
+    MODULE_BASE_PATH
+  );
 }
 `;
   writeFileSync(entryPath, entrySource, "utf8");

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import type { ResolvedUserOptions } from "../types.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { resolveModuleFromManifest } from "../helpers/resolveModuleFromManifest.js";
 
 /** Resolve a package subpath's `react-server` export target to an absolute path. */
 function reactServerExportTarget(
@@ -28,18 +29,6 @@ function reactServerExportTarget(
   }
 }
 
-/** Look up a source module's built output file in a Vite manifest. */
-function manifestFileFor(
-  manifest: Record<string, { file: string; src?: string }>,
-  source: unknown
-): string | null {
-  if (typeof source !== "string") return null;
-  if (manifest[source]?.file) return manifest[source].file;
-  // Fallback: match by source basename (handles minor key normalization).
-  const base = source.split("/").pop();
-  const hit = Object.values(manifest).find((e) => e.src?.split("/").pop() === base);
-  return hit?.file ?? null;
-}
 
 /**
  * Single-isolate edge bake (build.edge.singleIsolate). Generates a flight-
@@ -107,25 +96,45 @@ export async function buildEdgeBundle(opts: {
   const routeSource = (opt: unknown, url: string): unknown =>
     typeof opt === "function" ? (opt as (u: string) => unknown)(url) : opt;
 
+  // Map a source module to its built file via vprs's canonical manifest
+  // resolver (the same one the RSC worker + build loaders use — honors the
+  // normalizer and the moduleBase prefix), returning the absolute built path.
+  const resolveBuilt = (src: unknown): string | null => {
+    if (typeof src !== "string") return null;
+    const { resolvedPath } = resolveModuleFromManifest({
+      moduleId: src,
+      normalizer: userOptions.normalizer,
+      manifest,
+      moduleBase: userOptions.moduleBase,
+      preserveModulesRoot: userOptions.build.preserveModulesRoot,
+      projectRoot,
+      buildOutDir: userOptions.build.outDir,
+      buildServerDir: userOptions.build.server,
+      verbose: userOptions.verbose,
+      logger,
+    });
+    return resolvedPath;
+  };
+
   const routes: {
     url: string;
     pageSrc: string;
-    pageFile: string;
+    pageAbs: string;
     propsSrc: string;
-    propsFile: string;
+    propsAbs: string;
   }[] = [];
   for (const url of urls ?? []) {
     const pageSrc = routeSource(userOptions.Page, url);
     const propsSrc = routeSource(userOptions.props, url);
-    const pageFile = manifestFileFor(manifest, pageSrc);
-    const propsFile = manifestFileFor(manifest, propsSrc);
+    const pageAbs = resolveBuilt(pageSrc);
+    const propsAbs = resolveBuilt(propsSrc);
     if (
       typeof pageSrc === "string" &&
       typeof propsSrc === "string" &&
-      pageFile &&
-      propsFile
+      pageAbs &&
+      propsAbs
     ) {
-      routes.push({ url, pageSrc, pageFile, propsSrc, propsFile });
+      routes.push({ url, pageSrc, pageAbs, propsSrc, propsAbs });
     } else {
       logger.warn(`${tag} could not resolve built Page/props for route ${url}; omitting`);
     }
@@ -179,20 +188,18 @@ export async function buildEdgeBundle(opts: {
   // manifest, no runtime import().
   const importLines: string[] = [];
   const idByFile = new Map<string, string>();
-  const nsFor = (file: string): string => {
-    let id = idByFile.get(file);
+  const nsFor = (absPath: string): string => {
+    let id = idByFile.get(absPath);
     if (!id) {
       id = `M${idByFile.size}`;
-      idByFile.set(file, id);
-      importLines.push(
-        `import * as ${id} from ${JSON.stringify(join(serverDir, file))};`
-      );
+      idByFile.set(absPath, id);
+      importLines.push(`import * as ${id} from ${JSON.stringify(absPath)};`);
     }
     return id;
   };
   const routeLines = routes.map((r) => {
-    const pageNs = nsFor(r.pageFile);
-    const propsNs = nsFor(r.propsFile);
+    const pageNs = nsFor(r.pageAbs);
+    const propsNs = nsFor(r.propsAbs);
     return `  ${JSON.stringify(r.url)}: { pagePath: ${JSON.stringify(
       r.pageSrc
     )}, propsPath: ${JSON.stringify(r.propsSrc)}, modules: { ${JSON.stringify(

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -224,6 +224,7 @@ export const DEFAULT_CONFIG = {
     // which will be done in createHandlerOptions.server.ts and createHandlerOptions.client.ts
     useRscWorker: !IS_SERVER && IS_BUILD,
     useHtmlWorker: IS_SERVER && IS_BUILD,
+    edge: { singleIsolate: false, outDir: "server-edge" },
   },
   DEV: {
     // these defaults rely on process.argv
@@ -294,5 +295,20 @@ export const DEFAULT_CONFIG = {
   REACT_LOADER_PATH: pluginRoot + "/loader/react-loader.js",
   CSS_LOADER_PATH: pluginRoot + "/loader/css-loader.js",
   ENV_LOADER_PATH: pluginRoot + "/loader/env-loader.js",
-  
+
+  // Single-isolate edge bake (build.edge.singleIsolate). The user-facing
+  // `outDir` default lives in BUILD.edge; these are the internal names the bake
+  // step uses, centralized here rather than scattered as literals.
+  EDGE: {
+    // The generated flight-producer entry the bake emits + bundles.
+    entryFileName: "render.js",
+    // Its exported per-route flight renderer: (url) => Web ReadableStream.
+    flightExport: "renderRouteToFlight",
+    // React subpaths re-aliased to their `react-server` exports so the bundle
+    // bakes SERVER React. The alias TARGETS are derived from react's own
+    // package `exports` map at bake time (no hardcoded `*.react-server.js`).
+    // ORDER MATTERS: the bare "react" alias prefix-matches "react/jsx-runtime",
+    // so the specific subpaths must come first (alias uses first match).
+    reactServerSubpaths: ["./jsx-runtime", "./jsx-dev-runtime", "."] as const,
+  },
 };

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -308,6 +308,17 @@ export const DEFAULT_CONFIG = {
     entryFileName: "render.js",
     // Its exported per-route flight renderer: (url) => Web ReadableStream.
     flightExport: "renderRouteToFlight",
+    // Its exported full-document renderer: (url, {cssFiles, globalCss}) =>
+    // { full, headless } Web ReadableStreams (Html-wrapped + Root-only), for the
+    // flash-free inline-flight document path (createEdgeHandler renderDocument).
+    documentExport: "renderRouteToDocument",
+    // Its exported baked server-action handler: (request, {projectRoot}) =>
+    // Response. A sealed gate over the action modules baked into the bundle, so a
+    // no-`--conditions` process dispatches actions without the on-disk transport.
+    actionExport: "handleRouteAction",
+    // Server-module manifest keys to bake as action candidates (the sealed-gate
+    // allowlist). Server actions live in `*.server.*` modules.
+    actionKeyPattern: "\\.server\\.[cm]?[jt]sx?$",
     // React subpaths re-aliased to their `react-server` exports so the bundle
     // bakes SERVER React. The alias TARGETS are derived from react's own
     // package `exports` map at bake time (no hardcoded `*.react-server.js`).

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -228,7 +228,7 @@ export const DEFAULT_CONFIG = {
     // which will be done in createHandlerOptions.server.ts and createHandlerOptions.client.ts
     useRscWorker: !IS_SERVER && IS_BUILD,
     useHtmlWorker: IS_SERVER && IS_BUILD,
-    edge: { singleIsolate: false, outDir: "server-edge" },
+    edge: { singleIsolate: false, outDir: "server-edge", minify: true },
   },
   DEV: {
     // these defaults rely on process.argv

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -228,7 +228,7 @@ export const DEFAULT_CONFIG = {
     // which will be done in createHandlerOptions.server.ts and createHandlerOptions.client.ts
     useRscWorker: !IS_SERVER && IS_BUILD,
     useHtmlWorker: IS_SERVER && IS_BUILD,
-    edge: { singleIsolate: false, outDir: "server-edge", minify: true },
+    edge: { enabled: true, outDir: "server-edge", minify: true },
   },
   DEV: {
     // these defaults rely on process.argv
@@ -300,7 +300,7 @@ export const DEFAULT_CONFIG = {
   CSS_LOADER_PATH: pluginRoot + "/loader/css-loader.js",
   ENV_LOADER_PATH: pluginRoot + "/loader/env-loader.js",
 
-  // Single-isolate edge bake (build.edge.singleIsolate). The user-facing
+  // Single-isolate edge bake (build.edge, on by default). The user-facing
   // `outDir` default lives in BUILD.edge; these are the internal names the bake
   // step uses, centralized here rather than scattered as literals.
   EDGE: {

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -5,8 +5,7 @@ import {
 import { pluginRoot } from "../root.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { getCondition } from "./getCondition.js";
-import { createLogger } from "vite";
-const LOGGER = createLogger();
+import type { Logger } from "vite";
 // Directive patterns - matching the logic in findDirectiveMatches.ts
 const DIRECTIVE_PATTERNS = {
   // Client directive must be at start of file
@@ -101,7 +100,12 @@ export const DEFAULT_LOADER_CONFIG = {
   parse: parse,
   mode: MODE,
   verbose: false,
-  logger: LOGGER,
+  // No eager default logger: constructing vite's createLogger() at module top
+  // dragged vite (a devDependency) into every prod/edge bundle that imports
+  // DEFAULT_CONFIG. Call sites supply their own logger; this defaults undefined.
+  // `import type { Logger }` is erased, so no runtime vite. (Typed as Logger to
+  // satisfy Required<LoaderConfig>; consumers already guard a missing logger.)
+  logger: undefined as unknown as Logger,
   moduleID: (moduleId: string, _sourceContent?: string) =>
     typeof moduleId === "string" ? moduleId : String(moduleId),
 } as const;

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -682,6 +682,7 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
         options.build?.edge?.singleIsolate ??
         DEFAULT_CONFIG.BUILD.edge.singleIsolate,
       outDir: options.build?.edge?.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir,
+      minify: options.build?.edge?.minify ?? DEFAULT_CONFIG.BUILD.edge.minify,
     },
   } satisfies ResolvedUserOptions["build"];
 

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -677,6 +677,12 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     renderMode: options.build?.renderMode ?? "parallel",
     batchSize: options.build?.batchSize ?? 8,
     inlineFlight: options.build?.inlineFlight ?? false,
+    edge: {
+      singleIsolate:
+        options.build?.edge?.singleIsolate ??
+        DEFAULT_CONFIG.BUILD.edge.singleIsolate,
+      outDir: options.build?.edge?.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir,
+    },
   } satisfies ResolvedUserOptions["build"];
 
   // Development configuration

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -677,13 +677,17 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     renderMode: options.build?.renderMode ?? "parallel",
     batchSize: options.build?.batchSize ?? 8,
     inlineFlight: options.build?.inlineFlight ?? false,
-    edge: {
-      singleIsolate:
-        options.build?.edge?.singleIsolate ??
-        DEFAULT_CONFIG.BUILD.edge.singleIsolate,
-      outDir: options.build?.edge?.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir,
-      minify: options.build?.edge?.minify ?? DEFAULT_CONFIG.BUILD.edge.minify,
-    },
+    edge: (() => {
+      // `build.edge`: boolean | EdgeBuildConfig, default ON. `false` disables;
+      // `true`/omitted enables with defaults; an object enables + overrides.
+      const edge = options.build?.edge;
+      const obj = edge && typeof edge === "object" ? edge : {};
+      return {
+        enabled: edge === false ? false : true,
+        outDir: obj.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir,
+        minify: obj.minify ?? DEFAULT_CONFIG.BUILD.edge.minify,
+      };
+    })(),
   } satisfies ResolvedUserOptions["build"];
 
   // Development configuration

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { DEFAULT_LOADER_CONFIG } from "../config/defaults.js";
 import { REACT_CONDITION } from "../config/getCondition.js";
 import { runDeferredStaticGeneration } from "../bundle/deferredStaticGeneration.js";
+import { buildEdgeBundle } from "../bundle/buildEdgeBundle.js";
 
 /**
  * Creates a plugin that ensures consistent hash generation across environments
@@ -353,6 +354,12 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
             }
             // Step 4: Run deferred static generation now that all manifests are available
             await runDeferredStaticGeneration();
+            // Step 5: Single-isolate edge bake (additive, gated on build.edge).
+            await buildEdgeBundle({
+              userOptions,
+              projectRoot: userOptions.projectRoot,
+              logger,
+            });
           },
         },
       };

--- a/plugin/error/handleError.ts
+++ b/plugin/error/handleError.ts
@@ -1,4 +1,3 @@
-import { createLogger } from "vite";
 import { toError } from "./toError.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
 import { logError } from "./logError.js";
@@ -19,7 +18,8 @@ export const handleError: HandleErrorFn = function _handleError(
   const {
     error,
     errorInfo,
-    logger = createLogger(),
+    // Default to `console` (not vite's createLogger) so this is edge-bundle safe.
+    logger = console,
     mode = getNodeEnv(),
     panicThreshold = "none",
     critical = false,

--- a/plugin/error/logError.ts
+++ b/plugin/error/logError.ts
@@ -1,4 +1,4 @@
-import { createLogger, type Logger } from "vite";
+import type { Logger } from "vite";
 import { getNodeEnv } from "../config/getNodeEnv.js";
 /**
  * Simple error logging function focused purely on logging errors
@@ -6,7 +6,10 @@ import { getNodeEnv } from "../config/getNodeEnv.js";
  */
 export function logError(
   err: Error,
-  logger: Logger | Console = createLogger(),
+  // Default to `console`, not vite's `createLogger()`: a top-level "vite" import
+  // would drag the dev-only bundler into the single-isolate edge bundle (this
+  // runs in the baked action gate). Callers pass a real logger when they have one.
+  logger: Logger | Console = console,
   mode: "development" | "production" | "test" = getNodeEnv()
 ) {
   // when a proper logger is provided

--- a/plugin/helpers/createElementWithReact.tsx
+++ b/plugin/helpers/createElementWithReact.tsx
@@ -1,4 +1,3 @@
-import { createLogger } from "vite";
 import type { CreateHandlerOptions } from "../types.js";
 
 export type CreateElementWithReactOptions = Pick<
@@ -54,9 +53,11 @@ export const createElementWithReact: CreateElementWithReactFN =
       url,
       as = "div",
       verbose = false,
-      logger = createLogger("info", {
-        prefix: "vite:plugin-react-server/helpers/createElementWithReact",
-      }),
+      // No default logger: importing one from "vite" would drag the dev-only
+      // bundler into the single-isolate edge bundle (this helper composes the
+      // baked document tree). Call sites that want logs pass their own; the
+      // verbose branches below are already `logger?.`-guarded.
+      logger = undefined,
     }
   ) {
     // Add debug logging

--- a/plugin/helpers/createRequestHandler.server.ts
+++ b/plugin/helpers/createRequestHandler.server.ts
@@ -4,8 +4,16 @@ import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { MIME_TYPES } from "../config/mimeTypes.js";
 import { isPathWithin } from "./isPathWithin.js";
-import { handleServerActionRequest } from "./handleServerAction.server.js";
 import type { ServerActionHandlerOptions } from "./handleServerActionHelper.js";
+
+/**
+ * A pre-built action handler — `(Request) => Response`. The single-isolate edge
+ * bake provides one (the baked action gate), so a no-`--conditions` process can
+ * dispatch actions without statically importing the react-server transport.
+ */
+export type ActionRequestHandler = (
+  request: Request
+) => Promise<Response> | Response;
 
 export interface CreateRequestHandlerOptions {
   /**
@@ -15,11 +23,16 @@ export interface CreateRequestHandlerOptions {
    */
   staticDir: string;
   /**
-   * Server-action handling. When provided, a POST carrying the action header is
-   * dispatched to {@link handleServerActionRequest} (same trust boundary as the
-   * Node handler). Omit to serve a read-only site.
+   * Server-action handling for a POST carrying the action header. Omit to serve
+   * a read-only site. Either:
+   *  - {@link ServerActionHandlerOptions} — the built-in disk-backed sealed gate
+   *    (needs `--conditions react-server`; the transport is imported lazily, only
+   *    when this form is used, so passing a function keeps the handler
+   *    condition-neutral); or
+   *  - an {@link ActionRequestHandler} function — e.g. the single-isolate edge
+   *    bake's baked action gate, for a no-`--conditions` process.
    */
-  action?: ServerActionHandlerOptions;
+  action?: ServerActionHandlerOptions | ActionRequestHandler;
   /**
    * Optional per-request renderer for dynamic routes. Called on a GET before the
    * static fallback; return a `Response` to handle the route dynamically (e.g.
@@ -75,6 +88,15 @@ export function createRequestHandler(
     const url = new URL(request.url);
 
     if (request.method === "POST" && action && request.headers.get(actionHeader)) {
+      if (typeof action === "function") return action(request);
+      // Lazy import: pulling handleServerActionRequest eagerly would static-link
+      // the react-server transport (asserts the `react-server` condition) into
+      // every importer — including no-`--conditions` edge servers that pass a
+      // baked action function instead. Imported only when the built-in gate is
+      // actually used.
+      const { handleServerActionRequest } = await import(
+        "./handleServerAction.server.js"
+      );
       return handleServerActionRequest(request, action);
     }
 

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -131,6 +131,12 @@ export async function resolveAndExecuteServerAction(
       verbose,
       logger
     );
+  } else if (options.resolveServerReference) {
+    // SEALED path, caller-supplied gate. The single-isolate edge bake passes a
+    // gate whose modules are baked into the edge bundle, so this runs with no
+    // `react-server` condition and never disk-imports the transport. Still
+    // sealed — an unregistered id throws inside the resolver.
+    action = (await options.resolveServerReference(id)) as Function;
   } else {
     // SEALED path (production trust boundary). Resolve the client-supplied id
     // through a gate built from the build's server manifest: an id the build

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -48,6 +48,15 @@ export type ServerActionHandlerOptions = {
    * default (no limit). Recommended for any internet-facing deploy.
    */
   maxBodyBytes?: number;
+  /**
+   * Resolve a client-supplied action id to its function, bypassing the built-in
+   * disk-backed sealed gate. The single-isolate edge bake passes a gate whose
+   * modules are baked into the edge bundle, so the action runs in a process with
+   * no `react-server` condition (the bake holds the server React). Still a sealed
+   * allowlist — an unregistered id rejects. When set, the sealed path uses this
+   * and never reads `<serverRoot>/.vite/manifest.json`.
+   */
+  resolveServerReference?: (id: string) => Promise<unknown>;
 };
 
 export type ServerActionRequest = {

--- a/plugin/references/createSealedServerReferenceGate.server.ts
+++ b/plugin/references/createSealedServerReferenceGate.server.ts
@@ -22,6 +22,16 @@ export interface SealedServerReferenceGateOptions {
   serverRoot: string;
   /** URL base the client prefixes onto reference ids (default `/`). */
   base?: string;
+  /**
+   * Override how a registered module is loaded. The default disk-imports
+   * `<serverRoot>/<entry.file>` — correct under `--conditions react-server`. The
+   * single-isolate edge bake injects a loader that returns a module STATICALLY
+   * BAKED into the edge bundle (server React inlined), so the gate runs in a
+   * process with no `react-server` condition and never disk-imports the
+   * transport. Called with the manifest key and its built file. The allowlist
+   * is unchanged: only manifest-enumerated keys are registered.
+   */
+  loadModule?: (key: string, file: string) => Promise<Record<string, unknown>>;
 }
 
 /**
@@ -53,6 +63,7 @@ export function createSealedServerReferenceGate({
   serverManifest,
   serverRoot,
   base = "/",
+  loadModule,
 }: SealedServerReferenceGateOptions): ReferenceGate {
   const gate = createReferenceGate({ mode: "sealed" });
   const prefix = base.endsWith("/") ? base : `${base}/`;
@@ -60,8 +71,9 @@ export function createSealedServerReferenceGate({
   for (const [key, entry] of Object.entries(serverManifest)) {
     if (!entry?.file) continue;
     const file = entry.file;
-    const load = () =>
-      import(join(serverRoot, file)) as Promise<Record<string, unknown>>;
+    const load = loadModule
+      ? () => loadModule(key, file)
+      : () => import(join(serverRoot, file)) as Promise<Record<string, unknown>>;
     // The directive transform bakes a BARE manifest-key id (`<srcKey>#<export>`);
     // a base-prefixed transport sends `<base><srcKey>#<export>`. Register both
     // shapes so resolution is an exact-key lookup either way. This does not widen

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -1,0 +1,93 @@
+import type {
+  CreateEdgeHandlerFn,
+  EdgeFetchHandler,
+} from "./createEdgeHandler.types.js";
+import { renderFlightToHtml } from "./renderFlightToHtml.client.js";
+import { assertNonReactServer } from "../config/getCondition.js";
+
+assertNonReactServer();
+
+/**
+ * Marker the baked flight producer uses for a url with no baked route (see the
+ * generated entry in plugin/bundle/buildEdgeBundle.ts — `"[edge] unknown route:
+ * " + url`). Kept here so the handler can map that one throw to a 404 without
+ * swallowing real render errors.
+ */
+const UNKNOWN_ROUTE_MARKER = "[edge] unknown route:";
+
+/**
+ * Compose a single-isolate edge build into a Web `fetch` handler.
+ *
+ * Wires the baked per-route flight producer (`dist/server-edge/render.js`'s
+ * `renderRouteToFlight`, server React) to the in-process HTML render
+ * (`renderFlightToHtml`, client React) and returns a `(Request) => Response`
+ * handler — the native entrypoint shape for Cloudflare Workers, Deno Deploy,
+ * Vercel Edge and Bun, and trivially adaptable to Node. No worker_threads, no
+ * runtime `--conditions`: the producer baked server React, this side runs
+ * client React, and they co-exist in one isolate (client islands resolve via
+ * the client transport's `import(moduleBaseURL + id)` into the ssr bundle, so
+ * point {@link CreateEdgeHandlerOptions.moduleBaseURL} at where `dist/client`
+ * is served).
+ *
+ * The returned handler streams: it responds as soon as the HTML shell is ready.
+ * Unknown routes get a 404 (override via `onNotFound`); other render errors
+ * propagate to the caller after `onError`.
+ */
+export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler(
+  options
+): EdgeFetchHandler {
+  const {
+    render,
+    moduleBaseURL = "/",
+    bootstrapModules,
+    bootstrapScriptContent,
+    nonce,
+    getURL = (request) => new URL(request.url).pathname,
+    headers,
+    onError,
+    onNotFound,
+    logger,
+    verbose,
+  } = options;
+
+  return async function edgeHandler(request: Request): Promise<Response> {
+    const url = getURL(request);
+
+    let rscStream: ReadableStream<Uint8Array>;
+    try {
+      rscStream = await render(url);
+    } catch (error) {
+      // The producer is a closed manifest over `build.pages`; an unknown url is
+      // a 404, not a 500. Everything else is a real failure — surface it.
+      if (error instanceof Error && error.message.includes(UNKNOWN_ROUTE_MARKER)) {
+        return onNotFound
+          ? onNotFound(url, request)
+          : new Response("Not Found", {
+              status: 404,
+              headers: { "content-type": "text/plain; charset=utf-8" },
+            });
+      }
+      onError?.(error);
+      throw error;
+    }
+
+    const htmlStream = await renderFlightToHtml({
+      rscStream,
+      moduleBaseURL,
+      bootstrapModules,
+      bootstrapScriptContent,
+      nonce,
+      onError,
+      signal: request.signal,
+      logger,
+      verbose,
+    });
+
+    return new Response(htmlStream, {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        ...(headers ? Object.fromEntries(new Headers(headers)) : {}),
+      },
+    });
+  };
+};

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -3,9 +3,34 @@ import type {
   EdgeFetchHandler,
 } from "./createEdgeHandler.types.js";
 import { renderFlightToHtml } from "./renderFlightToHtml.client.js";
+import { injectInlineFlightIntoHtml } from "../utils/inlineFlight.js";
 import { assertNonReactServer } from "../config/getCondition.js";
 
 assertNonReactServer();
+
+/** Drain a Web ReadableStream of bytes into a single Uint8Array. */
+async function collectBytes(
+  stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out;
+}
 
 /**
  * Marker the baked flight producer uses for a url with no baked route (see the
@@ -38,6 +63,7 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
 ): EdgeFetchHandler {
   const {
     render,
+    renderDocument,
     moduleBaseURL = "/",
     bootstrapModules,
     bootstrapScriptContent,
@@ -50,23 +76,73 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
     verbose,
   } = options;
 
+  if (!render && !renderDocument) {
+    throw new Error(
+      "[createEdgeHandler] one of `render` or `renderDocument` is required"
+    );
+  }
+
+  const htmlHeaders = (): Record<string, string> => ({
+    "content-type": "text/html; charset=utf-8",
+    ...(headers ? Object.fromEntries(new Headers(headers)) : {}),
+  });
+
+  const notFound = (url: string, request: Request): Response | Promise<Response> =>
+    onNotFound
+      ? onNotFound(url, request)
+      : new Response("Not Found", {
+          status: 404,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
+
+  /** The producer 404s an unbaked route by throwing the unknown-route marker. */
+  const isUnknownRoute = (error: unknown): boolean =>
+    error instanceof Error && error.message.includes(UNKNOWN_ROUTE_MARKER);
+
   return async function edgeHandler(request: Request): Promise<Response> {
     const url = getURL(request);
 
+    // Full flash-free document: render the Html-wrapped `full` flight to a
+    // complete HTML document and inline the `headless` flight so the client
+    // hydrates in place with no `.rsc` refetch. Buffers the (small) dynamic
+    // document to splice the inline script before </body>.
+    if (renderDocument) {
+      let flights;
+      try {
+        flights = await renderDocument(url);
+      } catch (error) {
+        if (isUnknownRoute(error)) return notFound(url, request);
+        onError?.(error);
+        throw error;
+      }
+      const htmlStream = await renderFlightToHtml({
+        rscStream: flights.full,
+        moduleBaseURL,
+        bootstrapModules,
+        bootstrapScriptContent,
+        nonce,
+        onError,
+        signal: request.signal,
+        logger,
+        verbose,
+      });
+      const [htmlString, headlessBytes] = await Promise.all([
+        new Response(htmlStream).text(),
+        collectBytes(flights.headless),
+      ]);
+      return new Response(
+        injectInlineFlightIntoHtml(htmlString, headlessBytes),
+        { headers: htmlHeaders() }
+      );
+    }
+
     let rscStream: ReadableStream<Uint8Array>;
     try {
-      rscStream = await render(url);
+      rscStream = await render!(url);
     } catch (error) {
       // The producer is a closed manifest over `build.pages`; an unknown url is
       // a 404, not a 500. Everything else is a real failure — surface it.
-      if (error instanceof Error && error.message.includes(UNKNOWN_ROUTE_MARKER)) {
-        return onNotFound
-          ? onNotFound(url, request)
-          : new Response("Not Found", {
-              status: 404,
-              headers: { "content-type": "text/plain; charset=utf-8" },
-            });
-      }
+      if (isUnknownRoute(error)) return notFound(url, request);
       onError?.(error);
       throw error;
     }
@@ -83,11 +159,6 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
       verbose,
     });
 
-    return new Response(htmlStream, {
-      headers: {
-        "content-type": "text/html; charset=utf-8",
-        ...(headers ? Object.fromEntries(new Headers(headers)) : {}),
-      },
-    });
+    return new Response(htmlStream, { headers: htmlHeaders() });
   };
 };

--- a/plugin/stream/createEdgeHandler.types.ts
+++ b/plugin/stream/createEdgeHandler.types.ts
@@ -1,0 +1,55 @@
+import type { Logger } from "vite";
+
+/**
+ * A Web `fetch` handler: the standard edge-runtime entrypoint shape
+ * (Cloudflare Workers, Deno Deploy, Vercel Edge, Bun, Node via an adapter).
+ */
+export type EdgeFetchHandler = (request: Request) => Promise<Response>;
+
+/**
+ * Options for {@link CreateEdgeHandlerFn}. Composes the baked per-route flight
+ * producer (`dist/server-edge/render.js`'s `renderRouteToFlight`) with the
+ * in-process HTML render (`renderFlightToHtml`) into a single Web `fetch`
+ * handler — no worker_threads, no runtime `--conditions`.
+ */
+export type CreateEdgeHandlerOptions = {
+  /**
+   * The baked per-route flight producer: the `renderRouteToFlight` export of
+   * the single-isolate edge bundle (`dist/server-edge/render.js`). Maps a route
+   * url to a Flight RSC `ReadableStream`.
+   */
+  render: (url: string) => Promise<ReadableStream<Uint8Array>>;
+  /**
+   * Base URL the client transport uses to resolve client-reference modules —
+   * point it at where the client (ssr) bundle is served (`dist/client`). Must
+   * match the base path the bundle is actually hosted under (mind a non-root
+   * deploy base). @default "/"
+   */
+  moduleBaseURL?: string;
+  /** Client entry modules to bootstrap for hydration (react-dom bootstrapModules). */
+  bootstrapModules?: string[];
+  /** Inline bootstrap script content (react-dom bootstrapScriptContent). */
+  bootstrapScriptContent?: string;
+  /** Nonce forwarded to the HTML renderer (CSP). */
+  nonce?: string;
+  /**
+   * Map an incoming `Request` to the route url the producer was baked with
+   * (a `build.pages` entry). @default `req => new URL(req.url).pathname`
+   */
+  getURL?: (request: Request) => string;
+  /** Extra response headers, merged over the default `content-type: text/html`. */
+  headers?: HeadersInit;
+  /** Render-time error hook (forwarded to react-dom/server.edge onError). */
+  onError?: (error: unknown) => void;
+  /**
+   * Build the response for a url the bundle has no baked route for. The default
+   * returns a 404 `text/plain` "Not Found".
+   */
+  onNotFound?: (url: string, request: Request) => Response | Promise<Response>;
+  logger?: Logger;
+  verbose?: boolean;
+};
+
+export type CreateEdgeHandlerFn = (
+  options: CreateEdgeHandlerOptions
+) => EdgeFetchHandler;

--- a/plugin/stream/createEdgeHandler.types.ts
+++ b/plugin/stream/createEdgeHandler.types.ts
@@ -12,13 +12,35 @@ export type EdgeFetchHandler = (request: Request) => Promise<Response>;
  * in-process HTML render (`renderFlightToHtml`) into a single Web `fetch`
  * handler — no worker_threads, no runtime `--conditions`.
  */
+/**
+ * The two flights of the flash-free document path (the `renderRouteToDocument`
+ * export of the edge bundle): the Html/Root-wrapped `full` document and the
+ * Root-only `headless` payload, rendered from the same live props.
+ */
+export type EdgeDocumentFlights = {
+  full: ReadableStream<Uint8Array>;
+  headless: ReadableStream<Uint8Array>;
+};
+
 export type CreateEdgeHandlerOptions = {
   /**
    * The baked per-route flight producer: the `renderRouteToFlight` export of
    * the single-isolate edge bundle (`dist/server-edge/render.js`). Maps a route
-   * url to a Flight RSC `ReadableStream`.
+   * url to a Flight RSC `ReadableStream` rendered straight to HTML.
+   *
+   * Provide either `render` (partial markup) or `renderDocument` (full
+   * flash-free document). `renderDocument` wins if both are set.
    */
-  render: (url: string) => Promise<ReadableStream<Uint8Array>>;
+  render?: (url: string) => Promise<ReadableStream<Uint8Array>>;
+  /**
+   * The baked full-document producer: the `renderRouteToDocument` export of the
+   * edge bundle (typically closed over the live `cssFiles`/`globalCss` the
+   * consumer collected). Returns the `full` + `headless` flights. The handler
+   * renders `full` to a complete HTML document and inlines `headless` as
+   * `<script id="vprs-flight">`, so the browser hydrates in place with no
+   * `.rsc` round-trip.
+   */
+  renderDocument?: (url: string) => Promise<EdgeDocumentFlights>;
   /**
    * Base URL the client transport uses to resolve client-reference modules —
    * point it at where the client (ssr) bundle is served (`dist/client`). Must

--- a/plugin/stream/index.client.ts
+++ b/plugin/stream/index.client.ts
@@ -23,6 +23,15 @@ export * from "./createFromReadableStream.client.js";
 // plugin/worker/html, for edge / single-isolate builds.
 export * from "./renderFlightToHtml.client.js";
 
+// Edge fetch handler: compose the baked flight producer + renderFlightToHtml
+// into a Web `(Request) => Response` handler for edge runtimes.
+export * from "./createEdgeHandler.client.js";
+export type {
+  CreateEdgeHandlerOptions,
+  CreateEdgeHandlerFn,
+  EdgeFetchHandler,
+} from "./createEdgeHandler.types.js";
+
 // HTML stream creation
 export * from "./createHtmlStream.client.js";
 

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1165,6 +1165,13 @@ export type EdgeBuildConfig = {
   singleIsolate?: boolean;
   /** Output dir for the baked edge bundle, under `build.outDir`. @default "server-edge" */
   outDir?: string;
+  /**
+   * Minify the baked edge bundle. The artifact bakes React in, so it is large;
+   * edge runtimes (Cloudflare Workers, Deno Deploy, Vercel Edge) enforce bundle
+   * size limits, so minification is on by default. Set `false` to emit readable
+   * output for inspection/debugging. @default true
+   */
+  minify?: boolean;
 };
 
 export type DevConfig = {

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1146,6 +1146,25 @@ export type BuildConfig = {
    * @default false
    */
   inlineFlight?: boolean;
+  /**
+   * Single-isolate edge build. When `singleIsolate` is set, the build emits an
+   * additional baked rsc bundle to `build.edge.outDir` (default
+   * `server-edge`): the server graph with React INLINED (via esbuild under the
+   * react-server condition), so it runs in one isolate with no worker_threads
+   * and no runtime `--conditions`. The default worker-based build (`dist/server`)
+   * is untouched — this is additive. Pair it at runtime with
+   * `renderFlightToHtml`, pointing `moduleBaseURL` at the ssr bundle
+   * (`dist/client`). Dev is unaffected.
+   * @default undefined (no edge bundle)
+   */
+  edge?: EdgeBuildConfig;
+};
+
+export type EdgeBuildConfig = {
+  /** Emit the single-isolate baked rsc bundle. @default false */
+  singleIsolate?: boolean;
+  /** Output dir for the baked edge bundle, under `build.outDir`. @default "server-edge" */
+  outDir?: string;
 };
 
 export type DevConfig = {

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -438,7 +438,7 @@ export type ResolvedUserOptions = {
   clientPipeableStreamOptions?: any; // For HTML worker
   autoDiscover: Required<AutoDiscoverConfig>;
   loader?: Required<LoaderConfig> | undefined;
-  build: Required<BuildConfig>;
+  build: Omit<Required<BuildConfig>, "edge"> & { edge: ResolvedEdgeConfig };
   dev: Required<DevConfig>;
   css: RootOptions<boolean>;
   components?: StreamPluginOptions["components"]; // Direct component overrides (optional)
@@ -1147,22 +1147,25 @@ export type BuildConfig = {
    */
   inlineFlight?: boolean;
   /**
-   * Single-isolate edge build. When `singleIsolate` is set, the build emits an
-   * additional baked rsc bundle to `build.edge.outDir` (default
-   * `server-edge`): the server graph with React INLINED (via esbuild under the
-   * react-server condition), so it runs in one isolate with no worker_threads
-   * and no runtime `--conditions`. The default worker-based build (`dist/server`)
-   * is untouched — this is additive. Pair it at runtime with
-   * `renderFlightToHtml`, pointing `moduleBaseURL` at the ssr bundle
-   * (`dist/client`). Dev is unaffected.
-   * @default undefined (no edge bundle)
+   * Single-isolate edge build. Emits an additional baked rsc bundle to
+   * `build.edge.outDir` (default `server-edge`): the server graph with React
+   * INLINED, so it runs in one isolate with no worker_threads and no runtime
+   * `--conditions` (drive it with `createEdgeHandler` / `renderRouteToDocument`).
+   * The default worker-based build (`dist/server`) is untouched — purely
+   * additive. Dev is unaffected.
+   *
+   * On by DEFAULT. Pass `false` to skip the artifact, or an {@link EdgeBuildConfig}
+   * object to tune it (presence still means enabled):
+   *   - `edge: false`            — disable
+   *   - `edge: true` / omitted   — enable with defaults
+   *   - `edge: { minify: false }` — enable, override a default
+   *
+   * @default true
    */
-  edge?: EdgeBuildConfig;
+  edge?: boolean | EdgeBuildConfig;
 };
 
 export type EdgeBuildConfig = {
-  /** Emit the single-isolate baked rsc bundle. @default false */
-  singleIsolate?: boolean;
   /** Output dir for the baked edge bundle, under `build.outDir`. @default "server-edge" */
   outDir?: string;
   /**
@@ -1172,6 +1175,13 @@ export type EdgeBuildConfig = {
    * output for inspection/debugging. @default true
    */
   minify?: boolean;
+};
+
+/** Resolved edge config (after normalizing the `boolean | EdgeBuildConfig` form). */
+export type ResolvedEdgeConfig = {
+  enabled: boolean;
+  outDir: string;
+  minify: boolean;
 };
 
 export type DevConfig = {

--- a/test/examples/build-edge-bundle.test.ts
+++ b/test/examples/build-edge-bundle.test.ts
@@ -78,7 +78,7 @@ describe.skipIf(!renderFlightToHtml)(
         build: {
           pages: ["/"],
           outDir: "dist",
-          edge: { singleIsolate: true },
+          edge: true,
         },
       } as any);
     });

--- a/test/examples/build-edge-bundle.test.ts
+++ b/test/examples/build-edge-bundle.test.ts
@@ -143,6 +143,32 @@ describe.skipIf(!renderFlightToHtml)(
       expect(html).toContain(clientEntry);
     });
 
+    it("renders a flash-free inline-flight document via renderDocument mode", async () => {
+      const { renderRouteToDocument } = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+      );
+      const clientManifest = JSON.parse(
+        await readFile(join(testDir, "dist/client/.vite/manifest.json"), "utf8")
+      );
+      const clientEntry = clientManifest["src/client.tsx"]?.file as string;
+
+      const handler = createEdgeHandler!({
+        renderDocument: (url: string) => renderRouteToDocument(url),
+        moduleBaseURL: "/",
+        bootstrapModules: ["/" + clientEntry],
+      });
+
+      const response = await handler(new Request("http://edge.test/"));
+      expect(response.status).toBe(200);
+      const html = await response.text();
+      // A full document, the live content, the inline flight (zero-refetch
+      // hydration), and the bootstrap entry.
+      expect(html).toContain("<html");
+      expect(html).toContain("edge-isolate");
+      expect(html).toContain('id="vprs-flight"');
+      expect(html).toContain(clientEntry);
+    });
+
     it("returns 404 for a route the bundle was not baked with", async () => {
       const { renderRouteToFlight } = await import(
         pathToFileURL(join(testDir, "dist/server-edge/render.js")).href

--- a/test/examples/build-edge-bundle.test.ts
+++ b/test/examples/build-edge-bundle.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import * as streamApi from "vite-plugin-react-server/stream";
+import { doBuild } from "../doBuild.js";
+
+// renderFlightToHtml is client-only (exported under the default condition, not
+// react-server), so the whole suite skips on the react-server leg of test-both
+// — same guard the other single-isolate stream tests use. We still run the
+// build under the client condition, which is enough to exercise the edge bake.
+const renderFlightToHtml = (streamApi as any).renderFlightToHtml as
+  | typeof import("../../plugin/stream/renderFlightToHtml.client.js").renderFlightToHtml
+  | undefined;
+
+const testDir = resolve(__dirname, "../fixtures/build-edge-bundle.test");
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/page"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/page/page.tsx"),
+    `export const Page = ({ name }: { name: string }) => <div id="root">Hello {name}</div>;`
+  );
+  await writeFile(
+    join(testDir, "src/page/props.ts"),
+    `export const props = (_url: string) => ({ name: "edge-isolate" });`
+  );
+  await writeFile(
+    join(testDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        jsx: "react-jsx",
+        strict: true,
+      },
+      include: ["src"],
+    })
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head><meta charset="utf-8" /></head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `import { use, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { createReactFetcher } from "vite-plugin-react-server/utils";
+const Shell = ({ data }: { data: any }) => <>{use(useState(data)[0])}</>;
+createRoot(document.getElementById("root")!).render(<Shell data={createReactFetcher()} />);`
+  );
+  // Resolve vite-plugin-react-server / react from the repo's node_modules.
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {}
+}
+
+describe.skipIf(!renderFlightToHtml)(
+  "build.edge single-isolate bake",
+  () => {
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+      await doBuild({
+        projectRoot: testDir,
+        moduleBase: "src",
+        Page: "src/page/page.tsx",
+        props: "src/page/props.ts",
+        build: {
+          pages: ["/"],
+          outDir: "dist",
+          edge: { singleIsolate: true },
+        },
+      } as any);
+    });
+
+    afterAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("emits a baked rsc bundle to dist/server-edge", () => {
+      expect(existsSync(join(testDir, "dist/server-edge/render.js"))).toBe(true);
+    });
+
+    it("keeps the default worker-based server build (additive)", () => {
+      // The normal dist/server output is untouched and still externalizes React.
+      expect(existsSync(join(testDir, "dist/server/page/page.js"))).toBe(true);
+    });
+
+    it("renders the baked bundle to HTML in one process via renderFlightToHtml", async () => {
+      const { renderRouteToFlight } = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+      );
+      const html = await new Response(
+        await renderFlightToHtml!({
+          rscStream: await renderRouteToFlight("/"),
+          moduleBaseURL: "/",
+        })
+      ).text();
+      expect(html).toContain("edge-isolate");
+      expect(html).toContain('id="root"');
+      expect(html).not.toContain("Switched to client rendering");
+    });
+  }
+);

--- a/test/examples/build-edge-bundle.test.ts
+++ b/test/examples/build-edge-bundle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { mkdir, rm, writeFile, symlink, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -12,6 +12,9 @@ import { doBuild } from "../doBuild.js";
 // build under the client condition, which is enough to exercise the edge bake.
 const renderFlightToHtml = (streamApi as any).renderFlightToHtml as
   | typeof import("../../plugin/stream/renderFlightToHtml.client.js").renderFlightToHtml
+  | undefined;
+const createEdgeHandler = (streamApi as any).createEdgeHandler as
+  | typeof import("../../plugin/stream/createEdgeHandler.client.js").createEdgeHandler
   | undefined;
 
 const testDir = resolve(__dirname, "../fixtures/build-edge-bundle.test");
@@ -106,6 +109,47 @@ describe.skipIf(!renderFlightToHtml)(
       expect(html).toContain("edge-isolate");
       expect(html).toContain('id="root"');
       expect(html).not.toContain("Switched to client rendering");
+    });
+
+    it("serves rendered HTML with a hydration bootstrap via createEdgeHandler", async () => {
+      const { renderRouteToFlight } = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+      );
+
+      // Derive the bootstrap entry from the client manifest, exactly as a real
+      // edge adapter would (so the served HTML can hydrate).
+      const clientManifest = JSON.parse(
+        await readFile(
+          join(testDir, "dist/client/.vite/manifest.json"),
+          "utf8"
+        )
+      );
+      const clientEntry = clientManifest["src/client.tsx"]?.file as string;
+      expect(clientEntry).toBeTruthy();
+
+      const handler = createEdgeHandler!({
+        render: renderRouteToFlight,
+        moduleBaseURL: "/",
+        bootstrapModules: ["/" + clientEntry],
+      });
+
+      const response = await handler(new Request("http://edge.test/"));
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/html");
+
+      const html = await response.text();
+      expect(html).toContain("edge-isolate");
+      // The bootstrap entry must be wired into the HTML for hydration.
+      expect(html).toContain(clientEntry);
+    });
+
+    it("returns 404 for a route the bundle was not baked with", async () => {
+      const { renderRouteToFlight } = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+      );
+      const handler = createEdgeHandler!({ render: renderRouteToFlight });
+      const response = await handler(new Request("http://edge.test/missing"));
+      expect(response.status).toBe(404);
     });
   }
 );


### PR DESCRIPTION
## What

Adds `build.edge.singleIsolate` — an **additive** build step that bakes the already-transformed server build into a single-isolate rsc bundle (`dist/server-edge`) with React **inlined**, so it runs on an edge runtime with **no `worker_threads` and no runtime `--conditions`**. The default worker-based `dist/server` build is untouched, and dev is unaffected.

Ships as a complete, deployable feature: the baked producer, a Web `fetch` handler that serves it, a size knob, a runnable example, and docs.

## Serving it: `createEdgeHandler`

The baked `render.js` exports `renderRouteToFlight(url)` — a Flight *producer*. `createEdgeHandler` (exported from `vite-plugin-react-server/stream`) composes it with the in-process `renderFlightToHtml` (#201) into a standard Web `(Request) => Response` handler — the native entrypoint for Cloudflare Workers, Deno Deploy, Vercel Edge and Bun:

```ts
import { renderRouteToFlight } from "./dist/server-edge/render.js";
import { createEdgeHandler } from "vite-plugin-react-server/stream";

export default {
  fetch: createEdgeHandler({
    render: renderRouteToFlight,
    moduleBaseURL: "/",                       // where dist/client is served
    bootstrapModules: ["/client-abc123.js"],  // client entry, for hydration
  }),
};
```

It streams (responds at shell-ready), 404s a url the bundle was not baked with (override via `onNotFound`), and propagates render errors after `onError`. Producing Flight stays server React (the baked bundle); the handler runs client React and the two co-exist in one isolate.

## `build.edge.minify`

The bundle inlines React, so it is large, and edge platforms cap bundle size — `minify` defaults to **`true`**. Set `false` to emit readable output for inspection.

## How

Runs after the env builds, next to the deferred static-generation step. It bundles through **Vite's own `build()`** (not a separate bundler), so it rides Vite's internal transformer (esbuild today, Oxc/Rolldown later) — no new dependency.

Two `resolve.alias` redirects do the work. An alias redirects the *path* before export-condition matching, so it catches even the vendored CJS `require('react')` that ignores `resolve.conditions`:
- the react-server subpaths → their `react-server` export targets (**derived from react's own package `exports`** — no hardcoded `*.react-server.js`), so the bundle bakes **server** React without a process-level `--conditions react-server` (which would break the client render that runs in the same isolate);
- the vendored `server.node` transport → `server.edge` (Web streams), so no `node:*` from the Node transport.

`preserveModules: false` (single graph) sidesteps the CJS `__require` interop the preserveModules server build hits when React is inlined.

**Router-aware, no resolution divergence.** Post-build, `build.pages` already enumerates every URL (the SSG just rendered them) and every page module is in `dist/server`, so the bake **calls** the (possibly functional) `Page`/`props` router per URL and maps each route to its built module — a closed enumeration over what the build produced. The generated `renderRouteToFlight(url)` routes through vprs's **canonical `resolvePageAndProps`** (the same resolver dev/SSG use — props-as-function/class/async, props-in-page-module fallback, `{url}` default, errors), fed a closed dictionary loader over statically-imported baked modules (no runtime `import()`). So the edge render matches the rest of the pipeline rather than re-implementing it.

Constants are centralized in `DEFAULT_CONFIG` (`BUILD.edge.outDir` + `EDGE.*`) — no scattered magic strings.

## Incidental fix: `DEFAULT_CONFIG` no longer drags vite

`defaults.tsx` constructed `createLogger()` (from `"vite"`) at module top, so importing `DEFAULT_CONFIG` pulled vite — a **devDependency**, absent from a prod `node_modules` — into any prod/edge bundle (the bake failed resolving `rollup`/`fsevents`). The eager logger is dropped; the loader's default logger is `undefined` (call sites supply their own), kept type-safe via an erased `import type`. This is a latent-hazard fix beyond this feature.

## Why no infinite loop

The nested `vite.build()` uses `configFile: false`, so it never re-reads the user's vite config → the vprs plugin isn't re-instantiated → `buildApp` can't re-fire. Confirmed empirically (below).

## Verification

- `test/examples/build-edge-bundle.test.ts`: builds a fixture with `build.edge.singleIsolate`, asserts the baked bundle is emitted, the default `dist/server` build is untouched (additive), `renderRouteToFlight` → `renderFlightToHtml` renders in one process, and **`createEdgeHandler` serves a 200 with the hydration bootstrap wired in** (plus a 404 for an unbaked route). Client-only; skips on the react-server leg of `test-both`.
- **Runnable example**: `examples/hello-world` enables the edge build and ships `edge-server.mjs` (a Node adapter around `createEdgeHandler`) behind `npm run edge`. Verified end-to-end — `GET /` streams the rendered HTML with the `modulepreload`/bootstrap script, `GET /missing` → 404, client assets serve.
- **Real-demo validation** against the bidoof-template (overlay build, then restored): no loop (`exit 0`), the bake produces `dist/server-edge/render.js` over functional routing, and the canonical resolver renders `/`, `/bidoof`, and the live SQLite-backed `/todos` flash-free in one process, no `--conditions`, no worker.
- `test:server` 677 · `test:client` 191 · `test:typecheck` 20 · `tsc --noEmit` clean.

## Docs

New [`docs/edge.md`](docs/edge.md) (linked from the docs index) covers the model, enabling it, `createEdgeHandler`, finding `bootstrapModules`, the Node adapter, when to use it, and limitations. `configuration.md`, `build-output.md`, and `api-reference.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

