### PR TITLE
chore(release): 3.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release. Bumps `package.json` + `package-lock.json` to **3.1.8**; no code changes.

## Ships

- **#246** — `fix(build): mark preserveModules node_modules chunks as ESM`. Vendored dependency chunks under `<outDir>/node_modules/<pkg>/…` now get a minimal `{"type":"module"}` package.json, so they still parse as ESM where the root package.json isn't co-located. Without it a serverless function reads them as CJS, named exports vanish, the SSR island fails to instantiate, and the page renders blank off a green build and a READY deploy.

  Verified on both bundlers in the peer range (vite 7 / rollup 4.62.2 and vite 8 / rolldown 1.1.5). Note the bug is latent on Node 22.12+/23+, which detect ESM from syntax regardless of package.json.

## Release checklist

- [ ] Merge this PR
- [ ] Tag `v3.1.8` (annotated) on the merge commit, and push the tag
- [ ] `npm publish` (`prepublishOnly` runs build + `verify:package`)

⚠️ **`v3.1.7` was never tagged** — it published to npm but has no tag locally or on the remote. Backfilled at `0a15166`, the commit that matches the published 3.1.7 tarball (contains #244, not #246). Worth noting `bump-version.mjs` only edits package.json/package-lock; it does not tag, so this step is manual every time and is easy to miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)