### PR TITLE
fix(worker): inactivity watchdog for worker startup (no more "Worker ready timeout" flake)

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,6 +317,7 @@
     "test:unit": "NODE_OPTIONS='--conditions react-server' vitest run test/unit/*",
     "test:tee": "rm -f build.log && npm run test:build 2>&1 | tee build.log",
     "test:rsc-worker": "npm run build && vitest run test/client/rsc-worker.test.ts",
+    "test:worker-startup": "npm run build && VPRS_WORKER_STRESS=1 NODE_OPTIONS='--conditions react-server' vitest run test/unit/worker-startup-watchdog.test.ts",
     "test:large-html": "npm run test:examples -- test/examples/large-html-handling.test.ts",
     "test:metrics": "npm run test:examples -- test/examples/metrics.test.ts",
     "test:error-boundaries": "npm run test:examples -- test/examples/error-boundaries-build.test.ts test/examples/error-boundaries.test.ts",

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -178,8 +178,14 @@ export const DEFAULT_CONFIG = {
   REACT_DIRECTIVES: new Set(["use client", "use server"]),
   RSC_TIMEOUT: 5000, // 5 seconds default timeout for RSC operations
   HTML_TIMEOUT: 15000, // 15 seconds default timeout for HTML generation operations
-  HTML_WORKER_STARTUP_TIMEOUT: 3000, // 3 seconds default timeout for HTML worker startup
-  RSC_WORKER_STARTUP_TIMEOUT: 3000, // 3 seconds default timeout for RSC worker startup
+  // Worker startup is an INACTIVITY budget (see createWorker.ts): re-armed on
+  // the worker's `online` event and every message, so spawn-queue latency under
+  // load doesn't count. 10s is a hang-guard for a worker that started but then
+  // went silent — not a perf SLA. A cold worker imports `vite` into a fresh
+  // isolate, which under heavy parallel load (e.g. a full test run) can take
+  // several seconds of wall time; 3s routinely killed healthy-but-slow starts.
+  HTML_WORKER_STARTUP_TIMEOUT: 10000, // 10s inactivity hang-guard for HTML worker startup
+  RSC_WORKER_STARTUP_TIMEOUT: 10000, // 10s inactivity hang-guard for RSC worker startup
   FILE_WRITE_TIMEOUT: 10000, // 10 seconds default timeout for file write operations
   WORKER_SHUTDOWN_TIMEOUT: 1000, // Reduced to 1 second for faster test cleanup
   // Default Html/Root components are intentionally NOT held here: they import

--- a/plugin/worker/createWorker.ts
+++ b/plugin/worker/createWorker.ts
@@ -381,16 +381,38 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
             ? DEFAULT_CONFIG.RSC_WORKER_STARTUP_TIMEOUT
             : DEFAULT_CONFIG.HTML_WORKER_STARTUP_TIMEOUT);
 
-        const timeout = setTimeout(() => {
-          reject({
-            type: "error",
-            error: new Error(
-              `Worker ready timeout after ${startupTimeout}ms (worker/${workerType})`
-            ),
-          });
-        }, startupTimeout);
+        // Inactivity watchdog instead of a fixed deadline measured from spawn.
+        // Under heavy parallel load a freshly-spawned worker can sit queued for
+        // CPU for seconds before it executes a single line — that scheduling
+        // delay must not count against startup. Re-arm the timer on every sign
+        // of life ("online" = the isolate began executing; any message), so it
+        // only fires after `startupTimeout` ms of genuine silence. Real
+        // crashes/hangs are still caught by the exit/error handlers below,
+        // independently of this timer.
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        const onActivity = () => armWatchdog();
+        const clearStartupListeners = () => {
+          if (timeout) clearTimeout(timeout);
+          worker.removeListener("online", onActivity);
+          worker.removeListener("message", onActivity);
+        };
+        function armWatchdog() {
+          if (timeout) clearTimeout(timeout);
+          timeout = setTimeout(() => {
+            clearStartupListeners();
+            reject({
+              type: "error",
+              error: new Error(
+                `Worker ready timeout after ${startupTimeout}ms of inactivity (worker/${workerType})`
+              ),
+            });
+          }, startupTimeout);
+        }
+        armWatchdog();
+        worker.on("online", onActivity);
+        worker.on("message", onActivity);
         const exitHandler = (code: number) => {
-          clearTimeout(timeout);
+          clearStartupListeners();
           worker.removeListener("message", messageHandler);
           // Remove worker from registry when it exits
           activeWorkers.delete(worker);
@@ -413,7 +435,7 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
           if (msg.type === "READY" && msg.id === id) {
             if (verbose)
               logger.info(`[create:${id}] Worker running for ${msg.env}`);
-            clearTimeout(timeout);
+            clearStartupListeners();
             worker.removeListener("message", messageHandler);
             worker.removeListener("exit", exitHandler);
             // Compare against the NODE_ENV we spawned the worker with (the
@@ -443,7 +465,8 @@ Current condition: ${currentCondition}, Reverse condition: ${reverseCondition}`
         worker.on("error", (err: Error) => {
           // Remove worker from registry on error
           activeWorkers.delete(worker);
-          
+          clearStartupListeners();
+
           if (verbose && err != null) {
             logger.error(
               `[create:${id}] Worker error: ${err.message}.\n${err.stack}`,

--- a/test/unit/worker-startup-stub.mjs
+++ b/test/unit/worker-startup-stub.mjs
@@ -1,0 +1,37 @@
+// Stub worker for the startup-watchdog stress test (worker-startup-watchdog.test.ts).
+// Lives in test/unit (not test/fixtures, which is gitignored) because it must be
+// a committed file the worker thread loads by path. It deliberately does NOT
+// import React/vite — it just reproduces the timing shape of a real worker: the
+// thread comes 'online' (Node emits that the instant the script starts), then
+// spends `stubBusyMs` synchronously blocked (standing in for the cold import of
+// `vite` into a fresh isolate), and only then signals READY.
+//
+// With `stubSilent: true` it comes online but never signals ready and never
+// exits — a genuinely hung startup, which the inactivity watchdog should still
+// catch.
+import { parentPort, workerData } from "node:worker_threads";
+
+const busyMs = Number(workerData?.stubBusyMs ?? 0);
+const silent = workerData?.stubSilent === true;
+
+if (busyMs > 0) {
+  const end = Date.now() + busyMs;
+  // Busy-block the worker thread, exactly like a synchronous module evaluation.
+  while (Date.now() < end) {
+    /* spin */
+  }
+}
+
+if (silent) {
+  // Stay alive but never post READY (and never exit) → simulate a real hang.
+  setInterval(() => {}, 1000);
+} else {
+  parentPort?.postMessage({
+    type: "READY",
+    env: process.env.NODE_ENV,
+    pid: process.pid,
+    // createWorker sets workerData.id to its own computed id ("worker/rsc" here)
+    // when the caller doesn't pass one, and matches READY against that id.
+    id: workerData?.id ?? "worker/rsc",
+  });
+}

--- a/test/unit/worker-startup-watchdog.test.ts
+++ b/test/unit/worker-startup-watchdog.test.ts
@@ -22,7 +22,7 @@ const RUN = process.env["VPRS_WORKER_STRESS"] === "1";
 
 const stubPath = join(
   dirname(fileURLToPath(import.meta.url)),
-  "../fixtures/worker-startup/stub-worker.mjs"
+  "worker-startup-stub.mjs"
 );
 
 const silentLogger = { info() {}, warn() {}, error() {} } as never;

--- a/test/unit/worker-startup-watchdog.test.ts
+++ b/test/unit/worker-startup-watchdog.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Stress + behaviour coverage for the worker-startup handshake in
+ * createWorker.ts. The startup deadline is an INACTIVITY watchdog: it re-arms
+ * on the worker's `online` event and on every message, so spawn-queue latency
+ * under heavy parallel load no longer counts against a healthy-but-slow worker.
+ * Genuine hangs (online but then silent) still fail.
+ *
+ * These drive the real createWorker against a stub worker that reproduces the
+ * timing shape of a cold start (comes online, then blocks for a while) without
+ * pulling in React/vite.
+ */
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+// Spawns REAL worker threads, so it runs against the BUILT createWorker — the
+// worker's `--import register-vendor.js` only resolves from dist. Gated behind
+// VPRS_WORKER_STRESS so it only runs after a fresh build (the `test:worker-
+// startup` script), never against stale dist in the regular suite.
+import { createWorker } from "../../dist/plugin/worker/createWorker.js";
+
+const RUN = process.env["VPRS_WORKER_STRESS"] === "1";
+
+const stubPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../fixtures/worker-startup/stub-worker.mjs"
+);
+
+const silentLogger = { info() {}, warn() {}, error() {} } as never;
+
+function spawnStub(workerData: Record<string, unknown>) {
+  return createWorker({
+    workerPath: stubPath,
+    // Force the rsc id so the stub's READY id matches regardless of the
+    // condition the test file runs under.
+    reverseCondition: "react-server",
+    logger: silentLogger,
+    workerData,
+  } as never) as Promise<
+    | { type: "success"; worker: { terminate(): Promise<number> } }
+    | { type: "error"; error: Error }
+    | { type: "skip" }
+  >;
+}
+
+async function terminate(
+  results: Array<{ type: string; worker?: { terminate(): Promise<number> } }>
+) {
+  await Promise.all(
+    results.map((r) => (r.type === "success" ? r.worker!.terminate() : null))
+  );
+}
+
+describe.skipIf(!RUN)("worker startup watchdog", () => {
+  it("starts many workers concurrently under load without spurious timeouts", async () => {
+    // 16 workers spawned at once, each blocking ~800ms — heavy contention that
+    // would push some past a fixed 3s-from-spawn deadline on a busy machine.
+    const N = 16;
+    const results = await Promise.all(
+      Array.from({ length: N }, () => spawnStub({ stubBusyMs: 800 }))
+    );
+    try {
+      for (const r of results) expect(r.type).toBe("success");
+    } finally {
+      await terminate(results);
+    }
+  }, 30000);
+
+  it("does not kill a slow-but-alive worker that blocks well past the old 3s deadline", async () => {
+    const r = await spawnStub({ stubBusyMs: 4000 });
+    try {
+      expect(r.type).toBe("success");
+    } finally {
+      await terminate([r]);
+    }
+  }, 20000);
+
+  it("still fails a worker that comes online but never signals ready", async () => {
+    const r = await spawnStub({
+      stubSilent: true,
+      userOptions: { rscWorkerStartupTimeout: 600 },
+    });
+    expect(r.type).toBe("error");
+    if (r.type === "error") {
+      expect(String(r.error?.message)).toMatch(/timeout/i);
+    }
+  }, 15000);
+});


### PR DESCRIPTION
The RSC/HTML worker-ready handshake used a fixed `setTimeout` measured from spawn (default 3000ms). Under heavy parallel load a freshly-spawned worker can sit queued for CPU for seconds before it runs a single line, and a cold worker then imports `vite` into a fresh isolate — so a healthy-but-slow worker got killed with `Worker ready timeout`. That is a load-sensitive flake (it surfaced in a full test run), not a real failure.

## Why the deadline was the wrong tool
Genuine failures — crash, non-zero exit, thrown error — are already caught by the worker's `exit`/`error` handlers, independently of the timer. So the fixed deadline never protected against crashes; it only ever killed slow-but-alive starts.

## Change
- **Inactivity watchdog** instead of a fixed deadline: re-arm the timer on the worker's `online` event (the isolate began executing) and on every message, so spawn-queue latency no longer counts against startup and only genuine silence fails.
- Raise the default startup budget to **10s** and document it as a hang-guard, not a perf SLA (still overridable via `rscWorkerStartupTimeout` / `htmlWorkerStartupTimeout`).

## Test (`npm run test:worker-startup`)
A stress test spawns many real workers through the actual `createWorker` handshake:
- 16 workers concurrently, each blocking ~800ms → all start clean.
- one worker blocking 4000ms (past the old 3s deadline) → succeeds (proves slow-but-alive isn't killed).
- one worker that comes online but never signals ready → still times out (hang-guard intact).

Regression: `test:dev` (37) and the previously-flaky `preserve-modules-root` suite both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)