### PR TITLE
refactor(edge): one implementation of the pass-through consumer manifest

### DIFF
--- a/plugin/bundle/buildConsumerBundle.ts
+++ b/plugin/bundle/buildConsumerBundle.ts
@@ -2,8 +2,11 @@ import { build as viteBuild, type Logger } from "vite";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ResolvedUserOptions } from "../types.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { hostedPath } from "./clientManifest.js";
 
 /**
  * Bake the CONSUMER half of the single-isolate edge render: decode a Flight
@@ -73,8 +76,7 @@ export async function buildConsumerBundle(opts: {
     : {};
 
   const moduleBasePath = userOptions.moduleBasePath ?? "";
-  const hosted = (file: string): string =>
-    moduleBasePath.replace(/\/$/, "") + "/" + file;
+  const hosted = (file: string): string => hostedPath(moduleBasePath, file);
 
   // Register each ssr module under EVERY hosted id it can be asked for.
   //
@@ -132,12 +134,19 @@ export async function buildConsumerBundle(opts: {
   const webpackRuntime = projectRequire.resolve(
     "react-server-loader/webpack/runtime"
   );
+  // The SAME pass-through manifest the runtime decode uses, bundled in — one
+  // implementation of the contract both sides must agree on.
+  const consumerManifestHelper = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../stream/webpackConsumerManifest.js"
+  );
 
   const entryPath = join(clientDir, `.vprs-${consumerFileName}`);
   const entrySource = `import * as React from "react";
 import { renderToReadableStream } from "react-dom/server.edge";
 import { createFromReadableStream } from ${JSON.stringify(webpackClientEdge)};
 import { installWebpackGlobals } from ${JSON.stringify(webpackRuntime)};
+import { createPassthroughConsumerManifest } from ${JSON.stringify(consumerManifestHelper)};
 ${importLines.join("\n")}
 
 /**
@@ -165,24 +174,7 @@ installWebpackGlobals({
   },
 });
 
-// Pass-through module map: the payload's id is echoed back as its own chunk, so
-// the transport asks the registry for exactly the id it was given and never
-// composes a module path out of payload input.
-const moduleMap = new Proxy({}, {
-  get: (_outer, id) =>
-    typeof id !== "string"
-      ? undefined
-      : new Proxy({}, {
-          get: (_inner, name) =>
-            typeof name !== "string" ? undefined : { id, chunks: [id], name },
-        }),
-});
-
-const serverConsumerManifest = {
-  moduleMap,
-  serverModuleMap: null,
-  moduleLoading: null,
-};
+const serverConsumerManifest = createPassthroughConsumerManifest();
 
 /**
  * Decode a Flight stream and render it to an HTML stream, entirely in-process.

--- a/plugin/bundle/clientManifest.ts
+++ b/plugin/bundle/clientManifest.ts
@@ -33,7 +33,7 @@ export type WebpackClientManifestEntry = {
 export type WebpackClientManifest = Record<string, WebpackClientManifestEntry>;
 
 /** `moduleBasePath`-prefix a built file the same way the moduleID policy does. */
-function hostedPath(moduleBasePath: string, file: string): string {
+export function hostedPath(moduleBasePath: string, file: string): string {
   const base = moduleBasePath.replace(/\/$/, "");
   return base + "/" + file;
 }

--- a/plugin/stream/renderFlightToHtml.client.ts
+++ b/plugin/stream/renderFlightToHtml.client.ts
@@ -2,6 +2,7 @@ import type { RenderFlightToHtmlFn } from "./renderFlightToHtml.types.js";
 import { React, ReactDOMHtmlServerEdge } from "../vendor/vendor.client.js";
 import { ReactDOMClientEdge } from "../vendor/vendorEdge.client.js";
 import { assertNonReactServer } from "../config/getCondition.js";
+import { createPassthroughConsumerManifest } from "./webpackConsumerManifest.js";
 
 assertNonReactServer();
 
@@ -51,35 +52,13 @@ function getWebpackDecode(
             .href
         ),
     });
-    // Pass-through module map: outer key = the id the payload carries, inner
-    // key = the export name — both echoed into a {id, chunks, name} record.
-    // Chunks are just the module's own id: the payload's chunk closure names
-    // BROWSER-tree files (that's who preloads them), while this decode imports
-    // off the ssr tree (moduleBaseURL), where `import()` resolves the module's
-    // relative imports transitively — the closure would name files that don't
-    // exist here.
-    const moduleMap = new Proxy(
-      {},
-      {
-        get: (_outer, id: string | symbol) =>
-          typeof id !== "string"
-            ? undefined
-            : new Proxy(
-                {},
-                {
-                  get: (_inner, name: string | symbol) =>
-                    typeof name !== "string"
-                      ? undefined
-                      : { id, chunks: [id], name },
-                }
-              ),
-      }
-    );
-    const serverConsumerManifest = {
-      moduleMap,
-      serverModuleMap: null,
-      moduleLoading: null,
-    };
+    // Pass-through manifest (shared with the baked consumer — see
+    // webpackConsumerManifest.ts): the module's own id is its only chunk. The
+    // payload's chunk closure names BROWSER-tree files (that's who preloads
+    // them), while this decode imports off the ssr tree (moduleBaseURL), where
+    // `import()` resolves the module's relative imports transitively — the
+    // closure would name files that don't exist here.
+    const serverConsumerManifest = createPassthroughConsumerManifest();
     return ((stream) =>
       clientEdge.createFromReadableStream(stream, {
         serverConsumerManifest,

--- a/plugin/stream/webpackConsumerManifest.ts
+++ b/plugin/stream/webpackConsumerManifest.ts
@@ -1,0 +1,45 @@
+/**
+ * The pass-through server-consumer manifest for decoding a webpack-transport
+ * flight against a closed registry.
+ *
+ * The payload's reference id is echoed back as its own single chunk, so the
+ * transport asks the chunk loader for exactly the id it was given and never
+ * composes a module path out of payload input. Chunk loading (the
+ * `installWebpackGlobals({ load })` side) stays the caller's: the runtime
+ * decode imports off `moduleBaseURL`, the baked consumer looks up its
+ * compiled-in registry.
+ *
+ * ONE implementation on purpose: the runtime renderer and the baked consumer
+ * bundle (whose generated entry bundles this module in) must agree on this
+ * contract byte-for-byte — two hand-rolled copies is how they drift apart.
+ * Import-free leaf so the bake can bundle it without dragging anything else.
+ */
+
+type ConsumerManifestEntry = { id: string; chunks: string[]; name: string };
+
+export type ServerConsumerManifest = {
+  moduleMap: unknown;
+  serverModuleMap: null;
+  moduleLoading: null;
+};
+
+export function createPassthroughConsumerManifest(): ServerConsumerManifest {
+  const moduleMap = new Proxy(
+    {},
+    {
+      get: (_outer, id: string | symbol) =>
+        typeof id !== "string"
+          ? undefined
+          : new Proxy(
+              {},
+              {
+                get: (_inner, name: string | symbol): ConsumerManifestEntry | undefined =>
+                  typeof name !== "string"
+                    ? undefined
+                    : { id, chunks: [id], name },
+              }
+            ),
+    }
+  );
+  return { moduleMap, serverModuleMap: null, moduleLoading: null };
+}


### PR DESCRIPTION
Pre-release consolidation of duplication the 3.2.0 work introduced, before the tag lands.

- The webpack decode's pass-through moduleMap proxy existed twice: in the runtime renderer (`renderFlightToHtml.client.ts`) and inside the baked consumer's generated entry. It is the contract both decode paths must agree on byte-for-byte — two hand-rolled copies is how they drift. `webpackConsumerManifest.ts` (import-free leaf) is now the single implementation; the runtime imports it and the bake bundles it into the consumer entry by resolved path.
- `buildConsumerBundle`'s local `hosted()` now delegates to `hostedPath()` from `clientManifest.ts` beside it (newly exported).

Verified: full `test-all` green; starter rebaked — the composed producer + consumer + handler bundle stays free of `node:`/`require` and renders with no `process` global (the Workers probe).

Also audited but deliberately untouched: the near-identical wrapper pairs in `edge/index.ts` / `edge/web.ts` (four explicit lines each; the entries exist to have different module graphs), and npm pack / export resolution were verified clean from a real tarball install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs