### PR TITLE
feat(edge): createEdgeRequestHandler — the edge server in one call

### DIFF
--- a/docs/edge.md
+++ b/docs/edge.md
@@ -229,7 +229,7 @@ const dir = path.dirname(fileURLToPath(import.meta.url)); // dist/server/server
 async function main() {
   const handler = await createEdgeRequestHandler({
     buildDir: path.resolve(dir, "../.."), // → dist
-    base: process.env.BASE_URL || "/",
+    base: import.meta.env.BASE_URL, // the base this build was made for (baked in)
     dynamic: ["/todos"], // the only app-specific line
   });
   http.createServer(toNodeListener(handler)).listen(3000);

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -207,9 +207,59 @@ const handler = createRequestHandler({
 
 `createRequestHandler` lazy-imports its built-in (disk) gate, so passing the baked
 **function** keeps the whole server condition-neutral. The baked gate is still a
-sealed allowlist — an id the build did not enumerate is rejected. This is the
-shape that runs a full server-actions app (live data + flash-free SSR) in one
-isolate with `NODE_OPTIONS` unset; see the bidoof-template demo's `start.tsx`.
+sealed allowlist — an id the build did not enumerate is rejected.
+
+## The whole server in one call: `createEdgeRequestHandler`
+
+Static serving, the baked action gate, per-route document/flight rendering, CSS
+collection, bootstrap derivation — that wiring is the same for every consumer.
+`vite-plugin-react-server/edge` assembles it into one Web handler, so the server
+is a few lines and you supply only the runtime adapter:
+
+```ts
+// src/server/start.ts
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createEdgeRequestHandler } from "vite-plugin-react-server/edge";
+import { toNodeListener } from "vite-plugin-react-server/request-handler";
+
+const dir = path.dirname(fileURLToPath(import.meta.url)); // dist/server/server
+
+async function main() {
+  const handler = await createEdgeRequestHandler({
+    buildDir: path.resolve(dir, "../.."), // → dist
+    base: process.env.BASE_URL || "/",
+    dynamic: ["/todos"], // the only app-specific line
+  });
+  http.createServer(toNodeListener(handler)).listen(3000);
+}
+main();
+```
+
+It serves the prerendered `dist/static`, dispatches actions through the baked
+gate, and renders the `dynamic` routes live per request (flash-free document on a
+GET, headless flight on a client `.rsc` nav), collecting each route's CSS from the
+build manifests.
+
+`dynamic` is a **serving** decision — a url list or a `(url) => boolean`
+predicate — deliberately *not* on `Page`/`props`, which define the static page
+surface. A route is in `build.pages` because it's a page; you mark it `dynamic`
+here because rendering it live is a serving choice. Everything not matched is
+served from `dist/static`.
+
+| option           | default          | meaning |
+| ---------------- | ---------------- | ------- |
+| `buildDir`       | —                | build output dir (holds `static/`, `client/`, `server/`, `server-edge/`) |
+| `dynamic`        | `[]`             | routes to render live per request — url list or predicate |
+| `base`           | `"/"`            | url base the build was made for |
+| `inlineThreshold`| `10000`          | CSS at/under this many bytes inlines as `<style>`, else `<link>` |
+
+It returns the Web handler — *you* bring the runtime (node `http` above, or a
+Bun/Deno/platform `fetch` export). When you need custom middleware, auth, or your
+own routing, drop to the lower-level `createEdgeHandler` + `createRequestHandler`
+shown above: `createEdgeRequestHandler` is a thin wrapper over exactly those, so
+ejecting is swapping the wrapper, not a rewrite.
 
 > ⚠️ **Do not statically import or re-export your built `*.server.*` modules in
 > the no-`--conditions` process.** A built `"use server"` module imports the

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -267,6 +267,9 @@ for falls through to your own routes.
 
 ```ts
 import express from "express";
+import { createEdgeRequestHandler } from "vite-plugin-react-server/edge";
+import { toNodeListener } from "vite-plugin-react-server/request-handler";
+
 const handler = await createEdgeRequestHandler({ buildDir, dynamic: ["/todos"] });
 
 const app = express();

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -256,10 +256,38 @@ served from `dist/static`.
 | `inlineThreshold`| `10000`          | CSS at/under this many bytes inlines as `<style>`, else `<link>` |
 
 It returns the Web handler — *you* bring the runtime (node `http` above, or a
-Bun/Deno/platform `fetch` export). When you need custom middleware, auth, or your
-own routing, drop to the lower-level `createEdgeHandler` + `createRequestHandler`
-shown above: `createEdgeRequestHandler` is a thin wrapper over exactly those, so
-ejecting is swapping the wrapper, not a rewrite.
+Bun/Deno/platform `fetch` export).
+
+### Middleware (auth, logging, …)
+
+You don't eject for this — it's standard middleware. `toNodeListener(handler)` is
+a Connect/Express `(req, res, next)` middleware, so it slots into any Node stack:
+your middleware runs first, vprs serves the rest, and a request vprs has no page
+for falls through to your own routes.
+
+```ts
+import express from "express";
+const handler = await createEdgeRequestHandler({ buildDir, dynamic: ["/todos"] });
+
+const app = express();
+app.use(myAuth);                  // your middleware runs first
+app.use(rateLimit);
+app.use(toNodeListener(handler)); // vprs: static + actions + dynamic routes
+app.use("/api", myApiRouter);     // vprs 404s fall through to here (next())
+app.listen(3000);
+```
+
+On a Web runtime it's the same shape — middleware, then hand vprs the raw request:
+
+```ts
+app.use(myAuth);                  // Hono / itty / your framework
+app.all("*", (c) => handler(c.req.raw));
+```
+
+(For something more exotic than "wrap with middleware" — your own routing, a
+bespoke response envelope — the lower-level `createEdgeHandler` +
+`createRequestHandler` are the building blocks `createEdgeRequestHandler` is a
+thin wrapper over, so dropping a level is swapping the wrapper, not a rewrite.)
 
 > ⚠️ **Do not statically import or re-export your built `*.server.*` modules in
 > the no-`--conditions` process.** A built `"use server"` module imports the

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     },
     "./metrics": "./dist/plugin/metrics/index.js",
     "./request-handler": "./dist/plugin/helpers/createRequestHandler.server.js",
+    "./edge": "./dist/plugin/helpers/createEdgeRequestHandler.server.js",
     "./stream": {
       "react-server": "./dist/plugin/stream/index.server.js",
       "default": "./dist/plugin/stream/index.client.js"

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -290,6 +290,16 @@ const routes = {
 ${routeLines.join("\n")}
 };
 
+// Public route map: url -> { pagePath, propsPath } (no baked module refs). Lets a
+// runtime (e.g. createEdgeRequestHandler) collect each route's CSS from the build
+// manifests without knowing the Page/props routers.
+export const routeManifest = Object.fromEntries(
+  Object.entries(routes).map(([u, r]) => [
+    u,
+    { pagePath: r.pagePath, propsPath: r.propsPath },
+  ])
+);
+
 /** Resolve a route's Page component + live props through the canonical helper. */
 async function resolveRoute(url) {
   const route = routes[url];

--- a/plugin/helpers/createEdgeRequestHandler.server.ts
+++ b/plugin/helpers/createEdgeRequestHandler.server.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { Manifest } from "vite";
+import { createRequestHandler } from "./createRequestHandler.server.js";
+import { collectManifestCss } from "./collectManifestCss.js";
+import { createEdgeHandler } from "../stream/createEdgeHandler.client.js";
+import type { CssContent } from "../types.js";
+
+/**
+ * The baked edge bundle's public surface (`dist/server-edge/render.js`).
+ */
+type EdgeBundle = {
+  renderRouteToDocument: (
+    url: string,
+    opts?: { cssFiles?: Map<string, CssContent> }
+  ) => Promise<{
+    full: ReadableStream<Uint8Array>;
+    headless: ReadableStream<Uint8Array>;
+  }>;
+  handleRouteAction: (
+    request: Request,
+    opts?: { projectRoot?: string }
+  ) => Promise<Response>;
+  routeManifest: Record<string, { pagePath: string; propsPath: string }>;
+};
+
+export type CreateEdgeRequestHandlerOptions = {
+  /** The build output dir (holds `static/`, `client/`, `server/`, `server-edge/`). */
+  buildDir: string;
+  /**
+   * Which routes render live, per request (the serving-layer strategy — kept off
+   * `Page`/`props`, which define the static page surface). A list of urls or a
+   * predicate. Everything else is served from the prerendered `static/` build.
+   */
+  dynamic?: string[] | ((url: string) => boolean);
+  /** URL base the build was made for. @default "/" */
+  base?: string;
+  /** CSS at or under this many bytes inlines as `<style>`, else a `<link>`. @default 10000 */
+  inlineThreshold?: number;
+  /** Project root passed to the action gate (baked gate ignores it). @default process.cwd() */
+  projectRoot?: string;
+  /** Overrides for non-default output layouts. */
+  staticDir?: string;
+  clientDir?: string;
+  edgeBundlePath?: string;
+};
+
+/** Attach each server-manifest entry's CSS from the static build (so page+props resolve styles). */
+function transformServerManifestCss(
+  serverManifest: Manifest,
+  staticManifest: Manifest
+): Manifest {
+  return Object.fromEntries(
+    Object.entries(serverManifest).map(([key, entry]) => {
+      const e = entry as { isEntry?: boolean; file?: string };
+      if (e?.isEntry && e.file) {
+        for (const sv of Object.values(staticManifest)) {
+          const s = sv as { file?: string; css?: string[] };
+          if (s?.file === e.file && s.css?.length) {
+            return [key, { ...entry, css: s.css }];
+          }
+        }
+      }
+      return [key, entry];
+    })
+  ) as Manifest;
+}
+
+/** Build the `Map<file, CssContent>` a dynamic render passes for its page styles. */
+function toCssMap(
+  inputs: Record<string, string>,
+  staticDir: string,
+  base: string,
+  inlineThreshold: number
+): Map<string, CssContent> {
+  return new Map(
+    Object.values(inputs).map((file) => {
+      const code = readFileSync(join(staticDir, file), "utf-8");
+      const content: CssContent =
+        code.length <= inlineThreshold
+          ? { id: file, as: "style", type: "text/css", children: code }
+          : { id: file, as: "link", rel: "stylesheet", href: base + file, precedence: "high" };
+      return [file, content];
+    })
+  );
+}
+
+/**
+ * Assemble the whole no-`--conditions` edge server for a vprs build into one Web
+ * `(Request) => Response` — the thing every consumer's `start.tsx` was rebuilding
+ * by hand. It serves the prerendered `static/` build, dispatches `"use server"`
+ * actions through the bundle's baked gate, and renders the `dynamic` routes live
+ * per request (flash-free document on a GET, headless flight on a client `.rsc`
+ * navigation) with their CSS collected from the build manifests.
+ *
+ * Returns the handler; you supply the runtime adapter (node `http`, Bun, Deno, a
+ * platform `fetch` export) — so the "edge" promise stays yours. Pair it with a
+ * few-line entry instead of a hundred lines of wiring.
+ */
+export async function createEdgeRequestHandler(
+  options: CreateEdgeRequestHandlerOptions
+): Promise<(request: Request) => Promise<Response>> {
+  const {
+    buildDir,
+    base = "/",
+    inlineThreshold = 10000,
+    projectRoot = process.cwd(),
+  } = options;
+  const staticDir = options.staticDir ?? join(buildDir, "static");
+  const clientDir = options.clientDir ?? join(buildDir, "client");
+  const edgePath =
+    options.edgeBundlePath ?? join(buildDir, "server-edge", "render.js");
+
+  const readManifest = (dir: string): Manifest =>
+    JSON.parse(readFileSync(join(dir, ".vite", "manifest.json"), "utf-8"));
+  const staticManifest = readManifest(staticDir);
+  const serverManifest = readManifest(join(buildDir, "server"));
+  const transformedServer = transformServerManifestCss(
+    serverManifest,
+    staticManifest
+  );
+
+  // The in-process HTML render resolves client-component references from the ssr
+  // bundle (dist/client) on disk; the browser hydrates from `base` separately.
+  const ssrModuleBaseURL = pathToFileURL(clientDir).href + "/";
+  const indexFile = (staticManifest["index.html"] as { file?: string })?.file;
+  const bootstrapModules = indexFile ? [base + indexFile] : [];
+
+  const { renderRouteToDocument, handleRouteAction, routeManifest } =
+    (await import(pathToFileURL(edgePath).href)) as EdgeBundle;
+
+  const dynamic = options.dynamic ?? [];
+  const isDynamic =
+    typeof dynamic === "function"
+      ? dynamic
+      : (url: string) => dynamic.includes(url);
+
+  const cssCache = new Map<string, Map<string, CssContent>>();
+  const cssForRoute = (url: string): Map<string, CssContent> => {
+    let m = cssCache.get(url);
+    if (!m) {
+      const info = routeManifest[url];
+      const inputs = info
+        ? collectManifestCss(transformedServer, [info.pagePath, info.propsPath])
+        : {};
+      m = toCssMap(inputs, staticDir, base, inlineThreshold);
+      cssCache.set(url, m);
+    }
+    return m;
+  };
+
+  const normalizeRoute = (pathname: string): string =>
+    pathname.replace(/\/index\.rsc$|\.rsc$|\/$/, "") || "/";
+
+  return createRequestHandler({
+    staticDir,
+    action: (request) => handleRouteAction(request, { projectRoot }),
+    render: async (pathname, request) => {
+      const route = normalizeRoute(pathname);
+      if (!isDynamic(route)) return null;
+      const wantsFlight =
+        pathname.endsWith(".rsc") ||
+        (request.headers.get("accept") ?? "").includes("text/x-component");
+      try {
+        if (wantsFlight) {
+          // Client navigation: the live headless flight for #root.
+          const { headless } = await renderRouteToDocument(route, {
+            cssFiles: cssForRoute(route),
+          });
+          return new Response(headless as unknown as BodyInit, {
+            headers: {
+              "Content-Type": "text/x-component; charset=utf-8",
+              "Cache-Control": "no-cache",
+            },
+          });
+        }
+        // Document load: the full flash-free HTML with the live data + inline flight.
+        const handler = createEdgeHandler({
+          renderDocument: () =>
+            renderRouteToDocument(route, { cssFiles: cssForRoute(route) }),
+          moduleBaseURL: ssrModuleBaseURL,
+          bootstrapModules,
+          getURL: () => route,
+        });
+        return await handler(request);
+      } catch (error) {
+        // Degrade to the prerendered shell rather than 500.
+        console.error(
+          `[edge] dynamic render failed for ${route}; serving prerendered shell:`,
+          error
+        );
+        return null;
+      }
+    },
+  });
+}

--- a/plugin/helpers/createEdgeRequestHandler.server.ts
+++ b/plugin/helpers/createEdgeRequestHandler.server.ts
@@ -34,7 +34,12 @@ export type CreateEdgeRequestHandlerOptions = {
    * predicate. Everything else is served from the prerendered `static/` build.
    */
   dynamic?: string[] | ((url: string) => boolean);
-  /** URL base the build was made for. @default "/" */
+  /**
+   * URL base the build was made for. Pass your build's `import.meta.env.BASE_URL`
+   * (baked in at build time) rather than a runtime env var, so it can't drift
+   * from the base the prerendered assets and bootstrap paths were built with.
+   * @default "/"
+   */
   base?: string;
   /** CSS at or under this many bytes inlines as `<style>`, else a `<link>`. @default 10000 */
   inlineThreshold?: number;

--- a/plugin/helpers/createRequestHandler.server.ts
+++ b/plugin/helpers/createRequestHandler.server.ts
@@ -118,14 +118,26 @@ export function createRequestHandler(
 }
 
 /**
- * Adapt a Web `(Request) => Promise<Response>` handler to a Node
- * `http`/Connect request listener, so the same handler runs under
- * `http.createServer(toNodeListener(handler))` or as Express middleware.
+ * Adapt a Web `(Request) => Promise<Response>` handler to a Node `http`/Connect
+ * request listener — a standard `(req, res, next?)` so it drops into any
+ * Connect/Express/polka stack:
+ *
+ *   - `http.createServer(toNodeListener(handler))` — terminal (no `next`): the
+ *     handler's response is always sent, 404 included.
+ *   - `app.use(toNodeListener(handler))` — as middleware: a 404 from the handler
+ *     means vprs has nothing for this request, so it calls `next()` and the
+ *     request falls through to your other routes; a thrown error goes to
+ *     `next(err)`. Put your own middleware (auth, logging, body limits) before
+ *     it and your own routes after.
  */
 export function toNodeListener(
   handler: (request: Request) => Promise<Response>
-): (req: IncomingMessage, res: ServerResponse) => void {
-  return (req, res) => {
+): (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next?: (err?: unknown) => void
+) => void {
+  return (req, res, next) => {
     const url = `http://${req.headers.host ?? "localhost"}${req.url ?? "/"}`;
     const method = req.method ?? "GET";
     const headers = new Headers();
@@ -144,6 +156,12 @@ export function toNodeListener(
 
     handler(request)
       .then(async (response) => {
+        // Mounted as middleware, a 404 means "not mine" — fall through to the
+        // next handler instead of ending the chain. Terminal without `next`.
+        if (next && response.status === 404) {
+          next();
+          return;
+        }
         res.statusCode = response.status;
         response.headers.forEach((value, key) => res.setHeader(key, value));
         if (response.body) {
@@ -154,6 +172,10 @@ export function toNodeListener(
         res.end();
       })
       .catch((err) => {
+        if (next) {
+          next(err);
+          return;
+        }
         res.statusCode = 500;
         res.end(String(err instanceof Error ? err.message : err));
       });


### PR DESCRIPTION
Collapses the hand-rolled edge `start.tsx` (~130 lines of manifest/bootstrap/CSS/routing wiring) down to a handful.

## What
New `vite-plugin-react-server/edge` export:

```ts
const handler = await createEdgeRequestHandler({ buildDir, dynamic: ["/todos"] });
http.createServer(toNodeListener(handler)).listen(3000); // your adapter
```

It assembles the whole no-`--conditions` edge server from a vprs build:
- serves the prerendered `dist/static`,
- dispatches `"use server"` actions through the bundle's baked gate,
- renders the `dynamic` routes live per request (flash-free document on GET, headless flight on a client `.rsc` nav), collecting each route's CSS from the build manifests automatically.

`dynamic` is the **serving-layer** strategy (url list or predicate), kept off `Page`/`props` (which define the static page surface) — concerns stay separated. The consumer supplies only the runtime adapter, so node/Bun/Deno/edge `fetch` stays their call.

The baked bundle also gains a `routeManifest` export (url → `{pagePath, propsPath}`) so the handler resolves per-route CSS without needing the Page/props routers at runtime.

## Middleware (no eject)

`toNodeListener` is now a proper Connect/Express `(req, res, next)` middleware: mount it in any Node stack with your own middleware before and routes after — a request vprs has no page for falls through via `next()` (terminal as before under `http.createServer`).

```ts
app.use(myAuth);
app.use(toNodeListener(handler)); // static + actions + dynamic
app.use("/api", myApiRouter);     // vprs 404s fall through here
```

So auth/logging/etc. is the standard middleware pattern, not "drop to the low-level pieces."

## Verification
In-process against bidoof-template (the helper it now uses): actions persist through the baked gate, `/todos` renders live with inline flight + auto-collected CSS, static routes serve from the prerender. The build succeeds; the live socket-bound boot wasn't runnable in my sandbox, so that's a `npm run demo` confirm.

## Follow-ups (not in this PR)
- A vprs-level test driving `createEdgeRequestHandler` over the fixture.
- The bidoof `start.tsx` collapse lands after this releases (it imports `/edge`).
- Possible zero-config layer (`vprs serve`) on top of this primitive — discussed, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
