### PR TITLE
chore(release): 3.1.3 — hosted components usable in a consumer's document wrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release for the fix merged in #237.

## What ships

**The hosted `Css` / `Root` / `Html` components are importable from a consumer's document wrapper again.**

The build-mode RSC worker registered the `tsx` hook. tsx's package-type lookup stops at the nearest `node_modules` boundary, so the modules Rollup emits under `dist/server/node_modules/<pkg>/` — a directory with no `package.json` of its own — were read as CJS and their ESM named exports vanished at link time:

```
The requested module './node_modules/vite-plugin-react-server/dist/plugin/components/css.js'
does not provide an export named 'Css'
```

Loading the document wrapper then failed and the worker silently fell back to `React.Fragment`, so every route shipped without `<html>`/`<head>`/`<body>`. The worker no longer registers tsx in build mode (it imports only built JavaScript there); tsx stays registered in dev, where it covers the non-runner import path.

This was never specific to this package's own components — any dependency inlined into the server build hit the same trap.

A failed document-wrapper load now routes through `handleError` and re-throws instead of degrading to a headless fragment, so the cause surfaces rather than the symptom.

## Consumer impact

Consumers that worked around this by keeping a local copy of `Css` and taking `Root` from props can drop the copy and import from `vite-plugin-react-server/components` again.

Verified against the demo template on this build: with its document wrapper restored to `import { Css, Root as DefaultRoot } from "vite-plugin-react-server/components"`, the no-flag `vite build` exits 0 and all 5 routes emit real `<!DOCTYPE html><html>` documents with the hosted `Css` rendering its `<style>` tags. The same build fails on 3.1.2.

## Contents

- `package.json` / `package-lock.json`: 3.1.2 → 3.1.3

No source changes; the fix itself is already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)