### PR TITLE
fix(types): type the resolved loader's logger as optional, drop the cast

### DIFF
--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -5,7 +5,6 @@ import {
 import { pluginRoot } from "../root.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { getCondition } from "./getCondition.js";
-import type { Logger } from "vite";
 // Directive patterns - matching the logic in findDirectiveMatches.ts
 const DIRECTIVE_PATTERNS = {
   // Client directive must be at start of file
@@ -103,9 +102,8 @@ export const DEFAULT_LOADER_CONFIG = {
   // No eager default logger: constructing vite's createLogger() at module top
   // dragged vite (a devDependency) into every prod/edge bundle that imports
   // DEFAULT_CONFIG. Call sites supply their own logger; this defaults undefined.
-  // `import type { Logger }` is erased, so no runtime vite. (Typed as Logger to
-  // satisfy Required<LoaderConfig>; consumers already guard a missing logger.)
-  logger: undefined as unknown as Logger,
+  // The resolved loader types logger as optional, so no cast is needed.
+  logger: undefined,
   moduleID: (moduleId: string, _sourceContent?: string) =>
     typeof moduleId === "string" ? moduleId : String(moduleId),
 } as const;

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -468,7 +468,12 @@ export type ResolvedUserOptions = {
   serverPipeableStreamOptions?: any; // For dev server and RSC worker
   clientPipeableStreamOptions?: any; // For HTML worker
   autoDiscover: Required<AutoDiscoverConfig>;
-  loader?: Required<LoaderConfig> | undefined;
+  // Everything resolved to a default EXCEPT logger, which stays optional: the
+  // default is `undefined` (so defaults.tsx doesn't eagerly import vite's
+  // createLogger and drag vite — a devDep — into prod/edge bundles).
+  loader?:
+    | (Required<Omit<LoaderConfig, "logger">> & { logger?: Logger })
+    | undefined;
   build: Omit<Required<BuildConfig>, "edge"> & { edge: ResolvedEdgeConfig };
   dev: Required<DevConfig>;
   css: RootOptions<boolean>;


### PR DESCRIPTION
## What

`DEFAULT_LOADER_CONFIG.logger` is `undefined` on purpose — constructing Vite's `createLogger()` at module top dragged Vite (a devDependency) into every prod/edge bundle that imports `DEFAULT_CONFIG`. To satisfy `Required<LoaderConfig>`, the default was cast `undefined as unknown as Logger`.

This types the resolved loader's `logger` as optional instead:

```ts
loader?: (Required<Omit<LoaderConfig, "logger">> & { logger?: Logger }) | undefined;
```

so the default needs no cast and the unused `Logger` import in `defaults.tsx` is dropped. No use-site reads `loader.logger`, so nothing to guard.

## Verification

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)