### PR TITLE
chore(release): 3.1.1 — router dev-hydration + cache fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.0.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump **3.1.0 → 3.1.1**. Bug-fix batch, all router/client, no API changes.

## Included (already merged to main)
- **#231** fix(router): mount in dev when react-dom/client's exports land on `.default` — `startClient`/`hydrateOrRender`'s dynamic `import("react-dom/client")` read createRoot/hydrateRoot off the namespace top level; Vite dev serves the raw CJS module, landing them on `.default`, so `dev:ssr` and `dev:rsc` threw `createRoot is not a function` on first mount (build/preview unaffected).
- **#230** fix(router): bound the client flightCache with LRU eviction.
- **#229** fix(router): cache `orderPatterns` by content so the specificity sort caches across calls.
- **#232** fix(types): type the resolved loader's `logger` as optional, drop the `undefined as unknown as Logger` cast.
- (#228 test-only: skip a client-only test on the react-server leg.)

## Verification
- `test-all` (server / client / unit / typecheck): **0 failed** — 783 / 235 / 575 / 35 passed.
- `validate-sibling.sh` → mmc via a real npm tarball: `npm run build` passed (300 pages, edge bundle) and `dev:ssr` hydration is clean on the real install (#231 confirmed end-to-end).

Merge, then publish (`prepublishOnly` runs build + verify:package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)