### PR TITLE
ci: run the demo app's e2e against a packed build of this plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,59 @@ jobs:
 
       - name: Verify package manifest (publint + entrypoints)
         run: npm run build && npm run verify:package
+
+  # Drive a REAL browser against a REAL installed consumer.
+  #
+  # Everything above tests this repo against its own fixtures, which resolve the
+  # plugin by package self-reference. An installed consumer resolves it through
+  # `node_modules`, and that difference is not cosmetic — it is where the bugs
+  # live. Two shipped regressions were invisible to the fixtures and obvious
+  # here:
+  #
+  #   - a document wrapper importing the hosted `Css`/`Root` degraded every route
+  #     to an <html>-less fragment (only reproducible from node_modules), and
+  #   - the demo's production server — plain Node, deliberately NO
+  #     `--conditions react-server` — died on load, because the plugin's own
+  #     `stream/index.client.js` was being stubbed out as a client component.
+  #
+  # So: pack the plugin exactly as a consumer would install it, install THAT into
+  # the demo, build it, boot the plain-Node production server, and drive Chromium
+  # against it. Server actions round-trip and hydration is asserted.
+  e2e:
+    name: e2e (demo app, plain-Node prod server)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout the plugin
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Build + pack the plugin (the bytes a consumer installs)
+        run: |
+          npm ci
+          npm run build
+          npm pack
+
+      - name: Checkout the demo app
+        uses: actions/checkout@v6
+        with:
+          repository: nicobrinkkemper/vite-plugin-react-server-demo-official
+          path: demo
+
+      - name: Install the demo against THIS build of the plugin
+        working-directory: demo
+        run: |
+          npm ci
+          npm install ../vite-plugin-react-server-*.tgz
+
+      - name: Install Chromium
+        working-directory: demo
+        run: npx playwright install --with-deps chromium
+
+      - name: e2e — build, boot the prod server, drive the browser
+        working-directory: demo
+        run: npm run test:e2e


### PR DESCRIPTION
CI tested this repo only against its own fixtures, and Playwright ran **nowhere**. Those are the same gap.

## Why fixtures aren't enough

Our fixtures resolve the plugin by **package self-reference**. An installed consumer resolves it through **`node_modules`**. That difference is structural, and it is where the bugs live. Two regressions shipped that the fixtures could not see and a real consumer hit immediately:

**1. A document wrapper importing the hosted `Css`/`Root` degraded every route to an `<html>`-less fragment.** Only reproducible from `node_modules`: Rollup emits the inlined plugin under `dist/server/node_modules/<pkg>/` — a directory with no `package.json` — and the build-mode worker's `tsx` hook then read those chunks as CJS and dropped their ESM named exports. Our fixtures emit to `dist/server/dist/plugin/...`, with **no `node_modules` segment**, so the trap simply doesn't exist for them.

**2. The demo's production server died on load.** It runs on plain Node with **no `--conditions react-server`** — that is the whole point of the single-isolate edge build. `react-server-loader` was classifying the plugin's own `stream/index.client.js` as a client component *from its filename* and stubbing out every export that server imports.

Neither was catchable here. Both are trivially catchable in an installed consumer.

## What the job does

Packs the plugin **exactly as a consumer installs it**, installs that tarball into the demo app, builds it, boots the plain-Node production server, and drives Chromium against it:

```
✓ add persists across reload, then delete persists
✓ a client component that directly imports a server function can call it
✓ flash-free dynamic SSR: live todos in the initial HTML, hydrate with zero refetch
```

Server actions round-trip; hydration is asserted to happen with **zero refetch**.

## Validation

I ran the job's exact sequence locally — build + `npm pack`, `npm ci` in the demo, `npm install ../*.tgz`, `npm run test:e2e` — and it is **3/3 green, exit 0**.

## Merge order

Requires the demo's e2e repair (**demo PR #111**) on its `main` first. Until that lands this job is red for reasons in the demo, not here.

Closes the "e2e runs nowhere" gap that let the 3.1.1 `createRoot` dev-hydration bug slip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)