### PR TITLE
fix(static): keep build.pages authoritative over vite's index.html entry

### DIFF
--- a/plugin/react-static/fileWriter.ts
+++ b/plugin/react-static/fileWriter.ts
@@ -12,6 +12,18 @@
 import { join } from "node:path";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { Transform, PassThrough } from "node:stream";
+
+/**
+ * Maps a route to its output directory, relative to the static dir: `/` writes
+ * to the root, `/about` to `about/`.
+ *
+ * Exported because this rule decides which route owns `<staticDir>/index.html`,
+ * and `pruneUnclaimedEntryHtml` has to ask that question with the SAME rule the
+ * writer answers it with. Two copies would drift and the prune would delete a
+ * real page.
+ */
+export const routeToOutputDir = (route: string): string =>
+  route === "/" ? "" : route.replace(/^\//, "");
 import type { FileWriterFn } from "./types.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
 import { handleError } from "../error/handleError.js";
@@ -97,9 +109,7 @@ export const fileWriter: FileWriterFn = function _fileWriter(
   const isStreamWrapper =
     (stream as any).pipe && typeof (stream as any).pipe === "function";
 
-  // Remove leading slash from route for file path construction
-  const routePath =
-    options.route === "/" ? "" : options.route.replace(/^\//, "");
+  const routePath = routeToOutputDir(options.route);
   const baseDir = join(options.build.outDir, options.build.static);
   const outputPath = join(
     baseDir,

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -49,6 +49,7 @@ import { createWorkerStartupMetrics } from "../metrics/createWorkerStartupMetric
 import { processCssFilesForPages } from "./processCssFilesForPages.js";
 import { createBuildLoader } from "./createBuildLoader.client.js";
 import { maybeInlineFlight } from "./maybeInlineFlight.js";
+import { pruneUnclaimedEntryHtml } from "./pruneUnclaimedEntryHtml.js";
 import { getNodeEnv } from "../config/getNodeEnv.js";
 import { toError } from "../error/toError.js";
 import {
@@ -786,6 +787,17 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         if (userOptions.verbose) {
           logger?.info("[react-static-client] Static generation completed");
         }
+
+        // Keep build.pages authoritative: drop Vite's bare index.html template
+        // when no page claims "/". Runs before the inline pass so nothing
+        // downstream walks a shell SSG never wrote. The server-static plugin
+        // runs the SAME call at the same point (both build modes identical).
+        await pruneUnclaimedEntryHtml({
+          build: userOptions.build,
+          pages: Array.from(autoDiscoveredFiles?.urlMap.keys() ?? []),
+          logger,
+          verbose: userOptions.verbose,
+        });
 
         // Flash-free first render: inline each route's flight payload if
         // build.inlineFlight is enabled. The server-static plugin runs the

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -46,6 +46,7 @@ import { handleError } from "../error/handleError.js";
 import { shouldCausePanic } from "../error/panicThresholdHandler.js";
 import { renderPage } from "./renderPage.server.js";
 import { maybeInlineFlight } from "./maybeInlineFlight.js";
+import { pruneUnclaimedEntryHtml } from "./pruneUnclaimedEntryHtml.js";
 import { temporaryReferences } from "./temporaryReferences.server.js";
 import { configurePreviewServer } from "./configurePreviewServer.js";
 import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
@@ -538,6 +539,17 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         this.info(
           `Rendered ${finalResult.completedRoutes.size} pages in ${duration}ms`
         );
+
+        // Keep build.pages authoritative: drop Vite's bare index.html template
+        // when no page claims "/". Runs before the inline pass so nothing
+        // downstream walks a shell SSG never wrote. The client-static plugin
+        // runs the SAME call at the same point (both build modes identical).
+        await pruneUnclaimedEntryHtml({
+          build: userOptions.build,
+          pages: Array.from(autoDiscoveredFiles?.urlMap.keys() ?? []),
+          logger,
+          verbose: userOptions.verbose,
+        });
 
         // Flash-free first render: inline each route's flight payload if
         // build.inlineFlight is enabled. The client-static plugin runs the

--- a/plugin/react-static/pruneUnclaimedEntryHtml.ts
+++ b/plugin/react-static/pruneUnclaimedEntryHtml.ts
@@ -1,0 +1,79 @@
+/**
+ * pruneUnclaimedEntryHtml.ts
+ *
+ * Shared post-SSG step invoked by BOTH static plugins (server-static and
+ * client-static) at the same point, alongside `maybeInlineFlight`.
+ *
+ * `index.html` is a Vite build INPUT (it is what keys the client bootstrap in
+ * the manifest), so Vite emits it into the static outDir on every build. When a
+ * page claims `/`, SSG overwrites it with the prerendered document and all is
+ * well — which is why this is invisible in a normal static build.
+ *
+ * When `build.pages` does NOT claim `/`, nothing overwrites it and Vite's bare
+ * template survives into the output: an empty `<div id="root">` with no flight.
+ * `build.pages` is authoritative about which pages exist, so a file left at a
+ * path no page claims is a build intermediate leaking into the served output.
+ * On any host that matches the filesystem before applying a rewrite, that shell
+ * shadows the per-request route and the render function is never reached.
+ *
+ * Removing it here — where the page list is known — keeps `build.pages`
+ * authoritative and means consumers don't hand-roll a post-build delete pass.
+ * Note this deliberately teaches vprs nothing about any deploy target: it is
+ * about not publishing our own intermediate, not about anyone's routing rules.
+ */
+import { unlink } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { Logger } from "vite";
+import { routeToOutputDir } from "./fileWriter.js";
+
+export interface PruneUnclaimedEntryHtmlOptions {
+  build: {
+    outDir?: string;
+    static?: string;
+    htmlOutputPath?: string;
+  };
+  /**
+   * The routes SSG rendered (the resolved `build.pages`, i.e. `urlMap` keys).
+   */
+  pages: readonly string[];
+  logger?: Logger;
+  verbose?: boolean;
+}
+
+/**
+ * Returns the removed path, or `null` when there was nothing to prune.
+ */
+export async function pruneUnclaimedEntryHtml(
+  options: PruneUnclaimedEntryHtmlOptions
+): Promise<string | null> {
+  const { build, pages } = options;
+
+  // No SSG at all: `build.pages` isn't claiming anything either way, so the
+  // template is the deliverable — a client-only app's SPA shell is the whole
+  // point of that build. Only prune when SSG ran and still left `/` unclaimed.
+  if (pages.length === 0) return null;
+
+  // Same rule the writer uses, so "claimed" means exactly "SSG wrote here".
+  if (pages.some((page) => routeToOutputDir(page) === "")) return null;
+
+  const entryHtml = resolve(
+    build.outDir ?? "dist",
+    build.static ?? "static",
+    build.htmlOutputPath ?? "index.html"
+  );
+
+  try {
+    await unlink(entryHtml);
+  } catch (error) {
+    // Already absent is the desired state, not a failure.
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw error;
+  }
+
+  if (options.verbose) {
+    options.logger?.info(
+      `[vprs] removed ${entryHtml} — no page in build.pages claims "/"`
+    );
+  }
+  return entryHtml;
+}

--- a/test/unit/pruneUnclaimedEntryHtml.test.ts
+++ b/test/unit/pruneUnclaimedEntryHtml.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pruneUnclaimedEntryHtml } from "../../plugin/react-static/pruneUnclaimedEntryHtml.js";
+import { routeToOutputDir } from "../../plugin/react-static/fileWriter.js";
+
+const exists = async (p: string) =>
+  await access(p).then(
+    () => true,
+    () => false
+  );
+
+describe("react-static/routeToOutputDir", () => {
+  // fileWriter and the prune step MUST agree on which route owns
+  // <staticDir>/index.html — if these drift, the prune deletes a real page.
+  it("maps / to the static root and /about to about/", () => {
+    expect(routeToOutputDir("/")).toBe("");
+    expect(routeToOutputDir("/about")).toBe("about");
+    expect(routeToOutputDir("/blog/post")).toBe("blog/post");
+  });
+});
+
+describe("react-static/pruneUnclaimedEntryHtml", () => {
+  let dir: string;
+  let build: { outDir: string; static: string; htmlOutputPath: string };
+  let entryHtml: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vprs-prune-"));
+    build = { outDir: dir, static: "static", htmlOutputPath: "index.html" };
+    entryHtml = resolve(dir, "static", "index.html");
+    await mkdir(resolve(dir, "static"), { recursive: true });
+    await writeFile(entryHtml, '<div id="root"></div>');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("REGRESSION: removes the entry template when build.pages does not claim /", async () => {
+    // The router-era bug: pages excludes "/", but Vite's index.html input is
+    // emitted anyway and shadows the per-request route on the host.
+    const removed = await pruneUnclaimedEntryHtml({
+      build,
+      pages: ["/about"],
+    });
+
+    expect(removed).toBe(entryHtml);
+    expect(await exists(entryHtml)).toBe(false);
+  });
+
+  it("keeps index.html when a page claims / (it is the prerendered page)", async () => {
+    const removed = await pruneUnclaimedEntryHtml({
+      build,
+      pages: ["/", "/about"],
+    });
+
+    expect(removed).toBeNull();
+    expect(await exists(entryHtml)).toBe(true);
+  });
+
+  it("keeps index.html when there are no pages at all (SPA shell)", async () => {
+    // build.pages isn't claiming anything either way, so the template is the
+    // deliverable — a client-only build must not lose its entry.
+    const removed = await pruneUnclaimedEntryHtml({ build, pages: [] });
+
+    expect(removed).toBeNull();
+    expect(await exists(entryHtml)).toBe(true);
+  });
+
+  it("honors a custom htmlOutputPath", async () => {
+    const custom = resolve(dir, "static", "app.html");
+    await writeFile(custom, "<html></html>");
+
+    const removed = await pruneUnclaimedEntryHtml({
+      build: { ...build, htmlOutputPath: "app.html" },
+      pages: ["/about"],
+    });
+
+    expect(removed).toBe(custom);
+    expect(await exists(custom)).toBe(false);
+  });
+
+  it("is idempotent — an already-absent entry is the desired state, not an error", async () => {
+    await rm(entryHtml);
+    await expect(
+      pruneUnclaimedEntryHtml({ build, pages: ["/about"] })
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

`build.pages` says which pages exist. It didn't get the last word.

`index.html` is a Vite build **input** — it's what keys the client bootstrap in the manifest — so Vite emits it into the static outDir on every build. When a page claims `/`, SSG overwrites it with the prerendered document, which is why this is invisible in a normal static build. When no page claims `/`, Vite's bare template survives into the output: 850 bytes, `<div id="root"></div>`, no flight.

That shell then shadows the route on any host that matches the filesystem before applying a rewrite, so the render function is never reached and the page renders blank/CSR off a green build. Consumers work around it with a post-build delete pass over artifacts vprs shouldn't have emitted in the first place.

Measured on vprs-starter:

| `build.pages` | `dist/static/index.html` | what it is |
|---|---|---|
| `["/", "/about"]` | 18,126 bytes, SSR'd root | the prerendered page ✅ |
| `["/about"]` | 850 bytes, empty root | Vite's template, leaked ❌ |

## The fix

Prune the entry template after SSG when no page claims its path. This deliberately teaches vprs **nothing** about any deploy target — it's about not publishing our own build intermediate, not about anyone's routing rules. Platform specifics (rewrites, `includeFiles`) stay with the consumer.

- Runs from **both** static plugins at the same post-write point, exactly like `maybeInlineFlight` — client-first and server-first builds stay identical.
- Reuses the writer's own route→path rule (`routeToOutputDir`, now exported from `fileWriter`) so "claimed" means exactly "SSG wrote here". Two copies of that rule would drift and the prune would delete a real page.
- **No pages at all ⇒ no prune.** `build.pages` isn't claiming anything either way, and a client-only build's SPA shell is the deliverable. Only prunes when SSG ran and still left the path unclaimed.

## Tests

Adds the regression test that was missing — nothing covered "a route excluded from `build.pages` leaves no artifact at its path", which is how this slipped in with the router work. Covers the claimed/unclaimed/no-pages cases, a custom `htmlOutputPath`, idempotency, and that `routeToOutputDir` agrees with the writer.

Verified in a real consumer build, both directions: with `/` excluded the shell is gone and `/about` still prerenders; with `/` claimed, `index.html` survives at 18,126 bytes with its SSR'd root (the fix must never delete a real page).

Full suite green (797 passed) + typecheck clean.

## Follow-up (not in this PR)

The probe surfaced a **separate** silent failure: `pages: (routerPages) => …` is only fed the router-derived list when a `routes:` router is configured. The starter passes `Page`/`props`/`routePatterns` loose, so the transform is treated as the nullary replace form, called with no args — `routerPages` is `undefined`, `.filter` throws, `resolvePages` swallows it, and the build renders **zero** pages with no error and no `Rendered N pages` line. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)