### PR TITLE
fix(config): the resolved base reaches SSG emission — live #env reads, per-instance sync, projectRoot-anchored writes

### DIFF
--- a/plugin/config/effectiveModuleBaseURL.ts
+++ b/plugin/config/effectiveModuleBaseURL.ts
@@ -1,0 +1,33 @@
+import { getEnvValue } from "../env/getEnvKey.js";
+import type { ResolvedUserOptions } from "../types.js";
+
+/**
+ * The single base-precedence chain: env override (deploy-time) > explicit
+ * moduleBaseURL option (plugin-specific intent) > Vite's `config.base` (the
+ * way every other plugin's consumer sets a base) > the option's "/" default.
+ *
+ * One function because the chain has to be applied in more than one place:
+ * every sub-plugin resolves its OWN ResolvedUserOptions at factory time, so a
+ * winner written back during one instance's config hook never reaches another
+ * instance's copy. Each plugin whose copy feeds emission (worker env, edge
+ * bake, bootstrapModules) must re-apply the chain against the resolved config
+ * — with `moduleBaseURLExplicit` preserving the option-vs-default distinction
+ * that makes config.base reachable at all.
+ */
+export function effectiveModuleBaseURL(
+  userOptions: Pick<
+    ResolvedUserOptions,
+    "moduleBaseURL" | "moduleBaseURLExplicit"
+  >,
+  configBase: string | undefined,
+  envPrefix: string
+): string {
+  const envBaseUrl = getEnvValue("BASE_URL", envPrefix);
+  return envBaseUrl != null && envBaseUrl !== ""
+    ? envBaseUrl
+    : userOptions.moduleBaseURLExplicit
+    ? userOptions.moduleBaseURL
+    : typeof configBase === "string" && configBase !== ""
+    ? configBase
+    : userOptions.moduleBaseURL;
+}

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -21,6 +21,7 @@ import { DEFAULT_CONFIG } from "./defaults.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { REACT_CONDITION, type ReactCondition } from "./getCondition.js";
 import { getEnvValue, setEnvValue } from "../env/getEnvKey.js";
+import { effectiveModuleBaseURL } from "./effectiveModuleBaseURL.js";
 import {
   mergeClientPackagesNoExternal,
   mergeClientPackagesOptimizeDepsExclude,
@@ -345,7 +346,6 @@ export const resolveUserConfig: ResolveUserConfigFn =
     // Get environment variables (env vars take precedence over config)
     const primaryPrefix =
       typeof vitePrefix === "string" ? vitePrefix : vitePrefix[0];
-    const envBaseUrl = getEnvValue("BASE_URL", primaryPrefix);
 
     const envPublicOrigin = getEnvValue("PUBLIC_ORIGIN", primaryPrefix);
     const effectivePublicOrigin =
@@ -470,22 +470,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
       typeof config.server?.host === "string"
         ? config.server?.host
         : "localhost";
-    // Base precedence: the env var is the deploy-time override; an EXPLICIT
-    // moduleBaseURL option is plugin-specific intent; only then Vite's own
-    // config.base — the way every other plugin's consumer sets a base — fills
-    // in, ahead of the "/" default. The old chain put effectiveModuleBaseURL
-    // (which is never nullish — the option default-fills to "/") before
-    // config.base, making config.base dead code: a consumer configuring base
-    // the normal Vite way built against "/", and the SSG emitted the bootstrap
-    // module URL un-prefixed while every other asset carried the base.
-    const base =
-      envBaseUrl != null && envBaseUrl !== ""
-        ? envBaseUrl
-        : userOptions.moduleBaseURLExplicit
-        ? userOptions.moduleBaseURL
-        : typeof config.base === "string" && config.base !== ""
-        ? config.base
-        : userOptions.moduleBaseURL;
+    const base = effectiveModuleBaseURL(userOptions, config.base, primaryPrefix);
     // Write the winner back so every reader that takes userOptions directly —
     // the RSC/html workers, the edge bake, the SSG — agrees with the configs
     // resolved here. userOptions is mutated during config resolution by

--- a/plugin/environments/resolveEnvironmentConfig.ts
+++ b/plugin/environments/resolveEnvironmentConfig.ts
@@ -5,6 +5,7 @@ type OutputOptions = Rollup.OutputOptions;
 import { join } from "node:path";
 import { createLogger } from "vite";
 import { getEnvValue, setEnvValue } from "../env/getEnvKey.js";
+import { effectiveModuleBaseURL } from "../config/effectiveModuleBaseURL.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { REACT_CONDITION, type ReactCondition } from "../config/getCondition.js";
 
@@ -113,20 +114,14 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
       const primaryPrefix =
         typeof vitePrefix === "string" ? vitePrefix : vitePrefix[0];
       
-      const envBaseUrl = getEnvValue("BASE_URL", primaryPrefix);
-      // Same base precedence as resolveUserConfig (see the comment there):
-      // env override > explicit moduleBaseURL option > Vite's config.base >
-      // the "/" default — and the winner is written back into userOptions so
-      // the workers and the edge bake agree.
-      const effectiveModuleBaseURL =
-        envBaseUrl != null && envBaseUrl !== ""
-          ? envBaseUrl
-          : userOptions.moduleBaseURLExplicit
-          ? userOptions.moduleBaseURL
-          : typeof config.base === "string" && config.base !== ""
-          ? config.base
-          : userOptions.moduleBaseURL;
-      userOptions.moduleBaseURL = effectiveModuleBaseURL;
+      // The winner is written back into userOptions so the workers and the
+      // edge bake agree.
+      const resolvedModuleBaseURL = effectiveModuleBaseURL(
+        userOptions,
+        config.base,
+        primaryPrefix
+      );
+      userOptions.moduleBaseURL = resolvedModuleBaseURL;
 
       const envPublicOrigin = getEnvValue("PUBLIC_ORIGIN", primaryPrefix);
       const effectivePublicOrigin =
@@ -134,7 +129,7 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
 
       // Set process.env values to ensure they're available for server-side code
       if (!getEnvValue("BASE_URL", primaryPrefix)) {
-        setEnvValue("BASE_URL", effectiveModuleBaseURL, primaryPrefix);
+        setEnvValue("BASE_URL", resolvedModuleBaseURL, primaryPrefix);
       }
       if (!getEnvValue("PUBLIC_ORIGIN", primaryPrefix)) {
         setEnvValue("PUBLIC_ORIGIN", effectivePublicOrigin, primaryPrefix);

--- a/plugin/react-static/fileWriter.ts
+++ b/plugin/react-static/fileWriter.ts
@@ -9,7 +9,7 @@
  * 3. Handles file path construction
  * 4. Provides a clean interface for file operations
  */
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { createWriteStream, mkdirSync } from "node:fs";
 import { Transform, PassThrough } from "node:stream";
 
@@ -110,7 +110,16 @@ export const fileWriter: FileWriterFn = function _fileWriter(
     (stream as any).pipe && typeof (stream as any).pipe === "function";
 
   const routePath = routeToOutputDir(options.route);
-  const baseDir = join(options.build.outDir, options.build.static);
+  // Anchor a relative outDir to the project root, not the process CWD: the
+  // writer runs inside the html worker, whose CWD is wherever the build was
+  // launched from. With CWD ≠ projectRoot (monorepos, test runners) the SSG
+  // pages landed in a stray <cwd>/<outDir> tree while the Vite-piped assets
+  // went to the real outDir.
+  const baseDir = resolve(
+    options.projectRoot ?? ".",
+    options.build.outDir,
+    options.build.static
+  );
   const outputPath = join(
     baseDir,
     routePath,

--- a/plugin/react-static/maybeInlineFlight.ts
+++ b/plugin/react-static/maybeInlineFlight.ts
@@ -27,6 +27,7 @@ export interface MaybeInlineFlightOptions {
     htmlOutputPath?: string;
     rscOutputPath?: string;
   };
+  projectRoot?: string;
   logger?: Logger;
   verbose?: boolean;
 }
@@ -39,7 +40,11 @@ export async function maybeInlineFlight(
 ): Promise<number | null> {
   if (!options.build?.inlineFlight) return null;
 
+  // Anchor a relative outDir to the project root, not the process CWD — same
+  // rule as fileWriter, or the two would read/write different trees when the
+  // build is launched outside the project root.
   const staticDir = resolve(
+    options.projectRoot ?? ".",
     options.build.outDir ?? "dist",
     options.build.static ?? "static"
   );

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -45,6 +45,7 @@ import { shouldCausePanic } from "../error/panicThresholdHandler.js";
 import { configurePreviewServer } from "./configurePreviewServer.js";
 import { assertNonReactServer, REACT_CONDITION } from "../config/getCondition.js";
 import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
+import { effectiveModuleBaseURL } from "../config/effectiveModuleBaseURL.js";
 import { createWorkerStartupMetrics } from "../metrics/createWorkerStartupMetrics.js";
 import { processCssFilesForPages } from "./processCssFilesForPages.js";
 import { createBuildLoader } from "./createBuildLoader.client.js";
@@ -135,6 +136,15 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
       timing.configResolved = performance.now();
       logger = config.customLogger || createLogger();
       resolvedConfig = config;
+      // Re-apply the base chain to THIS instance's copy: every sub-plugin
+      // resolves its own userOptions at factory time, so the winner another
+      // instance's config hook wrote back never reaches this object — and this
+      // is the copy serialized into the rsc worker.
+      userOptions.moduleBaseURL = effectiveModuleBaseURL(
+        userOptions,
+        config.base,
+        envPrefixFromConfig(config)
+      );
 
       // Perform auto-discovery to populate autoDiscoveredFiles
       const autoDiscoverResult = await resolveAutoDiscover({
@@ -794,6 +804,7 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         // runs the SAME call at the same point (both build modes identical).
         await pruneUnclaimedEntryHtml({
           build: userOptions.build,
+          projectRoot: userOptions.projectRoot,
           pages: Array.from(autoDiscoveredFiles?.urlMap.keys() ?? []),
           logger,
           verbose: userOptions.verbose,
@@ -805,6 +816,7 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         // in both build modes (runs before build.ssg.end so consumers see it).
         await maybeInlineFlight({
           build: userOptions.build,
+          projectRoot: userOptions.projectRoot,
           logger,
           verbose: userOptions.verbose,
         });

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -50,6 +50,7 @@ import { pruneUnclaimedEntryHtml } from "./pruneUnclaimedEntryHtml.js";
 import { temporaryReferences } from "./temporaryReferences.server.js";
 import { configurePreviewServer } from "./configurePreviewServer.js";
 import { envPrefixFromConfig } from "../config/envPrefixFromConfig.js";
+import { effectiveModuleBaseURL } from "../config/effectiveModuleBaseURL.js";
 
 import { processCssFilesForPages } from "./processCssFilesForPages.js";
 import { createWorkerStartupMetrics } from "../metrics/createWorkerStartupMetrics.js";
@@ -119,6 +120,15 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
     },
     async configResolved(config) {
       resolvedConfig = config;
+      // Re-apply the base chain to THIS instance's copy: every sub-plugin
+      // resolves its own userOptions at factory time, so the winner another
+      // instance's config hook wrote back never reaches this object — and this
+      // is the copy serialized into the html worker and read by the edge bake.
+      userOptions.moduleBaseURL = effectiveModuleBaseURL(
+        userOptions,
+        config.base,
+        envPrefixFromConfig(config)
+      );
       if (!logger) {
         logger = config.customLogger ?? createLogger();
       }
@@ -546,6 +556,7 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         // runs the SAME call at the same point (both build modes identical).
         await pruneUnclaimedEntryHtml({
           build: userOptions.build,
+          projectRoot: userOptions.projectRoot,
           pages: Array.from(autoDiscoveredFiles?.urlMap.keys() ?? []),
           logger,
           verbose: userOptions.verbose,
@@ -557,6 +568,7 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         // in both build modes (runs before build.ssg.end so consumers see it).
         await maybeInlineFlight({
           build: userOptions.build,
+          projectRoot: userOptions.projectRoot,
           logger,
           verbose: userOptions.verbose,
         });

--- a/plugin/react-static/pruneUnclaimedEntryHtml.ts
+++ b/plugin/react-static/pruneUnclaimedEntryHtml.ts
@@ -32,6 +32,7 @@ export interface PruneUnclaimedEntryHtmlOptions {
     static?: string;
     htmlOutputPath?: string;
   };
+  projectRoot?: string;
   /**
    * The routes SSG rendered (the resolved `build.pages`, i.e. `urlMap` keys).
    */
@@ -56,7 +57,12 @@ export async function pruneUnclaimedEntryHtml(
   // Same rule the writer uses, so "claimed" means exactly "SSG wrote here".
   if (pages.some((page) => routeToOutputDir(page) === "")) return null;
 
+  // Anchor a relative outDir to the project root, not the process CWD — same
+  // rule as fileWriter, or the prune would look in (and delete from) a
+  // different tree than the one the writer wrote when the build is launched
+  // outside the project root.
   const entryHtml = resolve(
+    options.projectRoot ?? ".",
     build.outDir ?? "dist",
     build.static ?? "static",
     build.htmlOutputPath ?? "index.html"

--- a/plugin/react-static/types.ts
+++ b/plugin/react-static/types.ts
@@ -23,6 +23,7 @@ export type FileWriterOptions = Pick<
   | "worker"
   | "onEvent"
   | "logger"
+  | "projectRoot"
 >;
 
 export type FileWriterFn = (

--- a/plugin/utils/env.node.ts
+++ b/plugin/utils/env.node.ts
@@ -6,12 +6,27 @@
 const p: NodeJS.ProcessEnv | undefined =
   typeof process !== "undefined" ? process.env : undefined;
 
+// Getters, not a frozen snapshot: this module loads with the plugin, BEFORE the
+// config resolvers mirror the resolved base into process.env — a value captured
+// at import time would stay "/" for the whole build, and every emission-time
+// reader (bootstrapModules, SSG URLs) would build un-prefixed URLs while Vite's
+// own pipeline prefixes the rest of the same HTML.
 export const env = {
   // `||` (not `??`): an empty VITE_BASE_URL still means the root base "/".
-  BASE_URL: p?.["VITE_BASE_URL"] || "/",
-  PUBLIC_ORIGIN: p?.["VITE_PUBLIC_ORIGIN"] ?? "",
-  DEV: p?.["NODE_ENV"] !== "production",
-  MODE: p?.["NODE_ENV"] ?? "production",
-  PROD: p?.["NODE_ENV"] === "production",
+  get BASE_URL() {
+    return p?.["VITE_BASE_URL"] || "/";
+  },
+  get PUBLIC_ORIGIN() {
+    return p?.["VITE_PUBLIC_ORIGIN"] ?? "";
+  },
+  get DEV() {
+    return p?.["NODE_ENV"] !== "production";
+  },
+  get MODE() {
+    return p?.["NODE_ENV"] ?? "production";
+  },
+  get PROD() {
+    return p?.["NODE_ENV"] === "production";
+  },
   SSR: true,
 } as ImportMetaEnv;

--- a/test/examples/config-base-build.test.ts
+++ b/test/examples/config-base-build.test.ts
@@ -4,7 +4,7 @@ import { vitePluginReactServer } from "vite-plugin-react-server";
 import { setupTestProject } from "../setup.js";
 import { ensureFixture, hashSetupFn } from "./fixture-cache.js";
 import { testUserOptions } from "../test-config.js";
-import { readFile as readFileFs, readFile } from "node:fs/promises";
+import { readFile as readFileFs, readFile, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 
 /**
@@ -42,6 +42,11 @@ describe("vite config.base reaches the emitted bootstrap URL", () => {
     const setupSource = await readFileFs(resolve(__dirname, "../setup.ts"), "utf-8");
     await ensureFixture(testDir, setupTestProject, hashSetupFn(setupTestProject, [setupSource]));
 
+    // The fixture project is cached but the build output must not be: a stale
+    // dist from a previous (passing) run would satisfy the SSG-page assertion
+    // even when the code under test regressed.
+    await rm(resolve(testDir, OUT_DIR), { recursive: true, force: true });
+
     // testUserOptions minus everything that would make the base explicit —
     // moduleBaseURL must be ABSENT (an explicit option legitimately outranks
     // config.base; the default must not).
@@ -73,30 +78,22 @@ describe("vite config.base reaches the emitted bootstrap URL", () => {
     if (savedEnvOrigin !== undefined) process.env.VITE_PUBLIC_ORIGIN = savedEnvOrigin;
   });
 
-  it("mirrors config.base into the env channel and prefixes the emitted module src", async () => {
-    // The seam under test is the MIRROR: env.node.ts (and through it the
-    // workers, the SSG document path and the edge bake) reads
-    // process.env.VITE_BASE_URL — "the values vprs's config mirrors into
-    // process.env". Before the fix the mirror wrote "/" (config.base was dead
-    // code behind the never-nullish option default), so every runtime reader
-    // built un-prefixed URLs while Vite's own HTML pipeline prefixed the rest.
-    // (Direct SSG-page HTML can't be asserted here: this fixture only emits
-    // the root page, which Vite's pipeline handles natively.)
-    expect(process.env.VITE_BASE_URL).toBe(BASE);
-
-    const htmlPath = resolve(testDir, OUT_DIR, "static", "index.html");
+  const waitForModuleHtml = async (htmlPath: string) => {
     const deadline = Date.now() + 15_000;
-    let html = "";
     for (;;) {
       try {
-        html = await readFile(htmlPath, "utf-8");
-        if (/<script[^>]*type="module"/.test(html)) break;
+        const html = await readFile(htmlPath, "utf-8");
+        if (/<script[^>]*type="module"/.test(html)) return html;
       } catch {
         // not written yet
       }
-      if (Date.now() > deadline) throw new Error("timed out waiting for index.html");
+      if (Date.now() > deadline)
+        throw new Error(`timed out waiting for ${htmlPath}`);
       await new Promise((r) => setTimeout(r, 250));
     }
+  };
+
+  const expectPrefixedModuleSrcs = (html: string) => {
     const moduleSrcs = [
       ...html.matchAll(/<script[^>]*type="module"[^>]*src="([^"]+)"/g),
     ].map((m) => m[1]);
@@ -104,5 +101,47 @@ describe("vite config.base reaches the emitted bootstrap URL", () => {
     for (const src of moduleSrcs) {
       expect(src.startsWith(BASE)).toBe(true);
     }
+  };
+
+  it("mirrors config.base into the env channel", () => {
+    // The mirror seam: env.node.ts (and through it every #env reader) reads
+    // process.env.VITE_BASE_URL — "the values vprs's config mirrors into
+    // process.env". Before the precedence fix the mirror wrote "/"
+    // (config.base was dead code behind the never-nullish option default).
+    expect(process.env.VITE_BASE_URL).toBe(BASE);
+  });
+
+  it("prefixes the module src on the root page", async () => {
+    // Weak on its own: Vite's own pipeline emits/prefixes the root
+    // index.html, so this passes even when the SSG path is broken. Kept as a
+    // guard for the Vite-piped half; the SSG half is the page2 test below.
+    const html = await waitForModuleHtml(
+      resolve(testDir, OUT_DIR, "static", "index.html")
+    );
+    expectPrefixedModuleSrcs(html);
+  });
+
+  it("prefixes the module src on a worker-emitted SSG page", async () => {
+    // The emission seam. page2's HTML is written by the html worker, never by
+    // Vite's pipeline, so this asserts the full chain: the winner reaching the
+    // worker's userOptions snapshot AND the live (not import-frozen) #env read
+    // behind baseURL(). It also pins the fileWriter path fix: before it, this
+    // file was written relative to the process CWD (the repo root under
+    // vitest), not the project root, and no assertion could ever see it.
+    const html = await waitForModuleHtml(
+      resolve(testDir, OUT_DIR, "static", "page2", "index.html")
+    );
+    expectPrefixedModuleSrcs(html);
+  });
+
+  it("bakes the prefixed base into the edge bundle", async () => {
+    // The edge bake reads the static plugin's own userOptions copy at
+    // generateBundle time — the copy that goes stale when only another
+    // instance's config hook computed the winner.
+    const render = await readFile(
+      resolve(testDir, OUT_DIR, "server-edge", "render.js"),
+      "utf-8"
+    );
+    expect(render).toContain(BASE);
   });
 });


### PR DESCRIPTION
Follow-up to #269, which fixed the base precedence chain but not the readers: the winner was computed correctly and mirrored into `process.env.VITE_BASE_URL`, yet a consumer setting `base` the normal Vite way still shipped un-prefixed bootstrap URLs on every SSG page. Verified against a real consumer build (`--app`, base `/mmc/`): resolvers logged the right winner while the emitted HTML stayed `/index-*.js`.

Three emission-time readers never saw the winner:

- **`plugin/utils/env.node.ts` froze `process.env` at module import** — the plugin loads before the config resolvers run, so `baseURL()` (which stamps `bootstrapModules` and every other `#env`-derived URL) read `"/"` for the whole build no matter what the mirror said. The exported values are now getters over the live env.
- **Every sub-plugin resolves its own `userOptions` at factory time**, so the winner written back during one instance's config hook never reached the react-static plugins' copies — the ones serialized into the html/rsc workers (`workerData.userOptions.moduleBaseURL` arrived as `"/"`) and read by the edge bake (`MODULE_BASE_URL`). The chain now lives in one helper (`plugin/config/effectiveModuleBaseURL.ts`) used by both resolvers, and the static plugins re-apply it in `configResolved` on their own copies.
- **`fileWriter` / `maybeInlineFlight` / `pruneUnclaimedEntryHtml` resolved a relative `outDir` against the process CWD**, not the project root. With CWD ≠ projectRoot the SSG pages landed in a stray `<cwd>/<outDir>` tree — which is also why the fixture never appeared to emit `/page2`, and why no test assertion could ever see a worker-emitted page. All three now anchor to `projectRoot`.

## Why the #269 test passed on broken code

It asserted the env mirror (true) and the root page's module src — but the root `index.html` in the outDir is emitted and prefixed by Vite's own pipeline. The worker-written pages were both un-prefixed and in the wrong directory. The test now also asserts the worker-emitted `page2/index.html` (fails on pre-fix code: A/B verified) and the baked edge bundle, and clears the fixture outDir so a stale passing artifact can't mask a regression.

## Verified

- Full `test-all` green (unpiped exit code), typecheck clean.
- Real consumer, packed tarball install: `--app` build at base `/mmc/` with **no** `VITE_BASE_URL`/`VITE_PUBLIC_ORIGIN` env mirrors emits `/mmc/index-*.js` on the root page, nested SSG pages, and in the edge bundle's baked `bootstrapModules`; client-manifest registry keys stay bare (resolved against `moduleBaseURL` at runtime, as before).

After release, the consumer-side env-script mirrors (mmc #133, bidoof #114) become genuinely removable — #269 alone was not enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)