### PR TITLE
fix(router): bound the client flightCache with LRU eviction

### DIFF
--- a/plugin/router/flightCache.ts
+++ b/plugin/router/flightCache.ts
@@ -8,6 +8,12 @@
 export type FlightCacheOptions = {
   /** Injectable clock (defaults to Date.now); handy for tests. */
   now?: () => number;
+  /**
+   * Max number of cached entries before least-recently-used eviction. A
+   * long-lived SPA that navigates many distinct dynamic urls would otherwise
+   * grow the cache without bound. Default 100.
+   */
+  maxSize?: number;
 };
 
 export type FlightGetOptions<T> = {
@@ -27,11 +33,25 @@ export function createFlightCache<T>(
   options: FlightCacheOptions = {},
 ): FlightCache<T> {
   const now = options.now ?? Date.now;
+  const maxSize = Math.max(1, options.maxSize ?? 100);
   const cache = new Map<string, { promise: Promise<T>; at: number }>();
+
+  // Re-insert so the entry becomes most-recently-used (Map preserves insertion
+  // order), then evict from the front until within capacity.
+  const store = (url: string, entry: { promise: Promise<T>; at: number }) => {
+    cache.delete(url);
+    cache.set(url, entry);
+    while (cache.size > maxSize) {
+      const lru = cache.keys().next().value;
+      if (lru === undefined) break;
+      cache.delete(lru);
+    }
+  };
 
   const get = (url: string, opts: FlightGetOptions<T>): Promise<T> => {
     const hit = cache.get(url);
     if (hit && (opts.ttlMs === undefined || now() - hit.at < opts.ttlMs)) {
+      store(url, hit); // touch: mark most-recently-used
       return hit.promise;
     }
     const promise = Promise.resolve(opts.fetcher(url));
@@ -39,7 +59,7 @@ export function createFlightCache<T>(
     promise.catch(() => {
       if (cache.get(url)?.promise === promise) cache.delete(url);
     });
-    cache.set(url, { promise, at: now() });
+    store(url, { promise, at: now() });
     return promise;
   };
 

--- a/test/unit/flightCache.test.ts
+++ b/test/unit/flightCache.test.ts
@@ -70,4 +70,27 @@ describe("createFlightCache", () => {
     cache.invalidate();
     expect(cache.has("/b")).toBe(false);
   });
+
+  it("evicts the least-recently-used entry past maxSize", async () => {
+    const cache = createFlightCache<string>({ maxSize: 2 });
+    const fetcher = async (u: string) => `flight:${u}`;
+    await cache.get("/a", { fetcher });
+    await cache.get("/b", { fetcher });
+    await cache.get("/c", { fetcher }); // over capacity → evict LRU (/a)
+    expect(cache.has("/a")).toBe(false);
+    expect(cache.has("/b")).toBe(true);
+    expect(cache.has("/c")).toBe(true);
+  });
+
+  it("touches an entry on access, so LRU is by use, not insertion (not FIFO)", async () => {
+    const cache = createFlightCache<string>({ maxSize: 2 });
+    const fetcher = async (u: string) => `flight:${u}`;
+    await cache.get("/a", { fetcher });
+    await cache.get("/b", { fetcher });
+    await cache.get("/a", { fetcher }); // touch /a → /b is now the LRU
+    await cache.get("/c", { fetcher }); // over capacity → evict /b, keep /a
+    expect(cache.has("/a")).toBe(true);
+    expect(cache.has("/b")).toBe(false);
+    expect(cache.has("/c")).toBe(true);
+  });
 });


### PR DESCRIPTION
`createFlightCache`'s `Map` was never bounded — `get()` only evicted on rejection, and TTL expiry refetched without evicting other urls. A long-lived SPA that navigates many distinct dynamic urls grows the cache without limit (client memory leak).

**Fix:** add a `maxSize` option (default 100) with least-recently-used eviction. Entries are re-inserted on access (`Map` preserves insertion order, so the front key is the LRU entry) and evicted from the front once over capacity.

Tests cover eviction past capacity and that a touched entry survives while a stale one is evicted (LRU by use, not FIFO by insertion). Full flightCache suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS