### PR TITLE
fix(config): Vite's config.base reaches the build (bead: un-prefixed bootstrap 404)

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -254,6 +254,12 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     typeof options.moduleBaseURL === "string"
       ? options.moduleBaseURL
       : DEFAULT_CONFIG.MODULE_BASE_URL;
+  // Whether the USER set moduleBaseURL, as opposed to the default filling in.
+  // resolveUserConfig needs the distinction: an explicit option outranks
+  // Vite's config.base, but the default must NOT — otherwise config.base is
+  // dead code in the precedence chain and a consumer who configures base the
+  // normal Vite way builds against "/" (the un-prefixed-bootstrap 404).
+  const moduleBaseURLExplicit = typeof options.moduleBaseURL === "string";
 
   const moduleRootPath =
     typeof options.moduleRootPath === "string"
@@ -869,6 +875,7 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
       moduleBase,
       moduleBasePath,
       moduleBaseURL,
+      moduleBaseURLExplicit,
       moduleRootPath,
       publicOrigin,
       build: build,

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -346,10 +346,6 @@ export const resolveUserConfig: ResolveUserConfigFn =
     const primaryPrefix =
       typeof vitePrefix === "string" ? vitePrefix : vitePrefix[0];
     const envBaseUrl = getEnvValue("BASE_URL", primaryPrefix);
-    const effectiveModuleBaseURL =
-      envBaseUrl != null && envBaseUrl !== ""
-        ? envBaseUrl
-        : userOptions.moduleBaseURL;
 
     const envPublicOrigin = getEnvValue("PUBLIC_ORIGIN", primaryPrefix);
     const effectivePublicOrigin =
@@ -474,8 +470,27 @@ export const resolveUserConfig: ResolveUserConfigFn =
       typeof config.server?.host === "string"
         ? config.server?.host
         : "localhost";
+    // Base precedence: the env var is the deploy-time override; an EXPLICIT
+    // moduleBaseURL option is plugin-specific intent; only then Vite's own
+    // config.base — the way every other plugin's consumer sets a base — fills
+    // in, ahead of the "/" default. The old chain put effectiveModuleBaseURL
+    // (which is never nullish — the option default-fills to "/") before
+    // config.base, making config.base dead code: a consumer configuring base
+    // the normal Vite way built against "/", and the SSG emitted the bootstrap
+    // module URL un-prefixed while every other asset carried the base.
     const base =
-      effectiveModuleBaseURL ?? config.base ?? DEFAULT_CONFIG.MODULE_BASE_URL;
+      envBaseUrl != null && envBaseUrl !== ""
+        ? envBaseUrl
+        : userOptions.moduleBaseURLExplicit
+        ? userOptions.moduleBaseURL
+        : typeof config.base === "string" && config.base !== ""
+        ? config.base
+        : userOptions.moduleBaseURL;
+    // Write the winner back so every reader that takes userOptions directly —
+    // the RSC/html workers, the edge bake, the SSG — agrees with the configs
+    // resolved here. userOptions is mutated during config resolution by
+    // design (moduleID and loader already are).
+    userOptions.moduleBaseURL = base;
     if (configEnv.command === "serve" && !configEnv.isPreview) {
       // In dev mode, use empty publicOrigin so the client uses window.location.origin.
       // This avoids hardcoding a port that may change if the configured port is taken.

--- a/plugin/environments/resolveEnvironmentConfig.ts
+++ b/plugin/environments/resolveEnvironmentConfig.ts
@@ -114,10 +114,19 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
         typeof vitePrefix === "string" ? vitePrefix : vitePrefix[0];
       
       const envBaseUrl = getEnvValue("BASE_URL", primaryPrefix);
+      // Same base precedence as resolveUserConfig (see the comment there):
+      // env override > explicit moduleBaseURL option > Vite's config.base >
+      // the "/" default — and the winner is written back into userOptions so
+      // the workers and the edge bake agree.
       const effectiveModuleBaseURL =
         envBaseUrl != null && envBaseUrl !== ""
           ? envBaseUrl
+          : userOptions.moduleBaseURLExplicit
+          ? userOptions.moduleBaseURL
+          : typeof config.base === "string" && config.base !== ""
+          ? config.base
           : userOptions.moduleBaseURL;
+      userOptions.moduleBaseURL = effectiveModuleBaseURL;
 
       const envPublicOrigin = getEnvValue("PUBLIC_ORIGIN", primaryPrefix);
       const effectivePublicOrigin =

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -394,6 +394,12 @@ export type ResolvedUserOptions = {
   moduleBase: string;
   moduleBasePath: string;
   moduleBaseURL: string;
+  /**
+   * Whether the user set moduleBaseURL explicitly (vs the "/" default).
+   * Decides whether Vite's config.base may fill the base in — an explicit
+   * option outranks it, the default must not.
+   */
+  moduleBaseURLExplicit: boolean;
   moduleRootPath: string;
   publicOrigin: string;
   pageExportName: string;

--- a/test/examples/config-base-build.test.ts
+++ b/test/examples/config-base-build.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createBuilder } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { setupTestProject } from "../setup.js";
+import { ensureFixture, hashSetupFn } from "./fixture-cache.js";
+import { testUserOptions } from "../test-config.js";
+import { readFile as readFileFs, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+/**
+ * Regression: Vite's own `base` must reach the build (bead: config.base was
+ * dead code in the precedence chain).
+ *
+ * A consumer configuring `base` the normal Vite way — no VITE_BASE_URL env
+ * var, no explicit moduleBaseURL plugin option — used to build against "/":
+ * the SSG emitted the bootstrap module URL un-prefixed while every other
+ * asset in the same HTML carried the base (they go through Vite), which is
+ * exactly why it hid so well. bidoof's GitHub-Pages deploy shipped broken
+ * this way, and both known consumers papered over it by exporting
+ * VITE_BASE_URL in their npm scripts.
+ *
+ * Precedence under test: with neither the env var nor the option set, the
+ * emitted module script src must carry `config.base`.
+ */
+const BASE = "/base-via-vite/";
+
+const testDir = resolve(__dirname, "../fixtures/config-base/shared");
+const OUT_DIR = "dist-config-base";
+
+describe("vite config.base reaches the emitted bootstrap URL", () => {
+  let savedEnvBase: string | undefined;
+  let savedEnvOrigin: string | undefined;
+
+  beforeAll(async () => {
+    // The whole point is the NO-env-var spelling; other tests in this worker
+    // may have exported it.
+    savedEnvBase = process.env.VITE_BASE_URL;
+    savedEnvOrigin = process.env.VITE_PUBLIC_ORIGIN;
+    delete process.env.VITE_BASE_URL;
+    delete process.env.VITE_PUBLIC_ORIGIN;
+
+    const setupSource = await readFileFs(resolve(__dirname, "../setup.ts"), "utf-8");
+    await ensureFixture(testDir, setupTestProject, hashSetupFn(setupTestProject, [setupSource]));
+
+    // testUserOptions minus everything that would make the base explicit —
+    // moduleBaseURL must be ABSENT (an explicit option legitimately outranks
+    // config.base; the default must not).
+    const {
+      moduleBaseURL: _explicitBase,
+      onMetrics: _metrics,
+      ...pluginOptions
+    } = testUserOptions;
+
+    const builder = await createBuilder({
+      base: BASE,
+      mode: "test",
+      root: testDir,
+      plugins: vitePluginReactServer({
+        ...pluginOptions,
+        projectRoot: testDir,
+        build: {
+          ...testUserOptions.build,
+          pages: ["/", "/page2"],
+          outDir: OUT_DIR,
+        },
+      }),
+    });
+    await builder.buildApp();
+  }, 120_000);
+
+  afterAll(() => {
+    if (savedEnvBase !== undefined) process.env.VITE_BASE_URL = savedEnvBase;
+    if (savedEnvOrigin !== undefined) process.env.VITE_PUBLIC_ORIGIN = savedEnvOrigin;
+  });
+
+  it("mirrors config.base into the env channel and prefixes the emitted module src", async () => {
+    // The seam under test is the MIRROR: env.node.ts (and through it the
+    // workers, the SSG document path and the edge bake) reads
+    // process.env.VITE_BASE_URL — "the values vprs's config mirrors into
+    // process.env". Before the fix the mirror wrote "/" (config.base was dead
+    // code behind the never-nullish option default), so every runtime reader
+    // built un-prefixed URLs while Vite's own HTML pipeline prefixed the rest.
+    // (Direct SSG-page HTML can't be asserted here: this fixture only emits
+    // the root page, which Vite's pipeline handles natively.)
+    expect(process.env.VITE_BASE_URL).toBe(BASE);
+
+    const htmlPath = resolve(testDir, OUT_DIR, "static", "index.html");
+    const deadline = Date.now() + 15_000;
+    let html = "";
+    for (;;) {
+      try {
+        html = await readFile(htmlPath, "utf-8");
+        if (/<script[^>]*type="module"/.test(html)) break;
+      } catch {
+        // not written yet
+      }
+      if (Date.now() > deadline) throw new Error("timed out waiting for index.html");
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    const moduleSrcs = [
+      ...html.matchAll(/<script[^>]*type="module"[^>]*src="([^"]+)"/g),
+    ].map((m) => m[1]);
+    expect(moduleSrcs.length).toBeGreaterThan(0);
+    for (const src of moduleSrcs) {
+      expect(src.startsWith(BASE)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Fixes the P1 where a consumer configuring `base` the normal Vite way — no `VITE_BASE_URL` env var, no explicit `moduleBaseURL` option — built against `"/"`. The SSG emitted the bootstrap module URL un-prefixed while every Vite-piped asset carried the base, so deploys under a path 404'd the entry module on every page and never hydrated (how bidoof's GitHub-Pages demo shipped broken; mmc and bidoof both paper over it in npm scripts today).

**Root cause**: `effectiveModuleBaseURL ?? config.base ?? default` — the option default-fills to `"/"`, so the first term is never nullish and `config.base` was dead code.

**Fix**: `resolveOptions` records explicitness; both resolvers share one precedence — env override > explicit option > `config.base` > `"/"` — and write the winner back into `userOptions.moduleBaseURL` so the workers, SSG, and edge bake agree. The existing env mirror then propagates the right value; `env.node.ts`'s comment ("reads the values vprs's config mirrors into process.env") is finally true for the `config.base` spelling.

**Test**: regression asserts the mirror seam plus emitted module src, A/B-verified (fails on old code at the mirror line; a naive HTML-only assertion passes on broken code because Vite's own pipeline prefixes the root page — documented in the test).

**Verified**: full `test-all` green; consumer workarounds unaffected (env var still wins).

After merge both consumer-side mirrors (mmc PR #133, bidoof PR #114 env scripts) become removable — noted on the bead, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs