### PR TITLE
feat(edge): bake the consumer — the request path composes for Workers/Deno

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
       "types": "./dist/plugin/edge/index.d.ts",
       "default": "./dist/plugin/edge/index.js"
     },
+    "./edge/web": {
+      "types": "./dist/plugin/edge/web.d.ts",
+      "default": "./dist/plugin/edge/web.js"
+    },
     "./stream": {
       "react-server": "./dist/plugin/stream/index.server.js",
       "default": "./dist/plugin/stream/index.client.js"

--- a/plugin/bundle/buildConsumerBundle.ts
+++ b/plugin/bundle/buildConsumerBundle.ts
@@ -1,0 +1,267 @@
+import { build as viteBuild, type Logger } from "vite";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import type { ResolvedUserOptions } from "../types.js";
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+
+/**
+ * Bake the CONSUMER half of the single-isolate edge render: decode a Flight
+ * payload and render it to HTML, with client React and every client-reference
+ * module compiled in.
+ *
+ * The producer bundle (buildEdgeBundle) has been self-contained since the
+ * client manifest was baked into it. The consumer was not: at request time it
+ * resolved `react-dom/server.edge` out of the consumer's node_modules through
+ * `createRequire` (plugin/vendor/vendor.client.ts) and pulled client islands in
+ * with `import(moduleBaseURL + chunk)` off the ssr tree. Both need a filesystem
+ * and a Node module resolver, which is what kept the whole request path
+ * Node-bound even though the producer wasn't. Baking the consumer closes that:
+ * the pair composes on a runtime with no `node:` at all.
+ *
+ * WEBPACK ONLY, and not by preference. The esm client transport resolves a
+ * reference by `import(metadata.specifier)` with no loader seam, so there is no
+ * way to point it at a compiled-in registry — an esm build keeps the runtime
+ * consumer. The webpack transport resolves through a module map, which is
+ * exactly the seam a closed registry needs.
+ *
+ * Built as a SEPARATE bundle from the producer on purpose: the producer bakes
+ * SERVER React (the react-server export conditions) and this bakes CLIENT
+ * React. Both graphs have to co-exist in one isolate, which they can only do as
+ * two module graphs.
+ */
+export async function buildConsumerBundle(opts: {
+  userOptions: ResolvedUserOptions;
+  projectRoot: string;
+  logger: Logger;
+}): Promise<void> {
+  const { userOptions, projectRoot, logger } = opts;
+  const tag = "[build.edge]";
+
+  // The esm transport has no module-map seam to bind a registry to; leave those
+  // builds on the runtime consumer rather than emitting something that can't work.
+  if (userOptions.build.edge.transport !== "webpack") return;
+
+  const outRoot = join(projectRoot, userOptions.build.outDir);
+  const edgeDir = join(
+    outRoot,
+    userOptions.build.edge.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir
+  );
+  const clientDir = join(outRoot, userOptions.build.client);
+  const clientManifestPath = join(clientDir, ".vite/manifest.json");
+  if (!existsSync(clientManifestPath)) {
+    logger.warn(
+      `${tag} no client manifest at ${clientManifestPath}; skipping the consumer bake ` +
+        `(the runtime consumer still serves this build)`
+    );
+    return;
+  }
+
+  const staticManifestPath = join(
+    outRoot,
+    userOptions.build.static,
+    ".vite/manifest.json"
+  );
+  const clientManifest = JSON.parse(
+    readFileSync(clientManifestPath, "utf8")
+  ) as Record<string, { file?: string } | undefined>;
+  const staticManifest = existsSync(staticManifestPath)
+    ? (JSON.parse(readFileSync(staticManifestPath, "utf8")) as Record<
+        string,
+        { file?: string } | undefined
+      >)
+    : {};
+
+  const moduleBasePath = userOptions.moduleBasePath ?? "";
+  const hosted = (file: string): string =>
+    moduleBasePath.replace(/\/$/, "") + "/" + file;
+
+  // Register each ssr module under EVERY hosted id it can be asked for.
+  //
+  // The two build trees do NOT agree on filenames. They share the manifest KEY
+  // (the source path) but only sometimes the built file: a `"use client"`
+  // component hashes identically in both (src/Nav.client.tsx -> the same
+  // Nav.client-<hash>.js), while CSS-module and node_modules-shipped client
+  // modules do not (styles.js in the ssr tree vs styles-<hash>.js in the
+  // browser tree). The id the payload carries comes from the transform, so
+  // keying this registry off the ssr tree alone would miss whichever spelling
+  // the payload used and 404 at request time — the same class of mismatch that
+  // made the browser chunks 404 when they were derived from the ssr manifest.
+  // Keying off the source path and registering both spellings is the fix.
+  const importLines: string[] = [];
+  const registryLines: string[] = [];
+  const idByFile = new Map<string, string>();
+  let divergent = 0;
+
+  for (const [key, entry] of Object.entries(clientManifest)) {
+    const file = entry?.file;
+    if (!file || !/\.[cm]?js$/.test(file)) continue;
+    const abs = join(clientDir, file);
+    if (!existsSync(abs)) continue;
+
+    let ns = idByFile.get(abs);
+    if (!ns) {
+      ns = `C${idByFile.size}`;
+      idByFile.set(abs, ns);
+      importLines.push(`import * as ${ns} from ${JSON.stringify(abs)};`);
+    }
+
+    const ids = new Set<string>([hosted(file)]);
+    const staticFile = staticManifest[key]?.file;
+    if (staticFile && /\.[cm]?js$/.test(staticFile) && staticFile !== file) {
+      ids.add(hosted(staticFile));
+      divergent++;
+    }
+    for (const id of ids) {
+      registryLines.push(`  ${JSON.stringify(id)}: ${ns},`);
+    }
+  }
+
+  if (importLines.length === 0) {
+    logger.warn(
+      `${tag} no client modules found in ${clientDir}; skipping the consumer bake`
+    );
+    return;
+  }
+
+  const { consumerFileName, consumerExport } = DEFAULT_CONFIG.EDGE;
+  const projectRequire = createRequire(join(projectRoot, "package.json"));
+  const webpackClientEdge = projectRequire.resolve(
+    "react-server-loader/webpack/client.edge"
+  );
+  const webpackRuntime = projectRequire.resolve(
+    "react-server-loader/webpack/runtime"
+  );
+
+  const entryPath = join(clientDir, `.vprs-${consumerFileName}`);
+  const entrySource = `import * as React from "react";
+import { renderToReadableStream } from "react-dom/server.edge";
+import { createFromReadableStream } from ${JSON.stringify(webpackClientEdge)};
+import { installWebpackGlobals } from ${JSON.stringify(webpackRuntime)};
+${importLines.join("\n")}
+
+/**
+ * Every client-reference module in this build, compiled in and keyed by the
+ * hosted id the flight payload carries. This is the whole point of the bake:
+ * resolution is a property lookup, so nothing reaches for a module loader.
+ */
+const CLIENT_MODULES = {
+${registryLines.join("\n")}
+};
+
+// The transport's chunk loader, backed by the closed registry instead of
+// import(). React preloads a reference's chunks through __webpack_chunk_load__
+// before the synchronous require, so an async lookup is the supported seam.
+installWebpackGlobals({
+  load: async (chunkId) => {
+    const mod = CLIENT_MODULES[chunkId];
+    if (!mod) {
+      throw new Error(
+        "[edge:consumer] no baked client module for chunk: " + chunkId +
+          " (known: " + Object.keys(CLIENT_MODULES).join(", ") + ")"
+      );
+    }
+    return mod;
+  },
+});
+
+// Pass-through module map: the payload's id is echoed back as its own chunk, so
+// the transport asks the registry for exactly the id it was given and never
+// composes a module path out of payload input.
+const moduleMap = new Proxy({}, {
+  get: (_outer, id) =>
+    typeof id !== "string"
+      ? undefined
+      : new Proxy({}, {
+          get: (_inner, name) =>
+            typeof name !== "string" ? undefined : { id, chunks: [id], name },
+        }),
+});
+
+const serverConsumerManifest = {
+  moduleMap,
+  serverModuleMap: null,
+  moduleLoading: null,
+};
+
+/**
+ * Decode a Flight stream and render it to an HTML stream, entirely in-process.
+ * Same contract as the runtime renderFlightToHtml, minus the options that only
+ * describe how to FIND things (moduleBaseURL, clientManifest, flightTransport):
+ * this bundle already contains them.
+ */
+export async function ${consumerExport}(options) {
+  const {
+    rscStream,
+    bootstrapModules,
+    bootstrapScriptContent,
+    nonce,
+    onError,
+    signal,
+  } = options;
+
+  if (!rscStream) {
+    throw new Error("[edge:consumer] rscStream is required");
+  }
+
+  // Decode ONCE into a stable promise: a Web ReadableStream has a single
+  // reader, and the streaming HTML render may re-invoke its component on retry,
+  // so decoding inside the component would re-read a locked stream.
+  const elementPromise = createFromReadableStream(rscStream, {
+    serverConsumerManifest,
+  });
+
+  function Root() {
+    return React.use(elementPromise);
+  }
+
+  return renderToReadableStream(
+    React.createElement(React.Suspense, null, React.createElement(Root)),
+    { bootstrapModules, bootstrapScriptContent, nonce, onError, signal }
+  );
+}
+`;
+  writeFileSync(entryPath, entrySource, "utf8");
+
+  try {
+    await viteBuild({
+      root: clientDir,
+      logLevel: "warn",
+      configFile: false,
+      // No react-server aliasing here — that is the producer's job. This graph
+      // resolves React normally, which is what makes it the CLIENT half.
+      define: { "process.env.NODE_ENV": JSON.stringify("production") },
+      ssr: { target: "node", noExternal: true },
+      build: {
+        ssr: true,
+        outDir: edgeDir,
+        // The producer wrote this directory first; emptying it here would
+        // delete the bundle this one is meant to pair with.
+        emptyOutDir: false,
+        minify: userOptions.build.edge.minify,
+        rollupOptions: {
+          input: { [consumerFileName.replace(/\.js$/, "")]: entryPath },
+          output: { preserveModules: false, format: "es" },
+        },
+      },
+    });
+    const detail = divergent
+      ? ` (${divergent} module(s) registered under both tree spellings)`
+      : "";
+    logger.info(
+      `${tag} baked consumer bundle over ${idByFile.size} client module(s)${detail} → ` +
+        `${join(edgeDir, consumerFileName)}`
+    );
+  } catch (error) {
+    // Additive, like the producer bake: a failure here leaves the runtime
+    // consumer in place rather than failing an otherwise-good build.
+    logger.warn(
+      `${tag} consumer bake skipped — the runtime consumer still serves this build ` +
+        `(set build.edge:false to silence): ${
+          error instanceof Error ? error.message : String(error)
+        }`
+    );
+  } finally {
+    rmSync(entryPath, { force: true });
+  }
+}

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -9,6 +9,7 @@ import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { resolveModuleFromManifest } from "../helpers/resolveModuleFromManifest.js";
 import { UNKNOWN_ROUTE_MARKER } from "../stream/unknownRoute.js";
 import { buildWebpackClientManifest } from "./clientManifest.js";
+import { buildConsumerBundle } from "./buildConsumerBundle.js";
 
 /** Resolve a package subpath's `react-server` export target to an absolute path. */
 function reactServerExportTarget(
@@ -370,9 +371,19 @@ export async function buildEdgeBundle(opts: {
       ? projectRequire.resolve("react-server-loader/webpack/server.edge")
       : serverEdge;
 
+  // Stub the `node:` modules only dead disk-fallback branches reach (the baked
+  // entry always supplies its own resolver): even a lazy `import("node:path")`
+  // is a specifier bundlers resolve statically, and one is enough to fail a
+  // Workers build of an otherwise Node-free bundle. See nodeStub.ts.
+  const nodeStub = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "nodeStub.js"
+  );
   const alias: Record<string, string> = {
     [serverNode]: flightServerEntry,
     ...(transport === "webpack" ? { [serverEdge]: flightServerEntry } : {}),
+    "node:fs/promises": nodeStub,
+    "node:path": nodeStub,
   };
   for (const subpath of DEFAULT_CONFIG.EDGE.reactServerSubpaths) {
     const target = reactServerExportTarget(reactDir, subpath);
@@ -712,6 +723,11 @@ export async function ${actionExport}(request, opts = {}) {
       },
     });
     logger.info(`${tag} baked single-isolate rsc bundle → ${edgeDir}`);
+    // The consumer half (client React + a closed client-module registry), so
+    // the pair composes on a runtime with no module loader. No-ops on the esm
+    // transport. Emitted only after the producer succeeds — a consumer with
+    // nothing to decode is dead weight.
+    await buildConsumerBundle({ userOptions, projectRoot, logger });
   } catch (error) {
     // The edge bundle is ADDITIVE and on by default — a bake failure must not
     // fail an otherwise-good build. Warn loudly and skip the artifact; the

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -371,19 +371,27 @@ export async function buildEdgeBundle(opts: {
       ? projectRequire.resolve("react-server-loader/webpack/server.edge")
       : serverEdge;
 
-  // Stub the `node:` modules only dead disk-fallback branches reach (the baked
-  // entry always supplies its own resolver): even a lazy `import("node:path")`
-  // is a specifier bundlers resolve statically, and one is enough to fail a
-  // Workers build of an otherwise Node-free bundle. See nodeStub.ts.
+  // Webpack bakes only: stub the `node:` modules whose only reachable uses are
+  // dead disk-fallback branches (the baked entry always supplies its own
+  // resolver) — even a lazy `import("node:path")` is a specifier bundlers
+  // resolve statically, and one is enough to fail a Workers build of an
+  // otherwise Node-free bundle. See nodeStub.ts. The esm bake keeps them
+  // external: it is a Node bundle whose graph can carry modules that use
+  // node:path for real (the demo's action gate bakes the static file server,
+  // whose `extname` is live at request time).
   const nodeStub = join(
     dirname(fileURLToPath(import.meta.url)),
     "nodeStub.js"
   );
   const alias: Record<string, string> = {
     [serverNode]: flightServerEntry,
-    ...(transport === "webpack" ? { [serverEdge]: flightServerEntry } : {}),
-    "node:fs/promises": nodeStub,
-    "node:path": nodeStub,
+    ...(transport === "webpack"
+      ? {
+          [serverEdge]: flightServerEntry,
+          "node:fs/promises": nodeStub,
+          "node:path": nodeStub,
+        }
+      : {}),
   };
   for (const subpath of DEFAULT_CONFIG.EDGE.reactServerSubpaths) {
     const target = reactServerExportTarget(reactDir, subpath);

--- a/plugin/bundle/nodeStub.ts
+++ b/plugin/bundle/nodeStub.ts
@@ -1,0 +1,37 @@
+/**
+ * Aliased over `node:fs/promises` and `node:path` when the edge bundles are
+ * baked.
+ *
+ * The baked entries always supply `resolveServerReference` / `loadModule`, so
+ * the disk-fallback branches that lazily import these modules
+ * (handleServerAction's read-manifest-from-disk, the sealed gate's disk import)
+ * are unreachable in a bake — but bundlers resolve even a dead dynamic
+ * `import("node:fs/promises")` statically, and that one specifier is enough to
+ * fail a Workers build of an otherwise Node-free bundle. Aliasing the dead
+ * branches here removes the specifier; if one is ever reached anyway, the
+ * throw below names the real problem instead of a runtime-missing-module error.
+ */
+const unreachable =
+  (name: string) =>
+  (): never => {
+    throw new Error(
+      `[edge] ${name} was called inside a baked bundle. These disk-fallback ` +
+        `branches are unreachable when the baked entry provides its own ` +
+        `resolver — reaching one means the handler was invoked without it.`
+    );
+  };
+
+export const readFile = unreachable("node:fs/promises readFile");
+export const join = unreachable("node:path join");
+export const dirname = unreachable("node:path dirname");
+export const resolve = unreachable("node:path resolve");
+export const basename = unreachable("node:path basename");
+// Referenced by isPathWithin (the action helper's disk-branch containment
+// guard). Rollup requires every referenced name to EXIST at link time, even on
+// branches it later tree-shakes away — so these must be exported. They still
+// throw if actually called.
+export const relative = unreachable("node:path relative");
+export const isAbsolute = unreachable("node:path isAbsolute");
+// A constant, so it cannot throw; "/" keeps any surviving pure string logic
+// posix-correct.
+export const sep = "/";

--- a/plugin/bundle/nodeStub.ts
+++ b/plugin/bundle/nodeStub.ts
@@ -26,6 +26,13 @@ export const join = unreachable("node:path join");
 export const dirname = unreachable("node:path dirname");
 export const resolve = unreachable("node:path resolve");
 export const basename = unreachable("node:path basename");
+// The action gate's `.server.` filename pattern can bake vprs's own request
+// handler (the static file server) into a bundle that has actions; its names
+// are then referenced at link time even when nothing serves files through the
+// bake. (Its node:stream import is why that composition stays Node-bound —
+// this stub only covers path/fs.)
+export const extname = unreachable("node:path extname");
+export const normalize = unreachable("node:path normalize");
 // Referenced by isPathWithin (the action helper's disk-branch containment
 // guard). Rollup requires every referenced name to EXIST at link time, even on
 // branches it later tree-shakes away — so these must be exported. They still

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -4,6 +4,12 @@ import {
 } from "react-server-loader/transformer";
 import { pluginRoot } from "../root.js";
 import { proc } from "../proc.js";
+import {
+  PAGE_EXPORT_NAME,
+  PROPS_EXPORT_NAME,
+  LAYOUT_EXPORT_NAME,
+  RSC_OUTPUT_PATH,
+} from "./routeExportNames.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { getCondition } from "./getCondition.js";
 // Directive patterns - matching the logic in findDirectiveMatches.ts
@@ -153,14 +159,14 @@ export const DEFAULT_CONFIG = {
   PROPS: "props.ts",
   CLIENT_ENTRY: undefined,
   SERVER_ENTRY: undefined,
-  PAGE_EXPORT_NAME: "Page",
-  PROPS_EXPORT_NAME: "props",
+  PAGE_EXPORT_NAME,
+  PROPS_EXPORT_NAME,
   HTML_EXPORT_NAME: "Html",
   ROOT_EXPORT_NAME: "Root",
   // A `route.tsx` nested layout exports its component under this name (renders
   // `{children}` — the RSC-native `<Outlet/>`). Distinct from Page (leaf) and
   // Root (the #root shell): a segment can have both a Layout and a Page.
-  LAYOUT_EXPORT_NAME: "Layout",
+  LAYOUT_EXPORT_NAME,
   HTML_WORKER_PATH: `worker/html/html-worker.${
     process.env["NODE_ENV"] === "production" ? "production" : "development"
   }.js`,
@@ -206,7 +212,7 @@ export const DEFAULT_CONFIG = {
     assetsDir: "assets",
     hash: "hash",
     preserveModulesRoot: false,
-    rscOutputPath: "index.rsc",
+    rscOutputPath: RSC_OUTPUT_PATH,
     htmlOutputPath: "index.html",
     extensionMap: {
       // Module patterns
@@ -343,6 +349,14 @@ export const DEFAULT_CONFIG = {
     // This is the module-map the webpack transport renders against — the
     // closed-registry model a fully self-contained bundle needs.
     clientManifestExport: "clientManifest",
+    // The baked CONSUMER bundle: client React plus every client-reference
+    // module, so decoding a flight to HTML needs no module loader and no
+    // filesystem. Emitted beside the producer, webpack transport only (the esm
+    // client transport has no module-map seam to bind a registry to).
+    consumerFileName: "consumer.js",
+    // Its exported flight -> HTML renderer, shaped like the runtime
+    // renderFlightToHtml minus the "how to find things" options.
+    consumerExport: "renderFlightToHtml",
     // Server-module manifest keys to bake as action candidates (the sealed-gate
     // allowlist). Server actions live in `*.server.*` modules.
     actionKeyPattern: "\\.server\\.[cm]?[jt]sx?$",

--- a/plugin/config/routeExportNames.ts
+++ b/plugin/config/routeExportNames.ts
@@ -1,0 +1,20 @@
+/**
+ * Route-surface name defaults, in a dependency-free leaf.
+ *
+ * These live outside defaults.tsx because DEFAULT_CONFIG's module evaluates the
+ * whole config layer (the rsl transformer, root probes, condition sniffing) at
+ * import — side effects rollup cannot shake out. Modules that ride into baked
+ * edge bundles (resolvePageAndProps, the edge handler) need these four strings
+ * and nothing else, so importing them from here keeps the entire config layer
+ * out of those bundles. defaults.tsx composes DEFAULT_CONFIG from these same
+ * values, so there is one source of truth.
+ */
+
+/** Export name a page module publishes its component under. */
+export const PAGE_EXPORT_NAME = "Page";
+/** Export name a props module publishes its loader under. */
+export const PROPS_EXPORT_NAME = "props";
+/** Export name a `route.tsx` layout publishes its component under. */
+export const LAYOUT_EXPORT_NAME = "Layout";
+/** Filename the client router fetches a route's flight from. */
+export const RSC_OUTPUT_PATH = "index.rsc";

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -7,13 +7,7 @@ import type {
   EdgeRenderHook,
 } from "./createEdgeRequestHandler.types.js";
 
-/**
- * Mirrors DEFAULT_CONFIG.BUILD.rscOutputPath, deliberately NOT imported from it:
- * this module has to stay loadable on a Web runtime, and the defaults module
- * reaches for the transformer and the plugin root — Node-only, and no business
- * being dragged into a Worker bundle for the sake of one string.
- */
-const DEFAULT_RSC_OUTPUT_PATH = "index.rsc";
+import { RSC_OUTPUT_PATH as DEFAULT_RSC_OUTPUT_PATH } from "../config/routeExportNames.js";
 
 /**
  * Sentinel for "this bundle has no route here" coming back out of
@@ -183,6 +177,22 @@ export function createEdgeRenderHook(
  * render, so the page hydrates in place with no `.rsc` round-trip), the headless
  * flight on a client navigation, and `"use server"` actions through the bundle's
  * baked gate. No `worker_threads`, no runtime `--conditions`.
+ *
+ * On the webpack transport the build also emits a baked CONSUMER bundle beside
+ * the producer. Pass its renderer and the request path resolves no modules at
+ * all — client React and every client island are compiled in, so the pair runs
+ * on a runtime with no `node:` and no filesystem:
+ *
+ * ```js
+ * import * as bundle from "../dist/server-edge/render.js";
+ * import { renderFlightToHtml } from "../dist/server-edge/consumer.js";
+ *
+ * export const handler = createEdgeRequestHandler(bundle, { renderFlightToHtml });
+ * ```
+ *
+ * Omit it and the handler loads vprs's own renderer on first render instead,
+ * which resolves `react-dom/server` through a Node module resolver — correct on
+ * Node, unavailable on a Worker.
  *
  * Nothing here touches a filesystem or knows a platform: assets and any
  * prerendered snapshots are the host's to serve (a CDN already does it better).

--- a/plugin/edge/index.ts
+++ b/plugin/edge/index.ts
@@ -7,10 +7,45 @@
 // which does not export it, and the build dies on a module that would never have
 // run under that condition anyway. One target for both conditions is what makes
 // the import safe from anywhere.
-export {
-  createEdgeRequestHandler,
-  createEdgeRenderHook,
+// This entry injects vprs's own renderer as the `renderFlightToHtml` default,
+// which is what keeps `createEdgeRequestHandler(bundle)` zero-config on Node.
+// That injection is also why this entry's graph reaches the Node vendor layer:
+// bundling for a Worker, import "./edge/web" instead (explicit renderer, no
+// Node reachability).
+import type { EdgeFetchHandler } from "../stream/createEdgeHandler.types.js";
+import {
+  createEdgeRequestHandler as coreCreateEdgeRequestHandler,
+  createEdgeRenderHook as coreCreateEdgeRenderHook,
 } from "./createEdgeRequestHandler.js";
+import type {
+  CreateEdgeRequestHandlerOptions,
+  EdgeBundleExports,
+  EdgeRenderHook,
+} from "./createEdgeRequestHandler.types.js";
+import { builtInRenderFlightToHtml } from "./nodeRenderer.js";
+
+export function createEdgeRequestHandler(
+  bundle: EdgeBundleExports,
+  options: CreateEdgeRequestHandlerOptions = {}
+): EdgeFetchHandler {
+  return coreCreateEdgeRequestHandler(bundle, {
+    ...options,
+    renderFlightToHtml:
+      options.renderFlightToHtml ?? builtInRenderFlightToHtml,
+  });
+}
+
+export function createEdgeRenderHook(
+  bundle: EdgeBundleExports,
+  options: CreateEdgeRequestHandlerOptions = {}
+): EdgeRenderHook {
+  return coreCreateEdgeRenderHook(bundle, {
+    ...options,
+    renderFlightToHtml:
+      options.renderFlightToHtml ?? builtInRenderFlightToHtml,
+  });
+}
+
 export type {
   CreateEdgeRequestHandlerOptions,
   EdgeBundleExports,

--- a/plugin/edge/nodeRenderer.ts
+++ b/plugin/edge/nodeRenderer.ts
@@ -1,0 +1,19 @@
+import type { RenderFlightToHtmlFn } from "../stream/renderFlightToHtml.types.js";
+
+/**
+ * vprs's own flight -> HTML renderer, behind a lazy import.
+ *
+ * This module is the ONLY bridge from the edge-handler graph to the runtime
+ * renderer (whose vendor layer resolves react-dom through `createRequire`).
+ * The Node entry (`/edge`) imports it to keep its zero-config behavior; the web
+ * entry (`/edge/web`) must never import it, so a Worker bundle built from that
+ * entry contains no Node module resolution at all.
+ *
+ * Lazy for the same reason the old in-handler import was: react-dom/server is a
+ * throwing stub under the `react-server` condition, so the import must not run
+ * merely because a handler was constructed — only when a document is rendered.
+ */
+export const builtInRenderFlightToHtml: RenderFlightToHtmlFn = async (options) =>
+  (await import("../stream/renderFlightToHtml.client.js")).renderFlightToHtml(
+    options
+  );

--- a/plugin/edge/web.ts
+++ b/plugin/edge/web.ts
@@ -1,0 +1,69 @@
+// Public "./edge/web" entry: the per-request edge server for a Web runtime
+// (Cloudflare Workers, Deno Deploy) — same factories as "./edge", minus the
+// built-in Node renderer default.
+//
+// The difference is the module GRAPH, not the behavior: "./edge" can reach
+// vprs's runtime flight -> HTML renderer, whose vendor layer resolves react-dom
+// through `createRequire` — statically visible to every bundler, so a Worker
+// build from that entry drags `node:module` in even when the fallback is never
+// called. This entry cannot reach it, which is what lets a webpack-transport
+// deploy compose to a bundle with no `node:` at all:
+//
+// ```js
+// import * as bundle from "./dist/server-edge/render.js";
+// import { renderFlightToHtml } from "./dist/server-edge/consumer.js";
+// import { createEdgeRequestHandler } from "vite-plugin-react-server/edge/web";
+//
+// export default { fetch: createEdgeRequestHandler(bundle, { renderFlightToHtml }) };
+// ```
+//
+// The price is that `renderFlightToHtml` is REQUIRED here — the baked consumer
+// bundle the build emits beside the producer. Checked at creation, not first
+// request: a handler that cannot render documents should fail at compose time.
+import type { EdgeFetchHandler } from "../stream/createEdgeHandler.types.js";
+import {
+  createEdgeRequestHandler as coreCreateEdgeRequestHandler,
+  createEdgeRenderHook as coreCreateEdgeRenderHook,
+} from "./createEdgeRequestHandler.js";
+import type {
+  CreateEdgeRequestHandlerOptions,
+  EdgeBundleExports,
+  EdgeRenderHook,
+} from "./createEdgeRequestHandler.types.js";
+
+function requireRenderer(
+  options: CreateEdgeRequestHandlerOptions,
+  caller: string
+): void {
+  if (!options.renderFlightToHtml) {
+    throw new Error(
+      `[${caller}] \`renderFlightToHtml\` is required on the /edge/web entry: ` +
+        `pass the baked consumer bundle's renderer ` +
+        `(import { renderFlightToHtml } from "./dist/server-edge/consumer.js"). ` +
+        `On Node, 'vite-plugin-react-server/edge' supplies vprs's own instead.`
+    );
+  }
+}
+
+export function createEdgeRequestHandler(
+  bundle: EdgeBundleExports,
+  options: CreateEdgeRequestHandlerOptions = {}
+): EdgeFetchHandler {
+  requireRenderer(options, "createEdgeRequestHandler");
+  return coreCreateEdgeRequestHandler(bundle, options);
+}
+
+export function createEdgeRenderHook(
+  bundle: EdgeBundleExports,
+  options: CreateEdgeRequestHandlerOptions = {}
+): EdgeRenderHook {
+  requireRenderer(options, "createEdgeRenderHook");
+  return coreCreateEdgeRenderHook(bundle, options);
+}
+
+export type {
+  CreateEdgeRequestHandlerOptions,
+  EdgeBundleExports,
+  EdgeRenderHook,
+} from "./createEdgeRequestHandler.types.js";
+export type { EdgeFetchHandler } from "../stream/createEdgeHandler.types.js";

--- a/plugin/helpers/resolvePageAndProps.ts
+++ b/plugin/helpers/resolvePageAndProps.ts
@@ -1,4 +1,12 @@
-import { DEFAULT_CONFIG } from "../config/defaults.js";
+// Names come from the dependency-free leaf, NOT defaults.js: this module rides
+// into baked edge bundles, and importing DEFAULT_CONFIG evaluates the whole
+// config layer (rsl transformer, root probes) at module init there.
+import {
+  PAGE_EXPORT_NAME,
+  PROPS_EXPORT_NAME,
+  LAYOUT_EXPORT_NAME,
+  RSC_OUTPUT_PATH,
+} from "../config/routeExportNames.js";
 import { toError } from "../error/toError.js";
 import type {
   CreateHandlerOptions,
@@ -36,7 +44,7 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
           handlerOptions.route ?? "",
           handlerOptions.moduleBaseURL ?? "/",
           handlerOptions?.build?.rscOutputPath ??
-            DEFAULT_CONFIG.BUILD.rscOutputPath
+            RSC_OUTPUT_PATH
         );
 
       if (handlerOptions.verbose) {
@@ -52,7 +60,7 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
       // slash, so `/profile/42.rsc` resolves `{ id: "42" }`, not `"42.rsc"`.
       const rscSuffix =
         handlerOptions.build?.rscOutputPath ??
-        DEFAULT_CONFIG.BUILD.rscOutputPath;
+        RSC_OUTPUT_PATH;
       const params =
         handlerOptions.params ??
         (handlerOptions.routePatterns?.length
@@ -66,7 +74,7 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
       const resolvePagePromise = resolvePage({
         id: handlerOptions.pagePath,
         exportName:
-          handlerOptions.pageExportName ?? DEFAULT_CONFIG.PAGE_EXPORT_NAME,
+          handlerOptions.pageExportName ?? PAGE_EXPORT_NAME,
         loader: handlerOptions.loader,
       });
 
@@ -81,7 +89,7 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
         ctx: loaderCtx,
         id: handlerOptions.propsPath || handlerOptions.pagePath,
         exportName:
-          handlerOptions.propsExportName ?? DEFAULT_CONFIG.PROPS_EXPORT_NAME,
+          handlerOptions.propsExportName ?? PROPS_EXPORT_NAME,
         loader: async (idWithExport?: string) => {
           if (handlerOptions.verbose) {
             handlerOptions.logger?.info(
@@ -91,7 +99,7 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
           
           // Parse the id to extract the path and export name if using # syntax
           let propsId = handlerOptions.propsPath || handlerOptions.pagePath;
-          let propsExportName = handlerOptions.propsExportName ?? DEFAULT_CONFIG.PROPS_EXPORT_NAME;
+          let propsExportName = handlerOptions.propsExportName ?? PROPS_EXPORT_NAME;
           
           if (idWithExport && idWithExport.includes('#')) {
             const [id, exportName] = idWithExport.split('#');
@@ -261,10 +269,10 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
           loader: handlerOptions.loader,
           layoutExportName:
             handlerOptions.layoutExportName ??
-            DEFAULT_CONFIG.LAYOUT_EXPORT_NAME,
+            LAYOUT_EXPORT_NAME,
           propsExportName:
             handlerOptions.propsExportName ??
-            DEFAULT_CONFIG.PROPS_EXPORT_NAME,
+            PROPS_EXPORT_NAME,
           verbose: handlerOptions.verbose,
           logger: handlerOptions.logger,
         });

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -2,7 +2,6 @@ import type {
   CreateEdgeHandlerFn,
   EdgeFetchHandler,
 } from "./createEdgeHandler.types.js";
-import { renderFlightToHtml } from "./renderFlightToHtml.client.js";
 import { injectInlineFlightIntoHtml } from "../utils/inlineFlight.js";
 import { assertNonReactServer } from "../config/getCondition.js";
 import { isUnknownRoute } from "./unknownRoute.js";
@@ -69,11 +68,26 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
     verbose,
     flightTransport = "esm",
     clientManifest,
+    renderFlightToHtml,
   } = options;
 
   if (!render && !renderDocument) {
     throw new Error(
       "[createEdgeHandler] one of `render` or `renderDocument` is required"
+    );
+  }
+
+  // No default renderer HERE, deliberately: even a dynamic import of vprs's own
+  // renderer is statically visible to bundlers, so it would drag the Node
+  // vendor layer (createRequire on react-dom) into every Worker bundle that can
+  // reach this module. The Node-facing entries inject the built-in
+  // (`/edge`, and the `/stream` barrel's wrapper); the web entry (`/edge/web`)
+  // requires the baked consumer's renderer instead.
+  if (!renderFlightToHtml) {
+    throw new Error(
+      "[createEdgeHandler] `renderFlightToHtml` is required: pass the baked " +
+        "consumer bundle's renderer (dist/server-edge/consumer.js), or vprs's " +
+        "own from 'vite-plugin-react-server/stream' on Node"
     );
   }
 

--- a/plugin/stream/createEdgeHandler.types.ts
+++ b/plugin/stream/createEdgeHandler.types.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "vite";
+import type { RenderFlightToHtmlFn } from "./renderFlightToHtml.types.js";
 
 /**
  * A Web `fetch` handler: the standard edge-runtime entrypoint shape
@@ -69,6 +70,18 @@ export type CreateEdgeHandlerOptions = {
    * by the webpack decode path.
    */
   clientManifest?: Record<string, { id: string; chunks: string[]; name: string }>;
+  /**
+   * The flight -> HTML renderer. Defaults to vprs's own, which is loaded on
+   * first render (never at import) because it pulls `react-dom/server` in
+   * through a Node module resolver.
+   *
+   * Pass the baked consumer bundle's `renderFlightToHtml` to skip that path
+   * entirely: it carries client React and a closed client-module registry, so
+   * nothing resolves a module at request time and the handler composes on a
+   * runtime with no `node:` at all. `createEdgeRequestHandler` wires it up
+   * automatically when the bundle exports one.
+   */
+  renderFlightToHtml?: RenderFlightToHtmlFn;
   /** Nonce forwarded to the HTML renderer (CSP). */
   nonce?: string;
   /**

--- a/plugin/stream/index.client.ts
+++ b/plugin/stream/index.client.ts
@@ -22,10 +22,21 @@ export * from "./createFromReadableStream.client.js";
 // to an HTML ReadableStream in one process (no worker). The in-process twin of
 // plugin/worker/html, for edge / single-isolate builds.
 export * from "./renderFlightToHtml.client.js";
+import { renderFlightToHtml } from "./renderFlightToHtml.client.js";
+import { createEdgeHandler as coreCreateEdgeHandler } from "./createEdgeHandler.client.js";
+import type { CreateEdgeHandlerFn } from "./createEdgeHandler.types.js";
 
 // Edge fetch handler: compose the baked flight producer + renderFlightToHtml
-// into a Web `(Request) => Response` handler for edge runtimes.
-export * from "./createEdgeHandler.client.js";
+// into a Web `(Request) => Response` handler for edge runtimes. The core
+// requires a `renderFlightToHtml`; this barrel already carries vprs's own (the
+// static export above), so defaulting it here adds no reach the barrel didn't
+// have — and keeps `createEdgeHandler(...)` zero-config, as before. Web
+// bundles compose the core with a baked consumer via "/edge/web" instead.
+export const createEdgeHandler: CreateEdgeHandlerFn = (options) =>
+  coreCreateEdgeHandler({
+    ...options,
+    renderFlightToHtml: options.renderFlightToHtml ?? renderFlightToHtml,
+  });
 export type {
   CreateEdgeHandlerOptions,
   CreateEdgeHandlerFn,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -127,6 +127,14 @@ export default defineConfig({
         // Public "./edge" entry. Condition-neutral by design — one target serves
         // both conditions, see plugin/edge/index.ts.
         "plugin/edge/index": resolve(__dirname, "plugin/edge/index.ts"),
+        // Public "./edge/web" entry: the same factories without the built-in
+        // Node renderer in the graph, so a Worker bundle stays free of
+        // `node:module`. See plugin/edge/web.ts.
+        "plugin/edge/web": resolve(__dirname, "plugin/edge/web.ts"),
+        // Not public and imported by nothing: referenced BY PATH at bake time
+        // (buildEdgeBundle aliases node:fs/promises + node:path onto it), so it
+        // must be an entry to be emitted at all.
+        "plugin/bundle/nodeStub": resolve(__dirname, "plugin/bundle/nodeStub.ts"),
       },
       formats: ["es"],
     },


### PR DESCRIPTION
The bake-the-consumer rung, following #262: after this, a webpack-transport build's whole request path — flight producer, flight→HTML consumer, request handler — composes to a bundle with **no `node:` specifiers, no `require`, and no `process` dependency at all**.

## What ships

**`dist/server-edge/consumer.js`** (webpack transport only): client React, `react-dom/server.edge`, the webpack flight client, and every client-reference module compiled in behind a closed registry. Exports `renderFlightToHtml` with the runtime renderer's contract minus the "how to find things" options (`moduleBaseURL`, `clientManifest`, `flightTransport`) — the bundle already contains them. Emitted beside the producer; a separate module graph on purpose (producer bakes server React, consumer bakes client React).

The registry keys each module under **both** trees' hosted ids, joined by their shared manifest source key: `"use client"` components hash identically in both trees, but CSS-module and node_modules-shipped client modules do not. Keying off one tree alone 404s whichever spelling the payload carries.

**`vite-plugin-react-server/edge/web`**: the same handler factories as `/edge`, with `renderFlightToHtml` required at creation. The difference is the module graph, not behavior — the core handler no longer reaches vprs's built-in renderer even via dynamic import (a statically visible specifier that dragged `createRequire` into every Worker bundle). `/edge` and the `/stream` barrel inject the built-in, keeping their zero-config Node behavior unchanged.

```js
import * as bundle from "./dist/server-edge/render.js";
import { renderFlightToHtml } from "./dist/server-edge/consumer.js";
import { createEdgeRequestHandler } from "vite-plugin-react-server/edge/web";

export default { fetch: createEdgeRequestHandler(bundle, { renderFlightToHtml }) };
```

## What the composition probe forced

Bundling the pair with `platform=browser` (the Workers rehearsal) surfaced three Node leaks no test had:

1. The handler's built-in-renderer fallback import (above).
2. The dead disk-fallback `import("node:path")`/`import("node:fs/promises")` in the baked producer — unreachable (the baked entries supply their own resolvers) but still specifiers a bundler must resolve. The bake now aliases them onto a throwing stub; rollup requires every referenced name to exist at link time even on tree-shaken branches, so the stub exports the full referenced surface.
3. `resolvePageAndProps` importing `DEFAULT_CONFIG` for four strings, which evaluates the whole config layer at module init — including picocolors' bare `process ||` read, which crashes any runtime without the global. The strings now live in a dependency-free `routeExportNames.ts` leaf; `defaults.tsx` composes `DEFAULT_CONFIG` from the same values.

## Measured

- Composed request path (esbuild `--platform=browser`, starter build): **0 `node:` import specifiers, 0 `require(`**, 657 kB.
- Executed with `globalThis.process` **deleted**: `/about` renders a styled document with the SSR'd client island, inlined flight, and bootstrap preload.
- Node path unchanged: starter edge server + real-browser hydration gate green (client-side nav swaps content, sentinel survives, no React errors).
- Full `test-all` green (599+35 in the final phases, exit 0); `tsc` clean.

Remaining for the docs flip (#257): the positive Workers/Deno claim should document the `/edge/web` + `consumer.js` pairing as the supported path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs