### PR TITLE
fix(client): read the inlined flight payload only once the document is parsed (3.1.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -9,16 +9,55 @@ import { INLINE_FLIGHT_ID } from "./inlineFlightId.js";
 // load, i.e. the initial route's render — then fall back to the network for
 // client navigations, whose payloads aren't inlined.
 let inlineFlightConsumed = false;
-function takeInlineFlight(): Uint8Array | null {
-  if (inlineFlightConsumed || typeof document === "undefined") return null;
-  const el = document.getElementById(INLINE_FLIGHT_ID);
-  const encoded = el?.textContent?.trim();
+
+function decodeInlineFlight(el: Element): Uint8Array | null {
+  const encoded = el.textContent?.trim();
   if (!encoded) return null;
-  inlineFlightConsumed = true;
   const binary = atob(encoded);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
   return bytes;
+}
+
+/**
+ * Take the inlined payload, if this document carries one.
+ *
+ * Resolves to `null` when there is nothing to take, in which case the caller
+ * fetches `index.rsc` as usual.
+ *
+ * THE PAYLOAD IS THE TEXT OF AN INLINE `<script>`, and the client entry is an
+ * `async` module — its execution is not ordered against the HTML parser. When
+ * the entry is already in cache (a repeat visit, or a navigation away from a
+ * still-loading page) it can run WHILE THE PARSER IS STILL STREAMING TEXT INTO
+ * THAT ELEMENT. `textContent` then holds only the bytes parsed so far, and
+ * decoding it yields a truncated flight stream: React reaches the end of an
+ * incomplete payload and throws "Connection closed" (#412), which the caller
+ * can only degrade on — leaving the page un-hydrated until a reload.
+ *
+ * An element's text is guaranteed complete once the document is parsed, so when
+ * the parser is still running we wait for it. That wait only ever applies to
+ * this inline read: the payload element sits near the end of the body, so a
+ * parser that has not finished has, at most, the document's tail left to go.
+ * The network path below is untouched and still starts its fetch immediately.
+ */
+function takeInlineFlight(): Uint8Array | PromiseLike<Uint8Array | null> | null {
+  if (inlineFlightConsumed || typeof document === "undefined") return null;
+  const el = document.getElementById(INLINE_FLIGHT_ID);
+  // No element: either this document has no inlined payload, or the parser has
+  // not reached it yet. Both are served correctly by fetching index.rsc, which
+  // the static build emits alongside the inlined copy.
+  if (!el) return null;
+  inlineFlightConsumed = true;
+  if (document.readyState === "loading") {
+    return new Promise<Uint8Array | null>((resolve) => {
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => resolve(decodeInlineFlight(el)),
+        { once: true }
+      );
+    });
+  }
+  return decodeInlineFlight(el);
 }
 
 export function createReactFetcher({
@@ -62,30 +101,43 @@ export function createReactFetcher({
   // imported lazily so this module stays import-safe under the `react-server`
   // condition (a static import of client.browser would drag react-dom/client
   // into the server graph).
-  const inlineFlight = takeInlineFlight();
-  let content: PromiseLike<React.ReactNode>;
-  if (inlineFlight) {
-    content = import("react-server-dom-esm/client.browser").then(
+  const fromInline = (bytes: Uint8Array): PromiseLike<React.ReactNode> =>
+    import("react-server-dom-esm/client.browser").then(
       ({ createFromReadableStream }) =>
         createFromReadableStream(
           new ReadableStream<Uint8Array>({
             start(controller) {
-              controller.enqueue(inlineFlight);
+              controller.enqueue(bytes);
               controller.close();
             },
           }),
           decodeOptions
         )
     );
-  } else {
+
+  const fromNetwork = (): PromiseLike<React.ReactNode> => {
     // Start the fetch immediately, before the dynamic import resolves.
     const responsePromise = fetch(parsedURL.indexRSC, {
       headers: headers,
       signal,
     });
-    content = import("react-server-dom-esm/client.browser").then(
+    return import("react-server-dom-esm/client.browser").then(
       ({ createFromFetch }) => createFromFetch(responsePromise, decodeOptions)
     );
+  };
+
+  const inlineFlight = takeInlineFlight();
+  let content: PromiseLike<React.ReactNode>;
+  if (inlineFlight instanceof Uint8Array) {
+    content = fromInline(inlineFlight);
+  } else if (inlineFlight) {
+    // Deferred to DOMContentLoaded: the payload was still being parsed. If it
+    // turns out to be empty after all, fall back to the network.
+    content = Promise.resolve(inlineFlight).then((bytes) =>
+      bytes ? fromInline(bytes) : fromNetwork()
+    );
+  } else {
+    content = fromNetwork();
   }
   if (!signal) {
     return content;

--- a/test/unit/createReactFetcher.test.ts
+++ b/test/unit/createReactFetcher.test.ts
@@ -117,3 +117,130 @@ describe("createReactFetcher cancellation semantics", () => {
     await expect(Promise.resolve(content)).rejects.toThrow("network down");
   });
 });
+
+/**
+ * Reading the inlined flight payload.
+ *
+ * The payload is the TEXT of an inline `<script>` near the end of the body, and
+ * the client entry is an `async` module — so a cached entry can execute while the
+ * parser is still streaming text into that element. Reading `textContent` then
+ * yields a TRUNCATED payload, React hits the end of an incomplete flight stream
+ * and throws "Connection closed" (#412), and the page never hydrates.
+ *
+ * These pin the read to a point where the text is guaranteed complete: the
+ * fetcher must not touch `textContent` while `readyState === "loading"`.
+ */
+const PAYLOAD = Buffer.from('0:"ok"\n').toString("base64");
+
+function stubParsingDocument(initial: "loading" | "complete") {
+  const listeners: Record<string, Array<() => void>> = {};
+  /** readyState captured at each `textContent` access — when the read happened. */
+  const readsAt: string[] = [];
+  let state = initial;
+  /** Mid-parse, the element holds only the bytes seen so far. */
+  let text = initial === "loading" ? PAYLOAD.slice(0, 4) : PAYLOAD;
+
+  const el = {
+    get textContent() {
+      readsAt.push(state);
+      return text;
+    },
+  };
+
+  const document = {
+    get readyState() {
+      return state;
+    },
+    getElementById: (id: string) => (id === "vprs-flight" ? el : null),
+    addEventListener: (type: string, cb: () => void) => {
+      (listeners[type] ??= []).push(cb);
+    },
+  };
+
+  return {
+    document,
+    readsAt,
+    /** The parser finishes: the element's text is now whole. */
+    finishParsing() {
+      state = "complete";
+      text = PAYLOAD;
+      for (const cb of listeners["DOMContentLoaded"] ?? []) cb();
+    },
+  };
+}
+
+describe("createReactFetcher inline flight payload", () => {
+  beforeEach(() => {
+    // The fetcher consumes the inlined payload once per module instance.
+    vi.resetModules();
+  });
+
+  it("does NOT read the payload while the document is still parsing", async () => {
+    const createReactFetcher = await importFetcher();
+    const dom = stubParsingDocument("loading");
+    vi.stubGlobal("document", dom.document);
+    globalThis.fetch = vi.fn(async () => flightResponse()) as any;
+
+    const content = createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost",
+    });
+    // Swallow the decode: react-server-dom is not the subject here.
+    Promise.resolve(content).then(
+      () => {},
+      () => {}
+    );
+
+    // The element exists, so the inlined payload is claimed — but its text must
+    // NOT have been touched yet, because it is still being written.
+    expect(dom.readsAt).toEqual([]);
+    // ...and it must not have silently fallen back to the network either.
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    dom.finishParsing();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Read exactly once, and only after the document was parsed.
+    expect(dom.readsAt).toEqual(["complete"]);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("reads the payload immediately when the document is already parsed", async () => {
+    const createReactFetcher = await importFetcher();
+    const dom = stubParsingDocument("complete");
+    vi.stubGlobal("document", dom.document);
+    globalThis.fetch = vi.fn(async () => flightResponse()) as any;
+
+    const content = createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost",
+    });
+    Promise.resolve(content).then(
+      () => {},
+      () => {}
+    );
+
+    expect(dom.readsAt).toEqual(["complete"]);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches index.rsc when the document carries no inlined payload", async () => {
+    const createReactFetcher = await importFetcher();
+    vi.stubGlobal("document", {
+      readyState: "complete",
+      getElementById: () => null,
+      addEventListener: () => {},
+    });
+    globalThis.fetch = vi.fn(async () => flightResponse()) as any;
+
+    createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost",
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## The bug

With `build.inlineFlight`, the initial route's payload ships as the **text of an inline `<script id="vprs-flight">`** near the end of the body. `createReactFetcher` read that text the moment it ran.

The client entry is an **`async` module**, so its execution is not ordered against the HTML parser. When the entry is already in cache — a repeat visit, or navigating away from a still-loading page — it can run **while the parser is still streaming text into that element**. `textContent` then returns only the bytes parsed so far, we decode a truncated payload, and React reaches the end of an incomplete flight stream and throws **"Connection closed" (#412)**.

Callers can only degrade on that. `hydrateOrRender` catches it and leaves the prerendered HTML in place, so the failure is **silent**: content renders, but the app never hydrates and client-side navigation is dead until a manual reload.

## Evidence

Measured on a production consumer (mmcelebration.com) by patching `document.getElementById` before any page script and recording the payload length at read time:

| scenario | payload read | result |
|---|---|---|
| direct load | `readyState: "interactive"` — **22088** of 22088 chars | hydrates |
| navigate mid-load | `readyState: "loading"` — **1319** of 22088 chars | #412, stays static |

The assets are not corrupt (full transfer/decoded sizes), a direct load of the same page hydrates fine, and a reload recovers. Same bytes, different timing — a read-time race.

**The trigger is a warm module cache plus slow HTML, not any user action.** A cached async entry executes immediately and beats the parser to the payload; clicking mid-load merely manufactures that state (the abandoned document warms the JS, then the destination HTML arrives over a slow pipe). A repeat visitor on a poor connection can hit this without interacting at all.

## The fix

An element's text is only guaranteed complete once the document is parsed, so when the parser is still running we wait for `DOMContentLoaded` before reading.

The wait applies **only** to this inline read. The payload element sits near the end of the body, so a parser that has not finished has at most the document's tail left to go. Unchanged:

- the **network path** still starts its `fetch` immediately (no added latency for apps without an inlined payload);
- a document with **no** payload element still falls straight through to `index.rsc`, which the static build emits alongside the inlined copy;
- the payload is still consumed exactly once.

## Tests

New regression coverage in `test/unit/createReactFetcher.test.ts` — the inline read had **no** coverage before, which is how this shipped:

- does NOT touch the payload's text while `readyState === "loading"`, and reads it exactly once after `DOMContentLoaded` (and does not silently fall back to the network in the meantime)
- reads immediately when the document is already parsed
- fetches `index.rsc` when there is no inlined payload

The first fails on the previous implementation with `expected [ 'loading' ] to deeply equal []`.

## Gates

- `test:unit` — 569 passed
- `test:server` — 780 passed
- `test:client` — 238 passed
- `build` — clean

`test:e2e`: 2 pre-existing failures in `dev-client-imported-server-fn.spec.ts` reproduce identically on `main` (unrelated to this change); the `hmr.spec.ts` CSS assertion is a flake under full-suite load and passes in isolation on this branch.

Version bumped to **3.1.5**.