### PR TITLE
docs: Vite 6/7/8 support + Rolldown dynamic-import limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ which is itself built with vprs.
   transport exports) ship in stable React; the matching `react-server-dom-esm`
   transport comes from the `react-server-loader` dependency, which tracks your
   React track. See [React Compatibility](./docs/react-type-compatibility.md).
-- Vite 6+
+- **Vite 6, 7, or 8** (`vite` peer: `^6.3.5 || ^7 || ^8`). Vite 8 builds with
+  Rolldown/Oxc instead of Rollup/esbuild; vprs runs on all three.
 
 ## TypeScript
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -168,6 +168,23 @@ vitePluginReactServer({
 });
 ```
 
+## Variable Dynamic Imports on Vite 8 (Rolldown)
+
+A *variable* dynamic import in a server module — ``import(`./pages/${name}.js`)``
+where the specifier is built from a variable — fails to build on Vite 8. The
+plugin's server bundle uses `preserveModules`, and Rolldown does not emit its
+dynamic-import helper module in that mode, so the build can't resolve it:
+
+```
+Failed to load url ../_virtual/_rolldown_dynamic_import_helper.js
+Component resolution failed: missing required components (Page: false)
+```
+
+This is an upstream Rolldown limitation, not vprs-specific. Workarounds:
+
+- Replace the variable import with a static map (`{ light: () => import("./light.js"), … }[name]()`), or
+- Build that route on **Vite 6 or 7** (Rollup), which emit the helper.
+
 ## Checklist for New Projects
 
 - [ ] React packages have matching versions (19+)


### PR DESCRIPTION
Docs for the 2.11.0 (Vite 7/8) release:

- **README requirements**: `- Vite 6+` → explicit `vite` peer `^6.3.5 || ^7 || ^8`, with a note that Vite 8 builds on Rolldown/Oxc. (README is the only doc that ships in the npm package.)
- **Troubleshooting**: new entry for the one known Vite 8/Rolldown limitation — variable dynamic imports in a `preserveModules` server build fail because Rolldown doesn't emit its dynamic-import helper — with workarounds (static import map, or build that route on Vite 6/7).

Docs-only; no code change.