### PR TITLE
fix(build): mark preserveModules node_modules chunks as ESM

### DIFF
--- a/plugin/environments/createVendoredPackageJsonPlugin.ts
+++ b/plugin/environments/createVendoredPackageJsonPlugin.ts
@@ -27,9 +27,13 @@ export const resolveVendoredPackageDir = (fileName: string): string | null => {
 };
 
 /**
- * Rollup's `preserveModules` lays dependency chunks out under
+ * `preserveModules` lays dependency chunks out under
  * `<outDir>/node_modules/<pkg>/…` but copies none of those packages' own
- * `package.json`. The chunks are ESM (`export { Link }`), and with no local
+ * `package.json`. Holds for both bundlers in vprs's peer range — rollup on
+ * Vite 6/7, rolldown on Vite 8 — which share the option and the
+ * `generateBundle`/`emitFile` API this relies on.
+ *
+ * The chunks are ESM (`export { Link }`), and with no local
  * `"type": "module"` Node decides their format from the nearest PARENT
  * package.json.
  *
@@ -44,6 +48,10 @@ export const resolveVendoredPackageDir = (fileName: string): string | null => {
  * Stamping a minimal package.json into each vendored package dir makes the
  * chunks unambiguously ESM wherever they run. Emitted as a build asset rather
  * than written post-build so it lands through the normal output pipeline.
+ *
+ * Node 22.12+/23+ detect the chunk as ESM from its syntax regardless, which
+ * masks the bug — don't take a passing load on a modern runtime as proof this
+ * is unnecessary.
  */
 export const createVendoredPackageJsonPlugin = (): Plugin => {
   return {
@@ -62,8 +70,8 @@ export const createVendoredPackageJsonPlugin = (): Plugin => {
 
       for (const dir of packageDirs) {
         const fileName = `${dir}/package.json`;
-        // Never clobber a package.json the build already produced — rollup
-        // would also throw on the duplicate fileName.
+        // Never clobber a package.json the build already produced — the
+        // bundler would also throw on the duplicate fileName.
         if (bundle[fileName]) continue;
         this.emitFile({
           type: "asset",

--- a/plugin/environments/createVendoredPackageJsonPlugin.ts
+++ b/plugin/environments/createVendoredPackageJsonPlugin.ts
@@ -1,0 +1,76 @@
+import type { Plugin } from "vite";
+
+/**
+ * Derives the vendored package directory containing `fileName`, or `null` if
+ * the file doesn't live under a `node_modules/` segment.
+ *
+ * Uses the LAST `node_modules/` segment so a nested dependency
+ * (`node_modules/a/node_modules/b/x.js`) resolves to the innermost package —
+ * that's the directory whose `package.json` Node consults first.
+ *
+ * Scoped packages (`@scope/name`) span two segments.
+ */
+export const resolveVendoredPackageDir = (fileName: string): string | null => {
+  const marker = "node_modules/";
+  const at = fileName.lastIndexOf(marker);
+  if (at === -1) return null;
+
+  const start = at + marker.length;
+  const segments = fileName.slice(start).split("/");
+  const depth = segments[0]?.startsWith("@") ? 2 : 1;
+  // Needs the package segment(s) AND at least one file below them; otherwise
+  // there is no chunk here to govern.
+  if (segments.length <= depth) return null;
+  if (segments.slice(0, depth).some((s) => !s)) return null;
+
+  return fileName.slice(0, start) + segments.slice(0, depth).join("/");
+};
+
+/**
+ * Rollup's `preserveModules` lays dependency chunks out under
+ * `<outDir>/node_modules/<pkg>/…` but copies none of those packages' own
+ * `package.json`. The chunks are ESM (`export { Link }`), and with no local
+ * `"type": "module"` Node decides their format from the nearest PARENT
+ * package.json.
+ *
+ * From the project root that's ours (type:module) and it works. A serverless
+ * function ships only the build output, so the root package.json is not
+ * co-located, the function scope defaults to CommonJS, and Node reads the
+ * chunks as CJS: named exports vanish, `import { Link } from ".../link.js"`
+ * throws "does not provide an export named 'Link'", the island fails to
+ * instantiate during SSR, and the document degrades to a shell with no #root.
+ * Build is green and the deploy is READY — it only fails in the function.
+ *
+ * Stamping a minimal package.json into each vendored package dir makes the
+ * chunks unambiguously ESM wherever they run. Emitted as a build asset rather
+ * than written post-build so it lands through the normal output pipeline.
+ */
+export const createVendoredPackageJsonPlugin = (): Plugin => {
+  return {
+    name: "vite-plugin-react-server:vendored-package-json",
+    enforce: "post",
+    apply: "build",
+
+    generateBundle(_outputOptions, bundle) {
+      // Every vprs build environment emits `format: "esm"`, so this holds for
+      // whichever output we're stamping.
+      const packageDirs = new Set<string>();
+      for (const fileName of Object.keys(bundle)) {
+        const dir = resolveVendoredPackageDir(fileName);
+        if (dir) packageDirs.add(dir);
+      }
+
+      for (const dir of packageDirs) {
+        const fileName = `${dir}/package.json`;
+        // Never clobber a package.json the build already produced — rollup
+        // would also throw on the duplicate fileName.
+        if (bundle[fileName]) continue;
+        this.emitFile({
+          type: "asset",
+          fileName,
+          source: `${JSON.stringify({ type: "module" })}\n`,
+        });
+      }
+    },
+  };
+};

--- a/plugin/orchestrator/createPluginOrchestrator.impl.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.impl.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "vite";
 import { createEnvironmentPlugin } from "../environments/createEnvironmentPlugin.js";
 import { createBuildEventPlugin } from "../environments/createBuildEventPlugin.js";
+import { createVendoredPackageJsonPlugin } from "../environments/createVendoredPackageJsonPlugin.js";
 import { createTransformerPlugin } from "../transformer/createTransformerPlugin.js";
 import { serverReferenceClientPlugin } from "../transformer/serverReferenceClientPlugin.js";
 import { virtualRscHmrPlugin } from "../dev-server/virtualRscHmrPlugin.js";
@@ -67,6 +68,11 @@ export const createPluginOrchestratorImpl = (
     availableEnvironments;
   plugins.push(createEnvironmentPlugin(userOptions));
   plugins.push(createBuildEventPlugin(userOptions));
+
+  // Mark `preserveModules`-emitted dependency chunks under `node_modules/` as
+  // ESM, so they still parse as ESM where the root package.json isn't
+  // co-located (serverless functions ship only the build output).
+  plugins.push(createVendoredPackageJsonPlugin());
 
   const devServerPlugins = strategy.devServerPlugin(userOptions);
   if (Array.isArray(devServerPlugins)) {

--- a/test/unit/vendoredPackageJson.test.ts
+++ b/test/unit/vendoredPackageJson.test.ts
@@ -36,7 +36,7 @@ describe("environments/resolveVendoredPackageDir", () => {
   });
 });
 
-/** Minimal stand-in for the rollup plugin context `generateBundle` runs under. */
+/** Minimal stand-in for the plugin context `generateBundle` runs under. */
 const runGenerateBundle = (fileNames: string[]) => {
   const plugin = createVendoredPackageJsonPlugin();
   const bundle = Object.fromEntries(
@@ -72,8 +72,8 @@ describe("environments/createVendoredPackageJsonPlugin", () => {
   });
 
   it("does not clobber a package.json the build already emitted", () => {
-    // Rollup throws on a duplicate fileName, so a real package.json in the
-    // bundle must win.
+    // The bundler throws on a duplicate fileName, so a real package.json in
+    // the bundle must win.
     const emitFile = runGenerateBundle([
       "node_modules/pkg/dist/x.js",
       "node_modules/pkg/package.json",

--- a/test/unit/vendoredPackageJson.test.ts
+++ b/test/unit/vendoredPackageJson.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createVendoredPackageJsonPlugin,
+  resolveVendoredPackageDir,
+} from "../../plugin/environments/createVendoredPackageJsonPlugin.js";
+
+describe("environments/resolveVendoredPackageDir", () => {
+  it("returns null for output outside node_modules", () => {
+    expect(resolveVendoredPackageDir("assets/index-a1b2.js")).toBeNull();
+    expect(resolveVendoredPackageDir("src/page.js")).toBeNull();
+  });
+
+  it("resolves an unscoped package dir", () => {
+    expect(
+      resolveVendoredPackageDir("node_modules/vite-plugin-react-server/dist/link.js")
+    ).toBe("node_modules/vite-plugin-react-server");
+  });
+
+  it("resolves a scoped package dir across both segments", () => {
+    expect(
+      resolveVendoredPackageDir("node_modules/@chakra-ui/react/dist/x.js")
+    ).toBe("node_modules/@chakra-ui/react");
+  });
+
+  it("resolves the INNERMOST package for a nested dependency", () => {
+    // Node consults the nearest parent package.json, so a nested dep's own
+    // directory is the one that governs its chunks.
+    expect(
+      resolveVendoredPackageDir("node_modules/a/node_modules/b/dist/x.js")
+    ).toBe("node_modules/a/node_modules/b");
+  });
+
+  it("returns null when there is no file below the package segments", () => {
+    expect(resolveVendoredPackageDir("node_modules/pkg")).toBeNull();
+    expect(resolveVendoredPackageDir("node_modules/@scope/pkg")).toBeNull();
+  });
+});
+
+/** Minimal stand-in for the rollup plugin context `generateBundle` runs under. */
+const runGenerateBundle = (fileNames: string[]) => {
+  const plugin = createVendoredPackageJsonPlugin();
+  const bundle = Object.fromEntries(
+    fileNames.map((f) => [f, { type: "chunk", fileName: f }])
+  );
+  const emitFile = vi.fn();
+  const hook = plugin.generateBundle;
+  const handler = typeof hook === "function" ? hook : hook?.handler;
+  handler?.call({ emitFile } as never, {} as never, bundle as never, false);
+  return emitFile;
+};
+
+describe("environments/createVendoredPackageJsonPlugin", () => {
+  it("stamps one type:module package.json per vendored package", () => {
+    const emitFile = runGenerateBundle([
+      "node_modules/vite-plugin-react-server/dist/link.js",
+      "node_modules/vite-plugin-react-server/dist/router-react.js",
+      "node_modules/@chakra-ui/react/dist/x.js",
+      "assets/index-a1b2.js",
+    ]);
+
+    expect(emitFile).toHaveBeenCalledTimes(2);
+    const emitted = emitFile.mock.calls.map(([c]) => c.fileName);
+    expect(emitted).toContain("node_modules/vite-plugin-react-server/package.json");
+    expect(emitted).toContain("node_modules/@chakra-ui/react/package.json");
+    expect(JSON.parse(emitFile.mock.calls[0][0].source)).toEqual({
+      type: "module",
+    });
+  });
+
+  it("emits nothing when no chunk lands under node_modules", () => {
+    expect(runGenerateBundle(["assets/index-a1b2.js"])).not.toHaveBeenCalled();
+  });
+
+  it("does not clobber a package.json the build already emitted", () => {
+    // Rollup throws on a duplicate fileName, so a real package.json in the
+    // bundle must win.
+    const emitFile = runGenerateBundle([
+      "node_modules/pkg/dist/x.js",
+      "node_modules/pkg/package.json",
+    ]);
+    expect(emitFile).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The bug

`preserveModules` lays dependency chunks out under `<outDir>/node_modules/<pkg>/…` but copies none of those packages' own `package.json`. Those chunks are ESM (`export { Link }`), and with no local `"type": "module"` Node decides their format from the nearest **parent** package.json.

From the project root that's ours (`type: module`) and everything works. A serverless function ships only the build output (e.g. `includeFiles: dist/**`), so the root package.json isn't co-located and the function scope defaults to CommonJS. Node then reads the chunk as CJS, its named exports vanish, and `import { Link } from ".../link.js"` throws `does not provide an export named 'Link'`. The island fails to instantiate during SSR, the document render degrades to a shell with no `#root`, the client throws `startClient: #root element not found`, and the page is blank.

What makes it expensive: the build is green and the deploy is READY. It fails only inside the function, so nothing points at the cause.

## The fix

Emit a minimal `{"type":"module"}` package.json into each vendored package dir, so the chunks are unambiguously ESM wherever they run. Emitted as a build **asset** (`generateBundle` → `emitFile`) rather than a post-build fs write, so it lands through the normal output pipeline. A package.json the build already produced is never clobbered — the bundler would throw on the duplicate fileName anyway.

Path derivation handles scoped packages (`@scope/name` spans two segments) and nested deps (`node_modules/a/node_modules/b/…` resolves to the innermost package, which is the one Node consults first).

## Verification

Unit tests cover the derivation and the emit. The runtime behaviour needed more care, because two separate things mask it locally:

**1. Both bundlers.** vprs peers `vite ^6.3.5 || ^7 || ^8`, and Vite 8 bundles with **rolldown**, not rollup. Both implement `preserveModules` and the `generateBundle`/`emitFile` API this relies on, but that's an assumption worth testing rather than asserting. Built a real consumer (vprs-starter) with its own local workaround removed, so only the upstream fix could stamp. It landed on both:

| | bundler | stamp emitted |
|---|---|---|
| Vite 7.3.6 | rollup 4.62.2 | ✅ |
| Vite 8.1.4 | rolldown 1.1.5 | ✅ |

**2. Node syntax detection.** Reproduced the serverless scope (only the build output, no root package.json above it) and A/B'd the chunk load. On Node 22.12+/23+ **both sides pass** — those runtimes detect the chunk as ESM from its syntax regardless of any package.json, so the bug is masked and a naive repro looks like a non-repro. Under `--no-experimental-detect-module` the A/B separates cleanly: without the stamp the chunk fails to load as ESM, with it `Link` exports fine.

So this is **latent on newer runtimes** and bites ones without detection. Worth fixing either way — correctness here shouldn't depend on a runtime's detection heuristic — but it's a narrower blast radius than "every serverless deploy is broken".

Full suite green (791 passed) + typecheck clean.

## Follow-up

vprs-starter currently stamps this itself in `scripts/emit-client-entry.mjs` as a workaround. Once this releases, that workaround should be deleted rather than merged into the official starter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)