### PR TITLE
fix(router): cache orderPatterns by content so the specificity sort caches

### DIFF
--- a/plugin/router/matchRoute.ts
+++ b/plugin/router/matchRoute.ts
@@ -157,15 +157,21 @@ export function patternProbeUrl(
 
 /** Match a pathname against many patterns, most-specific first. */
 // Specificity ordering only depends on the pattern list, but matchRoutes runs
-// per request (dev / edge / Node). Cache the sorted order by array identity —
-// callers pass a stable patterns array (fileRouter's routePatterns, the edge
-// bundle's ROUTE_PATTERNS) — so we sort once, not on every request.
-const orderedCache = new WeakMap<readonly string[], readonly string[]>();
-const orderPatterns = <P extends string>(patterns: readonly P[]): readonly P[] => {
-  let ordered = orderedCache.get(patterns) as readonly P[] | undefined;
+// per request (dev / edge / Node). Cache the sorted order so we sort once, not
+// on every request. Key by CONTENT, not array identity: per-request callers
+// (e.g. createSerializableHandlerOptions' `[...routePatterns]` copy) mint a
+// fresh array each time, so an identity WeakMap never hit and the sort ran every
+// request. The map is bounded by the number of distinct route sets (≈1).
+const orderedCache = new Map<string, readonly string[]>();
+/** Order patterns most-specific first (cached by content). Exported for tests. */
+export const orderPatterns = <P extends string>(
+  patterns: readonly P[],
+): readonly P[] => {
+  const key = patterns.join("\n");
+  let ordered = orderedCache.get(key) as readonly P[] | undefined;
   if (!ordered) {
     ordered = [...patterns].sort((a, b) => moreSpecific(score(a), score(b)));
-    orderedCache.set(patterns, ordered);
+    orderedCache.set(key, ordered);
   }
   return ordered;
 };

--- a/test/unit/matchRoute.test.ts
+++ b/test/unit/matchRoute.test.ts
@@ -3,6 +3,7 @@ import {
   matchRoute,
   matchRoutes,
   normalizePathForMatch,
+  orderPatterns,
   patternProbeUrl,
 } from "../../plugin/router/matchRoute.js";
 
@@ -136,5 +137,28 @@ describe("normalizePathForMatch", () => {
 
   it("honors a custom rsc suffix", () => {
     expect(normalizePathForMatch("/p/42.flight", ".flight")).toBe("/p/42");
+  });
+});
+
+describe("orderPatterns", () => {
+  it("orders literal > param > catch-all", () => {
+    expect([...orderPatterns(["/$", "/$id", "/about"])]).toEqual([
+      "/about",
+      "/$id",
+      "/$",
+    ]);
+  });
+
+  it("caches the order by content, not array identity", () => {
+    // Per-request callers mint a fresh array each time
+    // (createSerializableHandlerOptions' `[...routePatterns]`), so the old
+    // identity-keyed WeakMap never hit and re-sorted every request. Content
+    // keying returns the same cached order for two distinct-but-equal arrays.
+    const a = ["/$id", "/about", "/$"];
+    const b = ["/$id", "/about", "/$"];
+    expect(a).not.toBe(b);
+    const first = orderPatterns(a);
+    const second = orderPatterns(b);
+    expect(second).toBe(first);
   });
 });


### PR DESCRIPTION
`matchRoutes` orders patterns by specificity via a WeakMap keyed on **array identity**, assuming callers pass a stable array. But per-request callers mint a fresh copy (`createSerializableHandlerOptions`' `[...routePatterns]`), so the WeakMap **never hit** — the sort re-ran on every request and the cache was effectively dead.

**Fix:** key the cache by content (the joined pattern list), so equal pattern sets share one sorted order regardless of array identity. The map is bounded by the number of distinct route sets (≈1).

Low severity (small arrays, cheap sort), but the cache is now actually a cache. Exported `orderPatterns` and added coverage: specificity ordering (literal > param > catch-all) and the content-cache hit (two distinct-but-equal arrays return the same cached order — fails on the old identity WeakMap). Full matchRoute suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS