### PR TITLE
fix(router): collect route.tsx layout CSS into each route's manifest

### DIFF
--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -226,6 +226,7 @@ export const configureReactServer: ConfigureReactServerFn =
           route: info.route,
           pagePath,
           propsPath,
+          layouts,
           logger: logger,
           manifest: serverManifest,
           server,
@@ -325,6 +326,26 @@ export const configureReactServer: ConfigureReactServerFn =
             if (panicError != null) {
               return next(panicError);
             }
+          }
+        }
+
+        // Load each route.tsx layout module too, so its CSS (e.g. a per-theme
+        // stylesheet) is registered in the module graph before collection. The
+        // page doesn't import the chain — it's folded separately below — so
+        // without this its layouts' CSS would be missing from the response.
+        for (const layer of layouts ?? []) {
+          if (!layer?.component) continue;
+          try {
+            await loader(layer.component);
+          } catch (error) {
+            handleError({
+              error,
+              logger,
+              panicThreshold: userHandlerOptions.panicThreshold,
+              critical: false,
+              context: `configureReactServer: load layout from ${layer.component}`,
+              log: true,
+            });
           }
         }
 

--- a/plugin/helpers/collectViteModuleGraphCss.ts
+++ b/plugin/helpers/collectViteModuleGraphCss.ts
@@ -40,6 +40,7 @@ type CollectViteModuleGraphCssResult =
 export type CollectViteModuleGraphCssOptions = Pick<
   CreateHandlerOptions,
   | "pagePath"
+  | "layouts"
   | "moduleBaseURL"
   | "moduleBasePath"
   | "moduleRootPath"
@@ -99,32 +100,38 @@ export const collectViteModuleGraphCss: CollectViteModuleGraphCssFn =
       logger.info(`Getting module by URL: ${pagePath}`);
     }
     
-    // Try multiple path formats since different module graphs use different URL schemes
-    let pageModule = await moduleGraph.getModuleByUrl(pagePath, true);
-    
-    // If not found, try with full path (server environment uses full paths)
-    if (!pageModule && projectRoot && !pagePath.startsWith('/')) {
-      const fullPath = `${projectRoot}/${pagePath}`;
-      if(verbose) {
-        logger.info(`Trying full path: ${fullPath}`);
+    // Resolve a module by path, trying the URL schemes different module graphs
+    // use (dev client vs. server-environment full paths vs. leading slash).
+    const getModule = async (path: string) => {
+      let mod = await moduleGraph.getModuleByUrl(path, true);
+      if (!mod && projectRoot && !path.startsWith('/')) {
+        mod = await moduleGraph.getModuleByUrl(`${projectRoot}/${path}`, true);
       }
-      pageModule = await moduleGraph.getModuleByUrl(fullPath, true);
-    }
-    
-    // Also try with leading slash
-    if (!pageModule && !pagePath.startsWith('/')) {
-      const slashPath = `/${pagePath}`;
-      if(verbose) {
-        logger.info(`Trying slash path: ${slashPath}`);
+      if (!mod && !path.startsWith('/')) {
+        mod = await moduleGraph.getModuleByUrl(`/${path}`, true);
       }
-      pageModule = await moduleGraph.getModuleByUrl(slashPath, true);
-    }
-    
+      return mod;
+    };
+
+    const pageModule = await getModule(pagePath);
+
     if (!pageModule) {
       if(verbose) {
         logger.info(`No page module found for any path variant, skipping`);
       }
       return { type: "skip" };
+    }
+
+    // `route.tsx` layouts resolve from a separate module graph than the page
+    // (resolveLayoutChain loads them directly), so a layout's CSS module — e.g.
+    // a per-theme `.Theme` stylesheet — is collected only if we also seed the
+    // walk with each layout module. Mirrors the static build path in
+    // processCssFilesForPages.
+    const layoutModules = [];
+    for (const layer of handlerOptions.layouts ?? []) {
+      if (!layer?.component) continue;
+      const mod = await getModule(layer.component);
+      if (mod) layoutModules.push(mod);
     }
 
     if(verbose) {
@@ -235,6 +242,9 @@ export const collectViteModuleGraphCss: CollectViteModuleGraphCssFn =
         logger.info(`Starting module walk`);
       }
       await walkModule(pageModule);
+      for (const mod of layoutModules) {
+        await walkModule(mod);
+      }
       if(verbose) {
         logger.info(`Module walk completed successfully`);
       }

--- a/plugin/react-static/processCssFilesForPages.ts
+++ b/plugin/react-static/processCssFilesForPages.ts
@@ -87,7 +87,7 @@ export function processCssFilesForPages({
   });
 
   // Collect CSS files for each page and its props
-  for (const [url, { page, props }] of urlMap) {
+  for (const [url, { page, props, layouts }] of urlMap) {
     if (userOptions.verbose) {
       logger.info(
         `[plugin.server] Processing route: ${url}, page: ${page}, props: ${props}`
@@ -113,10 +113,18 @@ export function processCssFilesForPages({
       }
     }
     
-    const cssInputs = collectManifestCss(
-      transformedServerManifest,
-      props ? [page, props] : page
-    );
+    // Seed the walk with the page, its props loader, AND every `route.tsx`
+    // layout wrapping this route (+ each layer's props). Layouts resolve from a
+    // separate module graph than the page (resolveLayoutChain), so a layout's
+    // CSS module — e.g. a per-theme `.Theme` stylesheet — only reaches this
+    // route's manifest if its component is an explicit collection root.
+    const cssRoots = [page];
+    if (props) cssRoots.push(props);
+    for (const layer of layouts ?? []) {
+      if (layer.component) cssRoots.push(layer.component);
+      if (layer.props) cssRoots.push(layer.props);
+    }
+    const cssInputs = collectManifestCss(transformedServerManifest, cssRoots);
     if (userOptions.verbose) {
       logger.info(
         `[plugin.server] CSS inputs for ${url}: ${


### PR DESCRIPTION
Nested-layout routes (`route.tsx`) were silently dropping their own CSS. A layout's stylesheet — e.g. a per-theme `.Theme` module that scopes styling to one route subtree — never reached the route's CSS manifest: the class landed on the element but the stylesheet was never linked or inlined.

**Cause.** Each route's CSS is collected from the *page's* module graph. Layouts resolve from a separate graph (`resolveLayoutChain` loads them directly), so their CSS imports were invisible to collection. A page only received a layout's CSS if it happened to import that layout itself.

**Fix.** Seed CSS collection with the resolved layout chain in both render paths:
- Static build (`processCssFilesForPages`): add each layer's component + props as roots for `collectManifestCss`.
- Dev server (`configureReactServer` + `collectViteModuleGraphCss`): load each layout module into the graph before collection and walk it too; thread `layouts` through the handler options.

This lets a `route.tsx` layout own CSS scoping — the file-router's headline use case — with zero per-page boilerplate.

**Verification.** Full server + client suite green (776 passed). Validated end-to-end against a consumer via a real npm tarball (`validate-sibling`): a per-theme layout now delivers exactly its own stylesheet on every route in its subtree, and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)