### PR TITLE
fix(router): bust the flight cache on RSC HMR so the view updates

### DIFF
--- a/plugin/router/createRouter.ts
+++ b/plugin/router/createRouter.ts
@@ -24,6 +24,8 @@ export type Router<T> = {
   prefetch: (to: ToPath) => void;
   /** The (cached) flight for a url; reuses a warmed/in-flight fetch. */
   flight: (url: string) => Promise<T>;
+  /** Drop a cached flight (one url, or all) so the next `flight()` refetches. */
+  invalidate: (url?: string) => void;
 };
 
 const currentUrl = () =>
@@ -73,5 +75,6 @@ export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
       cache.prefetch(to, { fetcher: opts.fetchFlight, ttlMs: ttlFor(to) });
     },
     flight,
+    invalidate: (url) => cache.invalidate(url),
   };
 }

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -61,6 +61,12 @@ function RouteView({
   }, [location, router]);
 
   useRscHmr(() => {
+    // A server-component edit can invalidate any route's flight, and the flight
+    // cache holds static routes indefinitely — so refetching straight through
+    // `router.flight` would just return the stale cached copy and the view would
+    // never update (HMR appears dead until a full reload). Drop the whole cache
+    // first, then refetch the current route.
+    router.invalidate();
     const url = router.getState().url;
     Promise.resolve(router.flight(url)).then(setNode);
   });


### PR DESCRIPTION
## Bug

With `startClient`, a server-component edit fires the RSC HMR event but the view never updates — HMR looks dead until a full manual page reload.

`RouteView`'s HMR handler refetched via `router.flight(url)`, which reads through the flight cache. Static routes are cached **indefinitely** (`ttlMs` only applies to `isDynamic` routes), so the "refetch" returned the *stale cached* flight. The hand-rolled client that `startClient` replaced called `createReactFetcher` directly (uncached), so it always got fresh content — which is why this regressed only after adopting `startClient`.

## Fix

- Expose `invalidate(url?)` on the `Router` (delegates to the flight cache).
- In the HMR handler, drop the whole cache before refetching the current route — a server edit can invalidate any route's flight, so clearing all of it keeps later navigations fresh too.

## Verification

Real dev server against bidoof (on `startClient`): the existing `hmr.spec.ts` › "server component change updates todos page" goes from **timing out** (marker never appears) on unpatched 3.1.1 to **passing** with this fix. Confirmed the inverse too (clean 3.1.1 reproduces the timeout).

## Notes

- Affects **all** `startClient` consumers (mmc, and bidoof once its migration lands) — so this wants a **3.1.2** release + a consumer bump.
- This is exactly the class `hmr.spec.ts` covers but that never runs in CI (bead itq6): the e2e suite isn't wired into the gate, which is why the `startClient` migration's HMR break wasn't caught automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)