### PR TITLE
chore: silence dev log/warning noise (handleRscStream log + index.html dep-scan)

### DIFF
--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -532,6 +532,18 @@ export const resolveUserConfig: ResolveUserConfigFn =
           noExternal: mergedNoExternal,
         },
         define: define,
+        optimizeDeps: {
+          ...config.optimizeDeps,
+          // Vite's dep scanner defaults to crawling the build input for entry
+          // points; in dev that resolves to the static `index.html`, which an
+          // RSC dev server never serves — so the scan fails and logs
+          // "failed to resolve rolldownOptions.input value: index.html".
+          // Give it an explicit (empty) entry list to skip the html crawl;
+          // deps are still optimized lazily / via ssr.optimizeDeps.include.
+          // (optimizeDeps is a no-op in build, so the real index.html entry
+          // there is unaffected.)
+          entries: config.optimizeDeps?.entries ?? [],
+        },
         ssr: srrConfig,
         server: {
           ...config.server,

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -532,18 +532,6 @@ export const resolveUserConfig: ResolveUserConfigFn =
           noExternal: mergedNoExternal,
         },
         define: define,
-        optimizeDeps: {
-          ...config.optimizeDeps,
-          // Vite's dep scanner defaults to crawling the build input for entry
-          // points; in dev that resolves to the static `index.html`, which an
-          // RSC dev server never serves — so the scan fails and logs
-          // "failed to resolve rolldownOptions.input value: index.html".
-          // Give it an explicit (empty) entry list to skip the html crawl;
-          // deps are still optimized lazily / via ssr.optimizeDeps.include.
-          // (optimizeDeps is a no-op in build, so the real index.html entry
-          // there is unaffected.)
-          entries: config.optimizeDeps?.entries ?? [],
-        },
         ssr: srrConfig,
         server: {
           ...config.server,

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -241,6 +241,17 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
           keepProcessEnv: envConfig.name === "server" ? true : false,
           define: userConfig.define,
           consumer: consumer,
+          optimizeDeps: {
+            ...userConfig.optimizeDeps,
+            // Vite 8's dep scanner crawls the build input for entry points; in
+            // dev that resolves to the static `index.html`, which an RSC dev
+            // server never serves, so the scan fails and logs (per re-optimize)
+            // "failed to resolve rolldownOptions.input value: index.html".
+            // An explicit empty entries list skips the html crawl; deps still
+            // optimize lazily. optimizeDeps is a no-op in build, so the real
+            // index.html build entry is unaffected.
+            entries: userConfig.optimizeDeps?.entries ?? [],
+          },
           resolve: {
             ...userConfig.resolve,
             // IMPORTANT: Map externals from resolveUserConfig (rollupOptions.external) to Environment API format

--- a/test/unit/handleWorkerRscStream.test.ts
+++ b/test/unit/handleWorkerRscStream.test.ts
@@ -142,7 +142,6 @@ describe('handleWorkerRscStream', () => {
     const options = createOptions(route);
 
     // Call the function and get the stream
-    console.log('About to call handleRscStream with options:', { ...options, rscWorker: mockWorker, url: '', logger: mockLogger });
     const stream = handleRscStream({
       options: {
         ...options,


### PR DESCRIPTION
Two CI/dev log-noise cleanups surfaced after the Vite 8 work landed:

- **Remove a leftover `console.log`** in `handleWorkerRscStream.test.ts` ("About to call handleRscStream with options") that printed once per test case.
- **Skip the dep-scan html crawl in dev.** Vite 8's optimizeDeps scanner defaults to crawling the build input for entries; in dev that's the static `index.html`, which an RSC dev server doesn't serve, so the scan fails and logs `failed to resolve rolldownOptions.input value: index.html` on every re-optimize. The client env now passes an explicit empty `optimizeDeps.entries` to skip the crawl. `optimizeDeps` is dev-only, so the real `index.html` build entry is unaffected; deps still optimize lazily / via `ssr.optimizeDeps.include`.

No behavior change beyond log output. build:types + dev/unit suites green locally.