### PR TITLE
chore(deps): adopt react-server-loader 19.2.17 / 172742b4 (dual-transport)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.16 || 0.0.0-experimental-c0c39a6b-20260709.1",
+        "react-server-loader": "^19.2.17 || 0.0.0-experimental-172742b4-20260716",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -6437,9 +6437,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.16.tgz",
-      "integrity": "sha512-XKvj9VhvziYlCYEJMvMrId/guwKzQ2uknDRRSZ2N+4b5wIinMwy3eer8DcpY+8JQnXQ+qUwTuC1BDNYZFMuJbw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.17.tgz",
+      "integrity": "sha512-XrmiJi2gPp1Fk0s9Bq8Fs+82WCYv+TDH7GLZQqNTvYU3caaOCOoVCyMw6YEYn8JQzNukvie2QsHqQcOvQUsHoA==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -436,7 +436,7 @@
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
-    "react-server-loader": "^19.2.16 || 0.0.0-experimental-c0c39a6b-20260709.1",
+    "react-server-loader": "^19.2.17 || 0.0.0-experimental-172742b4-20260716",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }


### PR DESCRIPTION
Adopts the dual-transport react-server-loader release:

- **stable arm**: `^19.2.16` → `^19.2.17` — same vendored React (19.2.7), now also carrying the vendored `react-server-dom-webpack` transport and the `react-server-loader/webpack/runtime` adapters.
- **experimental arm**: `0.0.0-experimental-c0c39a6b-20260709.1` → `0.0.0-experimental-172742b4-20260716` — the React build npm's `experimental` tag currently points at.

No code changes; the esm dev path is untouched. This is the base for the webpack prod path (baked client manifest emission, a `startClient` prod entry on `webpack/runtime`, and the action endpoint), which comes in follow-up PRs.

Verified: full `test-all` suite green against the published 19.2.17 bytes from the registry (not a local link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)