### PR TITLE
chore(deps): bump react-server-loader to 19.2.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6437,9 +6437,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.13.tgz",
-      "integrity": "sha512-vurFA5Z632WHBw+49jKGVEskHmgiNMgGl8RqRKC5abn8DftwSJ/EgUXIzSC/F8bwBGA1fwfH0DwPYrzovqvGyg==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.14.tgz",
+      "integrity": "sha512-hlSqNImloYIKbZ3+Iz7fGqam77t2q8QKJx9+SyKcsclabcii+1sa5eFWwPnzkd+8CfJQQYQG0srGvrmHJCQKVg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",


### PR DESCRIPTION
main is pinned to rsl **19.2.13**, which has the misplaced-directive regression — `test/unit/viteInjectedCode.test.ts` fails on it ("still throws on a genuine misplaced directive"). That also fails every open PR, since their CI runs against the merge with main.

19.2.14 fixes it (the directive decision is AST-based again). Lockfile-only bump; the `^19.2.12` range already allows it. Verified the directive test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)