### PR TITLE
test(e2e): dev-server hydration smoke (createRoot-interop regression guard)

### DIFF
--- a/test/e2e/dev-hydration.spec.ts
+++ b/test/e2e/dev-hydration.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Dev-server hydration smoke.
+ *
+ * The supplied client entry (`startClient` -> `hydrateOrRender`) lazily
+ * `import("react-dom/client")` to stay load-safe under the react-server
+ * condition. Vite's dev server serves that module as raw CJS, so a dynamic
+ * import can land createRoot/hydrateRoot on `.default` instead of the namespace
+ * top level; a regression there threw "createRoot is not a function" and left
+ * the page as UN-hydrated static HTML. That failure is invisible to a naive
+ * "#root has children" assertion, because hydrateOrRender's onError keeps the
+ * prerendered markup in place. Preview/build never reproduce it (react-dom/client
+ * is bundled with the exports at the top level) and jsdom resolves the module
+ * the Node way, so only a real browser against a real dev server catches it.
+ *
+ * This spec therefore asserts BOTH that the mount error is absent AND that the
+ * page is genuinely interactive: a client-side navigation preserves a window
+ * marker that a full-page reload would wipe. The e2e fixture runs dev:rsc; the
+ * browser client path is identical under dev:ssr.
+ */
+test.describe("dev-server hydration", () => {
+  test("mounts with no react-dom/client interop error", async ({ page }) => {
+    const mountErrors: string[] = [];
+    const watch = (text: string) => {
+      if (
+        /createRoot is not a function|hydrateOrRender: initial payload failed|did not expose createRoot/i.test(
+          text,
+        )
+      ) {
+        mountErrors.push(text);
+      }
+    };
+    page.on("console", (m) => watch(m.text()));
+    page.on("pageerror", (e) => watch(e.message));
+
+    await page.goto("/");
+    await expect(page.locator("#root")).not.toBeEmpty();
+    // Give hydrateOrRender's Promise.all (flight decode + react-dom import) time
+    // to resolve and either mount or fall back to onError.
+    await page.waitForTimeout(1000);
+
+    expect(
+      mountErrors,
+      `client mount logged react-dom/client errors:\n${mountErrors.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  test("is interactive after hydration (client nav keeps a reload-wiping marker)", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // A full-page reload wipes this; a hydrated client-side navigation keeps it.
+    // If hydration failed, the server-rendered <a> carries no React handler and
+    // the click does a native full navigation, dropping the marker.
+    await page.evaluate(() => {
+      (window as Window & { __hydrated?: string }).__hydrated = "yes";
+    });
+
+    const link = page.locator('a[href*="todos"]').first();
+    await expect(link).toBeVisible(); // fail loudly if the fixture changes, never a silent skip
+    await link.click();
+    await page.waitForURL(/\/todos/);
+
+    const survived = await page.evaluate(
+      () => (window as Window & { __hydrated?: string }).__hydrated,
+    );
+    expect(survived).toBe("yes");
+  });
+});


### PR DESCRIPTION
## Why

The 3.1.1 `createRoot is not a function` bug (dynamic `import("react-dom/client")` landing the exports on `.default` under Vite dev) slipped every gate. Root cause of the *miss*, not the bug:

- The 8 dev-server e2e specs are the right kind of test (real browser, real `vite dev`) but run against **bidoof, whose hand-rolled client uses a *static* `import { createRoot }`** — Vite's named-export interop covers that, so `hydrateOrRender`'s dynamic path is never exercised.
- Unit/build tests never see the raw-CJS shape: the production bundle and Node/jsdom both expose `createRoot` at the namespace top level.
- `validate-sibling.sh` runs mmc's `build`, not its dev server.

## What

A dev-server hydration smoke (`test/e2e/dev-hydration.spec.ts`). It asserts **both**:
1. no `createRoot is not a function` / `hydrateOrRender: initial payload failed` in console or page errors, and
2. the page is genuinely **interactive** — a client-side nav preserves a `window` marker a full reload would wipe.

Point 2 matters because `hydrateOrRender`'s `onError` keeps the prerendered HTML, so a `#root`-has-children check passes even when hydration *failed*. Verified locally against the bidoof dev server (both green).

## Follow-ups (not in this PR)
- This becomes the **direct `hydrateOrRender` guard** once the fixture adopts `startClient` (bidoof migration, tracked separately).
- **Wiring `test:e2e` into CI** is the real gate-closer and is blocked on bidoof being on `startClient` + current vprs (bidoof `main` is vprs 2.10). Tracked as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)