### PR TITLE
chore(release): 3.0.0 — restore missing 2.11.2 fix + bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.11.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "2.11.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "2.11.2",
+  "version": "3.0.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -384,7 +384,7 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   const hashOption = options.build?.hash ?? DEFAULT_CONFIG.BUILD.hash;
 
   // User-facing hash function that can take source content or filename
-  const hash = (input: string | null, _ssr: boolean, sourceContent?: string) => {
+  const hash = (input: string | null, ssr: boolean, sourceContent?: string) => {
     if (!input) return "";
     if (new RegExp(BASE_PATTERNS.EXT.NODE).test(input)) {
       return input;
@@ -415,11 +415,12 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     //   - pagePattern / propsPattern / serverPattern: SSR entry modules the
     //     runtime imports by literal path (see resolvePageAndProps), not
     //     browser-served assets so caching isn't a concern either
-    // Everything else falls through to content-based hashing so prod deploys
-    // bust browser/CDN caches. Cross-environment hash consistency is provided
-    // by handleSsrEntryName / handleSsrAssetName in resolveUserConfig.ts
-    // (which feed sourceContent through to this function) and the
-    // augmentChunkHash plugin.
+    // Everything else falls through to content-based hashing: in a browser/
+    // static build for cache-busting, and in an SSR build only for
+    // client-reference modules (see the ssr guard below). Cross-environment hash
+    // consistency is provided by handleSsrEntryName / handleSsrAssetName in
+    // resolveUserConfig.ts (which feed sourceContent through to this function)
+    // and the augmentChunkHash plugin.
     if (
       htmlPattern.test(input) ||
       rscPattern.test(input) ||
@@ -462,6 +463,21 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
      }
     }
     
+    // In an SSR build (server / ssr-client), only CLIENT-REFERENCE modules need
+    // a content-addressed name: they're loaded by the browser via the flight, so
+    // their hashed id must stay consistent with the client build. Pure
+    // server-only modules are loaded by Node from disk by literal path — hashing
+    // them busts no browser/CDN cache and only churns filenames (and can emit
+    // duplicate chunks), so keep their names stable. The browser/static build
+    // (ssr=false) still hashes everything for real cache-busting.
+    if (
+      ssr &&
+      !isClientComponentByName(input) &&
+      !isClientComponentByCode(contentToHash)
+    ) {
+      return input;
+    }
+
     // Generate hash using Rollup-like algorithm
     const hashCharacters = typeof hashOption === 'object' && hashOption?.format === 'hex' ? 'hex' : 'base36';
     const contentHash = createRollupLikeHash(contentToHash, hashCharacters);


### PR DESCRIPTION
Release bookkeeping for the router v2 / env work already on `main` (#220).

## ⚠️ Restores the published `2.11.2` fix that was missing from `main`

`v2.11.2` is tagged and on npm (commit `d5ed700`, *"only content-hash client references in the SSR build"*), but it was **never in `main`'s history** — the router-v2 branch predated it and the squash-merge (#220) reset `package.json` to `2.11.1`. Releasing without this would **regress** that SSR content-hash fix. This PR cherry-picks it back (clean apply — it touches the `hash` function, separate from the router changes).

## Bumps to `3.0.0`

Major, because the `./file-preserver` export was removed in #220 (its esbuild transform is a no-op under Vite 8 / Oxc; the self-referential `define` supersedes it). The `3.0.0` line also headlines router v2: the `routes` field, nested layouts + per-layer loaders, and the isomorphic env helpers.

## Notes
- Independent of #221 (router surface finalization: `scanRoutes` reads autoDiscover patterns + `build.pages(routerPages)`). They touch different files / different sections of `resolveOptions.ts`, so they merge in any order — but **land #221 before publishing** so `3.0.0` includes the finalized surface.
- `test:server` green (770) on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)