### PR TITLE
fix(worker): make the hosted components usable in a consumer's document wrapper

### DIFF
--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -589,12 +589,6 @@ async function loadComponentsWithCache(options: {
     if (verbose) {
       logger?.info(`[rsc-worker] Using headless Html component (empty string)`);
     }
-  } else if (htmlPath === undefined) {
-    // undefined = use default HTML component
-    if (verbose) {
-      logger?.info(`[rsc-worker] htmlPath is undefined, using default Html component`);
-    }
-    HtmlComponent = await loadDefaultHtml({ logger, panicThreshold, verbose });
   } else if (htmlPath) {
     if (verbose) {
       logger?.info(`[rsc-worker] Attempting to load custom Html component from: ${htmlPath}`);
@@ -658,6 +652,10 @@ async function loadComponentsWithCache(options: {
       }
     }
   } else {
+    // No html configured (undefined) — use the built-in document wrapper.
+    if (verbose) {
+      logger?.info(`[rsc-worker] No htmlPath configured, using default Html component`);
+    }
     HtmlComponent = await loadDefaultHtml({ logger, panicThreshold, verbose });
   }
 

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -1,6 +1,6 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { PassThrough } from "node:stream";
-import { createLogger } from "vite";
+import { createLogger, type Logger } from "vite";
 import { join, relative } from "node:path";
 import { createRscWorkerLoader } from "./createRscWorkerLoader.js";
 import { handleRscRender } from "./handleRscRender.server.js";
@@ -183,6 +183,41 @@ function cleanupRender(id: string) {
 
 function clearHeadlessError(route: string) {
   headlessStreamErrors.delete(route);
+}
+
+/**
+ * Load the built-in Html document wrapper (used when the app configures no
+ * `html` path). Imported lazily so the static import graph never roots React.
+ * A failure here means the plugin's own runtime can't load — never degrade to a
+ * headless fragment, which would ship every route without <html>/<head>/<body>.
+ */
+async function loadDefaultHtml({
+  logger,
+  panicThreshold,
+  verbose,
+}: {
+  logger?: Logger;
+  panicThreshold?: PanicThreshold;
+  verbose?: boolean;
+}): Promise<React.ElementType> {
+  try {
+    const { Html } = await import("../../components/html.js");
+    if (verbose) {
+      logger?.info(`[rsc-worker] Using built-in default Html component`);
+    }
+    return Html;
+  } catch (error) {
+    const htmlError = toError(error);
+    const panicError = handleError({
+      error: htmlError,
+      logger,
+      panicThreshold,
+      critical: true,
+      context: `rsc-worker: load built-in Html component`,
+      log: true,
+    });
+    throw panicError ?? htmlError;
+  }
 }
 
 /**
@@ -559,20 +594,7 @@ async function loadComponentsWithCache(options: {
     if (verbose) {
       logger?.info(`[rsc-worker] htmlPath is undefined, using default Html component`);
     }
-    try {
-      const { Html } = await import("../../components/html.js");
-      HtmlComponent = Html;
-      if (verbose) {
-        logger?.info(`[rsc-worker] Successfully loaded default Html component`);
-      }
-    } catch (error) {
-      logger?.warn(
-        `[rsc-worker] Error loading default Html component: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-      HtmlComponent = React.Fragment; // Fallback to headless if default fails
-    }
+    HtmlComponent = await loadDefaultHtml({ logger, panicThreshold, verbose });
   } else if (htmlPath) {
     if (verbose) {
       logger?.info(`[rsc-worker] Attempting to load custom Html component from: ${htmlPath}`);
@@ -615,30 +637,28 @@ async function loadComponentsWithCache(options: {
           );
         }
       } else {
-        // Handle component resolution failure gracefully (same as server environment)
-        if (verbose) {
-          logger?.warn(
-            `[rsc-worker] Failed to load Html component from ${htmlPath}: ${htmlResult.error?.message || 'Unknown error'}`
-          );
-          logger?.warn(`[rsc-worker] Html resolution error details:`, htmlResult.error);
-        }
-        // Use React.Fragment as fallback (same as server environment)
-        HtmlComponent = React.Fragment;
+        // The document wrapper failed to load. Falling back to React.Fragment
+        // here renders every route as an <html>-less fragment — a silent
+        // degrade that hides the real load error (the fileWriter's
+        // degraded-document guard then reports the symptom, not the cause).
+        // Mirror the Root path: route through handleError for dedup + panic
+        // handling, then re-throw so the outer worker catch propagates it.
+        const htmlError = htmlResult.error ?? new Error(
+          `[rsc-worker] Failed to load Html component from ${htmlPath}`,
+        );
+        const panicError = handleError({
+          error: htmlError,
+          logger,
+          panicThreshold,
+          critical: true,
+          context: `rsc-worker: load Html from ${htmlPath}`,
+          log: true,
+        });
+        throw panicError ?? htmlError;
       }
     }
   } else {
-    // Use default Html component
-    try {
-      const { Html } = await import("../../components/html.js");
-      HtmlComponent = Html;
-      if (verbose) {
-        logger?.info(`[rsc-worker] Using default Html component`);
-      }
-    } catch (error) {
-      logger?.warn(
-        `[rsc-worker] Error loading default Html component: ${error}`
-      );
-    }
+    HtmlComponent = await loadDefaultHtml({ logger, panicThreshold, verbose });
   }
 
   return { PageComponent, pageProps, RootComponent, HtmlComponent, layoutChain };

--- a/plugin/worker/rsc/rsc-worker.development.ts
+++ b/plugin/worker/rsc/rsc-worker.development.ts
@@ -39,11 +39,22 @@ try {
     );
   }
 
-  // Keep the tsx hook around for the rare non-runner import path where a
+  // Dev only: the tsx hook covers the rare non-runner import path where a
   // module that isn't transformed by Vite (e.g. a vendored dependency that
-  // ships .ts sources) still needs TypeScript stripping. Runner-loaded
-  // modules receive code that's already been through Vite's transform.
-  registerTsx();
+  // ships .ts sources) still needs TypeScript stripping. Runner-loaded modules
+  // receive code that's already been through Vite's transform.
+  //
+  // Never register it in build mode: everything the worker imports is built
+  // JavaScript, and tsx's package-type lookup stops at the nearest
+  // `node_modules` boundary. Modules Rollup emits under
+  // `dist/server/node_modules/<pkg>/` have no package.json of their own, so tsx
+  // reads them as CJS and their ESM named exports vanish at link time
+  // ("does not provide an export named 'Css'" when a document wrapper imports
+  // vite-plugin-react-server/components). Node's own resolution walks past that
+  // boundary to the project's package.json and loads them as ESM.
+  if (!isBuildMode) {
+    registerTsx();
+  }
 
   parentPort!.on("messageerror", (error: Error) => {
     logger.error("Parent port message serialization failed.", { error });

--- a/plugin/worker/rsc/rsc-worker.production.ts
+++ b/plugin/worker/rsc/rsc-worker.production.ts
@@ -161,7 +161,17 @@ try {
           DEFAULT_CONFIG.ENV_LOADER_PATH
         ));
 
-  // Only register loaders if not in build mode
+  // Serve mode only: register the loaders and the tsx hook.
+  //
+  // Build mode registers nothing. Everything the worker imports there is built
+  // JavaScript, and the tsx hook actively breaks it — tsx's package-type lookup
+  // stops at the nearest `node_modules` boundary, so the modules Rollup emits
+  // under `dist/server/node_modules/<pkg>/` (no package.json of their own) are
+  // read as CJS and their ESM named exports vanish at link time. That is what
+  // made a document wrapper importing vite-plugin-react-server/components fail
+  // with "does not provide an export named 'Css'" and degrade every route to an
+  // <html>-less fragment. Node's own resolution walks past that boundary to the
+  // project's package.json and loads them as ESM.
   if (!isBuildMode) {
     try {
       register(cssLoaderPath, {
@@ -230,17 +240,6 @@ try {
       });
       if (handledError != null) throw handledError;
     }
-  } else {
-    // Build mode: register nothing. Everything the worker imports is built
-    // JavaScript, and the tsx hook actively breaks it — tsx's package-type
-    // lookup stops at the nearest `node_modules` boundary, so the modules
-    // Rollup emits under `dist/server/node_modules/<pkg>/` (no package.json of
-    // their own) are read as CJS and their ESM named exports vanish at link
-    // time. That is what made a document wrapper importing
-    // vite-plugin-react-server/components fail with "does not provide an export
-    // named 'Css'" and degrade every route to an <html>-less fragment. Node's
-    // own resolution walks past that boundary to the project's package.json and
-    // loads them as ESM.
   }
 
   // Increase max listeners on parentPort to prevent warnings

--- a/plugin/worker/rsc/rsc-worker.production.ts
+++ b/plugin/worker/rsc/rsc-worker.production.ts
@@ -231,8 +231,16 @@ try {
       if (handledError != null) throw handledError;
     }
   } else {
-    // In build mode, just register tsx for basic TypeScript support
-    registerTsx();
+    // Build mode: register nothing. Everything the worker imports is built
+    // JavaScript, and the tsx hook actively breaks it — tsx's package-type
+    // lookup stops at the nearest `node_modules` boundary, so the modules
+    // Rollup emits under `dist/server/node_modules/<pkg>/` (no package.json of
+    // their own) are read as CJS and their ESM named exports vanish at link
+    // time. That is what made a document wrapper importing
+    // vite-plugin-react-server/components fail with "does not provide an export
+    // named 'Css'" and degrade every route to an <html>-less fragment. Node's
+    // own resolution walks past that boundary to the project's package.json and
+    // loads them as ESM.
   }
 
   // Increase max listeners on parentPort to prevent warnings

--- a/test/examples/hosted-components-document.test.ts
+++ b/test/examples/hosted-components-document.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve } from "path";
+import { mkdir, writeFile } from "fs/promises";
+import { setupTestProject } from "../setup.js";
+import { getSharedBuild } from "./shared-build.js";
+
+/**
+ * A document wrapper may import components from a package — the plugin's own
+ * `Css`/`Root` from `vite-plugin-react-server/components`, or any third-party
+ * component. The server build inlines such a package and Rollup emits its
+ * modules under `dist/server/node_modules/<pkg>/`, a directory with no
+ * package.json of its own.
+ *
+ * That shape used to break the SSG render: the RSC worker registered tsx even
+ * in build mode, and tsx's package-type lookup stops at the nearest
+ * `node_modules` boundary — so it read those emitted chunks as CJS, their ESM
+ * named exports vanished at link time ("does not provide an export named
+ * 'Css'"), loading the document wrapper failed, and the worker silently fell
+ * back to React.Fragment. Every route then shipped without <html>/<head>/<body>.
+ * Node's own resolution walks past that boundary to the project's package.json
+ * and loads them as ESM, so the worker no longer registers tsx in build mode.
+ *
+ * The repo's own fixtures resolve `vite-plugin-react-server` by package
+ * self-reference (emitting to `dist/server/dist/plugin/...`, no `node_modules`
+ * segment), which is why only installed consumers ever hit this. The local
+ * package below recreates the installed-dependency shape that does.
+ */
+describe("Document wrapper importing package components", () => {
+  let buildResult: any;
+
+  beforeAll(async () => {
+    buildResult = await getSharedBuild(
+      "hosted-components-document",
+      "hosted-components-document",
+      {
+        setupProject: async (testDir: string) => {
+          await setupTestProject(testDir);
+
+          // A dependency resolved through node_modules, so the server build
+          // emits it under dist/server/node_modules/doc-kit/ — the shape that
+          // regressed. ESM, named export, no default.
+          const docKit = resolve(testDir, "node_modules", "doc-kit");
+          await mkdir(docKit, { recursive: true });
+          await writeFile(
+            resolve(docKit, "package.json"),
+            JSON.stringify({
+              name: "doc-kit",
+              version: "1.0.0",
+              type: "module",
+              main: "index.js",
+              exports: { ".": "./index.js" },
+            })
+          );
+          await writeFile(
+            resolve(docKit, "index.js"),
+            `
+import React from "react";
+export const Meta = ({ title }) =>
+  React.createElement("meta", { name: "generator", content: title });
+`
+          );
+
+          await writeFile(
+            resolve(testDir, "src", "Html.tsx"),
+            `
+import React from "react";
+import { Css, Root as DefaultRoot } from "vite-plugin-react-server/components";
+import { Meta } from "doc-kit";
+import type { HtmlComponentType } from "vite-plugin-react-server/types";
+
+export const Html: HtmlComponentType = ({
+  Root = DefaultRoot,
+  cssFiles,
+  globalCss,
+  pageProps,
+  Page,
+  as = "div",
+}) => {
+  return React.createElement("html", { "data-hosted-document": "true" },
+    React.createElement("head", {},
+      React.createElement("title", {}, "Hosted Components Document"),
+      React.createElement(Meta, { title: "doc-kit" }),
+      React.createElement(Css, { cssFiles: globalCss })
+    ),
+    React.createElement("body", {},
+      React.createElement(Root as React.ElementType, {
+        as,
+        id: "root",
+        cssFiles,
+        pageProps,
+        Page,
+      })
+    )
+  );
+};
+`
+          );
+        },
+        pages: ["/"],
+        verbose: false,
+        Html: "src/Html.tsx",
+        // Inlines doc-kit into the server build, exactly as the plugin does to
+        // itself (it auto-discovers as a client package — it ships "use client"
+        // router modules). That is what makes Rollup emit it under
+        // dist/server/node_modules/doc-kit/ with no package.json of its own.
+        clientPackages: ["doc-kit"],
+      }
+    );
+  });
+
+  it("renders a full document, not a headless fragment", () => {
+    const htmlFiles = buildResult.htmlFiles();
+    expect(htmlFiles.length).toBeGreaterThan(0);
+
+    const [, htmlContent] = htmlFiles[0];
+    expect(htmlContent).toMatch(/^\s*(<!DOCTYPE html>)?\s*<html/i);
+    expect(htmlContent).toContain('<html data-hosted-document="true"');
+    expect(htmlContent).toContain("<head>");
+    expect(htmlContent).toContain("<body>");
+    expect(htmlContent).toContain("<title>Hosted Components Document</title>");
+  });
+
+  it("keeps the named exports of a package emitted under dist/server/node_modules", () => {
+    const [, htmlContent] = buildResult.htmlFiles()[0];
+    // Rendered by doc-kit's `Meta`, whose named export is what tsx's CJS
+    // misclassification used to drop.
+    expect(htmlContent).toContain('<meta name="generator" content="doc-kit"');
+  });
+
+  it("mounts the page through the plugin's own hosted Root", () => {
+    const [, htmlContent] = buildResult.htmlFiles()[0];
+    expect(htmlContent).toContain('id="root"');
+  });
+});


### PR DESCRIPTION
## Problem

A document wrapper (`Html.tsx`) that imports anything from `vite-plugin-react-server/components` degrades **every route** to an `<html>`-less fragment in a default `vite build`. Both real consumers had to work around it by copying `Css` locally and taking `Root` from props.

The plugin marks itself `noExternal` (it ships `"use client"` router modules, so it must be inlined for the transform to see them). The server build therefore inlines it and Rollup emits its modules under `dist/server/node_modules/vite-plugin-react-server/` — a directory with **no package.json of its own**.

The build-mode RSC worker registered `tsx`, and tsx's package-type lookup stops at the nearest `node_modules` boundary. It read those emitted chunks as CJS, so their ESM named exports vanished at link time:

```
The requested module './node_modules/vite-plugin-react-server/dist/plugin/components/css.js'
does not provide an export named 'Css'
```

Loading the Html component then failed, and the worker **silently** fell back to `React.Fragment` — a headless render, no `<html>`/`<head>`/`<body>`. The fileWriter's degraded-document guard reported the symptom; the cause never surfaced.

This is not specific to the plugin's own components: any package inlined into the server build hit the same trap.

## Fix

1. **Don't register the tsx hook in build mode.** The worker imports only built JavaScript there, and Node's own resolution walks past the `node_modules` boundary to the project's package.json and loads the chunks as ESM. tsx stays registered in dev, where it covers the non-runner import path (a dependency shipping `.ts` sources).
2. **Make a failed document-wrapper load loud.** The Html path now routes through `handleError` and re-throws, mirroring the Root path, instead of degrading to `React.Fragment`.

Externalizing the plugin from the server build was the other candidate; it would have broken the `noExternal` mechanism that makes its own `"use client"` router components work.

## Regression test

`test/examples/hosted-components-document.test.ts` — a document wrapper importing the hosted `Css`/`Root` plus a component from a local package inlined via `clientPackages`. It runs in both the react-server and default vitest conditions.

The test needs that local package because the repo's own fixtures resolve the plugin by **package self-reference**, emitting to `dist/server/dist/plugin/...` with no `node_modules` segment — which is exactly why CI never caught this and only installed consumers did. Verified it fails without the fix (same `does not provide an export named` link error) and passes with it.

## Validation

- `npm run test-all` green: 786 server / 238 client / 575 unit / 35 typecheck.
- The demo template, with its document wrapper restored to import `Css` and `Root` from `/components`, builds clean: exit 0, all 5 routes emit real `<html>` documents (it fails on 3.1.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)