### PR TITLE
fix(edge): survive workerd — eval-time URL guard + Buffer-free inline flight

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -537,11 +537,20 @@ export const ${bootstrapExport} = ${JSON.stringify(bakedBootstrapModules)};
  * runtime. The in-process HTML render imports client references from here, so it
  * must be a location that exists wherever the bundle is deployed — hence
  * import.meta.url, not a build-time absolute path or process.cwd().
+ *
+ * Guarded: on a runtime whose import.meta.url is not a usable absolute base
+ * (workerd rejects it at URL construction), this top-level export would crash
+ * the whole module at eval — and it only feeds the runtime-consumer path,
+ * which such a runtime never uses (the baked consumer carries its modules
+ * compiled in). "/" is the inert fallback.
  */
-export const ${clientBaseExport} = new URL(
-  ${JSON.stringify(relClientFromEdge + "/")},
-  import.meta.url
-).href;
+export const ${clientBaseExport} = (() => {
+  try {
+    return new URL(${JSON.stringify(relClientFromEdge + "/")}, import.meta.url).href;
+  } catch {
+    return "/";
+  }
+})();
 
 /**
  * The webpack-shaped client manifest: hosted client-reference id ->

--- a/plugin/utils/inlineFlight.ts
+++ b/plugin/utils/inlineFlight.ts
@@ -9,8 +9,11 @@
  *  - build-time:   inlineFlightPayload (rewrites prerendered index.html files)
  *  - per-request:  createHtmlStreamWithInlineFlight (dynamic SSR)
  *
- * Node-side only (uses Buffer for base64); the browser only ever *reads* the
- * element, never builds it, so the dependency-free id lives in inlineFlightId.ts.
+ * Runtime-agnostic: base64 rides Buffer where it exists (Node — fastest for
+ * large payloads) and chunked btoa elsewhere (workerd/Deno have no Buffer, and
+ * the per-request edge handler builds the element there). The browser only
+ * ever *reads* the element, never builds it, so the dependency-free id lives
+ * in inlineFlightId.ts.
  */
 import {
   INLINE_FLIGHT_ID,
@@ -28,8 +31,21 @@ export { INLINE_FLIGHT_ID, INLINE_FLIGHT_LENGTH_ATTR };
  * `data-length` stamps how many characters the payload has, so the reader can
  * tell a whole element from a half-written one — see INLINE_FLIGHT_LENGTH_ATTR.
  */
+function bytesToBase64(bytes: Uint8Array): string {
+  const B = (globalThis as { Buffer?: typeof Buffer }).Buffer;
+  if (B?.from) return B.from(bytes).toString("base64");
+  // btoa takes a binary string; build it in slices — a single
+  // String.fromCharCode(...bytes) blows the argument limit on large payloads.
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
 export function buildInlineFlightScript(flight: Uint8Array): string {
-  const base64 = Buffer.from(flight).toString("base64");
+  const base64 = bytesToBase64(flight);
   return `<script type="text/x-component" id="${INLINE_FLIGHT_ID}" data-encoding="base64" ${INLINE_FLIGHT_LENGTH_ATTR}="${base64.length}">${base64}</script>`;
 }
 


### PR DESCRIPTION
Running the composed producer + consumer + `/edge/web` pair on **actual workerd** (`wrangler dev`, no `nodejs_compat`) found two crashes that every Node-side proof missed — including the `delete globalThis.process` run, because `import.meta.url` was still a valid file URL and `Buffer` still existed there:

1. **Module-eval crash**: the baked producer computes `clientModuleBaseURL` at top level via `new URL(rel, import.meta.url)`, and workerd rejects its `import.meta.url` as a URL base — `Uncaught TypeError: Invalid URL string.` before any request. The value only feeds the runtime-consumer path, which a filesystem-less runtime never uses (the baked consumer carries its modules compiled in). The codegen now wraps it in try/catch with `"/"` as the inert fallback. Same failure class as #262's dead-branch `node:` imports: meaningless on this path, load-bearing at eval.
2. **Request-time 500**: `buildInlineFlightScript` base64-encodes through `Buffer`, which workerd doesn't have. Now feature-detected — `Buffer` where it exists (Node, fastest for large payloads), chunked `btoa` elsewhere.

**Verified on workerd itself** (the bar is no longer a Node simulation): `GET /about` serves the per-request document with the SSR'd nav island, the inline flight payload, and the bootstrap entry; the flight endpoint and root route both return 200.

Node side unchanged: full `test-all` green, starter hydration gate green (the inline-flight change also feeds the SSG and worker-SSR emitters, so the whole gate matters here).

Release note: this should land before the v3.2.0 tag — without it, the release's Workers claim (#263/#264) doesn't survive contact with the actual runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs