### PR TITLE
chore(deps): react-server-loader ^19.2.16 || experimental .1 (3.1.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.16",
+        "react-server-loader": "^19.2.16 || 0.0.0-experimental-c0c39a6b-20260709.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",
@@ -431,7 +431,7 @@
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
-    "react-server-loader": "^19.2.12 || >=0.0.0-0 <0.0.1",
+    "react-server-loader": "^19.2.16 || 0.0.0-experimental-c0c39a6b-20260709.1",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }


### PR DESCRIPTION
The last step of the react-server-loader repair. Locks out **every** rsl version carrying a known regression, on both trains.

| version | regression |
|---|---|
| `19.2.12` – `19.2.14` | classified a client component from its **filename** — which stubbed out the plugin's own `stream/index.client.js` in a consumer's server build and killed the demo's no-`--conditions` production server |
| `19.2.15` | the `"use server"` gate stopped seeing directives in **nested functions** — React's canonical inline Server Function — so those modules were never transformed at all |
| `0.0.0-experimental-12a4baec-20260707` | the filename bug |
| `0.0.0-experimental-c0c39a6b-20260709` | the nested-directive bug (deprecated; superseded by `.1`, which carries 19.2.16's transformer) |

Verified with semver — all six excluded, both fixed versions admitted:

```
excluded ✓  19.2.12 / 19.2.13 / 19.2.14 / 19.2.15
excluded ✓  0.0.0-experimental-12a4baec-20260707
excluded ✓  0.0.0-experimental-c0c39a6b-20260709
admitted ✓  19.2.16
admitted ✓  0.0.0-experimental-c0c39a6b-20260709.1
```

## Why the experimental half is an exact pin

Not a `>=`. Semver compares prerelease identifiers **lexically**, and git shas are random hex — so a *newer* React build whose sha starts with a low character sorts **below** an older one, and a `>=` range keeps admitting the very builds it means to exclude:

```js
semver.gt("0.0.0-experimental-0abc123-20260801",
          "0.0.0-experimental-12a4baec-20260707")  // false — despite being months newer
```

An exact pin is the only reliable exclusion on that train. It also matches the train's own model: the experimental peer is an exact React build, so the rsl that vendors it is exact too.

Full suite green: **119 / 62 / 63 / 8**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)