### PR TITLE
docs(edge): stop claiming the handler runs on Workers/Deno — it is Node-bound

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Read in order if you're new; each stands alone otherwise.
 - [Build Output](./build-output.md) — what the build produces, and how to serve it
 - [CSS Handling](./css-handling.md) — inline vs linked CSS, CSS modules
 - [Server Actions](./server-actions.md) — `"use server"`, form actions
-- [Edge / Single-Isolate](./edge.md) — flash-free SSR from one Web `fetch` handler, no workers and no `--conditions` (Cloudflare/Deno/Vercel/Bun)
+- [Edge / Single-Isolate](./edge.md) — flash-free SSR from one Web `fetch` handler, no workers and no `--conditions`, on Node-compatible hosts
 - [Storybook](./storybook.md) — rendering RSC components in stories
 - [Examples](./examples.md) — static site, dynamic server, custom routing
 - [Troubleshooting](./troubleshooting.md) — common errors and fixes

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -2,8 +2,8 @@
 
 The default build renders HTML through worker threads under a `--conditions
 react-server` process flag. That model is great on a full Node server, but it
-does not fit single-process targets — serverless functions and edge-style
-runtimes (Bun, Deno, Vercel/Netlify Functions) — which have no `worker_threads`
+does not fit single-process targets — serverless functions and single-process
+runtimes (Bun, Vercel/Netlify Functions) — which have no `worker_threads`
 and no process-level export conditions.
 
 The **single-isolate edge build** removes both requirements. It bakes a second,
@@ -13,11 +13,13 @@ runtime `--conditions`. You get flash-free streaming SSR from one Web `fetch`
 handler.
 
 One naming precision: "edge" here refers to the single-isolate *shape*, not to a
-literal V8-isolate runtime. Rendering a page with client islands imports the
-built client chunks off disk (see `moduleBaseURL` below), so the natural homes
-are Node-flavored serverless functions and single-process servers. A runtime
-with no filesystem, such as Cloudflare Workers, only fits when nothing in the
-render needs a disk import.
+literal V8-isolate runtime. The HTML half of the render resolves react-dom
+through `node:module` at request time, and client islands import the built
+client chunks off disk (see `moduleBaseURL` below) — so this runs on
+**Node-compatible hosts**: Node servers, Bun, Vercel/Netlify Node functions. It
+does not run on Cloudflare Workers or Deno Deploy today; those need a fully
+self-contained bundle with module-map reference resolution, which the current
+build does not produce.
 
 It is **additive**: the normal `dist/server` / `dist/static` output is untouched.
 Dev is unaffected.
@@ -105,7 +107,7 @@ import { createEdgeRequestHandler } from "vite-plugin-react-server/edge";
 
 export const handler = createEdgeRequestHandler(bundle);
 
-export default { fetch: handler };   // Bun / Deno / Cloudflare / serverless
+export default { fetch: handler };   // Node server, Bun, a Node serverless function
 ```
 
 That is the whole thing: a Web `(Request) => Response` serving the flash-free
@@ -173,7 +175,7 @@ const handler = createEdgeHandler({
   bootstrapModules: ["/client-abc123.js"],  // your client entry (for hydration)
 });
 
-export default { fetch: handler };          // Bun / Deno / serverless function
+export default { fetch: handler };          // Node server, Bun, a Node serverless function
 ```
 
 The handler **streams** (responds when the HTML shell is ready), returns **404**

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -13,13 +13,17 @@ runtime `--conditions`. You get flash-free streaming SSR from one Web `fetch`
 handler.
 
 One naming precision: "edge" here refers to the single-isolate *shape*, not to a
-literal V8-isolate runtime. The HTML half of the render resolves react-dom
-through `node:module` at request time, and client islands import the built
-client chunks off disk (see `moduleBaseURL` below) — so this runs on
-**Node-compatible hosts**: Node servers, Bun, Vercel/Netlify Node functions. It
-does not run on Cloudflare Workers or Deno Deploy today; those need a fully
-self-contained bundle with module-map reference resolution, which the current
-build does not produce.
+literal V8-isolate runtime. Which runtimes a handler reaches is a property of
+the **transport underneath**, not of the shape. This build renders through the
+esm transport, which resolves react-dom through `node:module` at request time
+and client islands by `import()` off disk (see `moduleBaseURL` below) — so it
+runs on **Node-compatible hosts**: Node servers, Bun, Vercel/Netlify Node
+functions. Filesystem-less runtimes (Cloudflare Workers, Deno Deploy) need the
+open resolution replaced with a closed module map — the webpack transport's
+model, which `react-server-loader` vendors alongside the esm one since 19.2.17.
+A render path built on it composes to a fully self-contained bundle with zero
+`node:` imports; until vprs ships that path, deploy this build to the
+Node-compatible hosts above.
 
 It is **additive**: the normal `dist/server` / `dist/static` output is untouched.
 Dev is unaffected.

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -157,11 +157,13 @@ export function createEdgeRenderHook(
  * hand it the baked bundle and get back a Web `(Request) => Response`.
  *
  * Runs on Node-compatible hosts (Node servers via `toNodeListener`, Bun,
- * Vercel/Netlify Node functions). NOT on Cloudflare Workers or Deno Deploy:
- * the HTML render underneath resolves react-dom through `node:module` at
- * request time, and client references resolve by `import()` off disk. "Edge"
- * names the single-isolate build shape (no worker_threads, no runtime
- * `--conditions`), not a literal isolate runtime.
+ * Vercel/Netlify Node functions). The Node binding is a property of the esm
+ * transport this render path uses — react-dom resolves through `node:module`
+ * at request time, client references by `import()` off disk — not of the
+ * `(Request) => Response` shape. A filesystem-less runtime (Cloudflare
+ * Workers, Deno Deploy) needs the webpack transport's closed module-map
+ * resolution instead. "Edge" names the single-isolate build shape (no
+ * worker_threads, no runtime `--conditions`), not a literal isolate runtime.
  *
  * ```js
  * import * as bundle from "../dist/server-edge/render.js";

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -153,10 +153,15 @@ export function createEdgeRenderHook(
 }
 
 /**
- * The whole per-request edge server for a vprs build, in one call: hand it the
- * baked bundle and get back the Web `(Request) => Response` every runtime speaks
- * (Vercel/Netlify functions, Cloudflare Workers, Deno Deploy, Bun, and Node
- * through `toNodeListener`).
+ * The whole per-request server for a single-isolate vprs build, in one call:
+ * hand it the baked bundle and get back a Web `(Request) => Response`.
+ *
+ * Runs on Node-compatible hosts (Node servers via `toNodeListener`, Bun,
+ * Vercel/Netlify Node functions). NOT on Cloudflare Workers or Deno Deploy:
+ * the HTML render underneath resolves react-dom through `node:module` at
+ * request time, and client references resolve by `import()` off disk. "Edge"
+ * names the single-isolate build shape (no worker_threads, no runtime
+ * `--conditions`), not a literal isolate runtime.
  *
  * ```js
  * import * as bundle from "../dist/server-edge/render.js";

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -46,10 +46,12 @@ async function collectBytes(
  * point {@link CreateEdgeHandlerOptions.moduleBaseURL} at where `dist/client`
  * is served).
  *
- * The shape is portable; the implementation today is not: the HTML render
- * resolves react-dom through `node:module` at request time, so this runs on
- * Node-compatible hosts (Node, Bun, Node serverless functions) — not on
- * Cloudflare Workers or Deno Deploy.
+ * The shape is portable; how far it travels is set by the transport underneath.
+ * This path uses the esm transport, whose HTML render resolves react-dom
+ * through `node:module` at request time — so it runs on Node-compatible hosts
+ * (Node, Bun, Node serverless functions). Filesystem-less runtimes (Cloudflare
+ * Workers, Deno Deploy) need a render path on the webpack transport's closed
+ * module-map resolution instead.
  *
  * The returned handler streams: it responds as soon as the HTML shell is ready.
  * Unknown routes get a 404 (override via `onNotFound`); other render errors

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -39,13 +39,17 @@ async function collectBytes(
  * Wires the baked per-route flight producer (`dist/server-edge/render.js`'s
  * `renderRouteToFlight`, server React) to the in-process HTML render
  * (`renderFlightToHtml`, client React) and returns a `(Request) => Response`
- * handler — the native entrypoint shape for Cloudflare Workers, Deno Deploy,
- * Vercel Edge and Bun, and trivially adaptable to Node. No worker_threads, no
- * runtime `--conditions`: the producer baked server React, this side runs
- * client React, and they co-exist in one isolate (client islands resolve via
- * the client transport's `import(moduleBaseURL + id)` into the ssr bundle, so
+ * handler in the Web-standard `fetch` shape. No worker_threads, no runtime
+ * `--conditions`: the producer baked server React, this side runs client
+ * React, and they co-exist in one isolate (client islands resolve via the
+ * client transport's `import(moduleBaseURL + id)` into the ssr bundle, so
  * point {@link CreateEdgeHandlerOptions.moduleBaseURL} at where `dist/client`
  * is served).
+ *
+ * The shape is portable; the implementation today is not: the HTML render
+ * resolves react-dom through `node:module` at request time, so this runs on
+ * Node-compatible hosts (Node, Bun, Node serverless functions) — not on
+ * Cloudflare Workers or Deno Deploy.
  *
  * The returned handler streams: it responds as soon as the HTML shell is ready.
  * Unknown routes get a 404 (override via `onNotFound`); other render errors

--- a/plugin/stream/createEdgeHandler.types.ts
+++ b/plugin/stream/createEdgeHandler.types.ts
@@ -1,8 +1,9 @@
 import type { Logger } from "vite";
 
 /**
- * A Web `fetch` handler: the standard edge-runtime entrypoint shape
- * (Cloudflare Workers, Deno Deploy, Vercel Edge, Bun, Node via an adapter).
+ * A Web `fetch` handler: the standard `(Request) => Response` entrypoint
+ * shape. The shape is universal; where a given handler actually runs depends
+ * on what its implementation touches — see the docs of the handler you use.
  */
 export type EdgeFetchHandler = (request: Request) => Promise<Response>;
 


### PR DESCRIPTION
The edge docs and JSDoc named Cloudflare Workers, Deno Deploy and Vercel Edge as targets for `createEdgeHandler` / `createEdgeRequestHandler`. That is false today, and it was measured rather than assumed: the HTML half of the render resolves react-dom through `node:module` (`createRequire` + `process.cwd`) at request time, and client references resolve by `import()` off disk. Neither exists on those runtimes — a consumer following the docs there gets a runtime failure on the first request.

## What changes

- **`docs/edge.md`** — the intro's "edge = the single-isolate shape" precision now states the full constraint (react-dom resolution is unconditional, not just client-island disk imports), and both `fetch: handler` examples name the honest hosts: Node servers, Bun, Node serverless functions.
- **`plugin/edge/createEdgeRequestHandler.ts`** — JSDoc drops Workers/Deno, states where it runs and why.
- **`plugin/stream/createEdgeHandler.client.ts`** — docblock separates the Web-standard *shape* (universal) from the *implementation* (Node-bound today).
- **`plugin/stream/createEdgeHandler.types.ts`** — `EdgeFetchHandler` describes only the shape.
- **`docs/README.md`** — index line for the edge doc corrected.

`docs/build-output.md` was already accurate ("'edge' refers to the single-isolate shape … rather than to literal isolate runtimes") and is untouched.

Docs + comments only; no behavior change. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)