### PR TITLE
feat: file-based router (dynamic params, typed nav, auto params into loaders)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.12 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.14",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -6437,9 +6437,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.13",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.13.tgz",
-      "integrity": "sha512-vurFA5Z632WHBw+49jKGVEskHmgiNMgGl8RqRKC5abn8DftwSJ/EgUXIzSC/F8bwBGA1fwfH0DwPYrzovqvGyg==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.14.tgz",
+      "integrity": "sha512-hlSqNImloYIKbZ3+Iz7fGqam77t2q8QKJx9+SyKcsclabcii+1sa5eFWwPnzkd+8CfJQQYQG0srGvrmHJCQKVg==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,14 @@
       "default": "./dist/plugin/config/index.client.js"
     },
     "./error": "./dist/plugin/error/index.js",
+    "./router": {
+      "types": "./dist/plugin/router/index.d.ts",
+      "default": "./dist/plugin/router/index.js"
+    },
+    "./router/client": {
+      "types": "./dist/plugin/router/client.d.ts",
+      "default": "./dist/plugin/router/client.js"
+    },
     "./references": "./dist/plugin/references/createSealedServerReferenceGate.server.js",
     "./vendor": {
       "react-server": "./dist/plugin/vendor/vendor.server.js",

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -283,6 +283,7 @@ const PROPS_EXPORT = ${JSON.stringify(propsExport)};
 const MODULE_BASE = ${JSON.stringify(moduleBase)};
 const MODULE_BASE_PATH = ${JSON.stringify(moduleBasePath)};
 const MODULE_BASE_URL = ${JSON.stringify(moduleBaseURL)};
+const ROUTE_PATTERNS = ${JSON.stringify(userOptions.routePatterns ?? [])};
 const HtmlComponent = ${htmlNs}[${JSON.stringify(htmlComp.exportName)}];
 const RootComponent = ${rootNs}[${JSON.stringify(rootComp.exportName)}];
 
@@ -300,6 +301,7 @@ async function resolveRoute(url) {
     pageExportName: PAGE_EXPORT,
     propsExportName: PROPS_EXPORT,
     moduleBaseURL: MODULE_BASE_URL,
+    routePatterns: ROUTE_PATTERNS,
     url,
     loader: async (id) => {
       // resolvePage/resolveProps may pass "<path>#<export>"; key by the path.

--- a/plugin/clientPackages/discover.ts
+++ b/plugin/clientPackages/discover.ts
@@ -1,11 +1,17 @@
 import { crawlFrameworkPkgs } from "vitefu";
 import type { Logger } from "vite";
 
+// React itself and the transport are never client-component packages. vprs is
+// intentionally NOT excluded: it ships "use client" modules (./router/client:
+// Link, RouterProvider, startClient) and has `react` in peerDependencies, so
+// letting discovery pick it up means a consumer using the router doesn't have
+// to hand-add clientPackages: ["vite-plugin-react-server"]. Only files that
+// carry the directive are treated as client references; vprs's server/plugin
+// code has no directive, so it stays server-side.
 const SELF_PACKAGES = new Set([
   "react",
   "react-dom",
   "react-server-dom-esm",
-  "vite-plugin-react-server",
 ]);
 
 export interface DiscoverOptions {

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -843,6 +843,7 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
       clientEntry: options.clientEntry ?? DEFAULT_CONFIG.CLIENT_ENTRY,
       serverEntry: options.serverEntry ?? DEFAULT_CONFIG.SERVER_ENTRY,
       clientPackages: (options as { clientPackages?: readonly string[] }).clientPackages,
+      routePatterns: (options as { routePatterns?: readonly string[] }).routePatterns,
       autoDiscover: autoDiscover,
       loader: loader,
       pipeableStreamOptions,

--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -365,6 +365,18 @@ export const configureReactServer: ConfigureReactServerFn =
             logger.info(`[configureReactServer] Loading props for route ${info.route}, pagePath: ${pagePath}, propsPath: ${propsPath}, url: ${info.url}`);
           }
           
+          // A Web Request for loaders that read headers/cookies. Available only
+          // on this dev request thread (undefined in worker/static/edge).
+          const reqHeaders = new Headers();
+          for (const [k, v] of Object.entries(req.headers)) {
+            if (typeof v === "string") reqHeaders.set(k, v);
+            else if (Array.isArray(v)) reqHeaders.set(k, v.join(", "));
+          }
+          const request = new Request(
+            new URL(req.url ?? info.url, `http://${req.headers.host ?? "localhost"}`),
+            { method: req.method ?? "GET", headers: reqHeaders }
+          );
+
           const propsResult = await resolvePageAndProps({
             pagePath,
             propsPath,
@@ -373,6 +385,8 @@ export const configureReactServer: ConfigureReactServerFn =
             url: info.url,
             route: info.route,
             moduleBaseURL: server.config.base,
+            routePatterns: userHandlerOptions.routePatterns,
+            request,
             loader,
             verbose,
             logger,

--- a/plugin/helpers/createSerializableHandlerOptions.ts
+++ b/plugin/helpers/createSerializableHandlerOptions.ts
@@ -62,7 +62,13 @@ export interface SerializableHandlerOptions {
   
   // Page props (must be serializable)
   pageProps: any;
-  
+
+  // Route patterns for request-time param resolution (plain strings, cloneable)
+  routePatterns?: readonly string[];
+  // Precomputed params (plain object, cloneable). `request` is intentionally
+  // excluded — a Request can't cross the worker boundary.
+  params?: Record<string, string>;
+
   // Panic threshold
   panicThreshold: PanicThreshold;
   
@@ -108,6 +114,8 @@ export function createSerializableHandlerOptions(
     cssFiles,
     globalCss,
     pageProps,
+    routePatterns,
+    params,
     css,
     autoDiscover,
     clientPipeableStreamOptions,
@@ -163,6 +171,8 @@ export function createSerializableHandlerOptions(
   if (cssFiles != null) result.cssFiles = cssFiles;
   if (globalCss != null) result.globalCss = globalCss;
   if (pageProps != null) result.pageProps = pageProps;
+  if (routePatterns != null) result.routePatterns = [...routePatterns];
+  if (params != null) result.params = params;
   if (clientPipeableStreamOptions != null) {
     // Use the existing helper to clean the object - this will handle all non-function properties
     const cleanedClientOptions = cleanObject(clientPipeableStreamOptions);

--- a/plugin/helpers/resolvePageAndProps.ts
+++ b/plugin/helpers/resolvePageAndProps.ts
@@ -41,12 +41,27 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
       }
 
       // Loader context: `props(url, { params, request })`. Params are either
-      // precomputed by the caller or derived here from the route patterns +
-      // url (file-based router). Back-compat: `(url) => …` loaders ignore it.
+      // precomputed by the caller or derived here from the route patterns.
+      // Match against the normalized pathname (same basis page-selection uses):
+      // drop the query, the `.rsc`/`.html` transport suffix, and a trailing
+      // slash, so `/profile/42.rsc` resolves `{ id: "42" }`, not `"42.rsc"`.
+      const rscSuffix =
+        handlerOptions.build?.rscOutputPath ??
+        DEFAULT_CONFIG.BUILD.rscOutputPath;
+      const normalizeForMatch = (u: string): string => {
+        let p = u.split("?")[0];
+        if (rscSuffix && p.endsWith(rscSuffix)) p = p.slice(0, -rscSuffix.length);
+        else if (p.endsWith(".html")) p = p.slice(0, -".html".length);
+        if (p.length > 1 && p.endsWith("/")) p = p.slice(0, -1);
+        return p || "/";
+      };
       const params =
         handlerOptions.params ??
         (handlerOptions.routePatterns?.length
-          ? matchRoutes(handlerOptions.routePatterns, url)?.params ?? {}
+          ? matchRoutes(
+              handlerOptions.routePatterns,
+              normalizeForMatch(handlerOptions.route || url)
+            )?.params ?? {}
           : {});
       const loaderCtx: LoaderCtx = { params, request: handlerOptions.request };
 

--- a/plugin/helpers/resolvePageAndProps.ts
+++ b/plugin/helpers/resolvePageAndProps.ts
@@ -6,8 +6,9 @@ import type {
   PagePropOpt,
 } from "../types.js";
 import { resolvePage } from "./resolvePage.js";
-import { resolveProps } from "./resolveProps.js";
+import { resolveProps, type LoaderCtx } from "./resolveProps.js";
 import { routeToURL } from "../utils/routeToURL.js";
+import { matchRoutes } from "../router/matchRoute.js";
 
 /**
  * Resolves the page and props for a given route, works in combination with resolveComponents
@@ -39,6 +40,16 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
         );
       }
 
+      // Loader context: `props(url, { params, request })`. Params are either
+      // precomputed by the caller or derived here from the route patterns +
+      // url (file-based router). Back-compat: `(url) => …` loaders ignore it.
+      const params =
+        handlerOptions.params ??
+        (handlerOptions.routePatterns?.length
+          ? matchRoutes(handlerOptions.routePatterns, url)?.params ?? {}
+          : {});
+      const loaderCtx: LoaderCtx = { params, request: handlerOptions.request };
+
       const resolvePagePromise = resolvePage({
         id: handlerOptions.pagePath,
         exportName:
@@ -54,6 +65,7 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
 
       const resolvePropsPromise = resolveProps({
         url,
+        ctx: loaderCtx,
         id: handlerOptions.propsPath || handlerOptions.pagePath,
         exportName:
           handlerOptions.propsExportName ?? DEFAULT_CONFIG.PROPS_EXPORT_NAME,
@@ -200,7 +212,7 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
           );
         }
         try {
-          pageProps = pageProps(url);
+          pageProps = pageProps(url, loaderCtx);
           // Await if it returns a Promise
           if (pageProps instanceof Promise) {
             pageProps = await pageProps;
@@ -274,6 +286,9 @@ export type ResolvePageAndPropsFn = <T extends PagePropOpt = PagePropOpt>(
     | "loader"
     | "verbose"
     | "logger"
+    | "routePatterns"
+    | "params"
+    | "request"
   > & {
     moduleBaseURL?: string;
     route?: string;

--- a/plugin/helpers/resolveProps.ts
+++ b/plugin/helpers/resolveProps.ts
@@ -1,11 +1,24 @@
 import { toError } from "../error/toError.js";
 import type { GenericModuleLoader, PagePropOpt, PropsName } from "../types.js";
 
+/**
+ * Second argument passed to a loader function: `props(url, ctx)`. Optional and
+ * back-compatible — a `(url) => …` loader simply ignores it.
+ */
+export type LoaderCtx = {
+  /** Params parsed from the request url against the matched route pattern. */
+  params: Record<string, string>;
+  /** In-flight request; present only on the dev request thread (see CreateHandlerOptions). */
+  request?: Request;
+};
+
 type ResolvePropsOptions = {
   id: string;
   url: string;
   exportName: string;
   loader: GenericModuleLoader;
+  /** Loader context threaded into `props(url, { params, request })`. */
+  ctx?: LoaderCtx;
 };
 
 type ValidPropTypes<T> =
@@ -13,7 +26,7 @@ type ValidPropTypes<T> =
   | Promise<T>
   | Array<T[keyof T]>
   | Array<[string, T[keyof T]]>
-  | ((url: string) => ValidPropTypes<T>);
+  | ((url: string, ctx?: LoaderCtx) => ValidPropTypes<T>);
 
 // prototype classes
 
@@ -69,6 +82,7 @@ export const resolveProps = async <
   url,
   exportName,
   loader,
+  ctx,
 }: ResolvePropsOptions): Promise<ResolvePropsResult<T, N>> => {
   // Check if this is a stashed page that needs special handling
   const propsLoadResult = await (async (): Promise<
@@ -133,10 +147,17 @@ export const resolveProps = async <
       let propsResult;
       if (props.prototype && props.prototype.constructor) {
         // Class constructor case
-        propsResult = new (props as unknown as new (url: string) => T)(url);
+        propsResult = new (props as unknown as new (
+          url: string,
+          ctx?: LoaderCtx
+        ) => T)(url, ctx);
       } else {
-        // Regular function case
-        propsResult = props(url);
+        // Regular function case — `props(url, { params, request })`.
+        // A `(url) => …` loader ignores the 2nd arg (back-compat).
+        propsResult = (props as (url: string, ctx?: LoaderCtx) => unknown)(
+          url,
+          ctx
+        );
       }
 
       // Handle recursive props validation
@@ -149,6 +170,7 @@ export const resolveProps = async <
           id,
           url,
           exportName,
+          ctx,
           loader: async () =>
             ({ [exportName]: propsResult } as {
               [key in N]: ValidPropTypes<T>;

--- a/plugin/react-static/renderPage.server.ts
+++ b/plugin/react-static/renderPage.server.ts
@@ -100,6 +100,7 @@ export const renderPage: RenderPageFn = async function* renderPage(
           route: handlerOptions.route,
           url: handlerOptions.url,
           moduleBaseURL: handlerOptions.moduleBaseURL,
+          routePatterns: handlerOptions.routePatterns,
           build: {
             rscOutputPath: handlerOptions.build.rscOutputPath,
           },

--- a/plugin/router/client.ts
+++ b/plugin/router/client.ts
@@ -1,0 +1,30 @@
+"use client";
+// Client runtime: flight cache + headless router + React bindings + Link + the
+// supplied client entry (startClient). Browser/entry code only.
+//
+// EXPLICIT named re-exports (not `export *`): a "use client" barrel is turned
+// into client references, and the reference transform can only enumerate
+// statically-named exports — star re-exports would leave e.g. `Link`
+// unresolvable ("not exported by client.js") when a server component imports it.
+export { createFlightCache } from "./flightCache.js";
+export type {
+  FlightCache,
+  FlightCacheOptions,
+  FlightGetOptions,
+} from "./flightCache.js";
+export { createRouter } from "./createRouter.js";
+export type {
+  CreateRouterOptions,
+  Router,
+  RouterState,
+} from "./createRouter.js";
+export {
+  RouterProvider,
+  useLocation,
+  useParams,
+  useRouter,
+} from "./router-react.js";
+export { Link } from "./link.js";
+export type { LinkPrefetch, LinkProps } from "./link.js";
+export { startClient } from "./startClient.js";
+export type { StartClientOptions } from "./startClient.js";

--- a/plugin/router/client.ts
+++ b/plugin/router/client.ts
@@ -28,3 +28,4 @@ export { Link } from "./link.js";
 export type { LinkPrefetch, LinkProps } from "./link.js";
 export { startClient } from "./startClient.js";
 export type { StartClientOptions } from "./startClient.js";
+export type { Register, RegisteredRoutes, ToPath } from "./register.js";

--- a/plugin/router/createRouter.ts
+++ b/plugin/router/createRouter.ts
@@ -1,4 +1,5 @@
 import { createFlightCache, type FlightCache } from "./flightCache.js";
+import type { ToPath } from "./register.js";
 
 // Headless client router: history + a flight cache + a subscribe store. The
 // React bindings (<Router>, useLocation, useParams) are a thin layer over this
@@ -19,8 +20,8 @@ export type CreateRouterOptions<T> = {
 export type Router<T> = {
   getState: () => RouterState;
   subscribe: (cb: () => void) => () => void;
-  navigate: (to: string, opts?: { replace?: boolean }) => void;
-  prefetch: (to: string) => void;
+  navigate: (to: ToPath, opts?: { replace?: boolean }) => void;
+  prefetch: (to: ToPath) => void;
   /** The (cached) flight for a url; reuses a warmed/in-flight fetch. */
   flight: (url: string) => Promise<T>;
 };

--- a/plugin/router/createRouter.ts
+++ b/plugin/router/createRouter.ts
@@ -1,0 +1,76 @@
+import { createFlightCache, type FlightCache } from "./flightCache.js";
+
+// Headless client router: history + a flight cache + a subscribe store. The
+// React bindings (<Router>, useLocation, useParams) are a thin layer over this
+// via useSyncExternalStore, so the navigation logic stays testable without React.
+export type RouterState = { url: string };
+
+export type CreateRouterOptions<T> = {
+  /** Fetch the RSC flight for a url (e.g. createReactFetcher({ url })). */
+  fetchFlight: (url: string) => T | Promise<T>;
+  /** Whether a url is a dynamic route → its flight gets a short cache ttl. */
+  isDynamic?: (url: string) => boolean;
+  /** Cache ttl (ms) for dynamic-route flights. Default 2000. */
+  dynamicTtlMs?: number;
+  /** Inject a cache (shared with prefetch / tests). */
+  cache?: FlightCache<T>;
+};
+
+export type Router<T> = {
+  getState: () => RouterState;
+  subscribe: (cb: () => void) => () => void;
+  navigate: (to: string, opts?: { replace?: boolean }) => void;
+  prefetch: (to: string) => void;
+  /** The (cached) flight for a url; reuses a warmed/in-flight fetch. */
+  flight: (url: string) => Promise<T>;
+};
+
+const currentUrl = () =>
+  typeof location === "undefined" ? "/" : location.pathname + location.search;
+
+export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
+  const cache = opts.cache ?? createFlightCache<T>();
+  const listeners = new Set<() => void>();
+  let state: RouterState = { url: currentUrl() };
+
+  const ttlFor = (url: string) =>
+    opts.isDynamic?.(url) ? (opts.dynamicTtlMs ?? 2000) : undefined;
+  const flight = (url: string) =>
+    cache.get(url, { fetcher: opts.fetchFlight, ttlMs: ttlFor(url) });
+
+  const setUrl = (url: string) => {
+    if (url === state.url) return;
+    state = { url };
+    for (const l of listeners) l();
+  };
+
+  const onPop = () => setUrl(currentUrl());
+
+  return {
+    getState: () => state,
+    subscribe: (cb) => {
+      listeners.add(cb);
+      if (listeners.size === 1 && typeof window !== "undefined") {
+        window.addEventListener("popstate", onPop);
+      }
+      return () => {
+        listeners.delete(cb);
+        if (listeners.size === 0 && typeof window !== "undefined") {
+          window.removeEventListener("popstate", onPop);
+        }
+      };
+    },
+    navigate: (to, { replace = false } = {}) => {
+      void flight(to); // warm (or reuse a prefetch) before we swap
+      if (typeof history !== "undefined") {
+        if (replace) history.replaceState({ url: to }, "", to);
+        else history.pushState({ url: to }, "", to);
+      }
+      setUrl(to);
+    },
+    prefetch: (to) => {
+      cache.prefetch(to, { fetcher: opts.fetchFlight, ttlMs: ttlFor(to) });
+    },
+    flight,
+  };
+}

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -1,5 +1,16 @@
-import { matchRoutes } from "./matchRoute.js";
+import { fillPattern, matchRoutes } from "./matchRoute.js";
 import { type RouteEntry, scanRoutes } from "./scanRoutes.js";
+
+// Per-dynamic-route enumeration of concrete paths to prerender. Each entry is a
+// full url ("/blog/tech/rsc") or a params object ({category:"tech",slug:"rsc"})
+// that fileRouter expands against the pattern. Keyed by route pattern. This is
+// vprs's getStaticPaths, kept in config (data-driven) rather than loaded from
+// route modules at build time.
+export type StaticPathEntry = string | Record<string, string>;
+export type StaticPathsMap = Record<
+  string,
+  () => Iterable<StaticPathEntry> | Promise<Iterable<StaticPathEntry>>
+>;
 
 // `fileRouter` turns a `src/routes/**` tree into the `Page` / `props` /
 // `build.pages` config vprs already consumes — so file-based routing is the
@@ -14,7 +25,7 @@ import { type RouteEntry, scanRoutes } from "./scanRoutes.js";
 export type FileRouterConfig = {
   Page: (url: string) => string;
   props: (url: string) => string | undefined;
-  build: { pages: string[] };
+  build: { pages: string[] | (() => Promise<string[]>) };
   /** The discovered table, exposed for getStaticPaths aggregation / tooling. */
   routes: RouteEntry[];
   /**
@@ -25,7 +36,10 @@ export type FileRouterConfig = {
   getParams: (url: string) => Record<string, string>;
 };
 
-export function fileRouter(routesDir: string): FileRouterConfig {
+export function fileRouter(
+  routesDir: string,
+  opts: { staticPaths?: StaticPathsMap } = {},
+): FileRouterConfig {
   const routes = scanRoutes(routesDir);
   const patterns = routes.map((r) => r.pattern);
   const byPattern = new Map(routes.map((r) => [r.pattern, r] as const));
@@ -36,12 +50,34 @@ export function fileRouter(routesDir: string): FileRouterConfig {
     return byPattern.get(m.pattern)!;
   };
 
+  const staticRoutes = routes.filter((r) => !r.dynamic).map((r) => r.pattern);
+
+  // Without staticPaths, only fully-static routes prerender; dynamic (`$`)
+  // routes resolve per-request. With staticPaths, each dynamic route's concrete
+  // urls are enumerated into the (async) prerender list too. A dynamic route
+  // with no staticPaths entry stays server-only.
+  const { staticPaths } = opts;
+  const pages: string[] | (() => Promise<string[]>) = staticPaths
+    ? async () => {
+        const out = [...staticRoutes];
+        for (const route of routes) {
+          if (!route.dynamic) continue;
+          const gen = staticPaths[route.pattern];
+          if (!gen) continue;
+          for (const entry of await gen()) {
+            out.push(
+              typeof entry === "string" ? entry : fillPattern(route.pattern, entry),
+            );
+          }
+        }
+        return out;
+      }
+    : staticRoutes;
+
   return {
     Page: (url) => matched(url).page,
     props: (url) => matched(url).props,
-    // Only fully-static routes are prerendered by default; dynamic (`$`) routes
-    // are matched per-request (and enumerated via getStaticPaths when wanted).
-    build: { pages: routes.filter((r) => !r.dynamic).map((r) => r.pattern) },
+    build: { pages },
     routes,
     getParams: (url) => matchRoutes(patterns, url)?.params ?? {},
   };

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -17,6 +17,12 @@ export type FileRouterConfig = {
   build: { pages: string[] };
   /** The discovered table, exposed for getStaticPaths aggregation / tooling. */
   routes: RouteEntry[];
+  /**
+   * Params for a concrete url, from the matched pattern (`/profile/123` →
+   * `{ id: "123" }`). This is what the loader plumbing threads into
+   * `props(url, { params, request })`; returns `{}` when nothing matches.
+   */
+  getParams: (url: string) => Record<string, string>;
 };
 
 export function fileRouter(routesDir: string): FileRouterConfig {
@@ -37,5 +43,6 @@ export function fileRouter(routesDir: string): FileRouterConfig {
     // are matched per-request (and enumerated via getStaticPaths when wanted).
     build: { pages: routes.filter((r) => !r.dynamic).map((r) => r.pattern) },
     routes,
+    getParams: (url) => matchRoutes(patterns, url)?.params ?? {},
   };
 }

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -29,6 +29,12 @@ export type FileRouterConfig = {
   /** The discovered table, exposed for getStaticPaths aggregation / tooling. */
   routes: RouteEntry[];
   /**
+   * The route patterns (`["/", "/profile/$id", "/blog/$category/$slug"]`).
+   * Spread into the plugin config so vprs can compute a loader's `params`
+   * automatically at request time — no `withParams` pattern to repeat.
+   */
+  routePatterns: string[];
+  /**
    * Params for a concrete url, from the matched pattern (`/profile/123` →
    * `{ id: "123" }`). This is what the loader plumbing threads into
    * `props(url, { params, request })`; returns `{}` when nothing matches.
@@ -79,6 +85,7 @@ export function fileRouter(
     props: (url) => matched(url).props,
     build: { pages },
     routes,
+    routePatterns: patterns,
     getParams: (url) => matchRoutes(patterns, url)?.params ?? {},
   };
 }

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -1,3 +1,4 @@
+import { relative, resolve, sep } from "node:path";
 import { fillPattern, matchRoutes } from "./matchRoute.js";
 import { type RouteEntry, scanRoutes } from "./scanRoutes.js";
 
@@ -44,9 +45,24 @@ export type FileRouterConfig = {
 
 export function fileRouter(
   routesDir: string,
-  opts: { staticPaths?: StaticPathsMap } = {},
+  opts: { staticPaths?: StaticPathsMap; root?: string } = {},
 ): FileRouterConfig {
-  const routes = scanRoutes(routesDir);
+  // `root` decouples "where to scan" from "what path to emit": scan
+  // `resolve(root, routesDir)` on disk but emit page/props paths relative to
+  // `root` (the project root vprs resolves modules against). Omitting it keeps
+  // the default — the emitted paths are exactly what `join(routesDir, …)`
+  // produces (relative for a relative routesDir, which is the common case where
+  // cwd is the project root). Supply `root` when cwd ≠ project root.
+  const { root } = opts;
+  const scanned = scanRoutes(root ? resolve(root, routesDir) : routesDir);
+  const toRel = (p: string) => relative(root!, p).split(sep).join("/");
+  const routes: RouteEntry[] = root
+    ? scanned.map((r) => ({
+        ...r,
+        page: toRel(r.page),
+        props: r.props ? toRel(r.props) : undefined,
+      }))
+    : scanned;
   const patterns = routes.map((r) => r.pattern);
   const byPattern = new Map(routes.map((r) => [r.pattern, r] as const));
 

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -1,0 +1,41 @@
+import { matchRoutes } from "./matchRoute.js";
+import { type RouteEntry, scanRoutes } from "./scanRoutes.js";
+
+// `fileRouter` turns a `src/routes/**` tree into the `Page` / `props` /
+// `build.pages` config vprs already consumes — so file-based routing is the
+// matcher + scanner feeding the EXISTING resolution pipeline (resolveBuildPages
+// → urlMap), with no core changes. It replaces the hand-rolled
+// `createRouter(file) => (url) => switch {…}` that mmc/bidoof write by hand:
+//
+//   vitePluginReactServer({ moduleBase: "src", ...fileRouter("src/routes") })
+//
+// Pass a project-root-relative `routesDir` so the emitted file paths are
+// root-relative too (matching how you'd hand-write `Page`/`props`).
+export type FileRouterConfig = {
+  Page: (url: string) => string;
+  props: (url: string) => string | undefined;
+  build: { pages: string[] };
+  /** The discovered table, exposed for getStaticPaths aggregation / tooling. */
+  routes: RouteEntry[];
+};
+
+export function fileRouter(routesDir: string): FileRouterConfig {
+  const routes = scanRoutes(routesDir);
+  const patterns = routes.map((r) => r.pattern);
+  const byPattern = new Map(routes.map((r) => [r.pattern, r] as const));
+
+  const matched = (url: string): RouteEntry => {
+    const m = matchRoutes(patterns, url);
+    if (!m) throw new Error(`fileRouter: no route matches "${url}"`);
+    return byPattern.get(m.pattern)!;
+  };
+
+  return {
+    Page: (url) => matched(url).page,
+    props: (url) => matched(url).props,
+    // Only fully-static routes are prerendered by default; dynamic (`$`) routes
+    // are matched per-request (and enumerated via getStaticPaths when wanted).
+    build: { pages: routes.filter((r) => !r.dynamic).map((r) => r.pattern) },
+    routes,
+  };
+}

--- a/plugin/router/flightCache.ts
+++ b/plugin/router/flightCache.ts
@@ -1,0 +1,57 @@
+// Per-url cache of in-flight / resolved RSC flight fetches, shared by
+// navigation and prefetch: hovering a <Link> warms an entry, the click reuses
+// it, so navigation needs no extra round-trip.
+//
+// Static routes can cache indefinitely (the flight is a fixed file). Dynamic
+// routes pass a short `ttlMs` so a prefetched snapshot can't pin stale
+// per-request data — the same rule as not build-time-inlining a live route.
+export type FlightCacheOptions = {
+  /** Injectable clock (defaults to Date.now); handy for tests. */
+  now?: () => number;
+};
+
+export type FlightGetOptions<T> = {
+  fetcher: (url: string) => T | Promise<T>;
+  /** Max age in ms. Omit (or Infinity) to cache indefinitely (static routes). */
+  ttlMs?: number;
+};
+
+export type FlightCache<T> = {
+  get(url: string, opts: FlightGetOptions<T>): Promise<T>;
+  prefetch(url: string, opts: FlightGetOptions<T>): void;
+  has(url: string): boolean;
+  invalidate(url?: string): void;
+};
+
+export function createFlightCache<T>(
+  options: FlightCacheOptions = {},
+): FlightCache<T> {
+  const now = options.now ?? Date.now;
+  const cache = new Map<string, { promise: Promise<T>; at: number }>();
+
+  const get = (url: string, opts: FlightGetOptions<T>): Promise<T> => {
+    const hit = cache.get(url);
+    if (hit && (opts.ttlMs === undefined || now() - hit.at < opts.ttlMs)) {
+      return hit.promise;
+    }
+    const promise = Promise.resolve(opts.fetcher(url));
+    // Evict a rejected entry so a failed nav/prefetch can be retried.
+    promise.catch(() => {
+      if (cache.get(url)?.promise === promise) cache.delete(url);
+    });
+    cache.set(url, { promise, at: now() });
+    return promise;
+  };
+
+  return {
+    get,
+    prefetch: (url, opts) => {
+      void get(url, opts);
+    },
+    has: (url) => cache.has(url),
+    invalidate: (url) => {
+      if (url === undefined) cache.clear();
+      else cache.delete(url);
+    },
+  };
+}

--- a/plugin/router/index.ts
+++ b/plugin/router/index.ts
@@ -1,0 +1,7 @@
+// File-based routing: config + loader helpers, used in vite.config (fileRouter)
+// and route loaders (withParams). Node/config-side and isomorphic-safe — no
+// React, so it's condition-agnostic. The client runtime lives in ./client.
+export * from "./matchRoute.js";
+export * from "./scanRoutes.js";
+export * from "./fileRouter.js";
+export * from "./withParams.js";

--- a/plugin/router/index.ts
+++ b/plugin/router/index.ts
@@ -5,3 +5,4 @@ export * from "./matchRoute.js";
 export * from "./scanRoutes.js";
 export * from "./fileRouter.js";
 export * from "./withParams.js";
+export type { Register, RegisteredRoutes, ToPath } from "./register.js";

--- a/plugin/router/link.tsx
+++ b/plugin/router/link.tsx
@@ -5,6 +5,7 @@ import type {
   AnchorHTMLAttributes,
   MouseEvent as ReactMouseEvent,
 } from "react";
+import type { ToPath } from "./register.js";
 import { useOptionalRouter } from "./router-react.js";
 
 // Client-side <Link> over the nav primitive: intercepts plain internal clicks
@@ -15,7 +16,8 @@ import { useOptionalRouter } from "./router-react.js";
 export type LinkPrefetch = "intent" | "hover" | false;
 
 export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
-  to: string;
+  /** Registered routes autocomplete; any string is still accepted. */
+  to: ToPath;
   replace?: boolean;
   /** "intent" (default): warm after a short hover/on focus; "hover": warm
    *  immediately; false: never. */

--- a/plugin/router/link.tsx
+++ b/plugin/router/link.tsx
@@ -1,0 +1,88 @@
+"use client";
+import React, {
+  type AnchorHTMLAttributes,
+  type MouseEvent as ReactMouseEvent,
+  useRef,
+} from "react";
+import { useRouter } from "./router-react.js";
+
+// Client-side <Link> over the nav primitive: intercepts plain internal clicks
+// to navigate without a reload, and warms the target's flight on hover/focus so
+// the click is instant. Modified clicks, target=_blank, and external/protocol
+// hrefs fall through to the browser. A plain <a> stays the 0-JS default for
+// static sites; this island only ships where used.
+export type LinkPrefetch = "intent" | "hover" | false;
+
+export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  to: string;
+  replace?: boolean;
+  /** "intent" (default): warm after a short hover/on focus; "hover": warm
+   *  immediately; false: never. */
+  prefetch?: LinkPrefetch;
+};
+
+const INTENT_MS = 60;
+
+const isModified = (e: ReactMouseEvent) =>
+  e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
+
+// Anything with a scheme (http:, mailto:, tel:) or protocol-relative // is external.
+const isExternal = (to: string) =>
+  /^[a-z][a-z0-9+.-]*:/i.test(to) || to.startsWith("//");
+
+export function Link({
+  to,
+  replace,
+  prefetch = "intent",
+  target,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  onFocus,
+  children,
+  ...rest
+}: LinkProps) {
+  const router = useRouter();
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const canIntercept = !isExternal(to) && (!target || target === "_self");
+  const warm = () => router.prefetch(to);
+  const cancel = () => {
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = undefined;
+  };
+
+  return (
+    <a
+      href={to}
+      target={target}
+      onClick={(e) => {
+        onClick?.(e);
+        if (e.defaultPrevented || !canIntercept || isModified(e)) return;
+        e.preventDefault();
+        cancel();
+        router.navigate(to, { replace });
+      }}
+      onMouseEnter={(e) => {
+        onMouseEnter?.(e);
+        if (!canIntercept || prefetch === false) return;
+        if (prefetch === "hover") warm();
+        else {
+          cancel();
+          timer.current = setTimeout(warm, INTENT_MS);
+        }
+      }}
+      onMouseLeave={(e) => {
+        onMouseLeave?.(e);
+        cancel();
+      }}
+      onFocus={(e) => {
+        onFocus?.(e);
+        if (canIntercept && prefetch !== false) warm();
+      }}
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+}

--- a/plugin/router/link.tsx
+++ b/plugin/router/link.tsx
@@ -1,10 +1,11 @@
 "use client";
-import React, {
-  type AnchorHTMLAttributes,
-  type MouseEvent as ReactMouseEvent,
-  useRef,
+// Namespace import for react-server barrel import-safety (see router-react.tsx).
+import * as React from "react";
+import type {
+  AnchorHTMLAttributes,
+  MouseEvent as ReactMouseEvent,
 } from "react";
-import { useRouter } from "./router-react.js";
+import { useOptionalRouter } from "./router-react.js";
 
 // Client-side <Link> over the nav primitive: intercepts plain internal clicks
 // to navigate without a reload, and warms the target's flight on hover/focus so
@@ -42,11 +43,14 @@ export function Link({
   children,
   ...rest
 }: LinkProps) {
-  const router = useRouter();
-  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  // Optional: Link also renders during static prerender (no provider yet) and
+  // as a plain <a> outside a router — it just doesn't intercept there.
+  const router = useOptionalRouter();
+  const timer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  const canIntercept = !isExternal(to) && (!target || target === "_self");
-  const warm = () => router.prefetch(to);
+  const canIntercept =
+    router !== null && !isExternal(to) && (!target || target === "_self");
+  const warm = () => router?.prefetch(to);
   const cancel = () => {
     if (timer.current) clearTimeout(timer.current);
     timer.current = undefined;
@@ -61,7 +65,7 @@ export function Link({
         if (e.defaultPrevented || !canIntercept || isModified(e)) return;
         e.preventDefault();
         cancel();
-        router.navigate(to, { replace });
+        router?.navigate(to, { replace });
       }}
       onMouseEnter={(e) => {
         onMouseEnter?.(e);

--- a/plugin/router/matchRoute.ts
+++ b/plugin/router/matchRoute.ts
@@ -70,6 +70,32 @@ function moreSpecific(a: number[], b: number[]): number {
   return 0;
 }
 
+/**
+ * Inverse of matchRoute: build a concrete url from a pattern + params
+ * (`/profile/$id` + `{id:"5"}` → `/profile/5`). Used to enumerate a dynamic
+ * route's static paths for prerendering. A bare `$` catch-all is filled from
+ * `params._splat` (kept raw — it may itself be a path); named params are
+ * percent-encoded. Throws if a named param is missing.
+ */
+export function fillPattern(
+  pattern: string,
+  params: Record<string, string>,
+): string {
+  const out = segs(pattern).map((seg) => {
+    if (seg === "$") return params["_splat"] ?? "";
+    if (seg.startsWith("$")) {
+      const name = seg.slice(1);
+      const value = params[name];
+      if (value === undefined) {
+        throw new Error(`fillPattern: missing param "${name}" for "${pattern}"`);
+      }
+      return encodeURIComponent(value);
+    }
+    return seg;
+  });
+  return `/${out.filter((s) => s !== "").join("/")}`;
+}
+
 /** Match a pathname against many patterns, most-specific first. */
 export function matchRoutes<P extends string>(
   patterns: readonly P[],

--- a/plugin/router/matchRoute.ts
+++ b/plugin/router/matchRoute.ts
@@ -41,7 +41,7 @@ export function matchRoute<P extends string>(
     const seg = p[i];
     if (seg === "$") {
       // Catch-all: take the rest of the path (may be empty).
-      params._splat = u.slice(i).map(decodeURIComponent).join("/");
+      params["_splat"] = u.slice(i).map(decodeURIComponent).join("/");
       return params as RouteParams<P>;
     }
     if (u[i] === undefined) return null;

--- a/plugin/router/matchRoute.ts
+++ b/plugin/router/matchRoute.ts
@@ -1,0 +1,84 @@
+// File-based route matching for vprs.
+//
+// Convention (borrowed from TanStack Router / Remix, which the team already
+// likes): a path segment written `$name` is a dynamic param; a bare `$` is a
+// catch-all that swallows the rest of the path. Everything else is a literal.
+//
+// The type-safety idea comes from mmc's hand-written router, which derived
+// params from a hand-maintained `VariableMap`. Here the params fall out of the
+// *pattern string itself* via template-literal types, so there's no map to keep
+// in sync and no codegen step — `RouteParams<"/profile/$id">` is `{ id: string }`.
+
+/** Split a pattern into its segments at the type level. */
+type Split<S extends string> = S extends `${infer Head}/${infer Tail}`
+  ? [Head, ...Split<Tail>]
+  : [S];
+
+/** A segment's param name, or `never` if it's a literal. Bare `$` → catch-all. */
+type ParamName<S extends string> = S extends `$${infer Name}`
+  ? Name extends ""
+    ? "_splat"
+    : Name
+  : never;
+
+/** Params inferred from a route pattern. `/blog/$cat/$slug` → `{cat,slug}`. */
+export type RouteParams<Pattern extends string> = {
+  [Seg in Split<Pattern>[number] as ParamName<Seg>]: string;
+};
+
+const segs = (s: string) => s.split("/").filter(Boolean);
+
+/** Match one pattern against a pathname. Returns typed params, or null. */
+export function matchRoute<P extends string>(
+  pattern: P,
+  pathname: string,
+): RouteParams<P> | null {
+  const p = segs(pattern);
+  const u = segs(pathname);
+  const params: Record<string, string> = {};
+
+  for (let i = 0; i < p.length; i++) {
+    const seg = p[i];
+    if (seg === "$") {
+      // Catch-all: take the rest of the path (may be empty).
+      params._splat = u.slice(i).map(decodeURIComponent).join("/");
+      return params as RouteParams<P>;
+    }
+    if (u[i] === undefined) return null;
+    if (seg.startsWith("$")) {
+      params[seg.slice(1)] = decodeURIComponent(u[i]);
+    } else if (seg !== u[i]) {
+      return null;
+    }
+  }
+  // No catch-all consumed the tail, so segment counts must match exactly.
+  return p.length === u.length ? (params as RouteParams<P>) : null;
+}
+
+/** Per-segment specificity: literal beats param beats catch-all. */
+function score(pattern: string): number[] {
+  return segs(pattern).map((s) => (s === "$" ? 0 : s.startsWith("$") ? 1 : 2));
+}
+
+/** Compare two specificity vectors left-to-right; more-specific sorts first. */
+function moreSpecific(a: number[], b: number[]): number {
+  const n = Math.max(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    const d = (b[i] ?? -1) - (a[i] ?? -1);
+    if (d) return d;
+  }
+  return 0;
+}
+
+/** Match a pathname against many patterns, most-specific first. */
+export function matchRoutes<P extends string>(
+  patterns: readonly P[],
+  pathname: string,
+): { pattern: P; params: RouteParams<P> } | null {
+  const ordered = [...patterns].sort((a, b) => moreSpecific(score(a), score(b)));
+  for (const pattern of ordered) {
+    const params = matchRoute(pattern, pathname);
+    if (params) return { pattern, params };
+  }
+  return null;
+}

--- a/plugin/router/register.ts
+++ b/plugin/router/register.ts
@@ -1,0 +1,23 @@
+// Typed route paths via declaration merging (the TanStack-style `Register`
+// pattern — no codegen). Consumers augment `Register` with their route union to
+// get autocomplete + checking on `Link`'s `to` and `navigate`:
+//
+//   declare module "vite-plugin-react-server/router/client" {
+//     interface Register {
+//       routes: "/" | "/greet/$name" | "/blog/$category/$slug";
+//     }
+//   }
+//
+// Without augmentation, route paths fall back to `string`.
+export interface Register {}
+
+export type RegisteredRoutes = Register extends {
+  routes: infer R extends string;
+}
+  ? R
+  : string;
+
+// A navigable path: a registered route (autocompleted) OR any string — so
+// concrete instances like "/greet/alice" are accepted while the patterns
+// autocomplete. `string & {}` preserves the literal-union autocomplete.
+export type ToPath = RegisteredRoutes | (string & {});

--- a/plugin/router/router-react.tsx
+++ b/plugin/router/router-react.tsx
@@ -1,0 +1,65 @@
+"use client";
+import React, {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
+import type { Router } from "./createRouter.js";
+import { matchRoutes, type RouteParams } from "./matchRoute.js";
+
+// Thin React bindings over the headless createRouter: a provider + hooks via
+// useSyncExternalStore. Client-only ("use client") — the nav logic itself lives
+// in createRouter so it stays testable without React.
+type RouterContextValue = {
+  router: Router<unknown>;
+  location: string;
+  params: Record<string, string>;
+};
+
+const RouterContext = createContext<RouterContextValue | null>(null);
+
+export function RouterProvider<T>({
+  router,
+  patterns = [],
+  children,
+}: {
+  router: Router<T>;
+  /** Route patterns, so useParams() can resolve params for the current url. */
+  patterns?: readonly string[];
+  children: ReactNode;
+}) {
+  const state = useSyncExternalStore(
+    router.subscribe,
+    router.getState,
+    router.getState,
+  );
+  const value = useMemo<RouterContextValue>(
+    () => ({
+      router: router as Router<unknown>,
+      location: state.url,
+      params: matchRoutes(patterns, state.url)?.params ?? {},
+    }),
+    [router, state.url, patterns],
+  );
+  return (
+    <RouterContext.Provider value={value}>{children}</RouterContext.Provider>
+  );
+}
+
+function useRouterContext(): RouterContextValue {
+  const ctx = useContext(RouterContext);
+  if (!ctx) {
+    throw new Error(
+      "useRouter / useLocation / useParams must be used inside <RouterProvider>",
+    );
+  }
+  return ctx;
+}
+
+export const useRouter = () => useRouterContext().router;
+export const useLocation = () => useRouterContext().location;
+export function useParams<P extends string = string>(): RouteParams<P> {
+  return useRouterContext().params as RouteParams<P>;
+}

--- a/plugin/router/router-react.tsx
+++ b/plugin/router/router-react.tsx
@@ -1,11 +1,11 @@
 "use client";
-import React, {
-  createContext,
-  type ReactNode,
-  useContext,
-  useMemo,
-  useSyncExternalStore,
-} from "react";
+// Namespace import (not named hooks) so this module is import-safe when the
+// react-server build traverses the ./client barrel — the react-server React
+// build omits client-only APIs like createContext, and a named import binds
+// eagerly (breaks); React.createContext defers the access. See
+// vprs_react_server_barrel_import_safety.
+import * as React from "react";
+import type { ReactNode } from "react";
 import type { Router } from "./createRouter.js";
 import { matchRoutes, type RouteParams } from "./matchRoute.js";
 
@@ -18,7 +18,7 @@ type RouterContextValue = {
   params: Record<string, string>;
 };
 
-const RouterContext = createContext<RouterContextValue | null>(null);
+const RouterContext = React.createContext<RouterContextValue | null>(null);
 
 export function RouterProvider<T>({
   router,
@@ -30,12 +30,12 @@ export function RouterProvider<T>({
   patterns?: readonly string[];
   children: ReactNode;
 }) {
-  const state = useSyncExternalStore(
+  const state = React.useSyncExternalStore(
     router.subscribe,
     router.getState,
     router.getState,
   );
-  const value = useMemo<RouterContextValue>(
+  const value = React.useMemo<RouterContextValue>(
     () => ({
       router: router as Router<unknown>,
       location: state.url,
@@ -49,7 +49,7 @@ export function RouterProvider<T>({
 }
 
 function useRouterContext(): RouterContextValue {
-  const ctx = useContext(RouterContext);
+  const ctx = React.useContext(RouterContext);
   if (!ctx) {
     throw new Error(
       "useRouter / useLocation / useParams must be used inside <RouterProvider>",
@@ -59,6 +59,15 @@ function useRouterContext(): RouterContextValue {
 }
 
 export const useRouter = () => useRouterContext().router;
+
+/**
+ * The router if inside a <RouterProvider>, else null — non-throwing, for
+ * components that must also render outside a provider (e.g. Link during static
+ * prerender, before startClient mounts the provider on the client).
+ */
+export function useOptionalRouter(): Router<unknown> | null {
+  return React.useContext(RouterContext)?.router ?? null;
+}
 export const useLocation = () => useRouterContext().location;
 export function useParams<P extends string = string>(): RouteParams<P> {
   return useRouterContext().params as RouteParams<P>;

--- a/plugin/router/scanRoutes.ts
+++ b/plugin/router/scanRoutes.ts
@@ -1,0 +1,44 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+// One route entry, shaped to feed vprs's existing `urlMap`
+// (`pattern → { page, props }`) — i.e. this replaces the hand-rolled
+// `createRouter(file) => (url) => switch {...}` that mmc/bidoof write by hand.
+export type RouteEntry = {
+  /** URL pattern with `$name` params, e.g. "/profile/$id". */
+  pattern: string;
+  /** Server component file for the route. */
+  page: string;
+  /** Sibling loader file, if present. */
+  props?: string;
+  /** True when the pattern has a `$` segment (can't be a fixed prerender). */
+  dynamic: boolean;
+};
+
+const PAGE = /^page\.(t|j)sx?$/;
+const PROPS = ["props.ts", "props.js"];
+
+// Convention: every `page.tsx` under `routesDir` defines a route; its directory
+// path (relative to routesDir) is the URL, with `$name` segments as params and a
+// bare `$` directory as a catch-all. A sibling `props.ts` is the route's loader.
+export function scanRoutes(routesDir: string, base = routesDir): RouteEntry[] {
+  const out: RouteEntry[] = [];
+  for (const name of readdirSync(routesDir).sort()) {
+    const abs = join(routesDir, name);
+    if (statSync(abs).isDirectory()) {
+      out.push(...scanRoutes(abs, base));
+    } else if (PAGE.test(name)) {
+      const rel = relative(base, routesDir);
+      const parts = rel === "" ? [] : rel.split(sep);
+      const pattern = parts.length ? "/" + parts.join("/") : "/";
+      const props = PROPS.map((p) => join(routesDir, p)).find(existsSync);
+      out.push({
+        pattern,
+        page: abs,
+        props,
+        dynamic: parts.some((p) => p.startsWith("$")),
+      });
+    }
+  }
+  return out;
+}

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -1,0 +1,105 @@
+"use client";
+// Namespace import for react-server barrel import-safety (see router-react.tsx).
+import * as React from "react";
+import type { ReactNode } from "react";
+import {
+  createReactFetcher,
+  hydrateOrRender,
+  useRscHmr,
+} from "../utils/index.client.js";
+import { createRouter, type Router } from "./createRouter.js";
+import { RouterProvider, useLocation } from "./router-react.js";
+
+// The supplied client entry: assembles createRouter + RouterProvider +
+// createReactFetcher + hydration + HMR so a consumer's client.tsx is one line:
+//
+//   import { startClient } from "vite-plugin-react-server/router";
+//   startClient({ patterns: ROUTES });
+//
+// Only pages that use client nav ship this; a pure-static page needs no entry.
+export type StartClientOptions = {
+  /** Root element id (default "root"). */
+  rootId?: string;
+  /** Route patterns, so useParams() resolves for the current url. */
+  patterns?: readonly string[];
+  moduleBaseURL?: string;
+  publicOrigin?: string;
+  /** Which urls are dynamic → short flight cache ttl. */
+  isDynamic?: (url: string) => boolean;
+  dynamicTtlMs?: number;
+  /** Wrap the tree with providers / an app shell. */
+  wrap?: (node: ReactNode) => ReactNode;
+};
+
+// Renders the current route's flight and swaps it (resolve-then-set, so the old
+// view stays during the fetch — no flash) when navigation changes location.
+function RouteView({
+  router,
+  initialNode,
+}: {
+  router: Router<ReactNode>;
+  initialNode: ReactNode;
+}) {
+  const location = useLocation();
+  const [node, setNode] = React.useState<ReactNode>(initialNode);
+  const shown = React.useRef<string>(router.getState().url);
+
+  React.useEffect(() => {
+    if (location === shown.current) return;
+    let cancelled = false;
+    const target = location;
+    Promise.resolve(router.flight(target)).then((next) => {
+      // Ignore a stale resolve (a newer navigation won the race).
+      if (!cancelled && router.getState().url === target) {
+        shown.current = target;
+        setNode(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [location, router]);
+
+  useRscHmr(() => {
+    const url = router.getState().url;
+    Promise.resolve(router.flight(url)).then(setNode);
+  });
+
+  return <>{node}</>;
+}
+
+export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
+  const {
+    rootId = "root",
+    patterns = [],
+    moduleBaseURL,
+    publicOrigin,
+    isDynamic,
+    dynamicTtlMs,
+    wrap,
+  } = opts;
+
+  const fetchFlight = (url: string): Promise<ReactNode> =>
+    Promise.resolve(
+      createReactFetcher({ url, moduleBaseURL, publicOrigin }),
+    ) as Promise<ReactNode>;
+
+  const router = createRouter<ReactNode>({ fetchFlight, isDynamic, dynamicTtlMs });
+
+  const root = document.getElementById(rootId);
+  if (!root) throw new Error(`startClient: #${rootId} element not found`);
+
+  hydrateOrRender(root, async () => {
+    // Resolve the initial flight (consumes the inline payload on first paint)
+    // BEFORE the first render — hydrateOrRender's #418-safe contract.
+    const initialNode = await router.flight(router.getState().url);
+    const tree = (
+      <RouterProvider router={router} patterns={patterns}>
+        <RouteView router={router} initialNode={initialNode} />
+      </RouterProvider>
+    );
+    return wrap ? wrap(tree) : tree;
+  });
+
+  return router;
+}

--- a/plugin/router/withParams.ts
+++ b/plugin/router/withParams.ts
@@ -9,9 +9,12 @@ import { matchRoute, type RouteParams } from "./matchRoute.js";
 //     id: params.id, // params.id: string (inferred from the pattern literal)
 //   }));
 //
-// Declare the same pattern as the route's file location. This is the minimal,
-// composable way to get params into a loader; an automatic (no-pattern) variant
-// can thread params through the handler pipeline later as an enhancement.
+// Declare the same pattern as the route's file location. `withParams` is now
+// OPTIONAL: when you configure the plugin via `fileRouter(...)`, vprs threads
+// `params` (and `request`) into your loader automatically as
+// `props(url, { params, request })` — no pattern to repeat. Reach for
+// `withParams` only when you want the params typed from a pattern literal
+// without wiring up the file router, or to parse params off a one-off url.
 export type LoaderContext<Pattern extends string> = {
   /** The concrete request url vprs passed to the loader. */
   url: string;

--- a/plugin/router/withParams.ts
+++ b/plugin/router/withParams.ts
@@ -1,0 +1,28 @@
+import { matchRoute, type RouteParams } from "./matchRoute.js";
+
+// vprs calls a route's `props` export as `props(url)`. `withParams` wraps a
+// loader so it instead receives typed params parsed from that url against the
+// route's pattern — no core plumbing, no codegen:
+//
+//   // src/routes/profile/$id/props.ts
+//   export const props = withParams("/profile/$id", ({ params }) => ({
+//     id: params.id, // params.id: string (inferred from the pattern literal)
+//   }));
+//
+// Declare the same pattern as the route's file location. This is the minimal,
+// composable way to get params into a loader; an automatic (no-pattern) variant
+// can thread params through the handler pipeline later as an enhancement.
+export type LoaderContext<Pattern extends string> = {
+  /** The concrete request url vprs passed to the loader. */
+  url: string;
+  /** Params parsed from `url` against `Pattern`; `{}` if it doesn't match. */
+  params: RouteParams<Pattern>;
+};
+
+export function withParams<Pattern extends string, T>(
+  pattern: Pattern,
+  loader: (ctx: LoaderContext<Pattern>) => T,
+): (url: string) => T {
+  return (url) =>
+    loader({ url, params: (matchRoute(pattern, url) ?? {}) as RouteParams<Pattern> });
+}

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -418,6 +418,13 @@ export type ResolvedUserOptions = {
    */
   clientPackages?: readonly string[];
 
+  /**
+   * Route patterns (`["/profile/$id", …]`) used to compute a loader's `params`
+   * automatically at request time. Supplied by `fileRouter(...)` (spread into
+   * the plugin config); empty when no file-based router is configured.
+   */
+  routePatterns?: readonly string[];
+
   // Required complex properties
   Page: StreamPluginOptions["Page"];
   Html: StreamPluginOptions["Html"]; // Unresolved: can be string, function
@@ -968,8 +975,22 @@ export type CreateHandlerOptions<
   | "workerShutdownTimeout"
   | "rscWorkerPath"
   | "htmlWorkerPath"
+  | "routePatterns"
 > & {
   id?: string;
+  /**
+   * Params parsed from the request url against the matched route pattern
+   * (`/profile/123` → `{ id: "123" }`). Passed to a loader as
+   * `props(url, { params, request })`. When absent, vprs derives it from
+   * `routePatterns` + `url`; `{}` when nothing matches.
+   */
+  params?: Record<string, string>;
+  /**
+   * The in-flight request, when rendering happens on the request thread
+   * (dev middleware). Undefined in the RSC worker, at static build, and on
+   * the edge-flight path — a loader must treat it as optional.
+   */
+  request?: Request;
   /** ID of headless stream to reuse for efficiency */
   reuseHeadlessStreamId?: string;
   /** Storage for headless stream reuse Map<id, { PageComponent: any, errored: boolean }> */

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -195,6 +195,7 @@ async function loadComponentsWithCache(options: {
   verbose?: boolean;
   logger?: any;
   panicThreshold?: PanicThreshold;
+  routePatterns?: readonly string[];  // For request-time param resolution
   resolvedPageProps?: Record<string, unknown>;  // Pre-resolved props from main thread
 }) {
   const {
@@ -211,6 +212,7 @@ async function loadComponentsWithCache(options: {
     verbose,
     logger,
     panicThreshold = "none",
+    routePatterns,
     resolvedPageProps,
   } = options;
   
@@ -310,6 +312,7 @@ async function loadComponentsWithCache(options: {
           pageExportName,
           propsExportName,
           url: normalizedUrl,
+          routePatterns,
           loader,
           verbose: verbose || false,
           logger,
@@ -392,11 +395,12 @@ async function loadComponentsWithCache(options: {
           pageExportName,
           propsExportName,
           url: normalizedUrl,
+          routePatterns,
           loader,
           verbose: verbose || false,
           logger,
         });
-        
+
         if (pageAndPropsResult.type === "success") {
           pageProps = pageAndPropsResult.pageProps;
 
@@ -771,6 +775,7 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             verbose,
             logger,
             panicThreshold: msg.options.panicThreshold,
+            routePatterns: msg.options.routePatterns ?? userOptions.routePatterns,
             resolvedPageProps: msg.options.resolvedPageProps,  // Pre-resolved from main thread
           });
 
@@ -1166,6 +1171,7 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             loader,
             verbose,
             logger,
+            routePatterns: workerData.userOptions?.routePatterns,
           });
 
           const resolutionTime = performance.now() - resolutionStartTime;

--- a/test/examples/file-router-dynamic.test.ts
+++ b/test/examples/file-router-dynamic.test.ts
@@ -39,11 +39,30 @@ export function Page() {
     // Dynamic route: profile/$id. The loader reads params.id — no pattern
     // repeated, no build entry per id.
     await mkdir(join(testDir, "src/routes/profile/$id"), { recursive: true });
+    // A real client component ("use client"). Under the react-server condition
+    // it must be emitted as a client reference, NOT executed server-side — the
+    // same mechanism the package's Link/RouterProvider ride on.
+    await writeFile(
+      join(testDir, "src/Counter.client.tsx"),
+      `"use client";
+import React from "react";
+export function Counter() {
+  const [n, setN] = React.useState(0);
+  return <button onClick={() => setN(n + 1)}>count {n}</button>;
+}
+`,
+    );
     await writeFile(
       join(testDir, "src/routes/profile/$id/page.tsx"),
       `import React from "react";
+import { Counter } from "../../../Counter.client.js";
 export function Page({ label }: { label: string }) {
-  return <div data-testid="profile">{label}</div>;
+  return (
+    <div data-testid="profile">
+      {label}
+      <Counter />
+    </div>
+  );
 }
 `,
     );
@@ -137,5 +156,17 @@ export function Page({ label }: { label: string }) {
   it("threads a catch-all's _splat (rest of the path) into the loader", async () => {
     const flight = await readFlight("/files/a/b/c.png/index.rsc");
     expect(flight).toContain("splat-a/b/c.png-end");
+  });
+
+  // Guards the concern that running dev under `--conditions react-server`
+  // breaks the (client) router: a "use client" component on a fileRouter route
+  // renders as a client reference here, so Link/RouterProvider (also client
+  // components) work the same way — they never execute in the server process.
+  it("emits a client component on a route as a client reference (react-server dev)", async () => {
+    const flight = await readFlight("/profile/42/index.rsc");
+    expect(flight).toContain("pid-42-end"); // server render still succeeded
+    // A client reference points at the client module; the flight carries the
+    // module id (with a $L/import marker), never the executed component.
+    expect(flight).toMatch(/Counter\.client/);
   });
 });

--- a/test/examples/file-router-dynamic.test.ts
+++ b/test/examples/file-router-dynamic.test.ts
@@ -57,6 +57,24 @@ export function Page({ label }: { label: string }) {
 `,
     );
 
+    // Catch-all route: files/$ -> loader reads params._splat (the rest of the path).
+    await mkdir(join(testDir, "src/routes/files/$"), { recursive: true });
+    await writeFile(
+      join(testDir, "src/routes/files/$/page.tsx"),
+      `import React from "react";
+export function Page({ label }: { label: string }) {
+  return <div data-testid="file">{label}</div>;
+}
+`,
+    );
+    await writeFile(
+      join(testDir, "src/routes/files/$/props.ts"),
+      `export const props = (_url: string, { params }: { params: { _splat: string } }) => ({
+  label: "splat-" + params._splat + "-end",
+});
+`,
+    );
+
     const fr = fileRouter(join(testDir, "src/routes"), { root: testDir });
 
     server = await createClientDevServer(
@@ -114,5 +132,10 @@ export function Page({ label }: { label: string }) {
     const flight = await readFlight("/profile/99/index.rsc");
     expect(flight).toContain("pid-99-end");
     expect(flight).not.toContain("pid-42-end");
+  });
+
+  it("threads a catch-all's _splat (rest of the path) into the loader", async () => {
+    const flight = await readFlight("/files/a/b/c.png/index.rsc");
+    expect(flight).toContain("splat-a/b/c.png-end");
   });
 });

--- a/test/examples/file-router-dynamic.test.ts
+++ b/test/examples/file-router-dynamic.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ViteDevServer } from "vite";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getCondition } from "vite-plugin-react-server/config";
+import { setupIndexHTML } from "../setup.js";
+import { createClientDevServer } from "../createDevServer.js";
+import { fileRouter } from "../../plugin/router/fileRouter.js";
+
+// End-to-end proof that a file-based dynamic route (`profile/$id`) is matched
+// per-request and its loader receives the parsed params automatically
+// (`props(url, { params })`), with NO `withParams` and no per-id build entry.
+// Exercises the real dev pipeline: fileRouter → getRouteFiles match →
+// resolvePageAndProps params plumbing → RSC render.
+describe("file-based router — dynamic route renders per-request with params", () => {
+  let server: ViteDevServer | undefined;
+  let port = 5188;
+  const testDir = join(
+    process.cwd(),
+    `test/fixtures/${getCondition()}/file-router-dynamic`,
+  );
+
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+    await setupIndexHTML(testDir);
+
+    // Static index route.
+    await mkdir(join(testDir, "src/routes"), { recursive: true });
+    await writeFile(
+      join(testDir, "src/routes/page.tsx"),
+      `import React from "react";
+export function Page() {
+  return <div data-testid="home">Home</div>;
+}
+`,
+    );
+
+    // Dynamic route: profile/$id. The loader reads params.id — no pattern
+    // repeated, no build entry per id.
+    await mkdir(join(testDir, "src/routes/profile/$id"), { recursive: true });
+    await writeFile(
+      join(testDir, "src/routes/profile/$id/page.tsx"),
+      `import React from "react";
+export function Page({ label }: { label: string }) {
+  return <div data-testid="profile">{label}</div>;
+}
+`,
+    );
+    // Build a single unambiguous token from the param so the assertion can't
+    // collide with incidental digits in the flight (hashes, byte lengths).
+    await writeFile(
+      join(testDir, "src/routes/profile/$id/props.ts"),
+      `export const props = (_url: string, { params }: { params: { id: string } }) => ({
+  label: "pid-" + params.id + "-end",
+});
+`,
+    );
+
+    const fr = fileRouter(join(testDir, "src/routes"), { root: testDir });
+
+    server = await createClientDevServer(
+      {
+        projectRoot: testDir,
+        moduleBase: "src",
+        Page: fr.Page,
+        props: fr.props,
+        routePatterns: fr.routePatterns,
+        build: { pages: fr.build.pages as string[] },
+        verbose: false,
+      } as any,
+      port,
+    );
+    port = server.config.server.port ?? port;
+  });
+
+  afterAll(async () => {
+    try {
+      await server?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  async function readFlight(path: string): Promise<string> {
+    const res = await fetch(`http://localhost:${port}${path}`, {
+      headers: { Accept: "text/x-component; charset=utf-8" },
+    });
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("no response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let out = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      out += decoder.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    return out;
+  }
+
+  it("threads the parsed param into the loader for /profile/42", async () => {
+    const flight = await readFlight("/profile/42/index.rsc");
+    expect(flight).toContain("pid-42-end");
+  });
+
+  it("resolves a different id per-request (not cached to one page)", async () => {
+    const flight = await readFlight("/profile/99/index.rsc");
+    expect(flight).toContain("pid-99-end");
+    expect(flight).not.toContain("pid-42-end");
+  });
+});

--- a/test/router-fixtures/routes/blog/$category/$slug/page.tsx
+++ b/test/router-fixtures/routes/blog/$category/$slug/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes/files/$/page.tsx
+++ b/test/router-fixtures/routes/files/$/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes/page.tsx
+++ b/test/router-fixtures/routes/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes/profile/$id/page.tsx
+++ b/test/router-fixtures/routes/profile/$id/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes/profile/$id/props.ts
+++ b/test/router-fixtures/routes/profile/$id/props.ts
@@ -1,0 +1,1 @@
+export const props = ({ params }) => ({ id: params.id });

--- a/test/router-fixtures/routes/profile/me/page.tsx
+++ b/test/router-fixtures/routes/profile/me/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router/link.test.tsx
+++ b/test/router/link.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createRouter } from "../../plugin/router/createRouter.js";
+import { Link } from "../../plugin/router/link.js";
+import { RouterProvider } from "../../plugin/router/router-react.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+beforeEach(() => {
+  history.replaceState(null, "", "/");
+});
+
+async function mount(ui: React.ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(ui);
+  });
+  return container.querySelector("a") as HTMLAnchorElement;
+}
+
+function withRouter(node: React.ReactNode) {
+  const router = createRouter({ fetchFlight: async (u: string) => u });
+  return { router, ui: <RouterProvider router={router}>{node}</RouterProvider> };
+}
+
+describe("Link", () => {
+  it("intercepts a plain internal click and navigates", async () => {
+    const { router, ui } = withRouter(<Link to="/about">about</Link>);
+    const navigate = vi.spyOn(router, "navigate");
+    const a = await mount(ui);
+    const ev = new MouseEvent("click", { bubbles: true, cancelable: true });
+    await act(async () => {
+      a.dispatchEvent(ev);
+    });
+    expect(ev.defaultPrevented).toBe(true);
+    expect(navigate.mock.calls[0]?.[0]).toBe("/about");
+  });
+
+  it("lets modified clicks through to the browser", async () => {
+    const { router, ui } = withRouter(<Link to="/about">about</Link>);
+    const navigate = vi.spyOn(router, "navigate");
+    const a = await mount(ui);
+    const ev = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      metaKey: true,
+    });
+    await act(async () => {
+      a.dispatchEvent(ev);
+    });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("does not intercept external links", async () => {
+    const { router, ui } = withRouter(<Link to="https://example.com">x</Link>);
+    const navigate = vi.spyOn(router, "navigate");
+    const a = await mount(ui);
+    await act(async () => {
+      a.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("warms the flight on hover when prefetch='hover'", async () => {
+    const { router, ui } = withRouter(
+      <Link to="/p" prefetch="hover">
+        p
+      </Link>,
+    );
+    const prefetch = vi.spyOn(router, "prefetch");
+    const a = await mount(ui);
+    await act(async () => {
+      a.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    expect(prefetch).toHaveBeenCalledWith("/p");
+  });
+
+  it("does not prefetch when prefetch={false}", async () => {
+    const { router, ui } = withRouter(
+      <Link to="/p" prefetch={false}>
+        p
+      </Link>,
+    );
+    const prefetch = vi.spyOn(router, "prefetch");
+    const a = await mount(ui);
+    await act(async () => {
+      a.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+    expect(prefetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/router/link.test.tsx
+++ b/test/router/link.test.tsx
@@ -94,4 +94,16 @@ describe("Link", () => {
     });
     expect(prefetch).not.toHaveBeenCalled();
   });
+
+  it("renders a plain anchor (no interception) outside a RouterProvider", async () => {
+    // During static prerender there's no provider yet — Link must still render
+    // and must NOT intercept (the browser handles the navigation).
+    const a = await mount(<Link to="/x">x</Link>);
+    expect(a.getAttribute("href")).toBe("/x");
+    const ev = new MouseEvent("click", { bubbles: true, cancelable: true });
+    await act(async () => {
+      a.dispatchEvent(ev);
+    });
+    expect(ev.defaultPrevented).toBe(false);
+  });
 });

--- a/test/router/router-react.test.tsx
+++ b/test/router/router-react.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createRouter } from "../../plugin/router/createRouter.js";
+import {
+  RouterProvider,
+  useLocation,
+  useParams,
+} from "../../plugin/router/router-react.js";
+
+// Required for React's act() outside a testing-library harness.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+beforeEach(() => {
+  history.replaceState(null, "", "/");
+});
+
+function Probe() {
+  const loc = useLocation();
+  const { id } = useParams<"/profile/$id">();
+  return (
+    <div>
+      {loc}|{id ?? "none"}
+    </div>
+  );
+}
+
+describe("RouterProvider + hooks", () => {
+  it("exposes location + params and re-renders on navigate", async () => {
+    const router = createRouter({ fetchFlight: async (u: string) => u });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <RouterProvider router={router} patterns={["/profile/$id"]}>
+          <Probe />
+        </RouterProvider>,
+      );
+    });
+    expect(container.textContent).toBe("/|none");
+
+    await act(async () => {
+      router.navigate("/profile/42");
+    });
+    expect(container.textContent).toBe("/profile/42|42");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/test/types/matchRoute.test.ts
+++ b/test/types/matchRoute.test.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { matchRoute, type RouteParams } from "../../plugin/router/matchRoute.js";
+
+// Params are inferred from the pattern literal via template-literal types — no
+// codegen, no hand-maintained map. Run under `vitest --typecheck`.
+
+describe("RouteParams inference", () => {
+  it("infers a single param", () => {
+    expectTypeOf<RouteParams<"/profile/$id">>().toEqualTypeOf<{ id: string }>();
+  });
+
+  it("infers multiple params", () => {
+    expectTypeOf<RouteParams<"/blog/$category/$slug">>().toEqualTypeOf<{
+      category: string;
+      slug: string;
+    }>();
+  });
+
+  it("has no keys for a fully-static route", () => {
+    expectTypeOf<keyof RouteParams<"/profile/me">>().toEqualTypeOf<never>();
+    expectTypeOf<keyof RouteParams<"/">>().toEqualTypeOf<never>();
+  });
+
+  it("maps a bare $ catch-all to _splat", () => {
+    expectTypeOf<RouteParams<"/files/$">>().toEqualTypeOf<{ _splat: string }>();
+  });
+
+  it("types matchRoute's return as params-or-null", () => {
+    expectTypeOf(matchRoute("/profile/$id", "/profile/1")).toEqualTypeOf<
+      { id: string } | null
+    >();
+  });
+});

--- a/test/types/register.test.ts
+++ b/test/types/register.test.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { ToPath } from "../../plugin/router/register.js";
+
+// The Register pattern narrows route paths via declaration merging. Run under
+// `vitest --typecheck`.
+describe("Register / ToPath", () => {
+  it("falls back to string (accepts any path) with no augmentation", () => {
+    // Default Register is empty → ToPath accepts arbitrary concrete paths.
+    expectTypeOf<"/greet/alice">().toMatchTypeOf<ToPath>();
+    expectTypeOf<"/anything/at/all">().toMatchTypeOf<ToPath>();
+  });
+
+  it("narrows RegisteredRoutes to the declared union when augmented", () => {
+    // Mirrors the conditional the exported RegisteredRoutes uses, verified
+    // without a global module augmentation.
+    type Narrowed = { routes: "/" | "/greet/$name" } extends {
+      routes: infer R extends string;
+    }
+      ? R
+      : string;
+    expectTypeOf<Narrowed>().toEqualTypeOf<"/" | "/greet/$name">();
+  });
+});

--- a/test/types/withParams.test.ts
+++ b/test/types/withParams.test.ts
@@ -1,0 +1,26 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { withParams } from "../../plugin/router/withParams.js";
+
+// The loader's `params` are inferred from the pattern literal. Run under
+// `vitest --typecheck`.
+describe("withParams typing", () => {
+  it("infers params from the pattern", () => {
+    withParams("/profile/$id", (ctx) => {
+      expectTypeOf(ctx.params).toEqualTypeOf<{ id: string }>();
+      expectTypeOf(ctx.url).toEqualTypeOf<string>();
+      return ctx.params;
+    });
+  });
+
+  it("infers multiple params", () => {
+    withParams("/blog/$category/$slug", (ctx) => {
+      expectTypeOf(ctx.params).toEqualTypeOf<{ category: string; slug: string }>();
+      return null;
+    });
+  });
+
+  it("preserves the loader's return type", () => {
+    const props = withParams("/u/$name", ({ params }) => ({ name: params.name }));
+    expectTypeOf(props).toEqualTypeOf<(url: string) => { name: string }>();
+  });
+});

--- a/test/unit/createRouter.test.ts
+++ b/test/unit/createRouter.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createFlightCache } from "../../plugin/router/flightCache.js";
+import { createRouter } from "../../plugin/router/createRouter.js";
+
+beforeEach(() => {
+  history.replaceState(null, "", "/");
+});
+
+describe("createRouter", () => {
+  it("starts at the current location", () => {
+    history.replaceState(null, "", "/start");
+    const r = createRouter({ fetchFlight: async (u) => u });
+    expect(r.getState().url).toBe("/start");
+  });
+
+  it("navigate pushes history, warms the flight, and notifies", async () => {
+    const fetchFlight = vi.fn(async (u: string) => `flight:${u}`);
+    const r = createRouter({ fetchFlight });
+    const seen: string[] = [];
+    r.subscribe(() => seen.push(r.getState().url));
+
+    r.navigate("/profile/1");
+    expect(location.pathname).toBe("/profile/1");
+    expect(r.getState().url).toBe("/profile/1");
+    expect(seen).toEqual(["/profile/1"]);
+    expect(fetchFlight).toHaveBeenCalledWith("/profile/1");
+
+    // the warmed flight is reused (no second fetch)
+    await r.flight("/profile/1");
+    expect(fetchFlight).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a prefetched flight on navigate (one fetch total)", async () => {
+    const fetchFlight = vi.fn(async (u: string) => `flight:${u}`);
+    const r = createRouter({ fetchFlight });
+    r.prefetch("/profile/2");
+    r.navigate("/profile/2");
+    await r.flight("/profile/2");
+    expect(fetchFlight).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates state on popstate (back/forward)", () => {
+    const r = createRouter({ fetchFlight: async (u) => u });
+    const seen: string[] = [];
+    r.subscribe(() => seen.push(r.getState().url));
+    r.navigate("/a");
+    history.replaceState(null, "", "/b"); // simulate the browser moving location
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    expect(r.getState().url).toBe("/b");
+    expect(seen).toEqual(["/a", "/b"]);
+  });
+
+  it("unsubscribe stops notifications", () => {
+    const r = createRouter({ fetchFlight: async (u) => u });
+    const cb = vi.fn();
+    const off = r.subscribe(cb);
+    r.navigate("/x");
+    off();
+    r.navigate("/y");
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives dynamic-route flights a short ttl; static ones cache forever", async () => {
+    let t = 0;
+    const cache = createFlightCache<string>({ now: () => t });
+    const fetchFlight = vi.fn(async (u: string) => u);
+    const r = createRouter({
+      fetchFlight,
+      isDynamic: (u) => u.startsWith("/p/"),
+      dynamicTtlMs: 1000,
+      cache,
+    });
+
+    await r.flight("/static"); // #1 (no ttl)
+    await r.flight("/p/1"); // #2 (dynamic, ttl 1000)
+    expect(fetchFlight).toHaveBeenCalledTimes(2);
+
+    t = 500;
+    await r.flight("/p/1"); // fresh → reused
+    expect(fetchFlight).toHaveBeenCalledTimes(2);
+
+    t = 1500;
+    await r.flight("/p/1"); // #3 (expired)
+    expect(fetchFlight).toHaveBeenCalledTimes(3);
+
+    t = 9_999_999;
+    await r.flight("/static"); // still reused (no ttl)
+    expect(fetchFlight).toHaveBeenCalledTimes(3);
+  });
+});

--- a/test/unit/fileRouter.test.ts
+++ b/test/unit/fileRouter.test.ts
@@ -11,8 +11,32 @@ const ROUTES = join(
 describe("fileRouter", () => {
   const r = fileRouter(ROUTES);
 
-  it("prerenders only the fully-static routes", () => {
-    expect(new Set(r.build.pages)).toEqual(new Set(["/", "/profile/me"]));
+  it("prerenders only the fully-static routes (no staticPaths)", () => {
+    expect(new Set(r.build.pages as string[])).toEqual(
+      new Set(["/", "/profile/me"]),
+    );
+  });
+
+  it("enumerates dynamic routes via staticPaths into an async build.pages", async () => {
+    const withPaths = fileRouter(ROUTES, {
+      staticPaths: {
+        "/profile/$id": () => [{ id: "1" }, { id: "2" }],
+        "/blog/$category/$slug": async () => ["/blog/tech/rsc"], // full urls allowed too
+        // "/files/$" intentionally omitted → stays server-only
+      },
+    });
+    expect(typeof withPaths.build.pages).toBe("function");
+    const pages = await (withPaths.build.pages as () => Promise<string[]>)();
+    expect(new Set(pages)).toEqual(
+      new Set([
+        "/",
+        "/profile/me",
+        "/profile/1",
+        "/profile/2",
+        "/blog/tech/rsc",
+      ]),
+    );
+    expect(pages.some((p) => p.startsWith("/files"))).toBe(false);
   });
 
   it("resolves Page by matching the url (static beats param)", () => {

--- a/test/unit/fileRouter.test.ts
+++ b/test/unit/fileRouter.test.ts
@@ -64,4 +64,20 @@ describe("fileRouter", () => {
     expect(r.getParams("/profile/me")).toEqual({});
     expect(r.getParams("/nope/x")).toEqual({});
   });
+
+  it("emits page/props paths relative to `root` (cwd ≠ project root)", () => {
+    // ROUTES is <fixtures>/router-fixtures/routes; scanning it with the fixtures
+    // dir as root must yield project-root-relative, posix-slashed paths.
+    const projectRoot = join(ROUTES, "../..");
+    const rr = fileRouter(ROUTES, { root: projectRoot });
+    expect(rr.Page("/profile/123")).toBe(
+      "router-fixtures/routes/profile/$id/page.tsx",
+    );
+    expect(rr.props("/profile/123")).toBe(
+      "router-fixtures/routes/profile/$id/props.ts",
+    );
+    expect(rr.Page("/")).toBe("router-fixtures/routes/page.tsx");
+    // Matching + params are unaffected by the root rewrite.
+    expect(rr.getParams("/profile/123")).toEqual({ id: "123" });
+  });
 });

--- a/test/unit/fileRouter.test.ts
+++ b/test/unit/fileRouter.test.ts
@@ -33,4 +33,11 @@ describe("fileRouter", () => {
   it("throws on an unmatched url", () => {
     expect(() => r.Page("/nope/x")).toThrow(/no route matches/);
   });
+
+  it("extracts params for the loader (matched pattern), {} when unmatched", () => {
+    expect(r.getParams("/profile/123")).toEqual({ id: "123" });
+    expect(r.getParams("/blog/tech/rsc")).toEqual({ category: "tech", slug: "rsc" });
+    expect(r.getParams("/profile/me")).toEqual({});
+    expect(r.getParams("/nope/x")).toEqual({});
+  });
 });

--- a/test/unit/fileRouter.test.ts
+++ b/test/unit/fileRouter.test.ts
@@ -1,0 +1,36 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { fileRouter } from "../../plugin/router/fileRouter.js";
+
+const ROUTES = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../router-fixtures/routes",
+);
+
+describe("fileRouter", () => {
+  const r = fileRouter(ROUTES);
+
+  it("prerenders only the fully-static routes", () => {
+    expect(new Set(r.build.pages)).toEqual(new Set(["/", "/profile/me"]));
+  });
+
+  it("resolves Page by matching the url (static beats param)", () => {
+    expect(r.Page("/profile/me")).toMatch(/profile\/me\/page\.tsx$/);
+    expect(r.Page("/profile/123")).toMatch(/profile\/\$id\/page\.tsx$/);
+    expect(r.Page("/")).toMatch(/routes\/page\.tsx$/);
+  });
+
+  it("resolves props for a dynamic route, undefined when absent", () => {
+    expect(r.props("/profile/123")).toMatch(/profile\/\$id\/props\.ts$/);
+    expect(r.props("/profile/me")).toBeUndefined();
+  });
+
+  it("matches catch-all routes", () => {
+    expect(r.Page("/files/a/b.png")).toMatch(/files\/\$\/page\.tsx$/);
+  });
+
+  it("throws on an unmatched url", () => {
+    expect(() => r.Page("/nope/x")).toThrow(/no route matches/);
+  });
+});

--- a/test/unit/fillPattern.test.ts
+++ b/test/unit/fillPattern.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { fillPattern, matchRoute } from "../../plugin/router/matchRoute.js";
+
+describe("fillPattern", () => {
+  it("fills a single param", () => {
+    expect(fillPattern("/profile/$id", { id: "5" })).toBe("/profile/5");
+  });
+
+  it("fills multiple params", () => {
+    expect(fillPattern("/blog/$category/$slug", { category: "tech", slug: "rsc" })).toBe(
+      "/blog/tech/rsc",
+    );
+  });
+
+  it("returns / for the root pattern", () => {
+    expect(fillPattern("/", {})).toBe("/");
+  });
+
+  it("keeps a catch-all's raw path", () => {
+    expect(fillPattern("/files/$", { _splat: "a/b/c.png" })).toBe("/files/a/b/c.png");
+  });
+
+  it("percent-encodes named param values", () => {
+    expect(fillPattern("/u/$name", { name: "a b" })).toBe("/u/a%20b");
+  });
+
+  it("throws when a named param is missing", () => {
+    expect(() => fillPattern("/profile/$id", {})).toThrow(/missing param/);
+  });
+
+  it("round-trips with matchRoute", () => {
+    const url = fillPattern("/blog/$category/$slug", { category: "x", slug: "y" });
+    expect(matchRoute("/blog/$category/$slug", url)).toEqual({
+      category: "x",
+      slug: "y",
+    });
+  });
+});

--- a/test/unit/flightCache.test.ts
+++ b/test/unit/flightCache.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFlightCache } from "../../plugin/router/flightCache.js";
+
+describe("createFlightCache", () => {
+  it("dedupes concurrent gets for the same url", async () => {
+    const cache = createFlightCache<string>();
+    const fetcher = vi.fn(async (u: string) => `flight:${u}`);
+    const [a, b] = await Promise.all([
+      cache.get("/a", { fetcher }),
+      cache.get("/a", { fetcher }),
+    ]);
+    expect(a).toBe("flight:/a");
+    expect(b).toBe("flight:/a");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefetch warms an entry that a later get reuses", async () => {
+    const cache = createFlightCache<string>();
+    const fetcher = vi.fn(async (u: string) => `flight:${u}`);
+    cache.prefetch("/a", { fetcher });
+    expect(cache.has("/a")).toBe(true);
+    await cache.get("/a", { fetcher });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches indefinitely with no ttl (static routes)", async () => {
+    let t = 0;
+    const cache = createFlightCache<string>({ now: () => t });
+    const fetcher = vi.fn(async (u: string) => `flight:${u}`);
+    await cache.get("/a", { fetcher });
+    t = 10_000_000;
+    await cache.get("/a", { fetcher });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches after ttl expires (dynamic-route snapshots)", async () => {
+    let t = 0;
+    const cache = createFlightCache<string>({ now: () => t });
+    const fetcher = vi.fn(async (u: string) => `flight:${u}`);
+    await cache.get("/a", { fetcher, ttlMs: 1000 });
+    t = 500;
+    await cache.get("/a", { fetcher, ttlMs: 1000 }); // still fresh
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    t = 1500;
+    await cache.get("/a", { fetcher, ttlMs: 1000 }); // expired
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts a rejected fetch so it can be retried", async () => {
+    const cache = createFlightCache<string>();
+    const failing = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    await expect(cache.get("/a", { fetcher: failing })).rejects.toThrow("boom");
+    // allow the catch handler to run
+    await Promise.resolve();
+    expect(cache.has("/a")).toBe(false);
+    const ok = vi.fn(async () => "recovered");
+    await expect(cache.get("/a", { fetcher: ok })).resolves.toBe("recovered");
+  });
+
+  it("invalidate() drops one url or clears all", async () => {
+    const cache = createFlightCache<string>();
+    const fetcher = async (u: string) => `flight:${u}`;
+    await cache.get("/a", { fetcher });
+    await cache.get("/b", { fetcher });
+    cache.invalidate("/a");
+    expect(cache.has("/a")).toBe(false);
+    expect(cache.has("/b")).toBe(true);
+    cache.invalidate();
+    expect(cache.has("/b")).toBe(false);
+  });
+});

--- a/test/unit/matchRoute.test.ts
+++ b/test/unit/matchRoute.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { matchRoute, matchRoutes } from "../../plugin/router/matchRoute.js";
+
+// matchRoute works on a clean pathname; the caller (requestToRoute) strips the
+// query/hash before matching.
+
+describe("matchRoute", () => {
+  it("matches the root route to empty params", () => {
+    expect(matchRoute("/", "/")).toEqual({});
+  });
+
+  it("extracts a single $param", () => {
+    expect(matchRoute("/profile/$id", "/profile/123")).toEqual({ id: "123" });
+  });
+
+  it("extracts multiple $params", () => {
+    expect(matchRoute("/blog/$category/$slug", "/blog/tech/rsc")).toEqual({
+      category: "tech",
+      slug: "rsc",
+    });
+  });
+
+  it("returns null on a literal-segment mismatch", () => {
+    expect(matchRoute("/profile/me", "/profile/123")).toBeNull();
+  });
+
+  it("returns null on a segment-count mismatch", () => {
+    expect(matchRoute("/profile/$id", "/profile/123/extra")).toBeNull();
+    expect(matchRoute("/a/b", "/a")).toBeNull();
+  });
+
+  it("percent-decodes param values", () => {
+    expect(matchRoute("/u/$name", "/u/a%20b")).toEqual({ name: "a b" });
+  });
+
+  it("treats a bare $ as a catch-all (rest of path, decoded)", () => {
+    expect(matchRoute("/files/$", "/files/a/b/c.png")).toEqual({ _splat: "a/b/c.png" });
+  });
+
+  it("matches an empty tail for a catch-all", () => {
+    expect(matchRoute("/files/$", "/files")).toEqual({ _splat: "" });
+  });
+});
+
+describe("matchRoutes (specificity ordering)", () => {
+  const patterns = [
+    "/",
+    "/profile/$id",
+    "/profile/me",
+    "/blog/$category/$slug",
+    "/files/$",
+  ] as const;
+
+  it("prefers a static segment over a param", () => {
+    expect(matchRoutes(patterns, "/profile/me")).toEqual({
+      pattern: "/profile/me",
+      params: {},
+    });
+    expect(matchRoutes(patterns, "/profile/123")).toEqual({
+      pattern: "/profile/$id",
+      params: { id: "123" },
+    });
+  });
+
+  it("falls through to the catch-all only when nothing else matches", () => {
+    expect(matchRoutes(patterns, "/files/a/b")).toEqual({
+      pattern: "/files/$",
+      params: { _splat: "a/b" },
+    });
+  });
+
+  it("returns null when no pattern matches", () => {
+    expect(matchRoutes(patterns, "/nope/x")).toBeNull();
+  });
+});

--- a/test/unit/resolvePageAndProps.params.test.ts
+++ b/test/unit/resolvePageAndProps.params.test.ts
@@ -102,4 +102,78 @@ describe("resolvePageAndProps — automatic params", () => {
       url: "/profile/42",
     });
   });
+
+  it("passes multiple params (most-specific pattern wins)", async () => {
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((_url, ctx) => ctx?.params),
+      url: "/blog/tech/rsc",
+      routePatterns: ["/blog/$category/$slug", "/blog/$category/me"],
+      logger: noopLogger,
+    });
+
+    expect(result.type === "success" && result.pageProps).toEqual({
+      category: "tech",
+      slug: "rsc",
+    });
+  });
+
+  it("exposes a catch-all's _splat to the loader", async () => {
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((_url, ctx) => ({ splat: ctx?.params?._splat })),
+      url: "/files/a/b/c.png",
+      routePatterns: ["/files/$"],
+      logger: noopLogger,
+    });
+
+    expect(result.type === "success" && result.pageProps).toEqual({
+      splat: "a/b/c.png",
+    });
+  });
+
+  it("normalizes the match target: query, index.rsc suffix, trailing slash", async () => {
+    for (const url of [
+      "/profile/42?ref=x",
+      "/profile/42/index.rsc",
+      "/profile/42/",
+      "/profile/42.html",
+    ]) {
+      const result = await resolvePageAndProps({
+        pagePath: "virtual:page",
+        propsPath: "virtual:props",
+        propsExportName: "props",
+        loader: makeLoader((_url, ctx) => ctx?.params),
+        url,
+        routePatterns: ["/profile/$id"],
+        build: { rscOutputPath: "index.rsc" },
+        logger: noopLogger,
+      });
+      expect(result.type === "success" && result.pageProps, `for ${url}`).toEqual({
+        id: "42",
+      });
+    }
+  });
+
+  it("leaves request undefined on the non-request paths (worker/static)", async () => {
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((_url, ctx) => ({
+        hasRequest: ctx?.request !== undefined,
+      })),
+      url: "/profile/42",
+      routePatterns: ["/profile/$id"],
+      logger: noopLogger,
+    });
+
+    expect(result.type === "success" && result.pageProps).toEqual({
+      hasRequest: false,
+    });
+  });
 });

--- a/test/unit/resolvePageAndProps.params.test.ts
+++ b/test/unit/resolvePageAndProps.params.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { resolvePageAndProps } from "../../plugin/helpers/resolvePageAndProps.js";
+
+// The file router threads params/request into a loader automatically:
+// `props(url, { params, request })`, with params derived from routePatterns + url
+// (no `withParams` pattern to repeat). These tests exercise that plumbing
+// through the canonical resolvePageAndProps helper (the same one dev/static/
+// worker/edge call), independent of any built example.
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} } as any;
+
+/** A loader dispatching by base path (ignores the `#export` suffix). */
+function makeLoader(propsFn: (url: string, ctx?: any) => unknown) {
+  return async (id?: string) => {
+    const base = String(id).split("#")[0];
+    if (base === "virtual:props") return { props: propsFn };
+    return { Page: () => null };
+  };
+}
+
+describe("resolvePageAndProps — automatic params", () => {
+  it("derives params from routePatterns and passes them to the loader", async () => {
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((_url, ctx) => ({ id: ctx?.params?.id })),
+      url: "/profile/42",
+      routePatterns: ["/profile/$id"],
+      logger: noopLogger,
+    });
+
+    expect(result.type).toBe("success");
+    expect(result.type === "success" && result.pageProps).toEqual({ id: "42" });
+  });
+
+  it("passes the request through to the loader when present", async () => {
+    const request = new Request("http://localhost/profile/7", {
+      headers: { cookie: "session=abc" },
+    });
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((_url, ctx) => ({
+        cookie: ctx?.request?.headers.get("cookie") ?? null,
+      })),
+      url: "/profile/7",
+      routePatterns: ["/profile/$id"],
+      request,
+      logger: noopLogger,
+    });
+
+    expect(result.type === "success" && result.pageProps).toEqual({
+      cookie: "session=abc",
+    });
+  });
+
+  it("gives the loader empty params when nothing matches", async () => {
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((_url, ctx) => ({ params: ctx?.params })),
+      url: "/nope",
+      routePatterns: ["/profile/$id"],
+      logger: noopLogger,
+    });
+
+    expect(result.type === "success" && result.pageProps).toEqual({ params: {} });
+  });
+
+  it("prefers precomputed params over routePatterns", async () => {
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((_url, ctx) => ctx?.params),
+      url: "/profile/42",
+      routePatterns: ["/profile/$id"],
+      params: { id: "override" },
+      logger: noopLogger,
+    });
+
+    expect(result.type === "success" && result.pageProps).toEqual({
+      id: "override",
+    });
+  });
+
+  it("stays back-compatible with a plain (url) => props loader", async () => {
+    const result = await resolvePageAndProps({
+      pagePath: "virtual:page",
+      propsPath: "virtual:props",
+      propsExportName: "props",
+      loader: makeLoader((url) => ({ url })),
+      url: "/profile/42",
+      routePatterns: ["/profile/$id"],
+      logger: noopLogger,
+    });
+
+    expect(result.type === "success" && result.pageProps).toEqual({
+      url: "/profile/42",
+    });
+  });
+});

--- a/test/unit/scanRoutes.test.ts
+++ b/test/unit/scanRoutes.test.ts
@@ -1,0 +1,44 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { scanRoutes } from "../../plugin/router/scanRoutes.js";
+
+const ROUTES = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../router-fixtures/routes",
+);
+
+describe("scanRoutes", () => {
+  const routes = scanRoutes(ROUTES);
+  const byPattern = Object.fromEntries(routes.map((r) => [r.pattern, r]));
+
+  it("discovers every page.tsx as a route pattern", () => {
+    expect(new Set(routes.map((r) => r.pattern))).toEqual(
+      new Set([
+        "/",
+        "/profile/$id",
+        "/profile/me",
+        "/blog/$category/$slug",
+        "/files/$",
+      ]),
+    );
+  });
+
+  it("flags $-segment routes as dynamic", () => {
+    expect(byPattern["/profile/$id"].dynamic).toBe(true);
+    expect(byPattern["/blog/$category/$slug"].dynamic).toBe(true);
+    expect(byPattern["/files/$"].dynamic).toBe(true);
+    expect(byPattern["/"].dynamic).toBe(false);
+    expect(byPattern["/profile/me"].dynamic).toBe(false);
+  });
+
+  it("links a sibling props file only when present", () => {
+    expect(byPattern["/profile/$id"].props).toMatch(/profile\/\$id\/props\.ts$/);
+    expect(byPattern["/profile/me"].props).toBeUndefined();
+  });
+
+  it("points page at the route's page file", () => {
+    expect(byPattern["/profile/$id"].page).toMatch(/profile\/\$id\/page\.tsx$/);
+    expect(byPattern["/"].page).toMatch(/routes\/page\.tsx$/);
+  });
+});

--- a/test/unit/withParams.test.ts
+++ b/test/unit/withParams.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { withParams } from "../../plugin/router/withParams.js";
+
+describe("withParams", () => {
+  it("supplies parsed params to the loader", () => {
+    const props = withParams("/profile/$id", ({ params }) => ({ id: params.id }));
+    expect(props("/profile/123")).toEqual({ id: "123" });
+  });
+
+  it("passes the url through alongside params", () => {
+    const props = withParams("/blog/$category/$slug", (ctx) => ctx);
+    expect(props("/blog/tech/rsc")).toEqual({
+      url: "/blog/tech/rsc",
+      params: { category: "tech", slug: "rsc" },
+    });
+  });
+
+  it("gives the loader {} params when the url doesn't match the pattern", () => {
+    const props = withParams("/profile/$id", ({ params }) => params);
+    expect(props("/something/else/entirely")).toEqual({});
+  });
+
+  it("supports async loaders", async () => {
+    const props = withParams("/u/$name", async ({ params }) => `hi ${params.name}`);
+    await expect(props("/u/ada")).resolves.toBe("hi ada");
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -111,6 +111,12 @@ export default defineConfig({
         "plugin/orchestrator/createPluginOrchestrator.client": resolve(__dirname, "plugin/orchestrator/createPluginOrchestrator.client.ts"),
         "plugin/config/createHandlerOptions.server": resolve(__dirname, "plugin/config/createHandlerOptions.server.ts"),
         "plugin/config/createHandlerOptions.client": resolve(__dirname, "plugin/config/createHandlerOptions.client.ts"),
+        // Public "./router" + "./router/client" entries. Declaring them keeps
+        // the file-router API (fileRouter, fillPattern, matchRoutes, Link…)
+        // fully exported — otherwise cross-entry tree-shaking can drop a symbol
+        // only fileRouter uses (e.g. fillPattern) from the shared matchRoute chunk.
+        "plugin/router/index": resolve(__dirname, "plugin/router/index.ts"),
+        "plugin/router/client": resolve(__dirname, "plugin/router/client.ts"),
       },
       formats: ["es"],
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,9 +50,12 @@ export default defineConfig({
       // condition (they import from react-server-only paths). Streams stay
       // included in both modes — the worker mechanism handles RSC rendering
       // from a react-client process via spawning a react-server worker.
+      // The router client suite (Link / RouterProvider) imports
+      // react-dom/client, which throws under the react-server condition, so it
+      // runs client-mode only — mirror of the unit/server exclusion above.
       ...(getCondition() !== "react-server"
         ? ["test/unit/**/*.test.*", "test/server/**/*.test.*"]
-        : []),
+        : ["test/router/**/*.test.*"]),
     ],
   },
 });


### PR DESCRIPTION
## File-based router

Adds a file-based router so apps stop hand-rolling a `createRouter(url) => path`
switch and a manual prerender list. Routes are declared by the file tree, params
are inferred from the pattern literal (no codegen), and loaders receive their
params automatically.

```
src/routes/
  page.tsx                     ->  /
  profile/$id/page.tsx         ->  /profile/$id   (props.ts sibling = loader)
  files/$/page.tsx             ->  /files/$        (catch-all)
```

```ts
// vite.config — no clientPackages, no route list
import { fileRouter } from "vite-plugin-react-server/router";
vitePluginReactServer({ moduleBase: "src", ...fileRouter("src/routes") });

// src/routes/profile/$id/props.ts — params are handed in, no pattern to repeat
export const props = (url, { params, request }) => ({ id: params.id });
```

`RouteParams<"/profile/$id">` resolves to `{ id: string }` at the type level, so
`params.id` is typed without a hand-maintained map.

### What's included
- **Matcher** — `$name` params, bare `$` catch-all (`_splat`), static-beats-param
  specificity, template-literal param inference.
- **Scanner + `fileRouter`** — turns `src/routes/**` into the `Page` / `props` /
  `build.pages` the plugin already consumes. `{ root }` decouples the scan
  location from the emitted paths (monorepos / cwd ≠ project root).
- **Automatic params/request** — loaders are invoked as
  `props(url, { params, request })`. Params are derived from the matched pattern
  and threaded through every render path (dev, static build, RSC worker, edge).
  `request` is present only on the request thread (dev middleware); it is
  `undefined` in the worker, at static build, and on the edge-flight path, so a
  loader treats it as optional. `(url) => props` and object props keep working
  unchanged.
- **`getStaticPaths`** — `fileRouter(dir, { staticPaths })` enumerates a dynamic
  route's concrete urls for prerendering; a dynamic route with no entry stays
  server-only.
- **Client runtime** — headless router (navigate/history/subscribe), a flight
  cache for nav + hover/intent prefetch, `RouterProvider` + `useRouter` /
  `useLocation` / `useParams`, a `Link` that degrades to a plain `<a>` outside a
  provider (so it renders during static prerender), `startClient` bootstrap, and
  a typed `Link.to` / `navigate` via a `Register` declaration-merge. Shipped from
  the package under `./router` and `./router/client`.
- **Zero-config client packages** — the client runtime ships `"use client"`
  modules from the package, which requires the consumer to allow-list it.
  `vite-plugin-react-server` is now auto-detected by the client-package
  discovery (it lists `react` in `peerDependencies`) instead of self-excluding,
  so **no manual `clientPackages: ["vite-plugin-react-server"]` is needed**.
  Only files carrying the directive become client references; the server/plugin
  code has no directive and stays server-side.

### Scope boundary
The plugin stays a stateless artifact + manifest producer. Host rewrites/aliases
and cache headers (`.htaccess` / `vercel.json` / …) and deploy-state concerns
(pruning removed routes, cache invalidation) are deliberately out of core — they
need the deploy target or previous-deploy state a stateless build can't have.
Core owns only render-time pieces (`getStaticPaths`, canonical urls).

### Validation
- Unit + integration tests for the matcher, scanner, `fileRouter`, static-path
  enumeration, the automatic-params plumbing (multi-param, catch-all `_splat`,
  match-target normalization for query / `index.rsc` / `.html` / trailing slash,
  request-undefined, back-compat), and the client runtime / `Link`.
- Dev end-to-end tests drive the real pipeline **under the react-server
  condition**: `/profile/$id` matches per-request and the loader gets
  `params.id`; a catch-all threads `_splat`; and a `"use client"` component on a
  route is emitted as a client reference (proving the client router works when
  dev runs with `--conditions react-server` — client components are references,
  never executed in the server process).
- Built against a real ~300-page site (theme/level pages): identical page count
  and output after replacing its hand-rolled router with `fileRouter` +
  `staticPaths`.
- Zero-config client router verified against that same consumer: with **no**
  `clientPackages` set, a package-shipped `Link` renders through the full build —
  react-server treats it as a client reference (no `createContext` crash), it is
  emitted as a hosted client chunk under
  `dist/client/node_modules/vite-plugin-react-server/…`, SSR'd to `<a>`, and
  hydratable.

### Build fix (included)
`./router` and `./router/client` are now declared build entries, so cross-entry
tree-shaking no longer prunes a symbol only `fileRouter` uses (`fillPattern`)
from the shared matcher chunk — the built package previously threw
`does not provide an export named 'fillPattern'` for any consumer of `./router`.

### Known follow-up (not in this PR)
A **server** component importing a package-shipped client component *directly*
(e.g. `import { Link } from "vite-plugin-react-server/router/client"` inside a
server component) still needs a client-reference hosting-path fix; the supported
pattern today is to use the client router from the client entry / a first-party
`*.client.tsx`, which this PR makes zero-config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
