### PR TITLE
chore(release): 3.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.1.8",
+      "version": "3.1.9",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release. Bumps `package.json` + `package-lock.json` to **3.1.9**; no code changes.

## Ships

Two fixes that make `build.pages` actually authoritative over the build output, plus the docs refresh.

- **#248** — `fix(static): keep build.pages authoritative over vite's index.html entry`. A route excluded from `build.pages` no longer leaves Vite's bare `index.html` template (850 bytes, empty `#root`) standing at its path. That shell shadowed the render function on any host that matches the filesystem before applying a rewrite, so a per-request route rendered blank off a green build. Teaches vprs nothing about any deploy target — it's about not publishing our own build intermediate.

- **#249** — `fix(config): default a build.pages transform's input to the index`. `pages: (routerPages) => …` on a routerless app received `[]`, so an extend silently dropped the index and a filter silently prerendered nothing at all — exit 0, no error, empty site. A routerless app is the degenerate one-route router, so the transform now receives `["/"]`. Scope is the transform's input only: an unset `build.pages` still prerenders nothing, so client-only builds are unaffected.

- **#250** — `docs: refresh stale router/edge claims across user-facing docs`.

Both fixes ship the regression tests that were missing — nothing covered "a route excluded from `build.pages` leaves no artifact at its path", which is how #248 slipped in with the router work.

## Verification

Verified on merged `main`, not just on the PR branches: full suite green (**804 passed**) + typecheck clean.

## Release checklist

- [ ] Merge this PR
- [ ] Tag `v3.1.9` (annotated) on the merge commit, and push the tag
- [ ] `npm publish` (`prepublishOnly` runs build + `verify:package`)

Note `bump-version.mjs` only edits package.json/package-lock — it does not tag. That manual step is what lost `v3.1.7` (backfilled during the 3.1.8 release); worth folding into the script or a workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)