### PR TITLE
chore(release): 3.1.2 — fix RSC HMR stale-cache in startClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/router/createRouter.ts
+++ b/plugin/router/createRouter.ts
@@ -24,6 +24,8 @@ export type Router<T> = {
   prefetch: (to: ToPath) => void;
   /** The (cached) flight for a url; reuses a warmed/in-flight fetch. */
   flight: (url: string) => Promise<T>;
+  /** Drop a cached flight (one url, or all) so the next `flight()` refetches. */
+  invalidate: (url?: string) => void;
 };
 
 const currentUrl = () =>
@@ -73,5 +75,6 @@ export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
       cache.prefetch(to, { fetcher: opts.fetchFlight, ttlMs: ttlFor(to) });
     },
     flight,
+    invalidate: (url) => cache.invalidate(url),
   };
 }

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -61,6 +61,12 @@ function RouteView({
   }, [location, router]);
 
   useRscHmr(() => {
+    // A server-component edit can invalidate any route's flight, and the flight
+    // cache holds static routes indefinitely — so refetching straight through
+    // `router.flight` would just return the stale cached copy and the view would
+    // never update (HMR appears dead until a full reload). Drop the whole cache
+    // first, then refetch the current route.
+    router.invalidate();
     const url = router.getState().url;
     Promise.resolve(router.flight(url)).then(setNode);
   });


### PR DESCRIPTION
Version bump **3.1.1 → 3.1.2**. Single-fix patch. Self-contained: includes the fix commit + the version bump, so merging this alone gives main everything for 3.1.2.

## Fix — RSC HMR stale cache in `startClient`

With `startClient`, a server-component edit fired the RSC HMR event but the view never updated (HMR looked dead until a manual reload). `RouteView`'s handler refetched via `router.flight(url)`, which reads through the flight cache; static routes are cached **indefinitely** (`ttlMs` only applies to `isDynamic` routes), so the refetch returned the stale cached flight.

- Expose `Router.invalidate(url?)` (delegates to the flight cache).
- Bust the whole cache in the HMR handler before refetching the current route.

Affects **every** `startClient` consumer (mmc, and bidoof once its migration lands).

## Verification

- Real dev server against bidoof: `hmr.spec.ts` › "server component change updates todos page" times out on unpatched 3.1.1, passes with this fix.
- `test-all` (server / client / unit / typecheck): exit 0.

## After publishing

Bump mmc and bidoof to `^3.1.2` for the HMR fix. (Supersedes #235 — its fix commit is included here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)