### PR TITLE
chore(release): 3.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch: one bug fix and one docs slice, no new public surface.

## What's in it

- **[#269](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/269)** — `fix(config)`: Vite's `config.base` finally reaches the build. `effectiveModuleBaseURL ?? config.base` never fell through because the option default-filled to `"/"`, so a consumer configuring `base` the normal Vite way built against `"/"` — the SSG emitted the bootstrap module URL un-prefixed and path-prefixed deploys 404'd the entry module and never hydrated. Both resolvers now share one precedence (env override > explicit option > `config.base` > `"/"`) and write the winner back so the workers, SSG, and edge bake agree. Regression test asserts the mirror seam plus the emitted module src, A/B-verified against the old code.
- **[#270](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/270)** — docs audit slice 3: `build-output.md` and `server-actions.md` rewritten against 3.2 reality (both were major-stale). The insecure hand-rolled action example is gone in favor of `createRequestHandler` + the baked gate; runtime-reach is transport-conditional; hosting documents the three dispatch modes with the worker-free baked gate primary. Net +6 lines across the pair.

After this ships, the consumer-side `VITE_BASE_URL`/`VITE_PUBLIC_ORIGIN` mirrors in mmc's and bidoof's npm scripts become removable (mmc #133, bidoof #114).

## Release steps after merge

The bump is the only thing in this PR; `version:patch` does not tag. On merged `main`:

```bash
git checkout main && git pull
git tag -a v3.2.2 -m "v3.2.2"
git push origin v3.2.2
npm publish   # 2FA
```

`prepublishOnly` runs `verify:tag`, so a forgotten tag fails the publish rather than shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)