### PR TITLE
fix(dev): skip null-id module-graph nodes in CSS collection

### DIFF
--- a/plugin/helpers/collectViteModuleGraphCss.ts
+++ b/plugin/helpers/collectViteModuleGraphCss.ts
@@ -208,18 +208,20 @@ export const collectViteModuleGraphCss: CollectViteModuleGraphCssFn =
         }
         // Found imported modules
         for (const importedMod of importedModules) {
-          if (typeof importedMod === "object" && importedMod != null) {
-            if (
-              "id" in importedMod &&
-              importedMod.id &&
-              typeof importedMod.id === "string"
-            ) {
-              await walkModule(importedMod);
-            } else {
-              throw new Error(`Imported module has no id`);
-            }
-          } else {
-            throw new Error(`Imported module is not an object`);
+          // Vite's dev module graph can hold unresolved nodes whose `id` is
+          // still null (referenced but not yet resolved/transformed). They
+          // carry no CSS to collect and nothing to recurse into, so skip them
+          // rather than aborting the whole walk — a single such node used to
+          // throw `Imported module has no id` and break CSS collection for the
+          // entire page in dev:rsc.
+          if (
+            typeof importedMod === "object" &&
+            importedMod != null &&
+            "id" in importedMod &&
+            importedMod.id &&
+            typeof importedMod.id === "string"
+          ) {
+            await walkModule(importedMod);
           }
         }
       }


### PR DESCRIPTION
In `dev:rsc`, `collectViteModuleGraphCss`'s `walkModule` threw `Imported module has no id` on the first imported module lacking a string id, aborting CSS collection for the entire page:

```
Error: Imported module has no id
    at walkModule (collectViteModuleGraphCss.js)
    at _collectViteModuleGraphCss (...)
    at configureReactServer.server.js
```

Vite's dev module graph legitimately contains **unresolved nodes** (`id: null` — referenced but not yet resolved/transformed). They carry no CSS to collect and nothing to recurse into, so the walk should skip them, not abort. Non-object entries are skipped too.

**Verified:** reproduced on a real consumer (mmc) where `dev:rsc` threw on `/10mmc/levels/1`; after the fix that route and others render 200 with no error in the log. vprs dev test suite green (37 passed, incl. CSS HMR).
