### PR TITLE
fix(build): canonical bare transport specifier — repairs the hosted-shadow break in #267

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -383,15 +383,19 @@ export async function buildEdgeBundle(opts: {
     dirname(fileURLToPath(import.meta.url)),
     "nodeStub.js"
   );
+  // The transport master switch. dist/server modules import the transport by
+  // its BARE canonical specifier (react-server-dom-esm/server.node — the
+  // vendor alias externalizes it that way, keeping artifacts free of
+  // machine-absolute paths), so the bare keys re-transport the whole baked
+  // graph; the resolved-path keys cover dists built by older vprs versions
+  // that stamped the absolute vendored path.
   const alias: Record<string, string> = {
-    // dist/server modules import the transport by its BARE rsl subpath (the
-    // vendor alias externalizes it that way, keeping artifacts relocatable);
-    // the resolved-path keys stay for dists built by older versions.
-    "react-server-loader/server.node": flightServerEntry,
+    "react-server-dom-esm/server.node": flightServerEntry,
+    "react-server-dom-esm/server": flightServerEntry,
     [serverNode]: flightServerEntry,
     ...(transport === "webpack"
       ? {
-          "react-server-loader/server.edge": flightServerEntry,
+          "react-server-dom-esm/server.edge": flightServerEntry,
           [serverEdge]: flightServerEntry,
           "node:fs/promises": nodeStub,
           "node:path": nodeStub,

--- a/plugin/vendor/vendor-alias.ts
+++ b/plugin/vendor/vendor-alias.ts
@@ -85,18 +85,26 @@ export function vitePluginVendorAlias(): Plugin {
       if (!source.startsWith("react-server-dom-esm")) return;
       if (source === "react-server-dom-esm/client.browser") return;
 
-      // Server/static entries: mark external so the runner/bundler uses native
-      // import() rather than eval() — but external under the BARE rsl subpath,
-      // not the resolved vendored file. The resolved path is machine-absolute
-      // and used to be stamped into every emitted dist/server module (each
-      // client-reference proxy imported registerClientReference from
-      // /home/<user>/.../react-server-loader/vendor/...), binding the artifact
-      // to the build machine. rsl ≥ 19.2.17 exports every one of these files
-      // as a package subpath (./server.node, ./static.node, …), so the bare id
-      // names the IDENTICAL file and Node resolves it from whatever
-      // node_modules the deploy has.
+      // Server/static entries: mark external under the BARE canonical
+      // specifier, so the emitted artifact carries
+      // `import ... from "react-server-dom-esm/server.node"` — no
+      // machine-absolute path binding dist to the build machine (it used to
+      // stamp /home/<user>/.../react-server-loader/vendor/... into every
+      // client-reference proxy). Resolution at runtime is already provided
+      // for every consumer of dist/server: plain Node resolves through the
+      // node_modules/react-server-dom-esm symlink this plugin maintains
+      // (ensureVendoredPackageLinked — the vendored dir is a complete package
+      // with its own exports map), and the RSC worker's loader hook maps the
+      // bare ids directly.
+      //
+      // Two spellings deliberately NOT used: the resolved absolute path (the
+      // machine binding), and bare `react-server-loader/*` — dist can host a
+      // PARTIAL rsl copy under its own node_modules (the node_modules-shipped
+      // client-reference feature), and that shadow intercepts bare rsl
+      // resolution with an incomplete package. `react-server-dom-esm` is
+      // never hosted, so it has no shadow.
       if (isServerEntry(source)) {
-        return { id: bareRslSpecifier(source), external: true };
+        return { id: canonicalTransportSpecifier(source), external: true };
       }
 
       return resolveVendored(source);
@@ -157,15 +165,14 @@ function resolveVendored(source: string): string {
 }
 
 /**
- * The published rsl subpath naming the same vendored file `resolveVendored`
- * would return — `react-server-dom-esm/server` and `server.node` both resolve
- * to server.node.js, whose export is `react-server-loader/server.node`. Built
- * from the same subpathMap so the two can never disagree.
+ * The canonical bare form of a transport specifier — the vendored file's name
+ * minus `.js`, under the package name (`react-server-dom-esm/server` and
+ * `/server.node` both canonicalize to `react-server-dom-esm/server.node`).
+ * Derived from the same subpathMap as the vendored resolution so the two can
+ * never disagree; the vendored package.json exports every one of these.
  */
-function bareRslSpecifier(source: string): string {
+function canonicalTransportSpecifier(source: string): string {
   const file = subpathMap[source];
-  const sub = file
-    ? file.replace(/\.js$/, "")
-    : source.replace("react-server-dom-esm", "").replace(/^\//, "").replace(/\.js$/, "") || "index";
-  return `react-server-loader/${sub}`;
+  if (file) return `react-server-dom-esm/${file.replace(/\.js$/, "")}`;
+  return source;
 }


### PR DESCRIPTION
#267 merged with the bare `react-server-loader/*` emission, which breaks any build that **hosts a partial rsl copy** under `dist/server/node_modules` (the node_modules-shipped client-reference feature) — the shadow intercepts bare rsl resolution with an incomplete package. CI caught it (`build-edge-bundle.test`); main is currently red for builds with hosted rsl.

This lands the correction (authored on the #267 branch after it had already merged — my miss): emit the **canonical bare specifier** the system was designed around, `react-server-dom-esm/server.node`. Every consumer of `dist/server` already resolves it — plain Node through the `node_modules/react-server-dom-esm` symlink the plugin maintains (the vendored dir is a complete package with its own exports map), the RSC worker through its loader hook — and it is never hosted, so it has no shadow. A relative-externals design (`makeAbsoluteExternalsRelative`) was also measured and rejected: vprs remaps chunk filenames after rollup renders imports, so emitted `../..` depths disagree with the final layout.

The edge bake's master switch matches the canonical id as a plain alias key; the resolved-path key stays for dists built by older versions. Still zero machine-absolute paths — the original goal of #267 holds.

**Verified on this exact tree**: `build-edge-bundle.test` 16/16 (the CI catch); full `test-all` green; starter rebuilt — zero `/home/` in all three dist trees, proxies read `from "react-server-dom-esm/server.node"`; hydration gate green; workerd serves the composed webpack pair.

3.2.1 bump is already on main via #267 — after this merges, main is what `v3.2.1` should tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs