### PR TITLE
fix(router): mount in dev when react-dom/client exports land on .default

### DIFF
--- a/plugin/utils/hydrateOrRender.ts
+++ b/plugin/utils/hydrateOrRender.ts
@@ -59,7 +59,24 @@ export function hydrateOrRender(
     Promise.resolve().then(getInitialNode),
     import("react-dom/client"),
   ])
-    .then(([initialNode, { createRoot, hydrateRoot }]) => {
+    .then(([initialNode, mod]) => {
+      // react-dom/client's default (browser) build is CJS. A production bundle
+      // re-exports createRoot/hydrateRoot at the namespace top level, but Vite's
+      // dev server serves the raw CJS module — a dynamic `import()` then lands
+      // the exports on `.default`, where a static `import {}` would have been
+      // rewritten by Vite's named-export interop. (This helper must stay a
+      // dynamic import to remain load-safe under the react-server condition.)
+      // Read the top level first (build), fall back to `.default` (dev).
+      type ClientApi = Pick<typeof mod, "createRoot" | "hydrateRoot">;
+      const client = mod as unknown as ClientApi & { default?: ClientApi };
+      const createRoot = client.createRoot ?? client.default?.createRoot;
+      const hydrateRoot = client.hydrateRoot ?? client.default?.hydrateRoot;
+      if (!createRoot || !hydrateRoot) {
+        throw new Error(
+          "[vprs] react-dom/client did not expose createRoot/hydrateRoot " +
+            "(neither at the module top level nor on `.default`)"
+        );
+      }
       // hasChildNodes(): a prerendered/SSR'd shell already holds the server
       // markup, so hydrate it; an empty client-only shell gets a fresh render.
       if (root.hasChildNodes()) {


### PR DESCRIPTION
## Problem

Adopting `startClient` in a consumer (mmc) broke client hydration in **both** dev modes (`dev:ssr` and `dev:rsc`) with:

```
[vprs] hydrateOrRender: initial payload failed; staying static
TypeError: createRoot is not a function
```

`preview` / production builds were unaffected.

## Cause

`hydrateOrRender` lazily `import("react-dom/client")` (a *dynamic* import, kept dynamic so the helper stays load-safe under the `react-server` condition) and destructured `{ createRoot, hydrateRoot }` straight off the namespace.

`react-dom/client`'s default (browser) build is **CJS**. A production bundle re-exports `createRoot`/`hydrateRoot` at the namespace top level, but Vite's dev server serves the raw module: a **dynamic** `import()` then lands the exports on `.default`, whereas a **static** `import {}` gets rewritten by Vite's named-export interop. The consumer's old hand-rolled client used a static import, which is why the migration to `startClient` exposed this.

## Fix

Read the exports from the top level first (build), fall back to `.default` (dev); throw a clear error if neither shape exposes them.

## Verification

Headless load of an mmc dev server in **both** `dev:ssr` and `dev:rsc`: `#root` hydrates (8 children), no `createRoot` error, no hydration warnings. `tsc --noEmit` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)