### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.9",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.1.9",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.1.9",
+  "version": "3.2.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Minor rather than patch: `./edge` and `./edge/web` are new public exports.

## What's in it

The through-line of this release is the single-isolate edge path growing from "Node-bound convenience" to a request path that composes for filesystem-less runtimes.

- **[#253](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/253)** — `feat(edge): createEdgeRequestHandler`. The bundle bakes its own client entry (`bootstrapModules`) and client-bundle location (`clientModuleBaseURL`), so a per-request server is `createEdgeRequestHandler(bundle)` instead of ~90 lines of manifest reading per consumer. The `./edge` entry is condition-neutral.
- **[#258](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/258)** — adopt react-server-loader **19.2.17** (dual-transport: vendored esm + `webpack/*` from one pinned React build).
- **[#259](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/259)** — bake a webpack-shaped client manifest into the edge bundle (`clientManifest` export): closed-registry reference resolution, no runtime manifest reads.
- **[#261](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/261)** — `build.edge.transport: "esm" | "webpack"` (default esm, verified byte-identical). Webpack mode re-transports the whole baked graph through one alias entry; the bundle self-describes via `flightTransport`.
- **[#262](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/262)** — drop the baked bundle's remaining hard Node dependencies: dead disk-fallback `node:` imports made lazy, bare `process` reads guarded (`plugin/proc.ts`).
- **[#263](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/263)** — bake the **consumer** half (`dist/server-edge/consumer.js`: client React + closed client-module registry) and add **`./edge/web`** — the same handler factories without the Node renderer in the module graph. Measured: the composed producer + consumer + handler bundles for a Worker with zero `node:` specifiers and zero `require`, and runs with no `process` global.
- **[#264](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/264)** — docs: runtime claims follow the transport (Node hosts on esm; Workers/Deno via the baked consumer).
- **[#260](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/260)** — clean dist before the prepack build.
- **[#252](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/252)** — `prepublishOnly` blocks an untagged publish.
- #255/#256 — `render.d.ts` emission beside the baked bundle, tried and reverted (net zero).

## Release steps after merge

The bump is the only thing in this PR; `version:minor` does not tag. On merged `main`:

```bash
git checkout main && git pull
git tag -a v3.2.0 -m "v3.2.0"
git push origin v3.2.0
npm publish   # 2FA
```

`prepublishOnly` runs `verify:tag`, so a forgotten tag fails the publish rather than shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs
