### PR TITLE
chore(release): 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump 2.9.1 → 2.10.0 (minor — new feature, additive).

## What lands in 2.10.0

**Single-isolate edge build (`build.edge`, ON by default).** An additive postbuild step that bakes the server graph (React inlined) into `dist/server-edge/render.js`, so a route can render flash-free in one isolate with no `worker_threads` and no runtime `--conditions react-server`. The worker-based `dist/server` build is untouched; a bake failure warns rather than failing the build.

Exports from the baked bundle, driven via `vite-plugin-react-server/stream`:
- `renderRouteToFlight` — low-level per-route Flight producer.
- `renderRouteToDocument` — full Html/Root-wrapped document flight + headless flight, for flash-free inline-flight SSR.
- `handleRouteAction` — a sealed server-action gate baked into the bundle, so `"use server"` apps dispatch actions without the on-disk react-server transport.

Supporting surface:
- `createEdgeHandler` (`./stream`) — composes the above into a Web `(Request) => Response`, with an inline-flight document mode.
- `createRequestHandler` is now condition-neutral (lazy action import + accepts a baked action function); new `./request-handler` export.
- `build.edge` config is `boolean | { outDir?, minify? }`, default `true`.

Docs: new `docs/edge.md`; `configuration`, `build-output`, `api-reference` updated.

## Release checklist (per docs/releasing.md)
- [x] `npm run build` succeeds; edge tests pass.
- [ ] Verified against linked demo (bidoof-template) — browser e2e.
- [ ] `npm pack` + clean-fixture install (npm-consumer path).
- [ ] `npm publish` (2FA — human step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)