### PR TITLE
fix(stream): keep vite out of the runtime /stream barrel

### DIFF
--- a/plugin/stream/createRscStream.utils.ts
+++ b/plugin/stream/createRscStream.utils.ts
@@ -7,7 +7,30 @@ import type {
   BaseRscStreamResult,
 } from "./createRscStream.types.js";
 import type { PassThrough } from "node:stream";
-import { createLogger, type Logger } from "vite";
+import type { Logger } from "vite";
+
+/**
+ * Console fallback for `setupRscStreamEventHandlers`, used instead of vite's
+ * `createLogger()`.
+ *
+ * This module is reachable from the `/stream` barrel, which a consumer imports
+ * AT RUNTIME to build a request handler (`createEdgeHandler`). A value import of
+ * `vite` here therefore pulls vite — and with it rollup and esbuild — into that
+ * runtime. On a serverless platform that breaks the deploy outright: the file
+ * tracer cannot follow rollup's dynamic require of its native binding, so the
+ * function ships without it and throws on first import.
+ *
+ * The `Logger` type import above is erased at build time and costs nothing.
+ */
+const consoleLogger: Logger = {
+  info: (msg) => console.log(msg),
+  warn: (msg) => console.warn(msg),
+  warnOnce: (msg) => console.warn(msg),
+  error: (msg) => console.error(msg),
+  clearScreen: () => {},
+  hasErrorLogged: () => false,
+  hasWarned: false,
+};
 
 /**
  * Validates common RSC stream options
@@ -115,7 +138,7 @@ export function setupRscStreamEventHandlers(
     logger?: Logger;
   }
 ): () => void {
-  const { route, verbose = false, logger = createLogger() } = options;
+  const { route, verbose = false, logger = consoleLogger } = options;
 
   stream.on("data", (chunk: Buffer) => {
     if (verbose) {


### PR DESCRIPTION
## The bug

`plugin/stream/createRscStream.utils.ts` defaulted its logger to vite's `createLogger()`:

```ts
const { route, verbose = false, logger = createLogger() } = options;
```

That was the last value-level import of `vite` in a graph consumers load **at runtime**.

`/stream` is a barrel, so importing `createEdgeHandler` from it evaluates every sibling module — including this one — and drags `vite`, and with it **rollup and esbuild**, into the request handler. `createEdgeHandler` never touches this module: it imports only `getCondition`, `inlineFlight` and `renderFlightToHtml`.

## Why it's more than bloat

On a serverless platform this **breaks the deploy outright**. The file tracer can't follow rollup's dynamic require of its native binding, so the function ships without `@rollup/rollup-<platform>` and throws `ERR_MODULE_NOT_FOUND` the moment it's imported.

Nothing fails at build time. The deploy goes green and then every request 500s — which is exactly how it presented.

## The fix

Default to a small console logger. The `Logger` **type** import stays; it's erased at build time and costs nothing.

## Verification

- Full suite green: `npm test` → 783 passed / 33 skipped, and `test:typecheck` → no errors.
- Measured against vprs-starter's real Vercel function bundle (`vercel build`), before → after:
  - traced packages: **17 → 6** (`vite`, `rollup`, `esbuild`, `postcss`, `tsx` all drop out)
  - the built function, run **isolated from the repo** the way the platform runs it: previously threw `ERR_MODULE_NOT_FOUND` on import; now returns 200 and server-renders the route, with the request's geo headers in the HTML and the flight inlined.

Unblocks per-request (serverless/edge) rendering for consumers — a starter can't ship it until this is released.