### PR TITLE
feat(edge): webpack-transport render path behind build.edge.transport

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -167,15 +167,24 @@ export async function buildEdgeBundle(opts: {
     relative(edgeDir, clientDir).split(sep).join("/") || ".";
 
   // The webpack-shaped client manifest (hosted id -> {id, chunks, name}),
-  // derived from the client build's Vite manifest. This is the module map a
-  // webpack-transport render resolves client references against — baked and
-  // exported so no runtime ever reads `.vite/manifest.json` (same reasoning as
-  // the baked bootstrapModules above).
+  // baked and exported so no runtime ever reads `.vite/manifest.json` (same
+  // reasoning as the baked bootstrapModules above).
+  //
+  // The `chunks` arrays are what the BROWSER preloads, so they must name
+  // browser-servable files: derive from the STATIC build's manifest (the
+  // browser tree). The SSR decode ignores them — it imports only the module's
+  // own hosted id off dist/client, whose relative imports Node resolves
+  // transitively. The two trees share the hosted id itself (same hash
+  // policy), which is what keys the payload either way. Fall back to the
+  // client (ssr) manifest only when no static build exists.
   let bakedClientManifest: Record<string, unknown> = {};
   const clientManifestPath = join(clientDir, ".vite/manifest.json");
-  if (existsSync(clientManifestPath)) {
+  const manifestSourcePath = existsSync(staticManifestPath)
+    ? staticManifestPath
+    : clientManifestPath;
+  if (existsSync(manifestSourcePath)) {
     bakedClientManifest = buildWebpackClientManifest(
-      JSON.parse(readFileSync(clientManifestPath, "utf8")),
+      JSON.parse(readFileSync(manifestSourcePath, "utf8")),
       userOptions.moduleBasePath ?? ""
     );
     const count = Object.keys(bakedClientManifest).length;
@@ -184,7 +193,7 @@ export async function buildEdgeBundle(opts: {
     }
   } else {
     logger.warn(
-      `${tag} no client manifest at ${clientManifestPath}; the baked ` +
+      `${tag} no manifest at ${manifestSourcePath}; the baked ` +
         `${DEFAULT_CONFIG.EDGE.clientManifestExport} export will be empty`
     );
   }
@@ -348,7 +357,23 @@ export async function buildEdgeBundle(opts: {
   const serverEdge = projectRequire.resolve("react-server-loader/server.edge");
   const serverNode = projectRequire.resolve("react-server-loader/server.node");
 
-  const alias: Record<string, string> = { [serverNode]: serverEdge };
+  // Which RSC transport the bundle renders through. The transformed modules in
+  // dist/server import the esm transport by ABSOLUTE path (their register*
+  // calls), so re-transporting the whole baked graph is one alias entry: both
+  // esm server entries collapse onto the chosen flight server. The register*
+  // signatures are identical across the two transports (same flight core);
+  // what changes is reference RESOLUTION — open import(moduleBaseURL + id) on
+  // esm vs the baked closed client manifest on webpack.
+  const transport = userOptions.build.edge.transport;
+  const flightServerEntry =
+    transport === "webpack"
+      ? projectRequire.resolve("react-server-loader/webpack/server.edge")
+      : serverEdge;
+
+  const alias: Record<string, string> = {
+    [serverNode]: flightServerEntry,
+    ...(transport === "webpack" ? { [serverEdge]: flightServerEntry } : {}),
+  };
   for (const subpath of DEFAULT_CONFIG.EDGE.reactServerSubpaths) {
     const target = reactServerExportTarget(reactDir, subpath);
     if (!target) {
@@ -450,10 +475,16 @@ export async function buildEdgeBundle(opts: {
     );
   }
 
+  // The flight render's second argument is the transport's resolution input:
+  // esm takes the module base path (open import), webpack takes the baked
+  // client manifest (closed map). Both are top-level consts in the entry.
+  const flightArg =
+    transport === "webpack" ? clientManifestExport : "MODULE_BASE_PATH";
+
   const entryPath = join(serverDir, `.vprs-${entryFileName}`);
   const entrySource = `import * as React from "react";
 import { createElement } from "react";
-import { renderToReadableStream } from ${JSON.stringify(serverEdge)};
+import { renderToReadableStream } from ${JSON.stringify(flightServerEntry)};
 import { resolvePageAndProps } from ${JSON.stringify(resolveHelper)};
 import { matchRoutes } from ${JSON.stringify(matchRouteHelper)};
 import { createElementWithReact } from ${JSON.stringify(elementHelper)};
@@ -503,6 +534,13 @@ export const ${clientBaseExport} = new URL(
  * resolution a fully self-contained deployment needs.
  */
 export const ${clientManifestExport} = ${JSON.stringify(bakedClientManifest)};
+
+/**
+ * Which RSC transport this bundle renders through ("esm" | "webpack") — baked
+ * so the serving handlers self-configure their decode side. A bundle and its
+ * handler cannot disagree.
+ */
+export const flightTransport = ${JSON.stringify(transport)};
 
 const routes = {
 ${routeLines.join("\n")}
@@ -567,7 +605,7 @@ export async function ${flightExport}(url, request) {
       HtmlComponent: React.Fragment,
       RootComponent: React.Fragment,
     }),
-    MODULE_BASE_PATH
+    ${flightArg}
   );
 }
 
@@ -598,11 +636,11 @@ export async function ${documentExport}(url, opts = {}) {
   };
   const full = renderToReadableStream(
     createElementWithReact(React, { ...base, HtmlComponent }),
-    MODULE_BASE_PATH
+    ${flightArg}
   );
   const headless = renderToReadableStream(
     createElementWithReact(React, { ...base, HtmlComponent: React.Fragment }),
-    MODULE_BASE_PATH
+    ${flightArg}
   );
   return { full, headless };
 }

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -236,7 +236,14 @@ export const DEFAULT_CONFIG = {
     // which will be done in createHandlerOptions.server.ts and createHandlerOptions.client.ts
     useRscWorker: !IS_SERVER && IS_BUILD,
     useHtmlWorker: IS_SERVER && IS_BUILD,
-    edge: { enabled: true, outDir: "server-edge", minify: true },
+    edge: {
+      enabled: true,
+      outDir: "server-edge",
+      minify: true,
+      // The esm transport stays the default until the webpack path has parity
+      // e2e; "webpack" opts the baked bundle into closed module-map resolution.
+      transport: "esm" as const,
+    },
   },
   DEV: {
     // these defaults rely on process.argv

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -764,6 +764,7 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
         enabled: edge === false ? false : true,
         outDir: obj.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir,
         minify: obj.minify ?? DEFAULT_CONFIG.BUILD.edge.minify,
+        transport: obj.transport ?? DEFAULT_CONFIG.BUILD.edge.transport,
       };
     })(),
   } satisfies ResolvedUserOptions["build"];

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -112,6 +112,20 @@ export function createEdgeRenderHook(
           // knows its entry. An explicit option still wins.
           moduleBaseURL: options.moduleBaseURL ?? bundle.clientModuleBaseURL ?? "/",
           bootstrapModules: options.bootstrapModules ?? bundle.bootstrapModules,
+          // The bundle knows which transport it was baked with; the decode side
+          // and the browser must follow. The inline hint is how the (transport-
+          // agnostic) client entry learns to consume a webpack-encoded payload.
+          flightTransport: bundle.flightTransport ?? "esm",
+          clientManifest: bundle.clientManifest,
+          bootstrapScriptContent:
+            [
+              options.bootstrapScriptContent,
+              bundle.flightTransport === "webpack"
+                ? 'self.__vprsFlightTransport="webpack";'
+                : undefined,
+            ]
+              .filter(Boolean)
+              .join("") || undefined,
           getURL: (request) => routeOf(new URL(request.url).pathname, rscOutputPath),
           onNotFound: () => NOT_HANDLED,
         })

--- a/plugin/edge/createEdgeRequestHandler.types.ts
+++ b/plugin/edge/createEdgeRequestHandler.types.ts
@@ -51,6 +51,13 @@ export type EdgeBundleExports = {
    * fully self-contained deployment.
    */
   clientManifest?: Record<string, { id: string; chunks: string[]; name: string }>;
+  /**
+   * `flightTransport`: which RSC transport the bundle was baked with
+   * (`build.edge.transport`). The handlers pick their decode side from this,
+   * so a bundle and its server cannot disagree. Absent on pre-transport-flag
+   * bundles — treated as `"esm"`.
+   */
+  flightTransport?: "esm" | "webpack";
 };
 
 /**

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -67,6 +67,8 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
     onNotFound,
     logger,
     verbose,
+    flightTransport = "esm",
+    clientManifest,
   } = options;
 
   if (!render && !renderDocument) {
@@ -112,6 +114,8 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
       const htmlStream = await renderFlightToHtml({
         rscStream: flights.full,
         moduleBaseURL,
+        flightTransport,
+        clientManifest,
         bootstrapModules,
         bootstrapScriptContent,
         nonce,
@@ -144,6 +148,8 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
     const htmlStream = await renderFlightToHtml({
       rscStream,
       moduleBaseURL,
+      flightTransport,
+      clientManifest,
       bootstrapModules,
       bootstrapScriptContent,
       nonce,

--- a/plugin/stream/createEdgeHandler.types.ts
+++ b/plugin/stream/createEdgeHandler.types.ts
@@ -58,6 +58,17 @@ export type CreateEdgeHandlerOptions = {
   bootstrapModules?: string[];
   /** Inline bootstrap script content (react-dom bootstrapScriptContent). */
   bootstrapScriptContent?: string;
+  /**
+   * Which transport the flight producer encodes with. Baked bundles export it
+   * (`flightTransport`) and `createEdgeRequestHandler` forwards it — set it
+   * manually only when driving the producer yourself. @default "esm"
+   */
+  flightTransport?: "esm" | "webpack";
+  /**
+   * The baked webpack client manifest (bundle export `clientManifest`), used
+   * by the webpack decode path.
+   */
+  clientManifest?: Record<string, { id: string; chunks: string[]; name: string }>;
   /** Nonce forwarded to the HTML renderer (CSP). */
   nonce?: string;
   /**

--- a/plugin/stream/renderFlightToHtml.client.ts
+++ b/plugin/stream/renderFlightToHtml.client.ts
@@ -21,6 +21,64 @@ assertNonReactServer();
  * consumption + HTML render half, so it runs under the client renderer and
  * guards against being evaluated on the wrong side.
  */
+/**
+ * Webpack-transport decode: the flight encodes baked-manifest ids, so chunk
+ * loads resolve as `import(moduleBaseURL + chunk)` and the module map merely
+ * echoes ids through — the payload never composes a module path itself.
+ * Installed once per process (the runtime's globals are process-wide by the
+ * transport's design); everything webpack-flavored is lazy-imported so
+ * esm-transport users pay nothing for this branch.
+ */
+type WebpackDecode = (stream: ReadableStream<Uint8Array>) => Promise<unknown>;
+let webpackDecodeReady: Promise<WebpackDecode> | undefined;
+function getWebpackDecode(
+  moduleBaseURL: string
+): Promise<WebpackDecode> {
+  return (webpackDecodeReady ??= Promise.all([
+    import("react-server-loader/webpack/client.edge"),
+    import("react-server-loader/webpack/runtime"),
+  ]).then(([clientEdge, runtime]) => {
+    runtime.installWebpackGlobals({
+      load: (chunkId: string) =>
+        import(
+          /* @vite-ignore */ new URL(chunkId.replace(/^\//, ""), moduleBaseURL)
+            .href
+        ),
+    });
+    // Pass-through module map: outer key = the id the payload carries, inner
+    // key = the export name — both echoed into a {id, chunks, name} record.
+    // Chunks are just the module's own id: the payload's chunk closure names
+    // BROWSER-tree files (that's who preloads them), while this decode imports
+    // off the ssr tree (moduleBaseURL), where `import()` resolves the module's
+    // relative imports transitively — the closure would name files that don't
+    // exist here.
+    const moduleMap = new Proxy(
+      {},
+      {
+        get: (_outer, id: string | symbol) =>
+          typeof id !== "string"
+            ? undefined
+            : new Proxy(
+                {},
+                {
+                  get: (_inner, name: string | symbol) =>
+                    typeof name !== "string"
+                      ? undefined
+                      : { id, chunks: [id], name },
+                }
+              ),
+      }
+    );
+    const serverConsumerManifest = {
+      moduleMap,
+      serverModuleMap: null,
+      moduleLoading: null,
+    };
+    return (stream) =>
+      clientEdge.createFromReadableStream(stream, { serverConsumerManifest });
+  }));
+}
+
 export const renderFlightToHtml: RenderFlightToHtmlFn =
   async function _renderFlightToHtml(options) {
     const {
@@ -33,6 +91,7 @@ export const renderFlightToHtml: RenderFlightToHtmlFn =
       signal,
       logger,
       verbose = false,
+      flightTransport = "esm",
     } = options;
 
     if (!rscStream) {
@@ -44,9 +103,14 @@ export const renderFlightToHtml: RenderFlightToHtmlFn =
     // re-invoke its component on retry — so the decode must NOT live inside the
     // rendered component (that re-reads a locked stream). Decode here, React.use
     // the stable promise inside Root.
-    const elementPromise = ReactDOMClientEdge.createFromReadableStream(rscStream, {
-      moduleBaseURL: moduleBaseURL || "/",
-    });
+    const elementPromise =
+      flightTransport === "webpack"
+        ? ((await getWebpackDecode(moduleBaseURL || "/"))(
+            rscStream
+          ) as Promise<React.ReactNode>)
+        : ReactDOMClientEdge.createFromReadableStream(rscStream, {
+            moduleBaseURL: moduleBaseURL || "/",
+          });
 
     if (verbose) {
       logger?.info(

--- a/plugin/stream/renderFlightToHtml.client.ts
+++ b/plugin/stream/renderFlightToHtml.client.ts
@@ -30,11 +30,17 @@ assertNonReactServer();
  * esm-transport users pay nothing for this branch.
  */
 type WebpackDecode = (stream: ReadableStream<Uint8Array>) => Promise<unknown>;
-let webpackDecodeReady: Promise<WebpackDecode> | undefined;
+// Memoized PER moduleBaseURL: a first-call-wins memo would silently resolve a
+// second bundle's chunks against the first bundle's base. The runtime's
+// globals merge on reinstall (loaders accumulate; a loader whose base 404s
+// falls through to the next), so multiple bases in one process compose.
+const webpackDecodeByBase = new Map<string, Promise<WebpackDecode>>();
 function getWebpackDecode(
   moduleBaseURL: string
 ): Promise<WebpackDecode> {
-  return (webpackDecodeReady ??= Promise.all([
+  const memo = webpackDecodeByBase.get(moduleBaseURL);
+  if (memo) return memo;
+  const ready = Promise.all([
     import("react-server-loader/webpack/client.edge"),
     import("react-server-loader/webpack/runtime"),
   ]).then(([clientEdge, runtime]) => {
@@ -74,9 +80,13 @@ function getWebpackDecode(
       serverModuleMap: null,
       moduleLoading: null,
     };
-    return (stream) =>
-      clientEdge.createFromReadableStream(stream, { serverConsumerManifest });
-  }));
+    return ((stream) =>
+      clientEdge.createFromReadableStream(stream, {
+        serverConsumerManifest,
+      })) as WebpackDecode;
+  });
+  webpackDecodeByBase.set(moduleBaseURL, ready);
+  return ready;
 }
 
 export const renderFlightToHtml: RenderFlightToHtmlFn =

--- a/plugin/stream/renderFlightToHtml.types.ts
+++ b/plugin/stream/renderFlightToHtml.types.ts
@@ -13,6 +13,21 @@ export type RenderFlightToHtmlOptions = {
    * point this at the client-React (ssr) bundle so islands resolve in-process.
    */
   moduleBaseURL?: string;
+  /**
+   * Which transport produced the flight. `"esm"` (default) decodes with the
+   * esm client (`import(moduleBaseURL + id)`); `"webpack"` decodes with the
+   * webpack flight client against the baked client manifest — chunk loads
+   * resolve as `import()` of `moduleBaseURL + chunk`, references never
+   * compose module paths from payload input. Baked bundles export this as
+   * `flightTransport`, so handlers pass it straight through.
+   */
+  flightTransport?: "esm" | "webpack";
+  /**
+   * The baked webpack client manifest (`hosted id -> {id, chunks, name}`),
+   * used when `flightTransport` is `"webpack"` — the bundle exports it as
+   * `clientManifest`.
+   */
+  clientManifest?: Record<string, { id: string; chunks: string[]; name: string }>;
   /** Client entry modules to bootstrap for hydration (react-dom bootstrapModules). */
   bootstrapModules?: string[];
   /** Inline bootstrap script content (react-dom bootstrapScriptContent). */

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1290,6 +1290,24 @@ export type EdgeBuildConfig = {
    * output for inspection/debugging. @default true
    */
   minify?: boolean;
+  /**
+   * Which RSC transport the baked bundle renders through.
+   *
+   * - `"esm"` (default): the vendored esm transport — client references
+   *   resolve by `import(moduleBaseURL + id)` at request time. Runs on
+   *   Node-compatible hosts.
+   * - `"webpack"`: the vendored webpack transport — client references resolve
+   *   through the baked client manifest (closed module map, `{id, chunks,
+   *   name}` records). The flight payload encodes manifest ids, the
+   *   in-process HTML decode reads the manifest, and the browser consumes the
+   *   payload through the webpack flight client. This is the model a fully
+   *   self-contained deployment builds on.
+   *
+   * The baked bundle exports which transport it was built with
+   * (`flightTransport`), so the serving handlers self-configure — a bundle and
+   * its handler cannot disagree. @default "esm"
+   */
+  transport?: "esm" | "webpack";
 };
 
 /** Resolved edge config (after normalizing the `boolean | EdgeBuildConfig` form). */
@@ -1297,6 +1315,7 @@ export type ResolvedEdgeConfig = {
   enabled: boolean;
   outDir: string;
   minify: boolean;
+  transport: "esm" | "webpack";
 };
 
 export type DevConfig = {

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1305,7 +1305,16 @@ export type EdgeBuildConfig = {
    *
    * The baked bundle exports which transport it was built with
    * (`flightTransport`), so the serving handlers self-configure — a bundle and
-   * its handler cannot disagree. @default "esm"
+   * its handler cannot disagree.
+   *
+   * Do NOT mix transports across one deploy's routes: prerendered snapshots
+   * (SSG html / inlined flight / .rsc files) are esm-encoded, so serving them
+   * next to webpack-encoded dynamic routes breaks client-side navigation
+   * BETWEEN the two flavors (the browser picks its flight client per
+   * document, but a fetched .rsc of the other flavor cannot be decoded).
+   * With "webpack", serve every route through the edge bundle and drop the
+   * prerendered snapshots from serving (the prepare-vercel pattern).
+   * @default "esm"
    */
   transport?: "esm" | "webpack";
 };

--- a/plugin/types/react-server-loader-webpack.d.ts
+++ b/plugin/types/react-server-loader-webpack.d.ts
@@ -1,0 +1,10 @@
+// The vendored webpack transport entries in react-server-loader are plain JS
+// (React's built output) with no declarations. Typed loosely here — the
+// integration points cast to the shapes they use, mirroring the existing
+// react-server-dom-esm ambient declarations.
+declare module "react-server-loader/webpack/client.edge" {
+  export function createFromReadableStream(
+    stream: ReadableStream<Uint8Array>,
+    options: { serverConsumerManifest: unknown }
+  ): Promise<unknown>;
+}

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -132,18 +132,47 @@ export function createReactFetcher({
   // imported lazily so this module stays import-safe under the `react-server`
   // condition (a static import of client.browser would drag react-dom/client
   // into the server graph).
+  //
+  // WHICH flight client follows how the server encoded the payload. A
+  // webpack-transport bundle's document injects `self.__vprsFlightTransport`
+  // (see createEdgeRenderHook) and its payload carries baked-manifest ids —
+  // consumed through the webpack client over a chunk loader that `import()`s
+  // the served chunk URLs (the ids ARE the URLs; the map is closed, nothing is
+  // composed from payload input). Default: the esm client, unchanged.
+  type BrowserFlightClient = {
+    createFromReadableStream: (
+      stream: ReadableStream<Uint8Array>,
+      opts: typeof decodeOptions
+    ) => PromiseLike<React.ReactNode>;
+    createFromFetch: (
+      response: Promise<Response>,
+      opts: typeof decodeOptions
+    ) => PromiseLike<React.ReactNode>;
+  };
+  const flightClient = (): PromiseLike<BrowserFlightClient> =>
+    (globalThis as { __vprsFlightTransport?: string }).__vprsFlightTransport ===
+    "webpack"
+      ? (import("react-server-loader/webpack/runtime").then(
+          ({ createWebpackClient }) =>
+            createWebpackClient({
+              load: (chunk: string) => import(/* @vite-ignore */ chunk),
+            })
+        ) as PromiseLike<BrowserFlightClient>)
+      : (import(
+          "react-server-dom-esm/client.browser"
+        ) as unknown as PromiseLike<BrowserFlightClient>);
+
   const fromInline = (bytes: Uint8Array): PromiseLike<React.ReactNode> =>
-    import("react-server-dom-esm/client.browser").then(
-      ({ createFromReadableStream }) =>
-        createFromReadableStream(
-          new ReadableStream<Uint8Array>({
-            start(controller) {
-              controller.enqueue(bytes);
-              controller.close();
-            },
-          }),
-          decodeOptions
-        )
+    flightClient().then(({ createFromReadableStream }) =>
+      createFromReadableStream(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        }),
+        decodeOptions
+      )
     );
 
   const fromNetwork = (): PromiseLike<React.ReactNode> => {
@@ -152,8 +181,8 @@ export function createReactFetcher({
       headers: headers,
       signal,
     });
-    return import("react-server-dom-esm/client.browser").then(
-      ({ createFromFetch }) => createFromFetch(responsePromise, decodeOptions)
+    return flightClient().then(({ createFromFetch }) =>
+      createFromFetch(responsePromise, decodeOptions)
     );
   };
 


### PR DESCRIPTION
The render-path rung of the webpack prod ladder (#258 → #259 → this). Opt-in: `build.edge.transport: "webpack"` — the default stays `"esm"` and is verified byte-identical.

## How it works

**One alias is the master switch.** The transformed modules in `dist/server` import the esm transport by *absolute path*, so pointing that path (plus the esm `server.edge` entry) at `react-server-loader/webpack/server.edge` re-registers every client/server reference webpack-shaped — no transformer re-run, no second build. The flight render's second argument becomes the baked `clientManifest` (#259), and the bundle exports **`flightTransport`** so the serving handlers self-configure: a bundle and its handler cannot disagree.

**SSR decode** (`renderFlightToHtml`): a lazy webpack branch — `webpack/client.edge` with a pass-through Proxy module map over `installWebpackGlobals({ load: import(moduleBaseURL + chunk) })`. Payload ids echo through as `{id, chunks: [id], name}`; the ssr tree resolves a module's relative imports transitively, so only the module's own id loads. Ids are dictionary keys into the closed map — nothing composes module paths from payload input.

**Browser** (`createReactFetcher`): the webpack-baked document injects `self.__vprsFlightTransport`, and the fetcher branches to `createWebpackClient({ load: chunk => import(chunk) })` — the chunk ids ARE the served URLs.

**Actions need nothing**: vprs's action protocol is its own `{id, args}` envelope through the sealed gate — transport-independent.

## The bug the integration caught

The first run served correct HTML but the browser wiped the page on hydration: the baked manifest's `chunks` came from the **client (ssr) manifest**, whose file paths don't exist in the **static (browser) tree** — preloads 404'd. Fixed by deriving chunks from the static build's manifest (they're what the *browser* preloads; the hosted id itself is shared between trees by the hash policy, so payload keys are unchanged). This is exactly why the flag ships only after the starter loop passes.

## Verified (vprs-starter local loop, A/B)

- `transport: "webpack"`: payload encodes `I["/Nav.client-….js", ["/router-react-….js", …], "Nav"]` (closed-map form, static-tree chunks); served document carries the transport hint; **real-browser hydration green** — no React errors, client-side nav to `/about` and history back with a window sentinel intact.
- default (`esm`): payload and behavior byte-identical to before the change; same hydration check green.
- Full `test-all` suite + tsc clean.

Not yet in scope (next rung): baking the consumer side statically for filesystem-less runtimes — this PR's SSR decode still `import()`s off the ssr tree, deliberately. The browser side is already fully closed-map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)