### PR TITLE
docs: refresh stale router/edge claims across user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ between.
 — the full docs, and itself a vprs app (the site dogfoods the plugin).
 
 vprs is the low-level layer rather than a framework: it handles the RSC
-transform, runs the worker threads, and emits portable ESM — and leaves routing
-and app structure to you. Use it directly, or as the engine under your own
-conventions. Its closest peer is the official
+transform, runs the worker threads, and emits portable ESM — and leaves app
+structure to you. Routing is covered if you want it: since v3 an opt-in
+[file-based router](./docs/routing.md) (dynamic params, nested layouts,
+per-segment loaders, client-side `Link`) ships in the box, or map URLs to files
+yourself. Use it directly, or as the engine under your own conventions. Its
+closest peer is the official
 [`@vitejs/plugin-rsc`](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-rsc);
 vprs differs by being a small dev/build setup whose output is portable ESM you
 host yourself. (The RSC transport underneath is an implementation detail —
@@ -168,6 +171,7 @@ which is itself built with vprs.
 |-----|---------------|
 | [How vprs compares](./docs/comparison.md) | vprs vs `@vitejs/plugin-rsc`, Waku, Vike — and what vprs does not do |
 | [Getting Started](./docs/getting-started.md) | Install → first page → dev server → build → deploy |
+| [Routing](./docs/routing.md) | The file-based router: params, loaders, nested layouts, `Link` |
 | [Storybook](./docs/storybook.md) | One-line Storybook support for vprs apps |
 | [Build Output](./docs/build-output.md) | What the build produces, how to use the ESM modules |
 | [Configuration](./docs/configuration.md) | All plugin options |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -24,6 +24,8 @@ export const config = {
 | `publicOrigin` | `string` | Origin for moduleBaseURL | `"https://username.github.io"` |
 | `Page` | `(url: string) => string` | Maps URLs to page component files | - |
 | `props` | `(url: string) => string` | Maps URLs to props files | - |
+| `routes` | `RoutesOption` | File-based router (v3+): scans a route tree and derives `Page`, `props`, `routePatterns` and the prerender worklist. Takes `{ dir?, staticPaths? }` or a `fileRouter()` result. See [Routing](./routing.md). | `{ dir: "routes" }` |
+| `routePatterns` | `string[]` | Route patterns for param matching (derived by `routes`; state explicitly only without it) | `["/", "/greet/$name"]` |
 | `Html` | `React.ComponentType<HtmlProps>` | Wrapper component for production pages | - |
 | `pageExportName` | `string` | Name of the page export | `"Page"` |
 | `propsExportName` | `string` | Name of the props export | `"props"` |
@@ -476,6 +478,23 @@ import { vitePluginReactClient } from "vite-plugin-react-server/client";
 ```typescript
 import { vitePluginReactServer } from "vite-plugin-react-server/server";
 ```
+
+### Router (config side)
+
+```typescript
+// Condition-neutral: fileRouter builds the router table (used in vite.config),
+// withParams wraps a loader, matchRoutes/fillPattern are the pattern helpers.
+import { fileRouter, withParams, matchRoutes, fillPattern } from "vite-plugin-react-server/router";
+```
+
+### Router (client runtime)
+
+```typescript
+// "use client" side: startClient wires router + hydration + HMR in one call.
+import { startClient, Link, useParams, useLocation, useRouter, RouterProvider, createRouter } from "vite-plugin-react-server/router/client";
+```
+
+See [Routing](./routing.md) for the full guide.
 
 ### Stream Helpers
 

--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -140,30 +140,39 @@ hashed JS/CSS. Serve it from any static host, CDN, or edge network (GitHub
 Pages, Netlify, S3/CloudFront, Cloudflare Pages). There is no runtime
 requirement. For a fully static site this is the entire deployment.
 
-**Dynamic SSR runs on Node, not on the edge.** The moment you render HTML per
-request — the flash-free dynamic-route path (`createInlineFlightRenderer` and
-the html-worker behind it) — you need Node. vprs renders the react-dom HTML in a
-worker thread that runs in the *opposite* React condition from your main thread
-(server components resolve under `--conditions react-server`; react-dom renders
-the client half without it). That worker is `node:worker_threads`, and the
-streams it speaks are `node:stream` / `MessagePort`. Edge runtimes such as
-Cloudflare Workers and Deno Deploy have no `worker_threads`, so this path does
-not run there. The cross-condition worker is also what lets the single-condition
-ESM transport render both halves at all — see
-[Workers](./internals/workers.md) and [How vprs compares](./comparison.md).
+**Dynamic SSR runs on Node, in one of two shapes.**
+
+The *default* dynamic path (`createInlineFlightRenderer` and the html-worker
+behind it) renders the react-dom HTML in a worker thread that runs in the
+*opposite* React condition from your main thread (server components resolve
+under `--conditions react-server`; react-dom renders the client half without
+it). That worker is `node:worker_threads`, and the streams it speaks are
+`node:stream` / `MessagePort`, so this shape needs a full Node process. The
+cross-condition worker is also what lets the single-condition ESM transport
+render both halves at all — see [Workers](./internals/workers.md) and
+[How vprs compares](./comparison.md).
+
+The *single-isolate* shape is the [edge bundle](./edge.md) (`build.edge`, on by
+default): a baked `dist/server-edge/render.js` in which server React is inlined
+at build time, so the render needs **no** `worker_threads` and **no**
+`--conditions` flag — one process, one Web `fetch` handler, flash-free streaming
+SSR included. One precision matters here: "edge" refers to the single-isolate
+*shape*, not to a V8-isolate runtime. The render still imports the built client
+chunks and manifest off disk, so it deploys to Node-flavored serverless
+functions (Vercel/Netlify Functions, a small Node server) rather than to literal
+isolate runtimes like Cloudflare Workers.
 
 The runtime RSC-payload and server-action helpers are likewise implemented on
 Node primitives today. A *static* build has no server runtime and therefore no
 callable surface, so this only applies once you stand up a dynamic server.
 
-**The pattern for an edge deployment today is hybrid:** serve `dist/static/`
-from the edge/CDN (instant, global, no runtime) and put any dynamic SSR or
-server actions on a Node origin behind it. vprs does not currently ship an
-in-process edge SSR path (`react-dom/server.edge`, no worker); whether to add
-one is an open question, not a present feature. If first-class edge SSR is a
-hard requirement, `@vitejs/plugin-rsc` reaches the edge in-process today (via
-Vite's environment API and Cloudflare's child-environment workers) and is the
-better fit.
+**The pattern for an edge-network deployment is hybrid:** serve `dist/static/`
+from the edge/CDN (instant, global, no runtime) and put dynamic SSR or server
+actions on a Node origin or serverless function behind it — worker-based or
+single-isolate, your pick. If SSR inside a literal V8-isolate runtime is a hard
+requirement, `@vitejs/plugin-rsc` reaches it in-process today (via Vite's
+environment API and Cloudflare's child-environment workers) and is the better
+fit.
 
 ## Stream Types
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,9 +8,13 @@ If you want a framework to make the decisions for you, Waku or Vike are likely
 the better fit; if you want the official low-level building block, that is
 `@vitejs/plugin-rsc`. vprs is the niche in between: a small RSC dev/build setup,
 like the official plugin in spirit, but with portable output you host yourself.
-What mostly defines vprs is what it withholds: it takes no opinion on how your
-React app is built, so the optimizations that fit your app are yours to add
-rather than a general-purpose set baked in for you (more on that under
+Since v3 it also ships an opt-in [file-based router](./routing.md) — dynamic
+params, nested layouts, per-segment loaders, client-side navigation — without
+becoming a framework: the router is one config field, not an app structure you
+inherit. What mostly defines vprs is still what it withholds: it takes no
+opinion on how your React app is built, so the optimizations that fit your app
+are yours to add rather than a general-purpose set baked in for you (more on
+that under
 [What you get for wiring it yourself](#what-you-get-for-wiring-it-yourself)).
 The RSC transport underneath is supplied by `react-server-loader`; treat it as
 an implementation detail, not a knob you tune.
@@ -20,16 +24,16 @@ an implementation detail, not a knob you tune.
 | | **vprs** | **@vitejs/plugin-rsc** | **Waku** | **Vike** (+ vike-react-rsc) |
 |---|---|---|---|---|
 | Kind | Vite plugin | Vite plugin (official) | Framework | Framework (+ RSC extension) |
-| Imposes routing / app structure | No | No | Yes (file-based pages router) | Yes (file-based) |
+| Imposes routing / app structure | No — file-based router is opt-in (since v3) | No | Yes (file-based pages router) | Yes (file-based) |
 | React target | Stable 19.2+ (default) or experimental | Stable, canary, or experimental (your choice) | React 19 | React 19 |
 | RSC transport | `react-server-dom-esm`, via `react-server-loader` | `react-server-dom-webpack`, vendored (BYO to pin a version) | managed by the framework | managed by the extension |
 | Build output | `static/` + `client/` + `server/` portable ESM | app bundle via multi-environment build | framework-managed | framework-managed |
 | Host anywhere (static / Express / Hono) | Yes, you wire the server | Yes | Via the framework's server | Via vike-server |
 | Node `--conditions react-server` | Optional; works either way (see [below](#the-react-server-condition-is-optional)) | Used internally | Managed | Managed |
-| Maturity (mid-2026) | 2.x | 0.5.x, official and actively developed | 1.0 beta | extension is early-stage |
+| Maturity (mid-2026) | 3.x | 0.5.x, official and actively developed | 1.0 beta | extension is early-stage |
 
 Versions move fast; check each project for current numbers. One caveat on that
-Maturity row: vprs's `2.x` is not a maturity claim over the official plugin's
+Maturity row: vprs's `3.x` is not a maturity claim over the official plugin's
 `0.5.x`. vprs is the younger project with the smaller community; the two version
 lines simply count different things. The rows above describe positioning, not a
 scorecard, and every tool here is a legitimate choice for the job it is built
@@ -39,16 +43,19 @@ for.
 
 - **vprs** — you want RSC as a *plugin* on plain Vite, on stable React, with a
   build that produces portable ESM (a static site plus `client/` and `server/`
-  modules) you drop into your own static host or Node server. You are happy to
-  own routing and the server wiring, and you want a small RSC dev/build setup
-  rather than a framework.
+  modules) you drop into your own static host or Node server. Routing is
+  covered if you want it — the [file-based router](./routing.md) (v3+) gives you
+  dynamic params, nested layouts and loaders from one config field — or you map
+  URLs to files yourself. Either way you own the server wiring, and you want a
+  small RSC dev/build setup rather than a framework.
 - **`@vitejs/plugin-rsc`** — the official, framework-agnostic Vite RSC plugin
   and the foundation several tools build on. Reach for it when you want the
   canonical low-level plugin, the webpack-flavored transport, or the freedom to
   pin React (including canary/experimental) by installing
   `react-server-dom-webpack` yourself.
-- **Waku** — you want a minimal *framework*: a file-based pages router and the
-  conventions to go with it, batteries included, without assembling the pieces.
+- **Waku** — you want a minimal *framework*: not just a file-based pages router
+  but the whole set of conventions to go with it, batteries included, without
+  assembling the pieces.
 - **Vike (+ vike-react-rsc)** — you are already on Vike (or want its flexible
   framework model) and want to adopt RSC progressively, component by component.
 
@@ -89,9 +96,13 @@ strategy from a framework.
 
 Concretely, the build prerenders your pages to static HTML with each route's RSC
 payload inlined into the page, so a static route hydrates in place on first
-paint with no extra round-trip for its data. A route whose content depends on
-per-request data can render its HTML per request instead. You decide per route;
-nothing forces a single model across the whole app.
+paint with no extra round-trip for its data. The file writer that produces this
+output streams each route's HTML and `.rsc` payload straight to disk — no
+buffering the site in memory — and refuses to silently ship a degraded page: an
+HTML document that rendered without a root `<html>` element fails the build
+(under the default panic policy) instead of deploying broken. A route whose
+content depends on per-request data can render its HTML per request instead.
+You decide per route; nothing forces a single model across the whole app.
 
 This is not a claim that vprs is faster out of the box. A framework that bakes a
 strategy in is doing real work you would otherwise do yourself, and for many
@@ -141,10 +152,12 @@ responsibilities that remain yours.
 Being a plugin rather than a framework is the whole point, so a lot is out of
 scope on purpose:
 
-- **No router.** No file-based routing, no nested layouts, no data-loader
-  convention. You provide a `Page` (and optional `props`) and list the pages to
-  prerender; richer routing is yours to build (see
-  [Examples](./examples.md#custom-routing)).
+- **No imposed routing.** Since v3 vprs *does* ship a file-based router —
+  dynamic params, nested layouts, per-segment loaders, prerendering, client-side
+  `Link` navigation (see [Routing](./routing.md)) — but it is one opt-in config
+  field, not an app structure. Skip it and you provide a `Page` (and optional
+  `props`) yourself, mapping URLs to files however you like (see
+  [Examples](./examples.md#routing)).
 - **No framework conveniences.** No auth, i18n, head/meta management, image
   optimization, or plugin ecosystem. vprs transforms RSC boundaries, runs the
   workers, and emits ESM; the rest of the app is yours.
@@ -153,9 +166,13 @@ scope on purpose:
   needs the webpack transport, use `@vitejs/plugin-rsc`.
 - **No deployment/hosting layer.** The build emits ESM and a static directory;
   wiring them into a host (static CDN, Express, Hono, serverless) is up to you.
-  The static output runs anywhere (including the edge); dynamic SSR is Node-only
-  today, because the flash-free HTML path renders in a `worker_threads` worker.
-  See [Build Output → Where it runs](./build-output.md#where-it-runs-static-anywhere-dynamic-on-node).
+  The static output runs anywhere (including the edge). Dynamic SSR has two
+  shapes: the default worker-based build (Node, `worker_threads`) and the
+  [single-isolate edge bundle](./edge.md), which needs no workers and no
+  `--conditions` flag — but its render still imports built modules off disk, so
+  it targets Node-flavored serverless functions, not literal V8-isolate edge
+  runtimes. See
+  [Build Output → Where it runs](./build-output.md#where-it-runs-static-anywhere-dynamic-on-node).
 - **Two React trains, not any React build.** vprs pins React through
   `react-server-loader`, which ships a stable train and an experimental train;
   you pick one (see "React" above). `@vitejs/plugin-rsc` instead lets you bring

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,9 @@ export default defineConfig({
     Page: "src/page.tsx",              // string or (url: string) => string
     build: { pages: ["/"] },
 
+    // Optional — file-based routing (replaces Page/props/build.pages, see below)
+    routes: { dir: "routes" },         // scans src/routes/** — see docs/routing.md
+
     // Optional — component resolution
     props: "src/props.ts",             // string or (url: string) => string
     Html: "src/Html.tsx",              // string — HTML shell component
@@ -80,6 +83,26 @@ export default defineConfig({
   }),
 });
 ```
+
+## File-based routing (`routes`)
+
+`routes` turns on the file-based router (v3+): the file tree under the routes
+directory becomes the URL tree, and vprs derives `Page`, `props`,
+`routePatterns` and the prerender worklist from it — you don't restate them.
+
+```ts
+routes: {
+  dir: "routes",                       // relative to moduleBase; omit to scan moduleBase itself
+  staticPaths: {                       // vprs's getStaticPaths, per dynamic route
+    "/greet/$name": () => [{ name: "ada" }, { name: "grace" }],
+  },
+},
+```
+
+It also accepts an already-built router table — a `fileRouter()` result or a
+hand-rolled equivalent. Explicit `Page` / `props` / `routePatterns` /
+`build.pages` still win over what the router derives. Full guide:
+[Routing](./routing.md).
 
 ## Component Resolution
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -1,15 +1,23 @@
 # Edge / Single-Isolate Rendering
 
 The default build renders HTML through worker threads under a `--conditions
-react-server` process flag. That model is great on Node, but it does not fit
-edge runtimes (Cloudflare Workers, Deno Deploy, Vercel Edge, Bun), which have no
-`worker_threads` and no process-level export conditions.
+react-server` process flag. That model is great on a full Node server, but it
+does not fit single-process targets — serverless functions and edge-style
+runtimes (Bun, Deno, Vercel/Netlify Functions) — which have no `worker_threads`
+and no process-level export conditions.
 
 The **single-isolate edge build** removes both requirements. It bakes a second,
 self-contained bundle in which React is **inlined** under the `react-server`
 condition at build time, so the running isolate needs no `worker_threads` and no
 runtime `--conditions`. You get flash-free streaming SSR from one Web `fetch`
 handler.
+
+One naming precision: "edge" here refers to the single-isolate *shape*, not to a
+literal V8-isolate runtime. Rendering a page with client islands imports the
+built client chunks off disk (see `moduleBaseURL` below), so the natural homes
+are Node-flavored serverless functions and single-process servers. A runtime
+with no filesystem, such as Cloudflare Workers, only fits when nothing in the
+render needs a disk import.
 
 It is **additive**: the normal `dist/server` / `dist/static` output is untouched.
 Dev is unaffected.
@@ -23,12 +31,18 @@ Two bundles co-exist in one isolate:
   renders to an RSC Flight stream. It exports one function:
 
   ```ts
-  export function renderRouteToFlight(url: string): Promise<ReadableStream<Uint8Array>>;
+  export function renderRouteToFlight(url: string, request?: Request): Promise<ReadableStream<Uint8Array>>;
   ```
 
-  It is a **closed manifest** over `build.pages`: every prerendered route is
-  baked in by static import, so there is no runtime `import()`. An unknown url
-  throws.
+  It is a **closed manifest**: every module is baked in by static import, so
+  there is no runtime `import()`. The enumerated `build.pages` set is baked
+  route-by-route; with the [file router](./routing.md), each dynamic route
+  *pattern*'s modules are baked once as well, so an unenumerated concrete url
+  (any `/profile/<id>` that was not in `staticPaths`) still renders per-request
+  by matching the route patterns. A url matching nothing throws — which
+  `createEdgeHandler` turns into a 404. Pass the in-flight `request` so a
+  loader can gate on cookies/headers (authenticated routes); it is `undefined`
+  at prerender.
 
 - **`dist/client`** — the client (ssr) bundle. React is the normal client build.
   The HTML render and client islands live here.
@@ -97,12 +111,12 @@ const handler = createEdgeHandler({
   bootstrapModules: ["/client-abc123.js"],  // your client entry (for hydration)
 });
 
-export default { fetch: handler };          // Cloudflare / Deno / Bun
+export default { fetch: handler };          // Bun / Deno / serverless function
 ```
 
 The handler **streams** (responds when the HTML shell is ready), returns **404**
-for a url the bundle was not baked with (override via `onNotFound`), and
-propagates other render errors after `onError`.
+for a url that matches no baked route or route pattern (override via
+`onNotFound`), and propagates other render errors after `onError`.
 
 ### Options
 
@@ -241,8 +255,10 @@ import "./start.js";
 
 ## Limitations
 
-- The producer is a closed enumeration of `build.pages`; it is not a dynamic
-  router. Unbaked urls 404.
+- The producer is a closed manifest of baked modules. With the file router,
+  unenumerated urls that match a route *pattern* render per-request; urls that
+  match no pattern (and are not in `build.pages`) 404. There is no runtime
+  `import()` of new modules.
 - The bundle inlines React, so it is large — keep `minify: true` for deploys and
   watch your platform's size limit.
 - `createEdgeHandler` / `renderFlightToHtml` are client-condition exports (they


### PR DESCRIPTION
## Summary
- `docs/comparison.md`: the "No router" bullet is now "No imposed routing" — since v3 the opt-in file-based router (dynamic params, nested layouts, per-segment loaders, `Link`) ships in the box. Table routing row + Maturity `2.x` → `3.x`, intro/positioning and the vprs/Waku fit bullets updated. Documents the file writer: streams each route's HTML + `.rsc` to disk, degraded-document guard fails the build under the default panic policy.
- `docs/edge.md`: "closed enumeration of `build.pages`; not a dynamic router" was stale — `buildEdgeBundle` bakes per-pattern modules and matches `ROUTE_PATTERNS` at request time (covered by `test/examples/build-edge-router.test.ts`). Updated the manifest paragraph, `renderRouteToFlight(url, request)` signature, 404 wording, and Limitations. "Edge" clarified as the single-isolate *shape*, not a V8-isolate runtime (the render imports built chunks off disk).
- `docs/build-output.md`: "Dynamic SSR runs on Node, not on the edge" rewritten as the two shapes (worker-based vs single-isolate) with the same runtime precision; hybrid-deployment guidance updated.
- `README.md`: no longer claims vprs "leaves routing to you"; Routing added to the docs table.
- `docs/configuration.md` + `docs/api-reference.md`: the `routes` option documented (was entirely absent), plus `/router` and `/router/client` import paths.

## Test plan
- [ ] Docs-only change — proofread rendered markdown
- [ ] Verify internal links resolve (`docs/routing.md`, `docs/edge.md`, anchors)

Made with [Cursor](https://cursor.com)
