### PR TITLE
fix(env): split client env source by condition (#env) — no more hydration crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "LICENSE",
     "tsconfig.json"
   ],
+  "imports": {
+    "#env": {
+      "browser": "./dist/plugin/utils/env.browser.js",
+      "default": "./dist/plugin/utils/env.node.js"
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/plugin/loader/css-loader.ts
+++ b/plugin/loader/css-loader.ts
@@ -8,7 +8,7 @@ import type {
 import { fileURLToPath } from "node:url";
 import { preprocessCSS, resolveConfig } from "vite";
 import { readFile } from "node:fs/promises";
-import { env } from "../utils/env.js";
+import { env } from "#env";
 import type {
   CssFileMessage,
   InitializedCssLoaderMessage,

--- a/plugin/utils/callServer.ts
+++ b/plugin/utils/callServer.ts
@@ -1,4 +1,4 @@
-import { env } from "./env.js";
+import { env } from "#env";
 import { createCallServer } from "./createCallServer.js";
 
 export const callServer = createCallServer(env?.BASE_URL ?? "/");

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -1,6 +1,6 @@
 import type React from "react";
 import { createCallServer } from "./createCallServer.js";
-import { env } from "./env.js";
+import { env } from "#env";
 import { createPageURL } from "./urls.js";
 import { INLINE_FLIGHT_ID } from "./inlineFlightId.js";
 

--- a/plugin/utils/env.browser.ts
+++ b/plugin/utils/env.browser.ts
@@ -1,0 +1,7 @@
+// Browser env source. Selected under the `browser` condition (package.json
+// `imports` → `#env`), so this file is ONLY ever loaded in a browser bundle,
+// never in Node. The consumer's Vite statically replaces each `import.meta.env`
+// dot-access with a literal (vprs's self-referential define ships them unparsed
+// from vprs's own build), so the emitted object is plain values — there is no
+// runtime `import.meta.env` to be undefined, and no guard is needed.
+export const env: ImportMetaEnv = import.meta.env;

--- a/plugin/utils/env.node.ts
+++ b/plugin/utils/env.node.ts
@@ -1,0 +1,17 @@
+// Node / SSG / edge env source. Selected under the default condition
+// (package.json `imports` → `#env`) — i.e. everywhere `import.meta.env` is not a
+// real, injected object (vprs is external in bare Node, so it's undefined). Read
+// the values vprs's config mirrors into `process.env` instead. No
+// `import.meta.env` here at all, so nothing to throw or leave undefined.
+const p: NodeJS.ProcessEnv | undefined =
+  typeof process !== "undefined" ? process.env : undefined;
+
+export const env = {
+  // `||` (not `??`): an empty VITE_BASE_URL still means the root base "/".
+  BASE_URL: p?.["VITE_BASE_URL"] || "/",
+  PUBLIC_ORIGIN: p?.["VITE_PUBLIC_ORIGIN"] ?? "",
+  DEV: p?.["NODE_ENV"] !== "production",
+  MODE: p?.["NODE_ENV"] ?? "production",
+  PROD: p?.["NODE_ENV"] === "production",
+  SSR: true,
+} as ImportMetaEnv;

--- a/plugin/utils/env.ts
+++ b/plugin/utils/env.ts
@@ -1,9 +1,0 @@
-// Bracket access (`import.meta["env"]`) instead of `import.meta.env` so vprs's
-// own Vite build does NOT statically expand this into a baked object literal.
-// Expansion would inline vprs's build-time values (BASE_URL "/", empty origin)
-// AND — once the env keys are preserved for the browser env-URL helper — emit
-// `{ BASE_URL: import.meta.env.BASE_URL, … }`, which throws in raw-Node SSR
-// (vprs is external there, so `import.meta.env` is undefined). Shipping the bare
-// reference lets the CONSUMER's environment resolve it: the real `import.meta.env`
-// in the browser / Vite SSR, and a harmless `undefined` in bare Node.
-export const env = import.meta["env"];

--- a/plugin/utils/envUrls.ts
+++ b/plugin/utils/envUrls.ts
@@ -1,49 +1,19 @@
+import { env } from "#env";
 import { createAbsoluteURL, createBaseURL, createPageURL } from "./urls.js";
 
-// Isomorphic env-bound URL helpers — ONE module for every runtime (browser,
-// Node/SSG, edge). A consumer imports `absoluteURL` / `baseURL` / `pageURL`
-// once and it works regardless of which condition resolved it, so there's no
-// env.server/env.client split AND no dependence on client-reference condition
-// routing (a `"use client"` import that resolves under `react-server` still
-// works in the browser, because this same file handles both env sources).
-//
-// Priority per read:
-//   1. `import.meta.env.<KEY>` (dot access) — shipped UNPARSED from vprs (the
-//      self-referential `define` in vite.config shields it from Oxc), then
-//      statically replaced by the CONSUMER's Vite in browser + transformed-SSR
-//      builds. In bare Node (vprs is external there) `import.meta.env` is
-//      undefined, so the access throws — caught below.
-//   2. `process.env.VITE_<KEY>` — the Node/SSG/edge fallback (vprs's config sets
-//      these), also what vprs's own build-time code resolves against.
-type MetaEnv = {
-  base?: string;
-  origin?: string;
-  dev?: boolean | string;
-  mode?: string;
+// Env-bound URL helpers. The browser/Node split lives entirely in `#env`
+// (package.json `imports`): the browser build resolves it to baked
+// `import.meta.env` values, Node/SSG/edge to `process.env`. Here we just read
+// the resolved values — no runtime environment detection, no `import.meta.env`.
+const meta = env as {
+  BASE_URL?: string;
+  PUBLIC_ORIGIN?: string;
+  DEV?: boolean | string;
+  MODE?: string;
 };
 
-const fromImportMeta = (): MetaEnv => {
-  try {
-    // Each is a dot access so the consumer's Vite replaces it; reading them in
-    // one try means a bare-Node `undefined.BASE_URL` throw skips the whole block.
-    return {
-      base: import.meta.env.BASE_URL,
-      origin: import.meta.env.PUBLIC_ORIGIN,
-      dev: import.meta.env.DEV,
-      mode: import.meta.env.MODE,
-    };
-  } catch {
-    return {};
-  }
-};
-
-const fromProcess = (key: "VITE_BASE_URL" | "VITE_PUBLIC_ORIGIN"): string | undefined =>
-  typeof process !== "undefined" && process.env ? process.env[key] : undefined;
-
-const base = (): string =>
-  fromImportMeta().base ?? fromProcess("VITE_BASE_URL") ?? "/";
-const origin = (): string =>
-  fromImportMeta().origin ?? fromProcess("VITE_PUBLIC_ORIGIN") ?? "";
+const base = (): string => meta.BASE_URL ?? "/";
+const origin = (): string => meta.PUBLIC_ORIGIN ?? "";
 
 export const absoluteURL = (path: string) =>
   createAbsoluteURL(base(), origin())(path);
@@ -51,12 +21,6 @@ export const absoluteURL = (path: string) =>
 export const baseURL = (path: string) => createBaseURL(base())(path);
 
 export const pageURL = (path: string) => {
-  const meta = fromImportMeta();
-  const isDev =
-    typeof meta.dev === "boolean"
-      ? meta.dev
-      : meta.mode === "development" ||
-        (typeof process !== "undefined" &&
-          process.env?.NODE_ENV === "development");
+  const isDev = meta.DEV === true || meta.DEV === "true" || meta.MODE === "development";
   return createPageURL(base(), origin(), isDev)(path);
 };

--- a/plugin/utils/index.client.ts
+++ b/plugin/utils/index.client.ts
@@ -4,7 +4,7 @@ export * from "./hydrateOrRender.js";
 export * from "./useRscHmr.js";
 export * from "./callServer.js";
 export * from "./urls.js";
-export * from "./env.js";
+export * from "#env";
 export * from "./envUrls.js";
 export * from "./createCallServer.js";
 export * from "./routeToURL.js";

--- a/plugin/utils/index.server.ts
+++ b/plugin/utils/index.server.ts
@@ -9,7 +9,7 @@ export * from "./hydrateOrRender.js";
 export * from "./useRscHmr.js";
 export * from "./callServer.js";
 export * from "./urls.js";
-export * from "./env.js";
+export * from "#env";
 // Isomorphic env-bound URL helpers (absoluteURL / baseURL / pageURL): one module
 // that reads import.meta.env (browser/edge, statically replaced) with a
 // process.env fallback (Node/SSG), so a consumer imports them once and they work

--- a/plugin/utils/index.ts
+++ b/plugin/utils/index.ts
@@ -12,7 +12,7 @@ export * from "./hydrateOrRender.js";
 export * from "./useRscHmr.js";
 export * from "./callServer.js";
 export * from "./urls.js";
-export * from "./env.js";
+export * from "#env";
 export * from "./envUrls.js";
 export * from "./createCallServer.js";
 export * from "./routeToURL.js";

--- a/plugin/utils/moduleBaseURL.ts
+++ b/plugin/utils/moduleBaseURL.ts
@@ -1,4 +1,4 @@
-import { env } from "./env.js";
+import { env } from "#env";
 
 const { BASE_URL: baseURL, PUBLIC_ORIGIN: publicOrigin } = env;
 

--- a/plugin/utils/useRscHmr.ts
+++ b/plugin/utils/useRscHmr.ts
@@ -8,7 +8,7 @@
 import * as React from "react";
 import { RSC_HMR_EVENT } from "./createReactFetcher.js";
 import type { RscHmrData } from "./createReactFetcher.js";
-import { env } from "./env.js";
+import { env } from "#env";
 
 // Mirror of refreshCssLinks in virtualRscHmrPlugin.ts (see comment there).
 // data.file is the project-relative path (eg "src/css/9mmc.module.css") and

--- a/test/unit/env.test.ts
+++ b/test/unit/env.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 
-describe('env.ts', () => {
-  it('should export import.meta.env', async () => {
-    
-    // We need to dynamically import the module since it uses import.meta.env
+describe('#env (condition-split env source)', () => {
+  it('resolves to a defined env with a root BASE_URL', async () => {
+    // `env` is re-exported from the /utils barrel and resolved via package.json
+    // `imports` → `#env` (browser: import.meta.env; Node/edge: process.env). Under
+    // the test's node condition it's env.node, whose BASE_URL defaults to "/".
     const envModule = await import('vite-plugin-react-server/utils');
-    
-    // The env should be available (though it may be undefined in test environment)
+
     expect(envModule).toBeDefined();
     expect(envModule.env).toBeDefined();
     expect(envModule.env.BASE_URL).toBe('/');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,6 +59,11 @@ export default defineConfig({
         // re-export dangles. (Same hosted-module export-prune that bites
         // consumers — see bead c2u.8; keeping it fixed here is the pattern.)
         "plugin/utils/envUrls": resolve(__dirname, "plugin/utils/envUrls.ts"),
+        // Condition-split env source (package.json `imports` → `#env`): browser
+        // reads import.meta.env, Node/edge reads process.env. Entries so both are
+        // emitted; `#env` itself stays external so the CONSUMER picks the branch.
+        "plugin/utils/env.browser": resolve(__dirname, "plugin/utils/env.browser.ts"),
+        "plugin/utils/env.node": resolve(__dirname, "plugin/utils/env.node.ts"),
         "plugin/storybook/preset": resolve(__dirname, "plugin/storybook/preset.ts"),
         "plugin/metrics/index": resolve(__dirname, "plugin/metrics/index.ts"),
         
@@ -129,7 +134,14 @@ export default defineConfig({
         if (id.includes('/test/') || id.includes('\\test\\')) {
           return true;
         }
-        
+
+        // Keep `#env` (package.json `imports`) unresolved in the dist so the
+        // CONSUMER's resolver picks env.browser (browser) vs env.node (Node/edge)
+        // per condition — baking either here would defeat the split.
+        if (id === "#env") {
+          return true;
+        }
+
         // Check against the static external list
         const staticExternals = [
         // Node.js built-ins


### PR DESCRIPTION
The isomorphic `env` / `envUrls` helpers read `import.meta.env` at runtime with guards to survive bare Node. A consumer's minifier defeats every guard: it drops `?? {}` (Vite's env `define` marks `import.meta.env` "always defined"), inlines the `try/catch` when it hoists the shared reference, and normalizes `import.meta["env"]` back to `.env` *after* Vite's injection pass — leaving an un-injected, undefined reference. `createReactFetcher`'s default params then read `undefined.BASE_URL/.DEV` and throw uncaught, breaking hydration for any consumer ("can't access property DEV, undefined").

Separate the concern by condition instead of detecting it at runtime:
- `env.browser.ts` reads `import.meta.env` (the consumer's Vite bakes it to static values — no runtime access left to be undefined).
- `env.node.ts` reads `process.env` (no `import.meta.env` at all).
- package.json `imports` `#env` selects them (`browser` vs default); the build keeps `#env` external so the consumer picks the branch.
- `envUrls` drops its dual-source guard logic and reads the resolved `env` directly.

Verified against a real consumer: `env` in the client bundle is now a baked object (`{BASE_URL:"/",DEV:false,…}`) with zero runtime `import.meta.env`, so the `undefined.DEV` throw is structurally impossible; SSG/Node reads `process.env`. Full server+client suite green (776).

🤖 Generated with [Claude Code](https://claude.com/claude-code)