### PR TITLE
chore(release): 3.1.0 — degraded-document guard + worker error visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/dev-server/collectRunnerCss.ts
+++ b/plugin/dev-server/collectRunnerCss.ts
@@ -25,7 +25,12 @@ export async function collectRunnerCss(
   pagePath: string,
   projectRoot: string,
   logger: Logger,
-  verbose = false
+  verbose = false,
+  // `route.tsx` layouts resolve from a separate module graph than the page, so
+  // their CSS (a per-theme stylesheet, say) is collected only if we also seed
+  // the walk with each layout module. Mirrors the server-env path in
+  // collectViteModuleGraphCss.
+  layoutPaths: string[] = []
 ): Promise<CollectedCss[]> {
   const env = server.environments?.["server"];
   if (!env) {
@@ -34,38 +39,37 @@ export async function collectRunnerCss(
   }
 
   const moduleGraph: EnvironmentModuleGraph = env.moduleGraph;
-  const candidates = [
-    pagePath,
-    pagePath.startsWith("/") ? pagePath : `/${pagePath}`,
-    pagePath.startsWith(projectRoot) ? pagePath : `${projectRoot}/${pagePath}`,
-  ];
 
-  let pageModule: EnvironmentModuleNode | ModuleNode | undefined;
-  for (const url of candidates) {
-    pageModule = await moduleGraph.getModuleByUrl(url);
-    if (pageModule) break;
-  }
-
-  // Fallback: scan idToModuleMap for an entry whose id endsWith the pagePath.
-  // Vite keys server-env modules by full absolute path with optional query.
-  if (!pageModule) {
+  // Resolve a module by path, trying the URL schemes Vite's server graph uses,
+  // then a suffix scan of idToModuleMap (keyed by absolute path + optional query).
+  const resolveModule = async (
+    p: string
+  ): Promise<EnvironmentModuleNode | ModuleNode | undefined> => {
+    const candidates = [
+      p,
+      p.startsWith("/") ? p : `/${p}`,
+      p.startsWith(projectRoot) ? p : `${projectRoot}/${p}`,
+    ];
+    for (const url of candidates) {
+      const m = await moduleGraph.getModuleByUrl(url);
+      if (m) return m;
+    }
     const idMap = (moduleGraph as any).idToModuleMap as
       | Map<string, EnvironmentModuleNode>
       | undefined;
     if (idMap) {
       for (const [id, node] of idMap.entries()) {
-        if (id.endsWith(pagePath) || id.endsWith(`/${pagePath}`)) {
-          pageModule = node;
-          break;
-        }
+        if (id.endsWith(p) || id.endsWith(`/${p}`)) return node;
       }
     }
-  }
+    return undefined;
+  };
 
+  const pageModule = await resolveModule(pagePath);
   if (!pageModule) {
     if (verbose) {
       logger.warn(
-        `[collectRunnerCss] no module for pagePath: ${pagePath} (tried: ${candidates.join(", ")}; graph size: ${
+        `[collectRunnerCss] no module for pagePath: ${pagePath} (graph size: ${
           (moduleGraph as any).idToModuleMap?.size ?? "?"
         })`
       );
@@ -75,6 +79,10 @@ export async function collectRunnerCss(
   if (verbose) {
     logger.info(`[collectRunnerCss] resolved page module: ${pageModule.id}`);
   }
+
+  const layoutModules = (
+    await Promise.all(layoutPaths.map((p) => resolveModule(p)))
+  ).filter((m): m is EnvironmentModuleNode | ModuleNode => m != null);
 
   const seen = new Set<string>();
   const out: CollectedCss[] = [];
@@ -132,6 +140,9 @@ export async function collectRunnerCss(
   };
 
   await walk(pageModule);
+  for (const mod of layoutModules) {
+    await walk(mod);
+  }
 
   if (verbose) {
     logger.info(

--- a/plugin/dev-server/handleRunnerFetch.server.ts
+++ b/plugin/dev-server/handleRunnerFetch.server.ts
@@ -108,13 +108,18 @@ export function attachRunnerFetchHandler(
     try {
       let result: unknown;
       if (method === "collectCss") {
-        const [pagePath, projectRoot] = args as [string, string];
+        const [pagePath, projectRoot, layoutPaths] = args as [
+          string,
+          string,
+          string[]?,
+        ];
         result = await collectRunnerCss(
           server,
           pagePath,
           projectRoot,
           logger,
-          verbose
+          verbose,
+          layoutPaths ?? []
         );
       } else {
         throw new Error(`[runner-rpc] unsupported method: ${method}`);

--- a/plugin/react-static/fileWriter.ts
+++ b/plugin/react-static/fileWriter.ts
@@ -293,6 +293,34 @@ export const fileWriter: FileWriterFn = function _fileWriter(
               reject(error);
               return;
             }
+
+            // Loud guard against a silently-degraded document. A full-document
+            // SSG page must have a root <html> element; if the render fell back
+            // to a fragment (e.g. a server-component document wrapper failed to
+            // render), the file has content but no <html>/<head>/<body> — a
+            // broken page that would otherwise ship in a GREEN build. Surface it
+            // as a route.error so panic policy applies, instead of writing it
+            // silently. RSC payloads (fileType "rsc") are exempt — only the HTML
+            // document is expected to be a full document.
+            if (fileType === "html" && !/<html[\s>]/i.test(content)) {
+              const degradeError = new Error(
+                `[fileWriter] Degraded HTML document for route ${options.route}: ` +
+                  `${content.length} bytes emitted with no <html> root element. The ` +
+                  `document wrapper did not render — the page shipped without ` +
+                  `<html>/<head>/<body>. This is usually a server-component render ` +
+                  `that failed and fell back to a fragment (check for a swallowed ` +
+                  `RSC render error on this route).`
+              );
+              options.logger?.error(degradeError.message);
+              options.onEvent?.({
+                type: "route.error",
+                data: {
+                  error: degradeError,
+                  route: options.route,
+                  panicThreshold: options.panicThreshold,
+                },
+              });
+            }
           } else {
             // Instead of rejecting, let's be more lenient about empty content
             // This can happen legitimately with empty files or fast builds

--- a/plugin/stream/handleRscStream.client.ts
+++ b/plugin/stream/handleRscStream.client.ts
@@ -4,6 +4,8 @@ import { createMessageChannels, createTransferList } from "./createMessageChanne
 
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { join } from "node:path";
+import { toError } from "../error/toError.js";
+import { logError } from "../error/logError.js";
 
 /**
  * Client-side RSC stream handler using unified stream management
@@ -82,17 +84,21 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
           controlEndedReceived = true;
           rscStream.end();
           break;
-        case "ERROR":
+        case "ERROR": {
           // Always log: this is an RSC render error from the worker. Without
           // this log the failure surfaces only as an in-band RSC error frame
           // on the client, with nothing on the dev console.
-          options.logger?.error(
-            `[client] RSC render error for ${message.id}: ${
-              message.error?.message || "Unknown error"
-            }`,
-            { error: message.error }
-          );
+          //
+          // Log the FULL error (stack included) via logError, not just
+          // err.message — the worker serializes the stack across the thread
+          // boundary (serializeError → toError), so dev:ssr can surface the same
+          // detail as dev:rsc (the main-thread runner). Previously only the
+          // message was logged, so worker render failures looked stackless.
+          const err = toError(message.error, message.errorInfo);
+          err.message = `[client] RSC render error for ${message.id}: ${err.message}`;
+          logError(err, options.logger);
           break;
+        }
         default:
           if (options.verbose) {
             options.logger?.info(

--- a/plugin/utils/env.browser.ts
+++ b/plugin/utils/env.browser.ts
@@ -1,7 +1,19 @@
 // Browser env source. Selected under the `browser` condition (package.json
 // `imports` → `#env`), so this file is ONLY ever loaded in a browser bundle,
-// never in Node. The consumer's Vite statically replaces each `import.meta.env`
-// dot-access with a literal (vprs's self-referential define ships them unparsed
-// from vprs's own build), so the emitted object is plain values — there is no
-// runtime `import.meta.env` to be undefined, and no guard is needed.
-export const env: ImportMetaEnv = import.meta.env;
+// never in Node. Each `import.meta.env` dot-access is statically replaced by the
+// consumer's Vite (vprs's self-referential define ships them unparsed from vprs's
+// own build), so the emitted object is plain values — no runtime `import.meta.env`
+// left to be undefined, no guard needed.
+//
+// Defaults mirror env.node: an unset PUBLIC_ORIGIN must be "" (not undefined) and
+// an unset BASE_URL must be "/", or downstream string-building like
+// `${PUBLIC_ORIGIN}${BASE_URL}` (moduleBaseURL) yields "undefined/" and breaks
+// asset/flight URLs on client navigation.
+export const env = {
+  BASE_URL: import.meta.env.BASE_URL || "/",
+  PUBLIC_ORIGIN: import.meta.env.PUBLIC_ORIGIN ?? "",
+  DEV: import.meta.env.DEV,
+  MODE: import.meta.env.MODE,
+  PROD: import.meta.env.PROD,
+  SSR: import.meta.env.SSR,
+} as ImportMetaEnv;

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -883,7 +883,11 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             const cssFileUserOptions = getUserOptions();
             const collected = (await rpc<
               Array<{ id: string; code: string }>
-            >("collectCss", [msg.options.pagePath, projectRoot])) || [];
+            >("collectCss", [
+              msg.options.pagePath,
+              projectRoot,
+              (msg.options.layouts ?? []).map((l) => l.component),
+            ])) || [];
             for (const { id, code } of collected) {
               addCssFileContent(id, code, cssFileUserOptions);
             }

--- a/test/client/handleRscStream-error-surfaced.test.ts
+++ b/test/client/handleRscStream-error-surfaced.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { handleRscStream } from "vite-plugin-react-server/stream/client";
+import type { Worker } from "node:worker_threads";
+import type { Logger } from "vite";
+import type { StreamHandlers } from "vite-plugin-react-server/worker";
+
+// Regression guard for dev:ssr worker-error visibility.
+//
+// A worker RSC render throw crosses back to the main thread over the control
+// port. The worker serializes the FULL error (message + stack) — the client
+// stream handler must log the whole thing, matching what the main-thread runner
+// (dev:rsc / `--conditions react-server`) already shows. It used to log only
+// `err.message`, so a dev:ssr render failure surfaced without a stack and was
+// effectively undiagnosable.
+
+// Force dev-mode logging so logError emits the stack (production logging is
+// message-only by design).
+vi.mock("../../dist/plugin/config/getNodeEnv.js", () => ({
+  getNodeEnv: vi.fn(() => "development"),
+}));
+
+describe("handleRscStream (client) — worker error visibility", () => {
+  let mockWorker: Worker;
+  let mockLogger: Logger;
+  let mockHandlers: StreamHandlers<"server">;
+
+  beforeEach(() => {
+    mockWorker = {
+      postMessage: vi.fn(),
+      on: vi.fn(),
+      off: vi.fn(),
+      removeListener: vi.fn(),
+      removeAllListeners: vi.fn(),
+    } as unknown as Worker;
+
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      warnOnce: vi.fn(),
+      clearScreen: vi.fn(),
+      hasWarned: false,
+      hasErrorLogged: () => false,
+    };
+
+    mockHandlers = {
+      onError: vi.fn(),
+      onData: vi.fn(),
+      onEnd: vi.fn(),
+      onMetrics: vi.fn(),
+      onHmrAccept: vi.fn(),
+      onHmrUpdate: vi.fn(),
+      onCssFile: vi.fn(),
+      onShellError: vi.fn(),
+      onRscRender: vi.fn(),
+    } as unknown as StreamHandlers<"server">;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const options = {
+    route: "/test",
+    moduleBase: "src",
+    moduleRootPath: "dist/client/",
+    moduleBasePath: "/",
+    moduleBaseURL: "/",
+    projectRoot: "/",
+    publicOrigin: "/",
+    pageExportName: "Page",
+    propsExportName: "props",
+    rootExportName: "Root",
+    htmlExportName: "Html",
+    pagePath: "src/pages/test.tsx",
+    propsPath: "src/pages/test.props.ts",
+    serverPipeableStreamOptions: {},
+    clientPipeableStreamOptions: {},
+    verbose: false,
+    panicThreshold: "none" as const,
+    rscTimeout: 1000,
+    htmlTimeout: 1000,
+    fileWriteTimeout: 1000,
+    workerShutdownTimeout: 1000,
+    build: {
+      pages: ["/test"],
+      outDir: "dist",
+      server: "dist/server",
+      static: "dist/static",
+      client: "dist/client",
+      rscOutputPath: "index.rsc",
+      htmlOutputPath: "index.html",
+      assetsDir: "assets",
+    },
+    css: { inlineCss: false, inlineThreshold: 0, inlinePatterns: [], linkPatterns: [] },
+    manifest: {},
+    cssFiles: new Map(),
+    globalCss: new Map(),
+    url: "",
+  };
+
+  it("logs the full error (message + stack), not just the message", async () => {
+    handleRscStream({
+      options: { ...options, rscWorker: mockWorker, logger: mockLogger } as any,
+      handlers: mockHandlers,
+    });
+
+    // The INIT message posted to the worker carries controlPort2 — the worker's
+    // end of the control channel. Simulate the worker reporting a render throw.
+    const init = (mockWorker.postMessage as unknown as { mock: { calls: any[][] } })
+      .mock.calls[0][0];
+    const controlPort2 = init.controlPort as { postMessage: (m: unknown) => void };
+    controlPort2.postMessage({
+      type: "ERROR",
+      id: "/test",
+      error: {
+        name: "Error",
+        message: "boom-message",
+        stack: "Error: boom-message\n    at throwingComponent (src/page/page.tsx:2:9)",
+      },
+    });
+
+    // Control-port delivery is async; let it land.
+    await new Promise((r) => setTimeout(r, 40));
+
+    const logged = (mockLogger.error as unknown as { mock: { calls: any[][] } })
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(logged).toContain("boom-message");
+    // The stack frame proves the whole error surfaced, not just the bare message.
+    expect(logged).toMatch(/src\/page\/page\.tsx/);
+  });
+});

--- a/test/unit/fileWriter-degraded-html.test.ts
+++ b/test/unit/fileWriter-degraded-html.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { Readable } from "node:stream";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+// fileWriter is condition-agnostic (no assertNonReactServer), so importing the
+// built module directly is safe under either test leg.
+import { fileWriter } from "../../dist/plugin/react-static/fileWriter.js";
+
+// Guard: a full-document SSG HTML page must have a root <html> element. If the
+// render silently degrades to a fragment (a server-component document wrapper
+// that failed to render), the emitted file has content but no <html>/<body> —
+// a broken page that would otherwise ship in a green build. fileWriter must
+// surface that as a route.error rather than write it silently.
+
+const makeOptions = (onEvent: (e: any) => void) => ({
+  route: "/test",
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn() } as any,
+  panicThreshold: "none" as const,
+  verbose: false,
+  onEvent,
+  build: {
+    outDir: mkdtempSync(join(tmpdir(), "vprs-fw-")),
+    static: "static",
+    htmlOutputPath: "index.html",
+    rscOutputPath: "index.rsc",
+  },
+});
+
+describe("fileWriter — degraded-HTML guard", () => {
+  it("emits a route.error when the HTML has no <html> root (fragment degrade)", async () => {
+    const events: any[] = [];
+    await fileWriter(
+      Readable.from(["<div>page content, no document wrapper</div>"]) as any,
+      "html",
+      makeOptions((e) => events.push(e)) as any
+    );
+    const routeErrors = events.filter((e) => e.type === "route.error");
+    expect(routeErrors.length).toBeGreaterThan(0);
+    expect(String(routeErrors[0].data.error.message)).toMatch(/Degraded HTML/);
+  });
+
+  it("does NOT flag a well-formed document", async () => {
+    const events: any[] = [];
+    await fileWriter(
+      Readable.from([
+        `<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>`,
+      ]) as any,
+      "html",
+      makeOptions((e) => events.push(e)) as any
+    );
+    expect(events.filter((e) => e.type === "route.error")).toHaveLength(0);
+  });
+
+  it("does NOT flag rsc payloads (only the HTML document is a full document)", async () => {
+    const events: any[] = [];
+    await fileWriter(
+      Readable.from([`0:["$","div",null,{}]`]) as any,
+      "rsc",
+      makeOptions((e) => events.push(e)) as any
+    );
+    expect(events.filter((e) => e.type === "route.error")).toHaveLength(0);
+  });
+});

--- a/test/unit/fileWriter.test.ts
+++ b/test/unit/fileWriter.test.ts
@@ -30,7 +30,7 @@ describe("fileWriter", () => {
   it("should write file successfully with normal stream", async () => {
     const stream = new Readable({
       read() {
-        this.push("Hello, World!");
+        this.push("<html><body>Hello, World!</body></html>");
         this.push(null);
       },
     });
@@ -127,9 +127,13 @@ describe("fileWriter", () => {
   });
 
   it("should emit file.write and file.write.done events", async () => {
+    // A real HTML document (with an <html> root) so the degraded-document guard
+    // in fileWriter does not fire — this test exercises the event mechanics, not
+    // a fragment degrade.
+    const htmlDoc = "<html><body>Test content</body></html>";
     const stream = new Readable({
       read() {
-        this.push("Test content");
+        this.push(htmlDoc);
         this.push(null);
       },
     });
@@ -159,6 +163,6 @@ describe("fileWriter", () => {
     expect(events).toHaveLength(2);
     expect(events[0].type).toBe("file.write");
     expect(events[1].type).toBe("file.write.done");
-    expect(events[1].data.content).toBe("Test content");
+    expect(events[1].data.content).toBe(htmlDoc);
   });
 });


### PR DESCRIPTION
## 3.1.0

Bundles the fixes accumulated since 3.0.0. The headline is making failures in the no-flag worker render path **visible** instead of silent.

### Surface silent failures in the reverse-condition worker path (new)

In the no-flag build (`vite build --app` without `--conditions react-server`), RSC renders in a worker and failures could either ship in a green build or log without a stack:

- **Degraded-document guard** (`fileWriter`). A full-document SSG page whose render collapsed to a fragment — content emitted, but no `<html>` root element (the document wrapper did not render) — is now surfaced as a `route.error` instead of being written silently. A green build can no longer ship a page without `<html>/<head>/<body>`. Honours `panicThreshold`: fails the build by default, logs loudly when panics are disabled. RSC payloads are exempt (only the HTML document is a full document).
- **Full worker error in dev:ssr** (`handleRscStream`). dev:ssr now logs the worker RSC render error's message **and stack** (via `logError`) instead of only the message — matching what the main-thread runner (dev:rsc) already shows. The worker already serializes the stack across the thread boundary; the client handler was discarding it.

### Also included since 3.0.0

- `fix(env)`: default browser env `BASE_URL`/`PUBLIC_ORIGIN` so `moduleBaseURL` isn't `'undefined/'`.
- `fix(dev)`: collect `route.tsx` layout CSS in the runner path (dev:ssr).

### Tests

- Unit coverage for the degraded-document guard (fragment → `route.error`; well-formed document → clean; rsc payload exempt) and for the worker-error stack surfacing (fails without the fix).
- Full suite green on both condition legs (examples, client, unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS