### PR TITLE
fix(config): default a build.pages transform's input to the index

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -200,13 +200,9 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
             ? routerBuildPages
             : typeof routerBuildPages === "function"
               ? await routerBuildPages()
-              : // No `routes:` router: the app still has exactly one route —
-                // the index that `Page` serves — so that IS its derived list.
-                // Handing the transform `[]` here instead would make
-                // `(routerPages) => [...routerPages, "/extra"]` silently drop
-                // the index, and a filter silently prerender nothing at all.
-                // A routerless app is the degenerate one-route router.
-                // Fresh copy: this array is handed to user code.
+              : // `[]` here would make `(routerPages) => [...routerPages, "/x"]`
+                // silently drop the index, and a filter silently prerender
+                // nothing at all. Copied because it is handed to user code.
                 [...ROUTERLESS_PAGES];
           const out = (userBuildPages as (p: string[]) => unknown)(routerPages);
           return (out instanceof Promise ? await out : out) as string[];

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -187,6 +187,37 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   // transform stays a nullary async thunk downstream (resolvePages awaits it).
   const routerBuildPages = routerTable?.build?.pages;
   const userBuildPages = options.build?.pages;
+  // A `(routerPages) => …` transform has nothing to transform unless `routes:`
+  // is configured: with no router table the wrapper below hands it `[]`, the
+  // transform filters an empty list, and the build prerenders NOTHING — green,
+  // silent, and empty. Refuse the config instead of shipping an empty site.
+  //
+  // Arity separates the forms: the legacy nullary thunk (`() => [...]`, length
+  // 0) means "replace" and stays valid with no router.
+  if (
+    typeof userBuildPages === "function" &&
+    userBuildPages.length > 0 &&
+    !routerTable
+  ) {
+    const error = new Error(
+      "build.pages was given a `(routerPages) => …` transform, but no `routes:` router is " +
+        "configured — there is no router-derived list to pass it, so it would receive an empty " +
+        "array and the build would prerender nothing. Either set `routes:`, or give build.pages " +
+        "an array or a nullary thunk (e.g. `pages: router.build.pages`)."
+    );
+    // `log` so this surfaces even for callers that treat an error result as a
+    // no-op, and return the Error itself rather than handleError's value, which
+    // is null unless the panic threshold escalates.
+    handleError({
+      error,
+      logger,
+      panicThreshold,
+      context: "config(resolveOptions)",
+      critical: true,
+      log: true,
+    });
+    return { type: "error", error };
+  }
   const effectiveBuildPages =
     typeof userBuildPages === "function"
       ? async () => {

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -91,6 +91,12 @@ const registerPath = (path: string, pattern?: RegExp, ext?: string) => {
 
 let originalOptions: any | null = null;
 /**
+ * The page list a transform receives when no `routes:` router is configured.
+ * A routerless app has exactly one route: the index its `Page` serves.
+ */
+const ROUTERLESS_PAGES: readonly string[] = ["/"];
+
+/**
  * Resolves the user options for the plugin.
  *
  * @param options - The user options to resolve.
@@ -187,37 +193,6 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   // transform stays a nullary async thunk downstream (resolvePages awaits it).
   const routerBuildPages = routerTable?.build?.pages;
   const userBuildPages = options.build?.pages;
-  // A `(routerPages) => …` transform has nothing to transform unless `routes:`
-  // is configured: with no router table the wrapper below hands it `[]`, the
-  // transform filters an empty list, and the build prerenders NOTHING — green,
-  // silent, and empty. Refuse the config instead of shipping an empty site.
-  //
-  // Arity separates the forms: the legacy nullary thunk (`() => [...]`, length
-  // 0) means "replace" and stays valid with no router.
-  if (
-    typeof userBuildPages === "function" &&
-    userBuildPages.length > 0 &&
-    !routerTable
-  ) {
-    const error = new Error(
-      "build.pages was given a `(routerPages) => …` transform, but no `routes:` router is " +
-        "configured — there is no router-derived list to pass it, so it would receive an empty " +
-        "array and the build would prerender nothing. Either set `routes:`, or give build.pages " +
-        "an array or a nullary thunk (e.g. `pages: router.build.pages`)."
-    );
-    // `log` so this surfaces even for callers that treat an error result as a
-    // no-op, and return the Error itself rather than handleError's value, which
-    // is null unless the panic threshold escalates.
-    handleError({
-      error,
-      logger,
-      panicThreshold,
-      context: "config(resolveOptions)",
-      critical: true,
-      log: true,
-    });
-    return { type: "error", error };
-  }
   const effectiveBuildPages =
     typeof userBuildPages === "function"
       ? async () => {
@@ -225,11 +200,22 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
             ? routerBuildPages
             : typeof routerBuildPages === "function"
               ? await routerBuildPages()
-              : [];
+              : // No `routes:` router: the app still has exactly one route —
+                // the index that `Page` serves — so that IS its derived list.
+                // Handing the transform `[]` here instead would make
+                // `(routerPages) => [...routerPages, "/extra"]` silently drop
+                // the index, and a filter silently prerender nothing at all.
+                // A routerless app is the degenerate one-route router.
+                // Fresh copy: this array is handed to user code.
+                [...ROUTERLESS_PAGES];
           const out = (userBuildPages as (p: string[]) => unknown)(routerPages);
           return (out instanceof Promise ? await out : out) as string[];
         }
-      : (userBuildPages ?? routerBuildPages);
+      : // Absent `build.pages` keeps DEFAULT_CONFIG's empty worklist — only the
+        // TRANSFORM's input defaults to the index. Defaulting the worklist too
+        // would start prerendering an index for client-only builds that never
+        // asked for one.
+        (userBuildPages ?? routerBuildPages);
   // Nested layouts: the router table's per-url `route.tsx` chain resolver.
   // Threaded like Page/props so the renderer folds the nested tree.
   const effectiveLayouts = options.layouts ?? routerTable?.layouts;

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1182,11 +1182,16 @@ export type BuildConfig = {
   useRscWorker?: boolean;
   useHtmlWorker?: boolean;
   /**
-   * The prerender worklist. An array or a thunk, or — when a `routes` router is
-   * configured — a transform that receives the router-derived page list so you
-   * can filter / extend / replace it without restating routes
-   * (`pages: (routerPages) => [...routerPages, "/extra"]`). The pre-existing
-   * nullary function form still works (it ignores the argument = replace).
+   * The prerender worklist. An array or a thunk, or a transform that receives
+   * the derived page list so you can filter / extend / replace it without
+   * restating routes (`pages: (routerPages) => [...routerPages, "/extra"]`).
+   *
+   * With a `routes` router the transform receives the router-derived list; with
+   * no router it receives `["/"]`, since a routerless app's one route is the
+   * index its `Page` serves. The transform means the same thing either way.
+   *
+   * The pre-existing nullary function form still works (it ignores the argument
+   * = replace). Leaving `pages` unset prerenders nothing, router or not.
    */
   pages?:
     | string[]

--- a/test/unit/buildPagesTransformGuard.test.ts
+++ b/test/unit/buildPagesTransformGuard.test.ts
@@ -1,43 +1,75 @@
 import { describe, it, expect } from "vitest";
 import { resolveOptions } from "../../plugin/config/resolveOptions.js";
+import { resolvePages } from "../../plugin/config/resolvePages.js";
 
 /**
- * Regression guard for the silent-empty-site config mistake:
- * `build.pages: (routerPages) => …` only receives a list when `routes:` is
- * configured. Without a router table the transform was handed `[]`, filtered an
- * empty list, and the build prerendered nothing — green, silent, empty.
+ * `build.pages: (routerPages) => …` is documented as a transform over the
+ * derived page list. Without a `routes:` router it used to receive `[]`, so a
+ * filter prerendered NOTHING and an extend silently dropped the index — a
+ * green, empty build with no diagnostic.
+ *
+ * A routerless app is the degenerate one-route router: its derived list is the
+ * index its `Page` serves. These lock that in, and lock in that only the
+ * TRANSFORM's input defaults — never the worklist itself.
  */
 const base = { moduleBase: "src", forceResolve: true } as never;
 
-const resolve = (build: Record<string, unknown>) =>
-  resolveOptions({ ...(base as object), build } as never);
+const pagesFor = async (build: Record<string, unknown>) => {
+  const result = resolveOptions({ ...(base as object), build } as never);
+  expect(result.type).toBe("success");
+  const resolved = await resolvePages(
+    (result.userOptions as { build: { pages: unknown } }).build.pages as never
+  );
+  expect(resolved.type).toBe("success");
+  return resolved.pages;
+};
 
-describe("config/resolveOptions — build.pages transform guard", () => {
-  it("REGRESSION: rejects a (routerPages) => … transform when no routes: router is configured", () => {
-    const result = resolve({
-      pages: (routerPages: string[]) => routerPages.filter((p) => p !== "/"),
-    });
-
-    expect(result.type).toBe("error");
-    // Never null: callers that rethrow must get a real Error, and the message
-    // has to name both the cause and the way out.
-    expect(result.error).toBeInstanceOf(Error);
-    expect((result.error as Error).message).toMatch(/routes:/);
-    expect((result.error as Error).message).toMatch(/prerender nothing/);
+describe("config/resolveOptions — build.pages transform without a routes: router", () => {
+  it("REGRESSION: an extend transform keeps the index instead of dropping it", async () => {
+    // Was: [] -> ["/extra"], silently losing "/".
+    await expect(
+      pagesFor({ pages: (routerPages: string[]) => [...routerPages, "/extra"] })
+    ).resolves.toEqual(["/", "/extra"]);
   });
 
-  it("still accepts the legacy nullary thunk (replace form) without a router", () => {
-    const result = resolve({ pages: () => ["/", "/about"] });
-    expect(result.type).toBe("success");
+  it("REGRESSION: a filter transform sees the index, so it can act on it", async () => {
+    // Was: [] -> [] (empty site, no diagnostic). Now the index is really there,
+    // so excluding it is a deliberate choice with a visible effect.
+    await expect(
+      pagesFor({ pages: (routerPages: string[]) => routerPages.filter((p) => p !== "/") })
+    ).resolves.toEqual([]);
   });
 
-  it("still accepts an array without a router", () => {
-    const result = resolve({ pages: ["/", "/about"] });
-    expect(result.type).toBe("success");
+  it("passes the index through an identity transform", async () => {
+    await expect(
+      pagesFor({ pages: (routerPages: string[]) => routerPages })
+    ).resolves.toEqual(["/"]);
   });
 
-  it("accepts an absent build.pages", () => {
-    const result = resolve({});
-    expect(result.type).toBe("success");
+  it("hands the transform a FRESH array — user mutation can't leak across builds", async () => {
+    const mutate = (routerPages: string[]) => {
+      routerPages.push("/mutated");
+      return routerPages;
+    };
+    await expect(pagesFor({ pages: mutate })).resolves.toEqual(["/", "/mutated"]);
+    // A shared constant would now carry "/mutated" into the next resolve.
+    await expect(pagesFor({ pages: mutate })).resolves.toEqual(["/", "/mutated"]);
+  });
+
+  it("leaves the legacy nullary thunk (replace form) alone", async () => {
+    await expect(pagesFor({ pages: () => ["/only"] })).resolves.toEqual(["/only"]);
+  });
+
+  it("leaves an explicit array alone", async () => {
+    await expect(pagesFor({ pages: ["/", "/about"] })).resolves.toEqual([
+      "/",
+      "/about",
+    ]);
+  });
+
+  it("does NOT default the worklist: absent build.pages still prerenders nothing", async () => {
+    // Only the transform's INPUT defaults to the index. Defaulting the worklist
+    // would start prerendering an index for client-only builds.
+    await expect(pagesFor({})).resolves.toEqual([]);
   });
 });

--- a/test/unit/buildPagesTransformGuard.test.ts
+++ b/test/unit/buildPagesTransformGuard.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { resolveOptions } from "../../plugin/config/resolveOptions.js";
+
+/**
+ * Regression guard for the silent-empty-site config mistake:
+ * `build.pages: (routerPages) => …` only receives a list when `routes:` is
+ * configured. Without a router table the transform was handed `[]`, filtered an
+ * empty list, and the build prerendered nothing — green, silent, empty.
+ */
+const base = { moduleBase: "src", forceResolve: true } as never;
+
+const resolve = (build: Record<string, unknown>) =>
+  resolveOptions({ ...(base as object), build } as never);
+
+describe("config/resolveOptions — build.pages transform guard", () => {
+  it("REGRESSION: rejects a (routerPages) => … transform when no routes: router is configured", () => {
+    const result = resolve({
+      pages: (routerPages: string[]) => routerPages.filter((p) => p !== "/"),
+    });
+
+    expect(result.type).toBe("error");
+    // Never null: callers that rethrow must get a real Error, and the message
+    // has to name both the cause and the way out.
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toMatch(/routes:/);
+    expect((result.error as Error).message).toMatch(/prerender nothing/);
+  });
+
+  it("still accepts the legacy nullary thunk (replace form) without a router", () => {
+    const result = resolve({ pages: () => ["/", "/about"] });
+    expect(result.type).toBe("success");
+  });
+
+  it("still accepts an array without a router", () => {
+    const result = resolve({ pages: ["/", "/about"] });
+    expect(result.type).toBe("success");
+  });
+
+  it("accepts an absent build.pages", () => {
+    const result = resolve({});
+    expect(result.type).toBe("success");
+  });
+});


### PR DESCRIPTION
Follow-up to #248, which surfaced this while probing. Separate defect, separate PR.

> **Design changed mid-PR.** The first commit *rejected* this config; the second replaces that with a default. Nico's call, and the right one — see "Why not an error" below. Review the second commit as the design.

## The bug

`build.pages: (routerPages) => …` is documented as a transform over the derived page list. But the list is only derived when a `routes:` router is configured. Without one, the transform is handed `[]`:

- `(routerPages) => [...routerPages, "/extra"]` silently **drops the index**
- `(routerPages) => routerPages.filter(…)` silently **prerenders nothing at all** — exit 0, no error, no `Rendered N pages`, an empty site

A routerless app (`Page` + `props`, no `routes:` field — what `examples/hello-world` and vprs-starter both do) hits this with the documented API.

**The mechanism is not a swallowed exception.** `routerPages` is `[]`, never `undefined`, so nothing throws — there is no `try/catch` to fix. The transform is fed nothing and silently agrees.

## The fix

A routerless app is the **degenerate one-route router**: its only route is the index that `Page` serves. So that *is* its derived list, and the transform receives `["/"]`. Both forms then mean what they read as.

Scope is deliberately the transform's **input only**. An absent `build.pages` still resolves to `DEFAULT_CONFIG`'s empty worklist — defaulting that too would start prerendering an index for client-only builds that never asked for one, which is exactly the SPA shell #248 was careful to preserve.

The array is copied per call, since it's handed to user code and a shared constant would carry a caller's mutation into the next resolve. There's a test for that.

### Why not an error

The first commit rejected the combination at config time. That was wrong: "I don't want the router, but I do want static pages" is a legitimate setup, and it has an obvious right answer rather than an error. Defaulting removes the failure mode instead of teaching users to route around it — and it makes the transform form work uniformly whether or not a router is configured.

## Verification

Unit tests lock in both directions: the extend transform keeps the index, the filter transform can act on it, the legacy nullary thunk and explicit arrays are untouched, mutation can't leak across resolves, and **an absent `build.pages` still prerenders nothing**.

But a unit test only proves `resolveOptions` returns a list. On a real build (`examples/hello-world`, routerless, built in place):

| config | before | after |
|---|---|---|
| `pages: (routerPages) => [...routerPages, "/extra"]` | 0 pages, exit 0, silent | **2 pages** (`/`, `/extra`) |
| `pages: ["/"]` (its real config) | 1 page | 1 page |

Full suite green (804 passed) + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)