### PR TITLE
chore(release): 3.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Publishes the `/stream` runtime-barrel fix from #244, which merged after the v3.1.6 tag and so never reached npm. The currently published 3.1.6 still carries the bug.

## What ships
`createRscStream.utils.ts` no longer defaults its logger to vite's `createLogger()` — the one value-level `import ... from "vite"` reachable from the `/stream` barrel. Because `createEdgeHandler` is imported from that barrel, the import dragged vite (and, on Vite 6 and 7, rollup + esbuild) into the request handler at runtime.

On a serverless platform this broke the deploy outright: the file tracer can't follow rollup's dynamic require of its native binding, so the function shipped without `@rollup/rollup-<platform>` and threw `ERR_MODULE_NOT_FOUND` on first import — deploy green, every request 500. Measured on the starter's function bundle: 17 traced packages → 6.

Vite 8 (rolldown) lists neither rollup nor esbuild, so it was spared the deploy break; the runtime `import "vite"` was still needless weight there.

## Scope
Version bump only (`package.json` + `package-lock.json`, 3.1.6 → 3.1.7). The code change is already on `main` via #244; this is the release commit that publishes it. `build` + `verify:package` gate passes.