### PR TITLE
feat(edge): bake a webpack-shaped client manifest into the edge bundle

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -8,6 +8,7 @@ import { patternProbeUrl } from "../router/matchRoute.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { resolveModuleFromManifest } from "../helpers/resolveModuleFromManifest.js";
 import { UNKNOWN_ROUTE_MARKER } from "../stream/unknownRoute.js";
+import { buildWebpackClientManifest } from "./clientManifest.js";
 
 /** Resolve a package subpath's `react-server` export target to an absolute path. */
 function reactServerExportTarget(
@@ -164,6 +165,29 @@ export async function buildEdgeBundle(opts: {
   const clientDir = join(outRoot, userOptions.build.client);
   const relClientFromEdge =
     relative(edgeDir, clientDir).split(sep).join("/") || ".";
+
+  // The webpack-shaped client manifest (hosted id -> {id, chunks, name}),
+  // derived from the client build's Vite manifest. This is the module map a
+  // webpack-transport render resolves client references against — baked and
+  // exported so no runtime ever reads `.vite/manifest.json` (same reasoning as
+  // the baked bootstrapModules above).
+  let bakedClientManifest: Record<string, unknown> = {};
+  const clientManifestPath = join(clientDir, ".vite/manifest.json");
+  if (existsSync(clientManifestPath)) {
+    bakedClientManifest = buildWebpackClientManifest(
+      JSON.parse(readFileSync(clientManifestPath, "utf8")),
+      userOptions.moduleBasePath ?? ""
+    );
+    const count = Object.keys(bakedClientManifest).length;
+    if (count > 0) {
+      logger.info(`${tag} baking webpack client manifest over ${count} module(s)`);
+    }
+  } else {
+    logger.warn(
+      `${tag} no client manifest at ${clientManifestPath}; the baked ` +
+        `${DEFAULT_CONFIG.EDGE.clientManifestExport} export will be empty`
+    );
+  }
 
   // Enumerate every prerendered route. Post-build, build.pages already lists
   // all URLs (the SSG just rendered them) and every page module is in
@@ -352,6 +376,7 @@ export async function buildEdgeBundle(opts: {
     actionExport,
     bootstrapExport,
     clientBaseExport,
+    clientManifestExport,
   } = DEFAULT_CONFIG.EDGE;
   const pageExport = userOptions.pageExportName ?? "Page";
   const propsExport = userOptions.propsExportName ?? "props";
@@ -467,6 +492,17 @@ export const ${clientBaseExport} = new URL(
   ${JSON.stringify(relClientFromEdge + "/")},
   import.meta.url
 ).href;
+
+/**
+ * The webpack-shaped client manifest: hosted client-reference id ->
+ * { id, chunks, name }, derived from the client build's Vite manifest at bake
+ * time. Chunks list the module's own file plus its transitive import closure
+ * (all as hosted paths), so a consumer can preload before the sync require.
+ * This is the module map for rendering this build's flight through the
+ * webpack transport (react-server-loader/webpack/*) — the closed-registry
+ * resolution a fully self-contained deployment needs.
+ */
+export const ${clientManifestExport} = ${JSON.stringify(bakedClientManifest)};
 
 const routes = {
 ${routeLines.join("\n")}

--- a/plugin/bundle/clientManifest.ts
+++ b/plugin/bundle/clientManifest.ts
@@ -1,0 +1,82 @@
+/**
+ * Derive the webpack-shaped client manifest from the client build's Vite
+ * manifest.
+ *
+ * The webpack transport resolves a client reference by looking its `$$id` up
+ * in a manifest of `{ id, chunks, name }` records. The transformer registers
+ * references as `registerClientReference(proxy, hostedId, exportName)`, and
+ * vprs's moduleID policy makes the hosted id the module's own served chunk
+ * path (`moduleBasePath` + the built file) — the exact invariant the esm
+ * transport's `import(moduleBaseURL + id)` already relies on. So the entire
+ * map derives from the client `.vite/manifest.json`: every built module keys
+ * itself, and `chunks` is its file plus the transitive `imports` closure (what
+ * a browser must load before the module can execute).
+ *
+ * Keys are PER MODULE, not per export: the transport tries the exact `$$id`
+ * first, then falls back to everything before the last `#` and carries the
+ * export name through from the reference — so one record serves every export
+ * of a module (measured against the vendored transport, not assumed).
+ */
+
+/** The subset of a Vite manifest entry this derivation reads. */
+export type ViteManifestEntry = {
+  file?: string;
+  imports?: string[];
+};
+
+export type WebpackClientManifestEntry = {
+  id: string;
+  chunks: string[];
+  name: string;
+};
+
+export type WebpackClientManifest = Record<string, WebpackClientManifestEntry>;
+
+/** `moduleBasePath`-prefix a built file the same way the moduleID policy does. */
+function hostedPath(moduleBasePath: string, file: string): string {
+  const base = moduleBasePath.replace(/\/$/, "");
+  return base + "/" + file;
+}
+
+/**
+ * Build the webpack-shaped client manifest.
+ *
+ * @param manifest        the client build's `.vite/manifest.json` contents
+ * @param moduleBasePath  the configured moduleBasePath ("/" by default) — the
+ *                        prefix the moduleID policy puts on hosted ids
+ */
+export function buildWebpackClientManifest(
+  manifest: Record<string, ViteManifestEntry | undefined>,
+  moduleBasePath: string
+): WebpackClientManifest {
+  // Transitive `imports` closure per manifest key, memoized. `imports` holds
+  // manifest KEYS (source-relative ids), so the closure resolves each to its
+  // built file. Cycles are guarded by the shared `seen` set per root.
+  const out: WebpackClientManifest = {};
+
+  const closure = (key: string, seen: Set<string>, files: string[]): void => {
+    if (seen.has(key)) return;
+    seen.add(key);
+    const entry = manifest[key];
+    if (!entry?.file) return;
+    files.push(entry.file);
+    for (const dep of entry.imports ?? []) closure(dep, seen, files);
+  };
+
+  for (const [key, entry] of Object.entries(manifest)) {
+    // Only JS modules are referenceable; assets (css, images) ride along via
+    // the entries' own metadata, not as client references.
+    if (!entry?.file || !/\.[cm]?js$/.test(entry.file)) continue;
+    const files: string[] = [];
+    closure(key, new Set(), files);
+    const hostedId = hostedPath(moduleBasePath, entry.file);
+    out[hostedId] = {
+      id: hostedId,
+      // The module's own chunk first, then its dependency closure — the set a
+      // consumer preloads via `__webpack_chunk_load__` before the sync require.
+      chunks: files.map((f) => hostedPath(moduleBasePath, f)),
+      name: "",
+    };
+  }
+  return out;
+}

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -330,6 +330,11 @@ export const DEFAULT_CONFIG = {
     // Its exported location of the built client bundle, resolved from
     // import.meta.url at runtime (a deploy's root is not the build's root).
     clientBaseExport: "clientModuleBaseURL",
+    // Its exported webpack-shaped client manifest (hosted client-reference id
+    // -> { id, chunks, name }), derived from the client build's Vite manifest.
+    // This is the module-map the webpack transport renders against — the
+    // closed-registry model a fully self-contained bundle needs.
+    clientManifestExport: "clientManifest",
     // Server-module manifest keys to bake as action candidates (the sealed-gate
     // allowlist). Server actions live in `*.server.*` modules.
     actionKeyPattern: "\\.server\\.[cm]?[jt]sx?$",

--- a/plugin/edge/createEdgeRequestHandler.types.ts
+++ b/plugin/edge/createEdgeRequestHandler.types.ts
@@ -42,6 +42,15 @@ export type EdgeBundleExports = {
   bootstrapModules?: string[];
   /** `clientModuleBaseURL`: the built client bundle, resolved from import.meta.url. */
   clientModuleBaseURL?: string;
+  /**
+   * `clientManifest`: the webpack-shaped client manifest (hosted
+   * client-reference id -> `{ id, chunks, name }`), derived from the client
+   * build's Vite manifest at bake time. The module map for rendering this
+   * build's flight through the webpack transport
+   * (`react-server-loader/webpack/*`) — closed-registry resolution for a
+   * fully self-contained deployment.
+   */
+  clientManifest?: Record<string, { id: string; chunks: string[]; name: string }>;
 };
 
 /**

--- a/test/unit/clientManifest.test.ts
+++ b/test/unit/clientManifest.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { buildWebpackClientManifest } from "../../plugin/bundle/clientManifest.js";
+
+// The webpack-shaped client manifest derives entirely from the client build's
+// Vite manifest: hosted id = moduleBasePath + built file (the moduleID policy's
+// own invariant — the esm transport already imports moduleBaseURL + id), and
+// chunks = the module's file plus its transitive imports closure. Keys are per
+// module; the transport splits the export name off the reference's $$id itself.
+describe("buildWebpackClientManifest", () => {
+  // Shape lifted from a real examples/router build: a client component whose
+  // chunk imports a plugin chunk which imports another.
+  const viteManifest = {
+    "src/components/Nav.client.tsx": {
+      file: "components/Nav.client-1xvucgu.js",
+      imports: ["../../dist/plugin/router/link.js"],
+    },
+    "../../dist/plugin/router/link.js": {
+      file: "dist/plugin/router/link-17ncef7.js",
+      imports: ["../../dist/plugin/router/router-react.js"],
+    },
+    "../../dist/plugin/router/router-react.js": {
+      file: "dist/plugin/router/router-react-1fzwyvj.js",
+    },
+    "src/styles/global.css": { file: "assets/global-abc.css" },
+  };
+
+  it("keys every JS module by its hosted path with the closure as chunks", () => {
+    const m = buildWebpackClientManifest(viteManifest, "/");
+    expect(m["/components/Nav.client-1xvucgu.js"]).toEqual({
+      id: "/components/Nav.client-1xvucgu.js",
+      chunks: [
+        "/components/Nav.client-1xvucgu.js",
+        "/dist/plugin/router/link-17ncef7.js",
+        "/dist/plugin/router/router-react-1fzwyvj.js",
+      ],
+      name: "",
+    });
+    // Dependency modules are themselves referenceable (a "use client" module
+    // can be imported directly), so they get entries too.
+    expect(m["/dist/plugin/router/link-17ncef7.js"].chunks).toEqual([
+      "/dist/plugin/router/link-17ncef7.js",
+      "/dist/plugin/router/router-react-1fzwyvj.js",
+    ]);
+  });
+
+  it("skips non-JS assets", () => {
+    const m = buildWebpackClientManifest(viteManifest, "/");
+    expect(Object.keys(m)).not.toContain("/assets/global-abc.css");
+    expect(Object.keys(m)).toHaveLength(3);
+  });
+
+  it("applies a non-root moduleBasePath to ids and chunks alike", () => {
+    const m = buildWebpackClientManifest(viteManifest, "/app/");
+    const entry = m["/app/components/Nav.client-1xvucgu.js"];
+    expect(entry.id).toBe("/app/components/Nav.client-1xvucgu.js");
+    expect(entry.chunks[1]).toBe("/app/dist/plugin/router/link-17ncef7.js");
+  });
+
+  it("treats an empty moduleBasePath as root", () => {
+    const m = buildWebpackClientManifest(viteManifest, "");
+    expect(m["/components/Nav.client-1xvucgu.js"]).toBeDefined();
+  });
+
+  it("survives an import cycle", () => {
+    const m = buildWebpackClientManifest(
+      {
+        a: { file: "a-1.js", imports: ["b"] },
+        b: { file: "b-1.js", imports: ["a"] },
+      },
+      "/"
+    );
+    expect(m["/a-1.js"].chunks).toEqual(["/a-1.js", "/b-1.js"]);
+    expect(m["/b-1.js"].chunks).toEqual(["/b-1.js", "/a-1.js"]);
+  });
+
+  it("ignores dangling import keys", () => {
+    const m = buildWebpackClientManifest(
+      { a: { file: "a-1.js", imports: ["gone"] } },
+      "/"
+    );
+    expect(m["/a-1.js"].chunks).toEqual(["/a-1.js"]);
+  });
+});


### PR DESCRIPTION
First code rung of the webpack prod path (base #258 is merged; docs context in #257). Data only — nothing renders through it yet.

## What

The bake derives a webpack-shaped client manifest (`hosted id → {id, chunks, name}`) from the client build's Vite manifest and exports it from the baked edge entry as **`clientManifest`**, beside `bootstrapModules` and `clientModuleBaseURL` — same reasoning as those: baked at build time so no runtime ever reads `.vite/manifest.json`, and nothing extra ships.

- `plugin/bundle/clientManifest.ts` — the pure derivation (`buildWebpackClientManifest`), unit-tested on its own.
- `buildEdgeBundle.ts` — reads `dist/client/.vite/manifest.json`, emits the export into the generated entry.
- `defaults.tsx` (`EDGE.clientManifestExport`) + `EdgeBundleExports.clientManifest` typing.

## Why the derivation is sound

It leans on an invariant vprs already has: the moduleID policy makes a client reference's hosted id the module's **own served chunk path** — the esm transport literally does `import(moduleBaseURL + id)` today. So every key is `moduleBasePath + built file`, and `chunks` is the file plus its transitive `imports` closure (what a consumer preloads before the sync require).

Two facts were measured, not assumed:
- **Real-build key match**: in a fresh `examples/router` build, the `$$id` baked into `dist/server` (`/components/Nav.client-1xvucgu.js`) matches the emitted manifest key byte-for-byte, and the baked bundle exports the entry with its 3-chunk closure.
- **Per-module keys suffice**: the vendored transport's `resolveClientReferenceMetadata` tries the exact `$$id`, then falls back to the module part (before the last `#`) and carries the export name through from the reference — so one record serves every export of a module.

## Verified

- 6 new unit tests (closure, non-root base, cycles, dangling imports, asset skipping).
- `examples/router` rebuild: `[build.edge] baking webpack client manifest over 3 module(s)`; the baked `render.js` exports the expected entries.
- Full `test-all` suite green; tsc clean.

Next rungs (separate PRs): the webpack-transport edge render path consuming this export, the `startClient` prod entry on `react-server-loader/webpack/runtime`, and the action wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)