### PR TITLE
fix(vite8): stop the environments plugin re-emitting deprecated `esbuild`

### DIFF
--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -384,9 +384,19 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
       // Build order: client → ssr → server → static generation (step 4)
       // Server build runs LAST so dist/client exists when HTML rendering references client components
       // Static generation is deferred to run after ALL environments complete (needs server manifest)
+      // This hook echoes the incoming config via `...config`. On Vite 8 that
+      // re-emits any upstream `esbuild` option, and Vite attributes the
+      // deprecation warning to whichever plugin last emitted it — i.e. us. We
+      // don't own that option (the only knob we set, dev JSX, is mapped onto
+      // `oxc` in `esbuildJsxDevOverride`), so drop `esbuild` from the echo on
+      // Vite 8. The original value still lives on the resolved config; we just
+      // stop re-attributing the deprecated key to this plugin.
+      const { esbuild: _droppedEsbuild, ...configEcho } = config as UserConfig & {
+        esbuild?: unknown;
+      };
       return {
         root: userOptions.projectRoot,
-        ...config,
+        ...(isOxcVite ? configEcho : config),
         ...esbuildJsxDevOverride,
         environments,
         builder: {


### PR DESCRIPTION
On Vite 8 the dev server (and example builds) logged:

```
[vite] warning: `esbuild` option was specified by "vite:plugin-react-server/environments" plugin. This option is deprecated, please use `oxc` instead.
```

**Cause:** the environments plugin's `config` hook echoes the incoming config with `...config`. That re-emits any upstream `esbuild` option, and Vite 8 attributes the deprecation warning to whichever plugin's config hook last emitted it — so vprs got blamed for an option it doesn't own. (The one knob it does set, dev JSX, is already mapped onto `oxc` for Vite 8.)

**Fix:** drop `esbuild` from the echo on Vite 8 only. The value still lives on the resolved config — we just stop re-attributing the deprecated key to this plugin. Vite 6/7 keep the full echo unchanged.

**Verified:** warning gone across the dev suite (37 passed), an example build, and the hello-world example on Vite 8; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)