### PR TITLE
fix(edge): drop the baked bundle's remaining hard Node dependencies

### DIFF
--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -3,6 +3,7 @@ import {
   DEFAULT_LOADER_CONFIG as RSL_LOADER_DEFAULTS,
 } from "react-server-loader/transformer";
 import { pluginRoot } from "../root.js";
+import { proc } from "../proc.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { getCondition } from "./getCondition.js";
 // Directive patterns - matching the logic in findDirectiveMatches.ts
@@ -70,9 +71,7 @@ export const IS_SERVER = CONDITION === "react-server";
 export const IS_CLIENT = CONDITION === "react-client";
 // Note: This should be replaced with configEnv.command === "build" in functions that receive configEnv
 // This is kept for backward compatibility but should not be used in new code
-export const IS_BUILD =
-  (globalThis as { process?: NodeJS.Process }).process?.argv?.includes("build") ??
-  false;
+export const IS_BUILD = proc?.argv?.includes("build") ?? false;
 export const IS_SERVE = !IS_BUILD; // dont have to check for dev since it's the default
 
 // Helper to normalize directive strings

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -70,7 +70,9 @@ export const IS_SERVER = CONDITION === "react-server";
 export const IS_CLIENT = CONDITION === "react-client";
 // Note: This should be replaced with configEnv.command === "build" in functions that receive configEnv
 // This is kept for backward compatibility but should not be used in new code
-export const IS_BUILD = process.argv.includes("build");
+export const IS_BUILD =
+  (globalThis as { process?: NodeJS.Process }).process?.argv?.includes("build") ??
+  false;
 export const IS_SERVE = !IS_BUILD; // dont have to check for dev since it's the default
 
 // Helper to normalize directive strings

--- a/plugin/config/getCondition.ts
+++ b/plugin/config/getCondition.ts
@@ -1,6 +1,8 @@
 // Note: do not import Node-only modules here (e.g., 'node:worker_threads').
 // This file is consumed in both server and client plugin contexts.
 
+import { proc } from "../proc.js";
+
 /**
  * The two React resolution conditions vprs cares about. Named so call sites can
  * reference REACT_CONDITION.server / .client instead of the bare string
@@ -22,7 +24,7 @@ export type ReactCondition =
  * is two).
  */
 const tokenizeNodeOptions = (): string[] => {
-  const nodeOptions = (globalThis as { process?: NodeJS.Process }).process?.env?.["NODE_OPTIONS"] || "";
+  const nodeOptions = proc?.env?.["NODE_OPTIONS"] || "";
   if (!nodeOptions.trim()) {
     return [];
   }
@@ -117,9 +119,7 @@ export const getAllConditions = (): string[] => {
   const { conditions: envConditions } = parseNodeArgs(nodeOptionsTokens);
 
   // Parse command-line arguments
-  const { conditions: cliConditions } = parseNodeArgs(
-    (globalThis as { process?: NodeJS.Process }).process?.execArgv ?? []
-  );
+  const { conditions: cliConditions } = parseNodeArgs(proc?.execArgv ?? []);
 
   // Combine all conditions
   return [...envConditions, ...cliConditions];
@@ -147,8 +147,8 @@ export const warnIfAmbiguousReactConditions = (): void => {
   const unique = detectReactConditionAmbiguity();
   if (unique.includes("react-server") && unique.includes("react-client")) {
     didWarnAmbiguousConditions = true;
-    const nodeOptions = (globalThis as { process?: NodeJS.Process }).process?.env?.["NODE_OPTIONS"] || "";
-    const argv = ((globalThis as { process?: NodeJS.Process }).process?.execArgv ?? []).join(" ");
+    const nodeOptions = proc?.env?.["NODE_OPTIONS"] || "";
+    const argv = (proc?.execArgv ?? []).join(" ");
     const msg =
       `Both react-server and react-client conditions detected in NODE_OPTIONS/execArgv. ` +
       `This can lead to ambiguous resolution. Found: [${unique.join(", ")}]\n` +
@@ -156,7 +156,7 @@ export const warnIfAmbiguousReactConditions = (): void => {
       `Tip: set exactly one condition or let the plugin manage worker conditions.`;
     // Use process.emitWarning to avoid throwing
     try {
-      (globalThis as { process?: NodeJS.Process }).process?.emitWarning?.(msg, {
+      proc?.emitWarning?.(msg, {
         code: "VPRS_CONDITION_AMBIGUITY",
         detail: "vite-plugin-react-server detected conflicting conditions",
       } as any);

--- a/plugin/config/getCondition.ts
+++ b/plugin/config/getCondition.ts
@@ -22,7 +22,7 @@ export type ReactCondition =
  * is two).
  */
 const tokenizeNodeOptions = (): string[] => {
-  const nodeOptions = process.env["NODE_OPTIONS"] || "";
+  const nodeOptions = (globalThis as { process?: NodeJS.Process }).process?.env?.["NODE_OPTIONS"] || "";
   if (!nodeOptions.trim()) {
     return [];
   }
@@ -117,7 +117,9 @@ export const getAllConditions = (): string[] => {
   const { conditions: envConditions } = parseNodeArgs(nodeOptionsTokens);
 
   // Parse command-line arguments
-  const { conditions: cliConditions } = parseNodeArgs(process.execArgv);
+  const { conditions: cliConditions } = parseNodeArgs(
+    (globalThis as { process?: NodeJS.Process }).process?.execArgv ?? []
+  );
 
   // Combine all conditions
   return [...envConditions, ...cliConditions];
@@ -145,8 +147,8 @@ export const warnIfAmbiguousReactConditions = (): void => {
   const unique = detectReactConditionAmbiguity();
   if (unique.includes("react-server") && unique.includes("react-client")) {
     didWarnAmbiguousConditions = true;
-    const nodeOptions = process.env["NODE_OPTIONS"] || "";
-    const argv = process.execArgv.join(" ");
+    const nodeOptions = (globalThis as { process?: NodeJS.Process }).process?.env?.["NODE_OPTIONS"] || "";
+    const argv = ((globalThis as { process?: NodeJS.Process }).process?.execArgv ?? []).join(" ");
     const msg =
       `Both react-server and react-client conditions detected in NODE_OPTIONS/execArgv. ` +
       `This can lead to ambiguous resolution. Found: [${unique.join(", ")}]\n` +
@@ -154,7 +156,7 @@ export const warnIfAmbiguousReactConditions = (): void => {
       `Tip: set exactly one condition or let the plugin manage worker conditions.`;
     // Use process.emitWarning to avoid throwing
     try {
-      process.emitWarning(msg, {
+      (globalThis as { process?: NodeJS.Process }).process?.emitWarning?.(msg, {
         code: "VPRS_CONDITION_AMBIGUITY",
         detail: "vite-plugin-react-server detected conflicting conditions",
       } as any);

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -19,8 +19,15 @@ import {
 import type { ServerActionRequest } from "./handleServerActionHelper.js";
 import { createSealedServerReferenceGate } from "../references/createSealedServerReferenceGate.server.js";
 import type { ReferenceGate } from "react-server-loader/references";
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+// node:fs / node:path load lazily inside the disk-manifest fallback ONLY (see
+// resolveServerManifest): the baked edge path supplies resolveServerReference
+// and short-circuits before any disk access, and a top-level import would
+// crash module EVALUATION on a filesystem-less runtime regardless of whether
+// the fallback ever runs.
+const nodeDisk = () =>
+  Promise.all([import("node:fs/promises"), import("node:path")]).then(
+    ([fs, path]) => ({ readFile: fs.readFile, join: path.join })
+  );
 
 type ServerManifest = Record<string, { file: string; src?: string } | undefined>;
 
@@ -44,6 +51,7 @@ const manifestByRoot = new Map<string, ServerManifest | null>();
 async function resolveServerManifest(
   options: ServerActionHandlerOptions
 ): Promise<{ serverManifest: ServerManifest; serverRoot: string } | null> {
+  const { readFile, join } = await nodeDisk();
   if (options.serverManifest) {
     return {
       serverManifest: options.serverManifest,
@@ -148,7 +156,7 @@ export async function resolveAndExecuteServerAction(
       // to the open resolver — that would reopen the boundary we are enforcing.
       throw new Error(
         `[handleServerAction] No server manifest found (looked for ` +
-          `${join(options.serverRoot ?? join(projectRoot, "dist", "server"), ".vite", "manifest.json")}). ` +
+          `${options.serverRoot ?? `${projectRoot}/dist/server`}/.vite/manifest.json). ` +
           `Server actions resolve through a sealed allowlist; pass serverRoot for a ` +
           `custom build.outDir, or serverManifest directly. Refusing unsealed resolution.`
       );

--- a/plugin/proc.ts
+++ b/plugin/proc.ts
@@ -1,0 +1,14 @@
+/**
+ * The ambient `process`, or `undefined` on a runtime without one.
+ *
+ * Config-layer modules ride into baked edge bundles, and several of their
+ * probes run at module EVALUATION — a bare `process.*` read there crashes a
+ * filesystem-less runtime (Workers, Deno Deploy) even when the surrounding
+ * branch is dead on the baked path. Read through this instead.
+ *
+ * Binding the object once is safe: Node installs `process` at startup and
+ * never swaps it, and `proc.env` stays live because it is the same object.
+ *
+ * Keep this module import-free so the leaf modules that need it stay leaves.
+ */
+export const proc = (globalThis as { process?: NodeJS.Process }).process;

--- a/plugin/references/createSealedServerReferenceGate.server.ts
+++ b/plugin/references/createSealedServerReferenceGate.server.ts
@@ -1,4 +1,7 @@
-import { join } from "node:path";
+// node:path loads lazily inside the disk-import fallback ONLY: a top-level
+// import would crash module EVALUATION on a filesystem-less runtime, even
+// though a baked bundle (which always supplies loadModule) never takes that
+// branch. Top-level imports are load-bearing whether or not the code runs.
 import {
   createReferenceGate,
   type ReferenceGate,
@@ -73,7 +76,12 @@ export function createSealedServerReferenceGate({
     const file = entry.file;
     const load = loadModule
       ? () => loadModule(key, file)
-      : () => import(join(serverRoot, file)) as Promise<Record<string, unknown>>;
+      : async (): Promise<Record<string, unknown>> => {
+          const { join } = await import("node:path");
+          return import(join(serverRoot, file)) as Promise<
+            Record<string, unknown>
+          >;
+        };
     // The directive transform bakes a BARE manifest-key id (`<srcKey>#<export>`);
     // a base-prefixed transport sends `<base><srcKey>#<export>`. Register both
     // shapes so resolution is an exact-key lookup either way. This does not widen

--- a/plugin/root.ts
+++ b/plugin/root.ts
@@ -1,8 +1,14 @@
 export const pluginRoot = new URL("./", import.meta.url).pathname.replace(/\/$/, "");
+// `process` is optional: this module rides into baked edge bundles via config
+// imports, and these probes run at module EVALUATION — a bare `process.*` read
+// crashes a runtime without one (Workers/Deno Deploy). The probes only feed
+// dev-time link detection, so "/" is a safe non-answer there.
+const proc = (globalThis as { process?: NodeJS.Process }).process;
 export const userProjectRoot =
-  process.argv
-    .find((arg) => arg.includes("node_modules"))
+  proc?.argv
+    ?.find((arg) => arg.includes("node_modules"))
     ?.match(/^(.+?)\/node_modules\/.+$/)?.[1] ||
-  process.env["npm_config_local_prefix"] ||
-  process.cwd();
+  proc?.env?.["npm_config_local_prefix"] ||
+  proc?.cwd?.() ||
+  "/";
 export const isLinked = !pluginRoot.startsWith(userProjectRoot);

--- a/plugin/root.ts
+++ b/plugin/root.ts
@@ -1,9 +1,8 @@
+import { proc } from "./proc.js";
+
 export const pluginRoot = new URL("./", import.meta.url).pathname.replace(/\/$/, "");
-// `process` is optional: this module rides into baked edge bundles via config
-// imports, and these probes run at module EVALUATION — a bare `process.*` read
-// crashes a runtime without one (Workers/Deno Deploy). The probes only feed
-// dev-time link detection, so "/" is a safe non-answer there.
-const proc = (globalThis as { process?: NodeJS.Process }).process;
+// These probes only feed dev-time link detection, so "/" is a safe non-answer
+// on a runtime without `process`.
 export const userProjectRoot =
   proc?.argv
     ?.find((arg) => arg.includes("node_modules"))


### PR DESCRIPTION
Follow-up to #261, from the "any other hard Node dependencies?" audit. Two classes found in the webpack-flag baked bundle, both crashes **at module evaluation** on a filesystem-less runtime even though the code never runs on the baked path:

1. **Top-level `node:fs` / `node:path` imports on dead fallback branches** — `handleServerAction`'s read-manifest-from-disk fallback and the sealed gate's disk-import fallback. The baked entry always supplies `resolveServerReference` / `loadModule`, so these branches are unreachable there, but top-level imports are load-bearing regardless. Now lazy-imported inside the branch that uses them.
2. **Bare `process` reads via config drag** — `root.ts`'s project-root probes (module-scope `argv`/`env`/`cwd`), `getCondition`'s `NODE_OPTIONS`/`execArgv` sniffing, `defaults`' `IS_BUILD`. All now read through `globalThis.process` optional access; an absent `process` resolves to no-conditions / non-build defaults, which is the correct answer on Workers.

**Measured after** (starter, `transport: "webpack"`): the baked `dist/server-edge/render.js` has **zero `node:` imports and zero unguarded `process.*` reads**. Hydration gate re-run green; full `test-all` + tsc clean.

What deliberately remains Node-bound is the **serving** side, not the bundle: `renderFlightToHtml`'s vendor layer resolves react-dom through `node:module` at request time, and the webpack SSR chunk loader `import()`s off the ssr tree. That's the bake-the-consumer rung — after it, the whole request path composes for Workers/Deno and #257's docs can flip to the positive claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)