### PR TITLE
feat(router): finalize routes surface (scanRoutes patterns + build.pages transform)

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -136,7 +136,9 @@ export async function buildEdgeBundle(opts: {
   const urls: string[] = Array.isArray(rawPages)
     ? rawPages
     : typeof rawPages === "function"
-    ? await rawPages()
+    ? // Resolved build.pages is a nullary thunk (resolveOptions wraps any
+      // `(routerPages) => …` transform), so the no-arg call is sound.
+      await (rawPages as () => Promise<string[]> | string[])()
     : await rawPages;
 
   const routeSource = (opt: unknown, url: string): unknown =>

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -154,8 +154,24 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   // Page / props / routePatterns / build.pages from it. An explicit option
   // still wins over the router-derived value, so `routes` composes with manual
   // overrides and stays backward-compatible with the loose Page/props form.
+  // Page/props matchers, resolved up here so the router's scanner shares the
+  // SAME patterns as autoDiscover (a custom pagePattern/propsPattern is honored;
+  // no hardcoded divergence in scanRoutes). Reused for autoDiscover below.
+  const propsPattern = resolveRegExp(
+    options.autoDiscover?.propsPattern,
+    DEFAULT_CONFIG.AUTO_DISCOVER.propsPattern
+  );
+  const pagePattern = resolveRegExp(
+    options.autoDiscover?.pagePattern,
+    DEFAULT_CONFIG.AUTO_DISCOVER.pagePattern
+  );
+
   const routerTable = options.routes
-    ? resolveRoutesOption(options.routes, { moduleBase, projectRoot })
+    ? resolveRoutesOption(options.routes, {
+        moduleBase,
+        projectRoot,
+        patterns: { pagePattern, propsPattern },
+      })
     : undefined;
   const effectivePage = options.Page ?? routerTable?.Page;
   const effectiveProps = options.props ?? routerTable?.props;
@@ -326,15 +342,6 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     DEFAULT_CONFIG.AUTO_DISCOVER.nodeOnly
   );
 
-  const propsPattern = resolveRegExp(
-    options.autoDiscover?.propsPattern,
-    DEFAULT_CONFIG.AUTO_DISCOVER.propsPattern
-  );
-
-  const pagePattern = resolveRegExp(
-    options.autoDiscover?.pagePattern,
-    DEFAULT_CONFIG.AUTO_DISCOVER.pagePattern
-  );
 
   const cssModulePattern = resolveRegExp(
     options.autoDiscover?.cssModulePattern,

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -161,7 +161,28 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   const effectiveProps = options.props ?? routerTable?.props;
   const effectiveRoutePatterns =
     options.routePatterns ?? routerTable?.routePatterns;
-  const effectiveBuildPages = options.build?.pages ?? routerTable?.build?.pages;
+  // `build.pages` is the prerender worklist (an output concern). Its function
+  // form now receives the ROUTER-derived list, so a user can filter / extend /
+  // replace it without restating routes:
+  //   build: { pages: (routerPages) => [...routerPages, "/extra"] }
+  // A nullary function (the pre-existing form) simply ignores the argument =
+  // replace. An array or absent value behaves as before. The router list is
+  // resolved lazily (it may itself be async when `staticPaths` is set), so the
+  // transform stays a nullary async thunk downstream (resolvePages awaits it).
+  const routerBuildPages = routerTable?.build?.pages;
+  const userBuildPages = options.build?.pages;
+  const effectiveBuildPages =
+    typeof userBuildPages === "function"
+      ? async () => {
+          const routerPages = Array.isArray(routerBuildPages)
+            ? routerBuildPages
+            : typeof routerBuildPages === "function"
+              ? await routerBuildPages()
+              : [];
+          const out = (userBuildPages as (p: string[]) => unknown)(routerPages);
+          return (out instanceof Promise ? await out : out) as string[];
+        }
+      : (userBuildPages ?? routerBuildPages);
   // Nested layouts: the router table's per-url `route.tsx` chain resolver.
   // Threaded like Page/props so the renderer folds the nested tree.
   const effectiveLayouts = options.layouts ?? routerTable?.layouts;

--- a/plugin/config/resolvePages.ts
+++ b/plugin/config/resolvePages.ts
@@ -8,9 +8,12 @@ export async function resolvePages(
   }
 
   try {
-    // Handle function
+    // Handle function. The RESOLVED build.pages is always a nullary thunk (a
+    // `(routerPages) => …` transform is wrapped into one by resolveOptions), so
+    // calling with no args is sound — the cast just drops the input-only unary
+    // form from the shared BuildConfig type.
     if (typeof pages === "function") {
-      const result = pages();
+      const result = (pages as () => string[] | Promise<string[]>)();
       if(result instanceof Promise) {
         return resolvePages(await result);
       }

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -1,6 +1,11 @@
 import { join, relative, resolve, sep } from "node:path";
 import { fillPattern, matchRoutes } from "./matchRoute.js";
-import { type RouteEntry, type RouteLayer, scanRoutes } from "./scanRoutes.js";
+import {
+  type RouteEntry,
+  type RouteLayer,
+  type ScanPatterns,
+  scanRoutes,
+} from "./scanRoutes.js";
 
 // Per-dynamic-route enumeration of concrete paths to prerender. Each entry is a
 // full url ("/blog/tech/rsc") or a params object ({category:"tech",slug:"rsc"})
@@ -51,7 +56,12 @@ export type FileRouterConfig = {
 
 export function fileRouter(
   routesDir: string,
-  opts: { staticPaths?: StaticPathsMap; root?: string } = {},
+  opts: {
+    staticPaths?: StaticPathsMap;
+    root?: string;
+    /** page/props/layout matchers; the plugin passes the resolved autoDiscover ones. */
+    patterns?: ScanPatterns;
+  } = {},
 ): FileRouterConfig {
   // `root` decouples "where to scan" from "what path to emit": scan
   // `resolve(root, routesDir)` on disk but emit page/props paths relative to
@@ -60,7 +70,10 @@ export function fileRouter(
   // produces (relative for a relative routesDir, which is the common case where
   // cwd is the project root). Supply `root` when cwd ≠ project root.
   const { root } = opts;
-  const scanned = scanRoutes(root ? resolve(root, routesDir) : routesDir);
+  const scanned = scanRoutes(
+    root ? resolve(root, routesDir) : routesDir,
+    opts.patterns,
+  );
   const toRel = (p: string) => relative(root!, p).split(sep).join("/");
   const routes: RouteEntry[] = root
     ? scanned.map((r) => ({
@@ -151,12 +164,18 @@ export type RoutesOption = FileRoutesConfig | FileRouterConfig;
  */
 export function resolveRoutesOption(
   routes: RoutesOption,
-  opts: { moduleBase: string; projectRoot: string },
+  opts: {
+    moduleBase: string;
+    projectRoot: string;
+    /** Resolved autoDiscover page/props matchers so the scanner shares them. */
+    patterns?: ScanPatterns;
+  },
 ): FileRouterConfig {
   // A pre-built router table has a `Page` resolver; a declarative config
   // doesn't (so `dir` can be omitted to mean "scan moduleBase itself").
   if ("Page" in routes) return routes;
   return fileRouter(join(opts.moduleBase, routes.dir ?? ""), {
+    patterns: opts.patterns,
     staticPaths: routes.staticPaths,
     root: opts.projectRoot,
   });

--- a/plugin/router/scanRoutes.ts
+++ b/plugin/router/scanRoutes.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
 /** One layer of a route's nested-layout chain (a `route.tsx` + its loader). */
@@ -30,48 +30,68 @@ export type RouteEntry = {
   layouts: RouteLayer[];
 };
 
-const PAGE = /^page\.(t|j)sx?$/;
-const LAYOUT = /^route\.(t|j)sx?$/;
-const PROPS = ["props.ts", "props.js"];
+// File conventions for the scan. `pagePattern` / `propsPattern` default here but
+// the plugin passes the resolved `autoDiscover.pagePattern` / `propsPattern`
+// (see resolveRoutesOption) so the scanner and the rest of the build share one
+// source of truth — a custom autoDiscover pattern is honored, no divergence.
+// `route.tsx` layouts are router-specific (no autoDiscover equivalent).
+export type ScanPatterns = {
+  pagePattern?: RegExp;
+  propsPattern?: RegExp;
+  layoutPattern?: RegExp;
+};
 
-const findProps = (dir: string): string | undefined =>
-  PROPS.map((p) => join(dir, p)).find(existsSync);
+const DEFAULT_PAGE = /^page\.(t|j)sx?$/;
+const DEFAULT_PROPS = /^props\.(t|j)sx?$/;
+const DEFAULT_LAYOUT = /^route\.(t|j)sx?$/;
 
-// Convention: every `page.tsx` under `routesDir` defines a route; its directory
+// Convention: every page file under `routesDir` defines a route; its directory
 // path (relative to routesDir) is the URL, with `$name` segments as params and a
-// bare `$` directory as a catch-all. A sibling `props.ts` is the segment's
+// bare `$` directory as a catch-all. A sibling props file is the segment's
 // loader. A `route.tsx` in a segment is a LAYOUT that wraps that segment's page
-// and every descendant, sharing the segment's `props.ts`.
+// and every descendant, sharing the segment's props.
 export function scanRoutes(
   routesDir: string,
-  base = routesDir,
-  layouts: RouteLayer[] = [],
+  patterns: ScanPatterns = {},
 ): RouteEntry[] {
-  const out: RouteEntry[] = [];
-  const names = readdirSync(routesDir).sort();
-  const segProps = findProps(routesDir);
-  // A `route.tsx` here wraps this segment's page and all descendants, sharing
-  // this segment's loader — extend the chain for children and this page.
-  const layoutName = names.find((n) => LAYOUT.test(n));
-  const chain = layoutName
-    ? [...layouts, { component: join(routesDir, layoutName), props: segProps }]
-    : layouts;
-  for (const name of names) {
-    const abs = join(routesDir, name);
-    if (statSync(abs).isDirectory()) {
-      out.push(...scanRoutes(abs, base, chain));
-    } else if (PAGE.test(name)) {
-      const rel = relative(base, routesDir);
-      const parts = rel === "" ? [] : rel.split(sep);
-      const pattern = parts.length ? "/" + parts.join("/") : "/";
-      out.push({
-        pattern,
-        page: abs,
-        props: segProps,
-        dynamic: parts.some((p) => p.startsWith("$")),
-        layouts: chain,
-      });
+  const pagePattern = patterns.pagePattern ?? DEFAULT_PAGE;
+  const propsPattern = patterns.propsPattern ?? DEFAULT_PROPS;
+  const layoutPattern = patterns.layoutPattern ?? DEFAULT_LAYOUT;
+
+  const findProps = (names: string[], dir: string): string | undefined => {
+    const n = names.find((name) => propsPattern.test(name));
+    return n ? join(dir, n) : undefined;
+  };
+
+  const walk = (dir: string, layouts: RouteLayer[]): RouteEntry[] => {
+    const out: RouteEntry[] = [];
+    const names = readdirSync(dir).sort();
+    const segProps = findProps(names, dir);
+    // A `route.tsx` here wraps this segment's page and all descendants, sharing
+    // this segment's loader — extend the chain for children and this page.
+    const layoutName = names.find((name) => layoutPattern.test(name));
+    const chain = layoutName
+      ? [...layouts, { component: join(dir, layoutName), props: segProps }]
+      : layouts;
+    for (const name of names) {
+      const abs = join(dir, name);
+      if (statSync(abs).isDirectory()) {
+        out.push(...walk(abs, chain));
+      } else if (pagePattern.test(name)) {
+        const rel = relative(routesDir, dir);
+        const parts = rel === "" ? [] : rel.split(sep);
+        const pattern = parts.length ? "/" + parts.join("/") : "/";
+        out.push({
+          pattern,
+          page: abs,
+          props: segProps,
+          dynamic: parts.some((p) => p.startsWith("$")),
+          layouts: chain,
+        });
+      }
     }
-  }
-  return out;
+    return out;
+  };
+
+  return walk(routesDir, []);
 }

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1176,7 +1176,18 @@ export type BuildOutput = {
 export type BuildConfig = {
   useRscWorker?: boolean;
   useHtmlWorker?: boolean;
-  pages?: string[] | (() => Promise<string[]> | string[]) | Promise<string[]>;
+  /**
+   * The prerender worklist. An array or a thunk, or — when a `routes` router is
+   * configured — a transform that receives the router-derived page list so you
+   * can filter / extend / replace it without restating routes
+   * (`pages: (routerPages) => [...routerPages, "/extra"]`). The pre-existing
+   * nullary function form still works (it ignores the argument = replace).
+   */
+  pages?:
+    | string[]
+    | ((routerPages: string[]) => Promise<string[]> | string[])
+    | (() => Promise<string[]> | string[])
+    | Promise<string[]>;
   assetsDir?: string;
   client?: string; // Output directory for client files
   server?: string; // Output directory for server files

--- a/test/unit/build-pages-transform.test.ts
+++ b/test/unit/build-pages-transform.test.ts
@@ -1,0 +1,58 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { resolveOptions } from "../../plugin/config/resolveOptions.js";
+import { fileRouter } from "../../plugin/router/fileRouter.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../router-fixtures");
+
+// c2u.4: `build.pages` function form receives the ROUTER-derived worklist so a
+// user can filter / extend / replace it without restating routes.
+describe("build.pages(routerPages) transform", () => {
+  const fr = fileRouter("routes", { root });
+
+  async function resolvedPages(buildPages: unknown): Promise<string[]> {
+    const res = resolveOptions(
+      {
+        projectRoot: root,
+        moduleBase: "routes",
+        routes: fr,
+        build: { pages: buildPages },
+      } as never,
+      true,
+    );
+    if (res.type !== "success") throw res.error;
+    const pages = res.userOptions.build.pages;
+    const out =
+      typeof pages === "function"
+        ? await (pages as () => Promise<string[]> | string[])()
+        : pages;
+    return (out as string[]) ?? [];
+  }
+
+  it("passes the router's static routes into the transform (extend)", async () => {
+    const pages = await resolvedPages((routerPages: string[]) => [
+      ...routerPages,
+      "/extra",
+    ]);
+    expect(pages).toContain("/"); // a router static route
+    expect(pages).toContain("/extra"); // user-added
+  });
+
+  it("lets the transform filter the router list", async () => {
+    const pages = await resolvedPages((routerPages: string[]) =>
+      routerPages.filter((p) => p !== "/"),
+    );
+    expect(pages).not.toContain("/");
+  });
+
+  it("treats a nullary function as replace (ignores the router list)", async () => {
+    const pages = await resolvedPages(() => ["/only-this"]);
+    expect(pages).toEqual(["/only-this"]);
+  });
+
+  it("uses the router list as-is when build.pages is absent", async () => {
+    const pages = await resolvedPages(undefined);
+    expect(pages).toContain("/");
+  });
+});

--- a/test/unit/scanRoutes.test.ts
+++ b/test/unit/scanRoutes.test.ts
@@ -56,4 +56,18 @@ describe("scanRoutes", () => {
     // A page with no route.tsx above it beyond the root has just the root layer.
     expect(byPattern["/profile/$id"].layouts).toHaveLength(1);
   });
+
+  it("honors a custom pagePattern (shared with autoDiscover, no hardcoding)", () => {
+    // The plugin passes the resolved autoDiscover pagePattern; a pattern that
+    // matches nothing discovers no routes, proving the scanner uses it.
+    expect(scanRoutes(ROUTES, { pagePattern: /^__never__$/ })).toHaveLength(0);
+    // The default still finds the standard page files.
+    expect(scanRoutes(ROUTES).length).toBeGreaterThan(0);
+  });
+
+  it("honors a custom propsPattern", () => {
+    const routes = scanRoutes(ROUTES, { propsPattern: /^__never__$/ });
+    expect(routes.length).toBeGreaterThan(0); // pages still found
+    expect(routes.every((r) => r.props === undefined)).toBe(true); // no props matched
+  });
 });


### PR DESCRIPTION
Pre-release surface finalization for the router v2 `routes` API — two small tickets so the shape is stable before `3.0.0`.

## `scanRoutes` reads the autoDiscover page/props patterns

`scanRoutes` hardcoded `page.tsx` / `props.ts` regexes that duplicated `autoDiscover.pagePattern` / `propsPattern` and would silently diverge if a consumer customized them. It now accepts the patterns, and `resolveOptions` passes the resolved autoDiscover ones — one source of truth. `route.tsx` layouts keep a router-specific default (no autoDiscover equivalent). Recursion refactored into an inner walk; default-pattern behavior unchanged. New tests prove a custom `pagePattern`/`propsPattern` propagates.

## `build.pages(routerPages)` transform

`build.pages`' function form now receives the router-derived prerender list, so you can filter / extend / replace without restating routes:

```js
build: { pages: (routerPages) => [...routerPages, "/extra"] }
```

The pre-existing nullary form still works (ignores the argument = replace); array / Promise / absent unchanged. Resolved once in `resolveOptions` into a nullary thunk, so downstream consumers are untouched. New unit test covers extend / filter / replace / absent.

## Testing
- Full gate green: `test:server` (776), `test:client` (234), `test:unit` (568), typecheck.

Depends on nothing; independent of the `3.0.0` release PR (#222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)