### PR TITLE
chore(release): 2.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/helpers/collectViteModuleGraphCss.ts
+++ b/plugin/helpers/collectViteModuleGraphCss.ts
@@ -208,18 +208,20 @@ export const collectViteModuleGraphCss: CollectViteModuleGraphCssFn =
         }
         // Found imported modules
         for (const importedMod of importedModules) {
-          if (typeof importedMod === "object" && importedMod != null) {
-            if (
-              "id" in importedMod &&
-              importedMod.id &&
-              typeof importedMod.id === "string"
-            ) {
-              await walkModule(importedMod);
-            } else {
-              throw new Error(`Imported module has no id`);
-            }
-          } else {
-            throw new Error(`Imported module is not an object`);
+          // Vite's dev module graph can hold unresolved nodes whose `id` is
+          // still null (referenced but not yet resolved/transformed). They
+          // carry no CSS to collect and nothing to recurse into, so skip them
+          // rather than aborting the whole walk — a single such node used to
+          // throw `Imported module has no id` and break CSS collection for the
+          // entire page in dev:rsc.
+          if (
+            typeof importedMod === "object" &&
+            importedMod != null &&
+            "id" in importedMod &&
+            importedMod.id &&
+            typeof importedMod.id === "string"
+          ) {
+            await walkModule(importedMod);
           }
         }
       }


### PR DESCRIPTION
Release **2.11.1** (patch). Carries the dev-server CSS fix plus the version bump.

**Fix:** in `dev:rsc`, `collectViteModuleGraphCss`'s `walkModule` threw `Imported module has no id` on the first imported module lacking a string id. Vite's dev module graph legitimately holds unresolved nodes (`id: null`, referenced but not yet resolved/transformed), so one such node aborted CSS collection for the entire page. It now skips them.

Supersedes #210 (same fix, with the version bump and a clean commit history).

**Verified:** reproduced on a real consumer (mmc `dev:rsc` threw on `/10mmc/levels/1`); after the fix that route and others render 200 with no error. vprs dev suite green (37 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)