### PR TITLE
fix(release): clean dist before the prepack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,7 +366,8 @@
     "precoverage": "npm run build",
     "coverage": "npm run test:coverage",
     "test:dev:both": "bash scripts/test-dev-both-modes.sh",
-    "build:docs-site": "cd docs-site && NODE_OPTIONS='--conditions react-server' ../node_modules/.bin/vite build"
+    "build:docs-site": "cd docs-site && NODE_OPTIONS='--conditions react-server' ../node_modules/.bin/vite build",
+    "prepack": "rm -rf dist && tsc -p tsconfig.json"
   },
   "keywords": [
     "vite",


### PR DESCRIPTION
`prepack` ran `tsc` without cleaning `dist`, so a tarball packed after a branch switch ships **mixed artifacts**: current-branch source with other-branch compiled output for anything tsc chose not to re-emit, plus compiled strays whose sources no longer exist.

Found the honest way while setting up the vprs-starter local test loop: a tarball packed from a clean `main` checkout baked a feature (`clientManifest` emission) that only exists on unmerged #259 — `dist/plugin/bundle/clientManifest.js` had survived the branch switch and `buildEdgeBundle.js` was never re-emitted.

One line: `prepack` now `rm -rf dist` first. `npm pack` verified clean afterwards (stray absent, output matches the checked-out source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)