### PR TITLE
feat(edge): createEdgeRequestHandler — serve a build from the bundle alone

### DIFF
--- a/docs/edge.md
+++ b/docs/edge.md
@@ -95,11 +95,73 @@ failure is a warning, never a build failure).
 | `outDir`  | `"server-edge"`| output dir, under `build.dir` |
 | `minify`  | `true`         | minify the bundle. It bakes React in, so it is large; edge platforms cap bundle size. Set `false` for readable output. |
 
-## Serve it: `createEdgeHandler`
+## Serve it: `createEdgeRequestHandler`
 
-`createEdgeHandler` composes the producer and the HTML render into a standard
-Web `(Request) => Response` handler — the native entrypoint shape for edge
-runtimes:
+Hand the baked bundle to `createEdgeRequestHandler` and you have the server:
+
+```ts
+import * as bundle from "./dist/server-edge/render.js";
+import { createEdgeRequestHandler } from "vite-plugin-react-server/edge";
+
+export const handler = createEdgeRequestHandler(bundle);
+
+export default { fetch: handler };   // Bun / Deno / Cloudflare / serverless
+```
+
+That is the whole thing: a Web `(Request) => Response` serving the flash-free
+document on a GET, the headless flight on a client navigation, and `"use server"`
+actions through the bundle's baked gate.
+
+Import the bundle as a **namespace** and pass it whole. It carries its own routes,
+styles, client entry and action gate, so there is nothing to wire up — and a
+static import stays visible to a deploy's file tracer. Handing over a *path* for
+the handler to `import()` at runtime is what makes the module go missing on the
+platforms this handler exists to serve.
+
+`vite-plugin-react-server/edge` is condition-neutral: it resolves to the same
+module with or without `--conditions react-server`, so it is safe to import from
+code that a react-server-condition build also loads.
+
+### Options
+
+| option          | default            | meaning |
+| --------------- | ------------------ | ------- |
+| `dynamic`       | every baked route  | which routes render per request — a predicate, or a list of urls and/or route patterns (`/blog/$slug`). A serving-layer choice, so one build can be served static, dynamic, or a mix. |
+| `projectRoot`   | —                  | forwarded to the baked action gate |
+| `actionHeader`  | `"x-rsc-action"`   | header marking a POST as a server action |
+| `rscOutputPath` | `"index.rsc"`      | filename the client router fetches a flight from |
+
+It also accepts `createEdgeHandler`'s options below (`headers`, `nonce`,
+`onError`, `onNotFound`, …). `moduleBaseURL` and `bootstrapModules` come from the
+bundle's own bake; set them only to override.
+
+### Serving files from the same process
+
+`createEdgeRequestHandler` touches no filesystem: assets and prerendered
+snapshots are the host's to serve, and a CDN does it better. To serve them from
+disk anyway — a local runner, a Node self-host — compose `createEdgeRenderHook`
+into `createRequestHandler`:
+
+```ts
+import { createServer } from "node:http";
+import { createRequestHandler, toNodeListener } from "vite-plugin-react-server/request-handler";
+import { createEdgeRenderHook } from "vite-plugin-react-server/edge";
+import * as bundle from "./dist/server-edge/render.js";
+
+const app = createRequestHandler({
+  staticDir: "dist/static",
+  render: createEdgeRenderHook(bundle),   // null for a route it doesn't render
+  action: bundle.handleRouteAction,
+});
+
+createServer(toNodeListener(app)).listen(8787);
+```
+
+## The pieces underneath: `createEdgeHandler`
+
+`createEdgeRequestHandler` is built on `createEdgeHandler`, which composes the
+producer and the HTML render into a standard Web `(Request) => Response` handler.
+Reach for it directly only to drive the producer yourself:
 
 ```ts
 import { renderRouteToFlight } from "./dist/server-edge/render.js";
@@ -134,21 +196,35 @@ for a url that matches no baked route or route pattern (override via
 
 ### Finding `bootstrapModules`
 
-The bootstrap entry is your client entry's hashed filename, read from the client
-build manifest (`dist/client/.vite/manifest.json`) — the same mapping the static
-build uses:
+You don't. The bake reads the client entry's hashed filename out of the build
+manifest and exports it from the bundle as `bootstrapModules`, alongside
+`clientModuleBaseURL` (the built client bundle, resolved from `import.meta.url`).
+`createEdgeRequestHandler` uses both, which is why it needs no wiring.
+
+This is baked rather than read at runtime because a server that reads
+`.vite/manifest.json` on each boot forces the deploy to ship that dot-directory
+to the function — and platforms decline to in ways that only surface in
+production (Vercel's `includeFiles` glob skips dot-dirs, and its tracer will not
+follow a JSON import). Baking it into the module the server already imports
+leaves nothing extra to ship.
+
+Only when driving `createEdgeHandler` yourself do you pass them by hand:
 
 ```ts
-import { readFileSync } from "node:fs";
+import * as bundle from "./dist/server-edge/render.js";
 
-const manifest = JSON.parse(readFileSync("dist/client/.vite/manifest.json", "utf8"));
-const entry = manifest["src/client.tsx"]?.file;      // e.g. "client-abc123.js"
-const bootstrapModules = entry ? ["/" + entry] : [];
+createEdgeHandler({
+  render: bundle.renderRouteToFlight,
+  moduleBaseURL: bundle.clientModuleBaseURL,
+  bootstrapModules: bundle.bootstrapModules,
+});
 ```
 
-> Keep `moduleBaseURL` and the `bootstrapModules` prefix in sync with where you
-> actually host `dist/client`. A non-root deploy base (e.g. GitHub Pages) is the
-> usual reason hydration breaks — verify in a real prod build at the real base.
+> A non-root deploy base (e.g. GitHub Pages) is the usual reason hydration
+> breaks. The baked values already honor `base`; if you override them, keep
+> `moduleBaseURL` and the `bootstrapModules` prefix in sync with where you
+> actually host the client build — and verify in a real prod build at the real
+> base.
 
 ## Run it on Node
 
@@ -264,6 +340,9 @@ import "./start.js";
 - `createEdgeHandler` / `renderFlightToHtml` are client-condition exports (they
   run client React); import them from `vite-plugin-react-server/stream` **without**
   the `react-server` condition. Only the baked `render.js` is server React.
+  `vite-plugin-react-server/edge` has no such caveat — it resolves to one module
+  under either condition and defers the client-React import until a render, so
+  importing it from a react-server build is safe.
 - The baked action gate (`handleRouteAction`) enumerates `*.server.*` modules as
   the allowlist — a `"use server"` action must live in such a module (the common
   convention). Inline `"use server"` in a non-`.server.` file is not baked.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
     },
     "./metrics": "./dist/plugin/metrics/index.js",
     "./request-handler": "./dist/plugin/helpers/createRequestHandler.server.js",
+    "./edge": {
+      "types": "./dist/plugin/edge/index.d.ts",
+      "default": "./dist/plugin/edge/index.js"
+    },
     "./stream": {
       "react-server": "./dist/plugin/stream/index.server.js",
       "default": "./dist/plugin/stream/index.client.js"

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -1,12 +1,13 @@
 import { build as viteBuild, type Logger } from "vite";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import type { ResolvedUserOptions } from "../types.js";
 import { patternProbeUrl } from "../router/matchRoute.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { resolveModuleFromManifest } from "../helpers/resolveModuleFromManifest.js";
+import { UNKNOWN_ROUTE_MARKER } from "../stream/unknownRoute.js";
 
 /** Resolve a package subpath's `react-server` export target to an absolute path. */
 function reactServerExportTarget(
@@ -102,6 +103,14 @@ export async function buildEdgeBundle(opts: {
     userOptions.build.static,
     ".vite/manifest.json"
   );
+  // The browser's bootstrap module, baked from the same manifest. Its name is
+  // content-hashed, so it is only knowable from the build — and a server that
+  // reads it back out of `.vite/manifest.json` at runtime forces every deploy to
+  // ship that dot-directory to the function, which some platforms decline to do
+  // (Vercel's includeFiles glob skips dot-dirs, and its tracer won't follow a
+  // JSON import). Baking it into the bundle the server already imports removes
+  // the runtime read, so there is nothing extra to ship.
+  let bakedBootstrapModules: string[] = [];
   if (existsSync(staticManifestPath)) {
     const staticManifest = JSON.parse(readFileSync(staticManifestPath, "utf8"));
     const seen = new Set<string>();
@@ -125,7 +134,36 @@ export async function buildEdgeBundle(opts: {
         `${tag} baking ${bakedGlobalCss.length} stylesheet(s) into the document producer's default globalCss`
       );
     }
+    // The static build keys the browser bootstrap under the HTML input — that
+    // entry is the bundled client entry (startClient).
+    const entryFile = (
+      staticManifest as Record<string, { file?: string } | undefined>
+    )[userOptions.build.htmlOutputPath ?? DEFAULT_CONFIG.BUILD.htmlOutputPath]
+      ?.file;
+    if (entryFile) {
+      bakedBootstrapModules = [withBase(entryFile)];
+      logger.info(`${tag} baking client entry ${entryFile} as bootstrapModules`);
+    } else {
+      // Not fatal: a consumer can still pass bootstrapModules explicitly. But
+      // without one the document renders and never hydrates, which looks like a
+      // render bug rather than a missing entry — so say so here.
+      logger.warn(
+        `${tag} no HTML entry in the static manifest; the baked bootstrapModules ` +
+          `will be empty and the edge document will not hydrate unless the ` +
+          `handler is given bootstrapModules explicitly`
+      );
+    }
   }
+
+  // Where the built client (ssr) bundle sits RELATIVE to the edge bundle, so the
+  // handler can resolve client references without being told a path. Resolved
+  // from import.meta.url at runtime rather than baked absolute: the build machine
+  // and the deploy have different roots, and process.cwd() differs between a
+  // local `node server.mjs` and a platform function's task root. The relative
+  // layout is the one thing that holds across all of them.
+  const clientDir = join(outRoot, userOptions.build.client);
+  const relClientFromEdge =
+    relative(edgeDir, clientDir).split(sep).join("/") || ".";
 
   // Enumerate every prerendered route. Post-build, build.pages already lists
   // all URLs (the SSG just rendered them) and every page module is in
@@ -307,8 +345,14 @@ export async function buildEdgeBundle(opts: {
   // render does not diverge. moduleBasePath/URL come from the user config (the
   // SSG used the same), so client-reference ids align with the ssr bundle the
   // runtime points moduleBaseURL at.
-  const { entryFileName, flightExport, documentExport, actionExport } =
-    DEFAULT_CONFIG.EDGE;
+  const {
+    entryFileName,
+    flightExport,
+    documentExport,
+    actionExport,
+    bootstrapExport,
+    clientBaseExport,
+  } = DEFAULT_CONFIG.EDGE;
   const pageExport = userOptions.pageExportName ?? "Page";
   const propsExport = userOptions.propsExportName ?? "props";
   const layoutExport = userOptions.layoutExportName ?? "Layout";
@@ -406,6 +450,24 @@ const BAKED_GLOBAL_CSS = ${JSON.stringify(bakedGlobalCss)};
 const HtmlComponent = ${htmlNs}[${JSON.stringify(htmlComp.exportName)}];
 const RootComponent = ${rootNs}[${JSON.stringify(rootComp.exportName)}];
 
+/**
+ * The content-hashed browser entry to bootstrap hydration with, baked from the
+ * client manifest at build time — so no runtime manifest read, and nothing to
+ * ship beyond this bundle.
+ */
+export const ${bootstrapExport} = ${JSON.stringify(bakedBootstrapModules)};
+
+/**
+ * Where the built client (ssr) bundle lives, resolved relative to THIS module at
+ * runtime. The in-process HTML render imports client references from here, so it
+ * must be a location that exists wherever the bundle is deployed — hence
+ * import.meta.url, not a build-time absolute path or process.cwd().
+ */
+export const ${clientBaseExport} = new URL(
+  ${JSON.stringify(relClientFromEdge + "/")},
+  import.meta.url
+).href;
+
 const routes = {
 ${routeLines.join("\n")}
 };
@@ -425,7 +487,7 @@ async function resolveRoute(url, request) {
     const matched = matchRoutes(ROUTE_PATTERNS, url);
     if (matched) route = patternRoutes[matched.pattern];
   }
-  if (!route) throw new Error("[edge] unknown route: " + url);
+  if (!route) throw new Error(${JSON.stringify(UNKNOWN_ROUTE_MARKER + " ")} + url);
   const resolved = await resolvePageAndProps({
     pagePath: route.pagePath,
     propsPath: route.propsPath,

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -324,6 +324,12 @@ export const DEFAULT_CONFIG = {
     // Response. A sealed gate over the action modules baked into the bundle, so a
     // no-`--conditions` process dispatches actions without the on-disk transport.
     actionExport: "handleRouteAction",
+    // Its exported content-hashed browser entry (string[]), baked from the client
+    // manifest so no server has to read `.vite/manifest.json` at runtime.
+    bootstrapExport: "bootstrapModules",
+    // Its exported location of the built client bundle, resolved from
+    // import.meta.url at runtime (a deploy's root is not the build's root).
+    clientBaseExport: "clientModuleBaseURL",
     // Server-module manifest keys to bake as action candidates (the sealed-gate
     // allowlist). Server actions live in `*.server.*` modules.
     actionKeyPattern: "\\.server\\.[cm]?[jt]sx?$",

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -1,0 +1,217 @@
+import type { EdgeFetchHandler } from "../stream/createEdgeHandler.types.js";
+import { isUnknownRoute } from "../stream/unknownRoute.js";
+import { matchRoutes } from "../router/matchRoute.js";
+import type {
+  CreateEdgeRequestHandlerOptions,
+  EdgeBundleExports,
+  EdgeRenderHook,
+} from "./createEdgeRequestHandler.types.js";
+
+/**
+ * Mirrors DEFAULT_CONFIG.BUILD.rscOutputPath, deliberately NOT imported from it:
+ * this module has to stay loadable on a Web runtime, and the defaults module
+ * reaches for the transformer and the plugin root — Node-only, and no business
+ * being dragged into a Worker bundle for the sake of one string.
+ */
+const DEFAULT_RSC_OUTPUT_PATH = "index.rsc";
+
+/**
+ * Sentinel for "this bundle has no route here" coming back out of
+ * createEdgeHandler. Compared by IDENTITY, never by status: the hook has to tell
+ * an unbaked route apart from a 404 the app meant to return, and a status code
+ * cannot distinguish them.
+ */
+const NOT_HANDLED = new Response(null, { status: 404 });
+
+/**
+ * Strip the serving-layer decoration off a pathname to get the route key the
+ * bundle was baked with: a trailing flight filename (`/about/index.rsc`) or a
+ * trailing slash (`/about/`) both name the route `/about`.
+ */
+function routeOf(pathname: string, rscOutputPath: string): string {
+  const flightSuffix = "/" + rscOutputPath;
+  let route = pathname;
+  if (route.endsWith(flightSuffix)) route = route.slice(0, -flightSuffix.length);
+  else if (route.endsWith("/")) route = route.slice(0, -1);
+  return route || "/";
+}
+
+/** Whether the request wants the raw flight rather than an HTML document. */
+function wantsFlight(
+  pathname: string,
+  request: Request,
+  rscOutputPath: string
+): boolean {
+  return (
+    pathname.endsWith("/" + rscOutputPath) ||
+    (request.headers.get("accept") ?? "").includes("text/x-component")
+  );
+}
+
+/** Resolve the `dynamic` option to a predicate over route keys. */
+function toDynamicPredicate(
+  dynamic: CreateEdgeRequestHandlerOptions["dynamic"]
+): (url: string) => boolean {
+  // Omitted: render everything the bundle baked. The bundle is already a closed
+  // manifest, so it 404s a url it has no route for — no second gate needed.
+  if (!dynamic) return () => true;
+  if (typeof dynamic === "function") return dynamic;
+  // A list may hold exact urls and/or route patterns. matchRoutes treats a
+  // literal as a degenerate pattern, so one call covers both.
+  return (url: string) => matchRoutes(dynamic, url) !== null;
+}
+
+/**
+ * The per-request renderer behind {@link createEdgeRequestHandler}, exposed for
+ * composing into a server that ALSO serves files from disk — pass it as
+ * `createRequestHandler`'s `render` hook and it renders the dynamic routes while
+ * that handler serves the prerendered build and the assets:
+ *
+ * ```js
+ * import * as bundle from "./dist/server-edge/render.js";
+ * createRequestHandler({
+ *   staticDir: "dist/static",
+ *   render: createEdgeRenderHook(bundle),
+ *   action: bundle.handleRouteAction,
+ * });
+ * ```
+ *
+ * Returns `null` — not a 404 — for anything this bundle does not render, so the
+ * caller stays in charge of the fallback.
+ */
+export function createEdgeRenderHook(
+  bundle: EdgeBundleExports,
+  options: CreateEdgeRequestHandlerOptions = {}
+): EdgeRenderHook {
+  const {
+    dynamic,
+    rscOutputPath = DEFAULT_RSC_OUTPUT_PATH,
+    projectRoot: _projectRoot,
+    actionHeader: _actionHeader,
+    onNotFound: _onNotFound,
+    ...edgeOptions
+  } = options;
+
+  const isDynamic = toDynamicPredicate(dynamic);
+
+  // Loaded on first render, not at import. The HTML render pulls react-dom/server,
+  // which resolves to a stub that THROWS on import under the `react-server`
+  // condition — so an eager import would blow up merely by being reachable from a
+  // consumer's react-server-condition build, even though nothing would ever call
+  // it there. Deferring keeps `import ... from "vite-plugin-react-server/edge"`
+  // inert under either condition, which is the whole reason this entry exists.
+  // Memoized: built once, then reused for every request.
+  let documentHandler: Promise<EdgeFetchHandler> | undefined;
+  const getDocumentHandler = (): Promise<EdgeFetchHandler> =>
+    (documentHandler ??= import("../stream/createEdgeHandler.client.js").then(
+      ({ createEdgeHandler }) =>
+        createEdgeHandler({
+          ...edgeOptions,
+          renderDocument: (url, opts) => bundle.renderRouteToDocument(url, opts),
+          // From the bundle's own bake — the point is that the handler already
+          // knows its entry. An explicit option still wins.
+          moduleBaseURL: options.moduleBaseURL ?? bundle.clientModuleBaseURL ?? "/",
+          bootstrapModules: options.bootstrapModules ?? bundle.bootstrapModules,
+          getURL: (request) => routeOf(new URL(request.url).pathname, rscOutputPath),
+          onNotFound: () => NOT_HANDLED,
+        })
+    ));
+
+  return async function edgeRender(
+    route: string,
+    request: Request
+  ): Promise<Response | null> {
+    // `route` arrives as the raw pathname from createRequestHandler; normalize it
+    // the same way the document handler's getURL does, so both agree on the key.
+    const pathname = route.startsWith("/")
+      ? route
+      : new URL(request.url).pathname;
+    const url = routeOf(pathname, rscOutputPath);
+    if (!isDynamic(url)) return null;
+
+    if (wantsFlight(pathname, request, rscOutputPath)) {
+      // Client navigation: the Root-only payload, from the same producer (and so
+      // the same live props) the document path inlines on first paint.
+      try {
+        const { headless } = await bundle.renderRouteToDocument(url, { request });
+        return new Response(headless as unknown as BodyInit, {
+          headers: {
+            "content-type": "text/x-component; charset=utf-8",
+            "cache-control": "no-cache",
+          },
+        });
+      } catch (error) {
+        if (isUnknownRoute(error)) return null;
+        throw error;
+      }
+    }
+
+    const response = await (await getDocumentHandler())(request);
+    // An unbaked route is a fall-through for a hook, not an answer.
+    return response === NOT_HANDLED ? null : response;
+  };
+}
+
+/**
+ * The whole per-request edge server for a vprs build, in one call: hand it the
+ * baked bundle and get back the Web `(Request) => Response` every runtime speaks
+ * (Vercel/Netlify functions, Cloudflare Workers, Deno Deploy, Bun, and Node
+ * through `toNodeListener`).
+ *
+ * ```js
+ * import * as bundle from "../dist/server-edge/render.js";
+ * import { createEdgeRequestHandler } from "vite-plugin-react-server/edge";
+ *
+ * export const handler = createEdgeRequestHandler(bundle);
+ * ```
+ *
+ * It serves the flash-free document on a GET (markup and inlined flight from one
+ * render, so the page hydrates in place with no `.rsc` round-trip), the headless
+ * flight on a client navigation, and `"use server"` actions through the bundle's
+ * baked gate. No `worker_threads`, no runtime `--conditions`.
+ *
+ * Nothing here touches a filesystem or knows a platform: assets and any
+ * prerendered snapshots are the host's to serve (a CDN already does it better).
+ * To serve those from disk in the same process — a local runner, a Node
+ * self-host — compose {@link createEdgeRenderHook} into `createRequestHandler`
+ * instead.
+ */
+export function createEdgeRequestHandler(
+  bundle: EdgeBundleExports,
+  options: CreateEdgeRequestHandlerOptions = {}
+): EdgeFetchHandler {
+  const {
+    projectRoot,
+    actionHeader = "x-rsc-action",
+    onNotFound,
+    rscOutputPath = DEFAULT_RSC_OUTPUT_PATH,
+  } = options;
+
+  const render = createEdgeRenderHook(bundle, options);
+
+  return async function edgeRequestHandler(
+    request: Request
+  ): Promise<Response> {
+    const { pathname } = new URL(request.url);
+
+    if (
+      request.method === "POST" &&
+      request.headers.get(actionHeader) &&
+      bundle.handleRouteAction
+    ) {
+      return bundle.handleRouteAction(request, { projectRoot });
+    }
+
+    if (request.method === "GET" || request.method === "HEAD") {
+      const response = await render(pathname, request);
+      if (response) return response;
+    }
+
+    return onNotFound
+      ? onNotFound(routeOf(pathname, rscOutputPath), request)
+      : new Response("Not Found", {
+          status: 404,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
+  };
+}

--- a/plugin/edge/createEdgeRequestHandler.types.ts
+++ b/plugin/edge/createEdgeRequestHandler.types.ts
@@ -1,0 +1,92 @@
+import type { CreateEdgeHandlerOptions } from "../stream/createEdgeHandler.types.js";
+import type { CssContent } from "../types.js";
+
+/**
+ * The public surface of a baked edge bundle (`dist/server-edge/render.js`) — the
+ * shape {@link createEdgeRequestHandler} consumes.
+ *
+ * Import the bundle as a namespace and hand it over whole:
+ *
+ * ```js
+ * import * as bundle from "../dist/server-edge/render.js";
+ * export const handler = createEdgeRequestHandler(bundle);
+ * ```
+ *
+ * A STATIC import on purpose. The alternative — passing a path and letting the
+ * handler `import()` it — is invisible to the bundlers and file tracers that
+ * decide what a deploy actually ships, so the module goes missing at runtime on
+ * exactly the platforms this handler exists to serve.
+ */
+export type EdgeBundleExports = {
+  /** `renderRouteToDocument`: the full-document producer (`{ full, headless }`). */
+  renderRouteToDocument: (
+    url: string,
+    opts?: {
+      request?: Request;
+      cssFiles?: Map<string, CssContent>;
+      globalCss?: unknown;
+    }
+  ) => Promise<{
+    full: ReadableStream<Uint8Array>;
+    headless: ReadableStream<Uint8Array>;
+  }>;
+  /**
+   * `handleRouteAction`: the baked sealed action gate. Present whenever the build
+   * found `"use server"` modules; a read-only site has none.
+   */
+  handleRouteAction?: (
+    request: Request,
+    opts?: { projectRoot?: string }
+  ) => Promise<Response>;
+  /** `bootstrapModules`: the content-hashed browser entry, baked at build time. */
+  bootstrapModules?: string[];
+  /** `clientModuleBaseURL`: the built client bundle, resolved from import.meta.url. */
+  clientModuleBaseURL?: string;
+};
+
+/**
+ * Options for {@link createEdgeRequestHandler} / {@link createEdgeRenderHook}.
+ *
+ * Extends {@link CreateEdgeHandlerOptions} minus its producer fields: the bundle
+ * IS the producer, so `render`/`renderDocument` are not yours to set. Everything
+ * the bundle bakes (`bootstrapModules`, `moduleBaseURL`) is inherited from it and
+ * only needs setting to override.
+ */
+export type CreateEdgeRequestHandlerOptions = Omit<
+  CreateEdgeHandlerOptions,
+  "render" | "renderDocument"
+> & {
+  /**
+   * Which routes render live, per request. A predicate, or a list of urls and/or
+   * route patterns (`/blog/$slug`) matched with the router's own `matchRoutes`.
+   *
+   * This is a SERVING-layer choice, deliberately separate from `Page`/`props`
+   * (which define the page surface): the same build can be served fully static,
+   * fully dynamic, or a mix, without rebuilding.
+   *
+   * Omit to render every route the bundle baked — the right default for a deploy
+   * with no prerendered snapshots to fall back to.
+   */
+  dynamic?: string[] | ((url: string) => boolean);
+  /** Forwarded to the baked action gate (which ignores it — nothing loads from disk). */
+  projectRoot?: string;
+  /** Header marking a POST as a server action. @default "x-rsc-action" */
+  actionHeader?: string;
+  /**
+   * Filename the client router fetches a route's flight from.
+   * @default "index.rsc"
+   */
+  rscOutputPath?: string;
+};
+
+/**
+ * A dynamic-route renderer for
+ * {@link import("../helpers/createRequestHandler.server.js").createRequestHandler}'s
+ * `render` hook: returns a `Response` for a route this bundle renders, or `null`
+ * to fall through to whatever the caller serves next (a prerendered file, an
+ * asset, a 404).
+ */
+export type EdgeRenderHook = (
+  route: string,
+  request: Request
+) => Promise<Response | null>;

--- a/plugin/edge/index.ts
+++ b/plugin/edge/index.ts
@@ -1,0 +1,19 @@
+// Public "./edge" entry: the per-request edge server for a vprs build.
+//
+// Exported WITHOUT a `react-server` condition key, on purpose. The handler runs
+// client React (the baked bundle carries server React inside it), but consumers
+// import it from code that a react-server-condition build also has to load —
+// a `./stream`-style condition split resolves that import to a server barrel
+// which does not export it, and the build dies on a module that would never have
+// run under that condition anyway. One target for both conditions is what makes
+// the import safe from anywhere.
+export {
+  createEdgeRequestHandler,
+  createEdgeRenderHook,
+} from "./createEdgeRequestHandler.js";
+export type {
+  CreateEdgeRequestHandlerOptions,
+  EdgeBundleExports,
+  EdgeRenderHook,
+} from "./createEdgeRequestHandler.types.js";
+export type { EdgeFetchHandler } from "../stream/createEdgeHandler.types.js";

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -5,6 +5,7 @@ import type {
 import { renderFlightToHtml } from "./renderFlightToHtml.client.js";
 import { injectInlineFlightIntoHtml } from "../utils/inlineFlight.js";
 import { assertNonReactServer } from "../config/getCondition.js";
+import { isUnknownRoute } from "./unknownRoute.js";
 
 assertNonReactServer();
 
@@ -31,14 +32,6 @@ async function collectBytes(
   }
   return out;
 }
-
-/**
- * Marker the baked flight producer uses for a url with no baked route (see the
- * generated entry in plugin/bundle/buildEdgeBundle.ts — `"[edge] unknown route:
- * " + url`). Kept here so the handler can map that one throw to a 404 without
- * swallowing real render errors.
- */
-const UNKNOWN_ROUTE_MARKER = "[edge] unknown route:";
 
 /**
  * Compose a single-isolate edge build into a Web `fetch` handler.
@@ -97,10 +90,6 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
           status: 404,
           headers: { "content-type": "text/plain; charset=utf-8" },
         });
-
-  /** The producer 404s an unbaked route by throwing the unknown-route marker. */
-  const isUnknownRoute = (error: unknown): boolean =>
-    error instanceof Error && error.message.includes(UNKNOWN_ROUTE_MARKER);
 
   return async function edgeHandler(request: Request): Promise<Response> {
     const url = getURL(request);

--- a/plugin/stream/unknownRoute.ts
+++ b/plugin/stream/unknownRoute.ts
@@ -1,0 +1,16 @@
+/**
+ * Marker the baked flight producer throws for a url it has no route for (see the
+ * generated entry in plugin/bundle/buildEdgeBundle.ts). The bundle is a CLOSED
+ * manifest over `build.pages` + `routePatterns`, so an unmatched url is a 404,
+ * not a 500 — but a render that genuinely failed must still surface. This one
+ * marker is the seam between those two, so the bake and every handler that maps
+ * it have to agree on the exact string.
+ */
+export const UNKNOWN_ROUTE_MARKER = "[edge] unknown route:";
+
+/** Whether an error is the baked producer's "no such route" throw. */
+export function isUnknownRoute(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.includes(UNKNOWN_ROUTE_MARKER)
+  );
+}

--- a/test/examples/build-edge-bundle.test.ts
+++ b/test/examples/build-edge-bundle.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import * as streamApi from "vite-plugin-react-server/stream";
+import * as edgeApi from "vite-plugin-react-server/edge";
 import { doBuild } from "../doBuild.js";
 
 // renderFlightToHtml is client-only (exported under the default condition, not
@@ -16,6 +17,11 @@ const renderFlightToHtml = (streamApi as any).renderFlightToHtml as
 const createEdgeHandler = (streamApi as any).createEdgeHandler as
   | typeof import("../../plugin/stream/createEdgeHandler.client.js").createEdgeHandler
   | undefined;
+
+// ./edge is condition-NEUTRAL: unlike ./stream above, it resolves to the same
+// module under react-server, so it needs no `as any` unwrapping. It is still only
+// exercised on the client leg, where the render it defers to can actually run.
+const { createEdgeRequestHandler, createEdgeRenderHook } = edgeApi;
 
 const testDir = resolve(__dirname, "../fixtures/build-edge-bundle.test");
 
@@ -209,6 +215,137 @@ describe.skipIf(!renderFlightToHtml)(
       expect(response.status).toBe(200);
       // RSC success wire format `0:<json>` — bump(41) ran through the gate → 42.
       expect(await response.text()).toContain("0:42");
+    });
+
+    // The ./edge one-liner. Every test below imports the bundle as a NAMESPACE
+    // and hands it straight to createEdgeRequestHandler — no manifest read, no
+    // bootstrap derivation, no moduleBaseURL. That absence IS the feature: the
+    // hand-rolled versions of exactly those steps are what this entry replaces.
+    describe("createEdgeRequestHandler (./edge)", () => {
+      const loadBundle = () =>
+        import(pathToFileURL(join(testDir, "dist/server-edge/render.js")).href);
+
+      it("bakes the content-hashed client entry as bootstrapModules", async () => {
+        const bundle = await loadBundle();
+        // The value a consumer would otherwise dig out of
+        // dist/static/.vite/manifest.json and ship to the function themselves.
+        expect(bundle.bootstrapModules).toHaveLength(1);
+
+        const staticManifest = JSON.parse(
+          await readFile(join(testDir, "dist/static/.vite/manifest.json"), "utf8")
+        );
+        // The REAL hashed entry, not merely a plausible-looking path.
+        expect(bundle.bootstrapModules[0]).toBe(
+          "/" + staticManifest["index.html"].file
+        );
+      });
+
+      it("resolves clientModuleBaseURL relative to the bundle, not the cwd", async () => {
+        const bundle = await loadBundle();
+        // Must point at the built client bundle wherever the file actually sits:
+        // a deploy's task root and the build's root are different places, and
+        // process.cwd() is neither inside a platform function.
+        expect(bundle.clientModuleBaseURL).toBe(
+          pathToFileURL(join(testDir, "dist/client")).href + "/"
+        );
+      });
+
+      it("serves a hydratable flash-free document from the bundle alone", async () => {
+        const bundle = await loadBundle();
+        const handler = createEdgeRequestHandler(bundle);
+
+        const response = await handler(new Request("http://edge.test/"));
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toContain("text/html");
+
+        const html = await response.text();
+        expect(html).toContain("<html");
+        expect(html).toContain("edge-isolate");
+        // Inline flight (no .rsc round-trip) + the baked bootstrap entry, neither
+        // of them supplied by the caller.
+        expect(html).toContain('id="vprs-flight"');
+        expect(html).toContain(bundle.bootstrapModules[0]);
+      });
+
+      it("serves the headless flight for a client navigation", async () => {
+        const bundle = await loadBundle();
+        const handler = createEdgeRequestHandler(bundle);
+
+        const response = await handler(new Request("http://edge.test/index.rsc"));
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toContain("text/x-component");
+        expect(await response.text()).toContain("edge-isolate");
+      });
+
+      it("404s a route the bundle was not baked with", async () => {
+        const bundle = await loadBundle();
+        const handler = createEdgeRequestHandler(bundle);
+        const response = await handler(new Request("http://edge.test/missing"));
+        expect(response.status).toBe(404);
+      });
+
+      it("dispatches a server action through the bundle's baked gate", async () => {
+        const bundle = await loadBundle();
+        const handler = createEdgeRequestHandler(bundle, {
+          projectRoot: testDir,
+        });
+
+        const response = await handler(
+          new Request("http://edge.test/", {
+            method: "POST",
+            headers: {
+              "x-rsc-action": "src/page/actions.server.ts#bump",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify([41]),
+          })
+        );
+        expect(response.status).toBe(200);
+        expect(await response.text()).toContain("0:42");
+      });
+
+      it("renders only the routes `dynamic` selects", async () => {
+        const bundle = await loadBundle();
+        const handler = createEdgeRequestHandler(bundle, { dynamic: [] });
+        // "/" is baked, but the serving layer opted it out — a mixed deploy
+        // serves the prerendered snapshot for it instead.
+        const response = await handler(new Request("http://edge.test/"));
+        expect(response.status).toBe(404);
+      });
+
+      it("accepts route PATTERNS in `dynamic`, not just exact urls", async () => {
+        const bundle = await loadBundle();
+        // Matched through the router's own matchRoutes, so a pattern selects
+        // routes without the serving layer enumerating their urls — the point
+        // being that an unenumerated dynamic url (`/profile/<id>`) can be served
+        // per request.
+        const handler = createEdgeRequestHandler(bundle, { dynamic: ["/$"] });
+        const response = await handler(new Request("http://edge.test/"));
+        expect(response.status).toBe(200);
+        expect(await response.text()).toContain("edge-isolate");
+
+        // ...while a pattern that does NOT match still opts the route out, so the
+        // predicate is really matching rather than waving everything through.
+        const narrow = createEdgeRequestHandler(bundle, {
+          dynamic: ["/blog/$slug"],
+        });
+        expect((await narrow(new Request("http://edge.test/"))).status).toBe(404);
+      });
+
+      it("falls through, rather than 404ing, as a createRequestHandler render hook", async () => {
+        const bundle = await loadBundle();
+        const hook = createEdgeRenderHook(bundle);
+
+        // A baked route answers...
+        const rendered = await hook("/", new Request("http://edge.test/"));
+        expect(rendered?.status).toBe(200);
+
+        // ...and an unbaked one yields null, so the composing handler can serve a
+        // file or 404 itself. A 404 Response here would shadow the static build.
+        expect(
+          await hook("/missing", new Request("http://edge.test/missing"))
+        ).toBeNull();
+      });
     });
   }
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -124,6 +124,9 @@ export default defineConfig({
         // only fileRouter uses (e.g. fillPattern) from the shared matchRoute chunk.
         "plugin/router/index": resolve(__dirname, "plugin/router/index.ts"),
         "plugin/router/client": resolve(__dirname, "plugin/router/client.ts"),
+        // Public "./edge" entry. Condition-neutral by design — one target serves
+        // both conditions, see plugin/edge/index.ts.
+        "plugin/edge/index": resolve(__dirname, "plugin/edge/index.ts"),
       },
       formats: ["es"],
     },


### PR DESCRIPTION
The single-isolate edge bundle could already render every route, but it couldn't tell a server where its own client entry was. So every consumer rebuilt the same prelude: read `dist/static/.vite/manifest.json`, pull out the content-hashed entry, work out where `dist/client` sits, hand both to `createEdgeHandler`. Around 90 lines of it, per consumer, to reach a renderer that was already platform-agnostic.

The gap was never the platform — `createEdgeHandler` has been `(Request) => Response` all along. It was the **entry**.

## Bake the entry

- **`bootstrapModules`** — the hashed client entry, read from the manifest *at build time* and exported from the bundle. Reading it at runtime forces the deploy to ship `.vite/` to the function, which platforms decline to do in ways that only surface in production (Vercel's `includeFiles` glob skips dot-dirs; its tracer won't follow a JSON import). Baking it leaves nothing extra to ship.
- **`clientModuleBaseURL`** — where the built client bundle is, resolved from `import.meta.url`. Not a build-time absolute (the build's root isn't the deploy's) and not `process.cwd()` (which is neither, inside a platform function).

## The one-liner

```ts
import * as bundle from "./dist/server-edge/render.js";
import { createEdgeRequestHandler } from "vite-plugin-react-server/edge";

export const handler = createEdgeRequestHandler(bundle);
```

Serves the flash-free document on a GET, the headless flight on a client navigation, and `"use server"` actions through the bundle's baked gate. No filesystem, no platform knowledge — assets and snapshots stay the host's job.

The bundle goes in as a **namespace**: a static import stays visible to a deploy's file tracer, where a runtime path does not. `createEdgeRenderHook` exposes the same renderer as a `createRequestHandler` `render` hook (returning `null`, not a 404, so the caller keeps its fallback) for a process that also serves files from disk.

## Condition-neutrality is load-bearing

`./edge` has no `react-server` export key **and** defers the client-React import to first render. Both are needed: `react-dom/server` resolves to a stub that throws on import under that condition, so an eager import breaks a consumer's react-server build merely by being *reachable* — for a module that would never have run there anyway.

Measured before and after:

| import | before | after |
|---|---|---|
| `./edge` under `react-server` | throws `react-dom/server is not supported…` | resolves ✅ |
| `./edge` default condition | n/a | resolves ✅ |
| `./stream` under `react-server` | `createEdgeHandler` is `undefined` | unchanged (the documented footgun) |

## Scope

No CSS work: `build.edge` already bakes the stylesheets into the document producer's `globalCss`, and `routePatterns` already gives `matchRoutes` its pattern fallback. The entry was the one hand-rolled piece left.

## Verification

Against a real build (`vprs-starter`, installed from `npm pack` — not `file:`-linked, which hides dependency resolution):

- `/` and `/about` 200 with `#root` populated; `/index.rsc` returns `text/x-component`; `/missing` 404s; assets and the traversal guard still behave
- live per-request geo in the first paint (`data-state="live"` … `near Amsterdam, NL`), inline flight and the baked entry both wired in without the consumer naming either
- the emitted bundle keeps `import.meta.url` through the bundler and contains **zero** runtime manifest reads
- consumer wiring drops from 183 lines to 80, and one file disappears entirely

Full gate green (804 passed, matching baseline), `tsc --noEmit` clean, 9 new tests over the real baked bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)