### PR TITLE
chore(release): 3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch: one bug fix, no new public surface. Main is v3.2.2 plus exactly this.

## What's in it

- **[#272](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/272)** — `fix(config)`: the resolved base actually reaches SSG emission. #269 (shipped in 3.2.2) fixed the precedence chain but three emission-time readers never saw the winner: `#env` froze `process.env` at module import (now live getters); each sub-plugin's own `userOptions` copy went stale (the chain now lives in one helper and the static plugins re-apply it in `configResolved`, fixing the worker env and the edge bake); and the SSG writers anchored relative `outDir` to the process CWD instead of projectRoot. The regression test now asserts a worker-emitted page and the baked edge bundle — the artifacts that stayed broken while 3.2.2's root-page assertion passed.

With this release a consumer configuring Vite's `base` the normal way needs no `VITE_BASE_URL`/`VITE_PUBLIC_ORIGIN` env mirrors: verified by packing this and building mmc's GitHub-Pages target with zero mirrors — prefixed bootstrap on every SSG page and in the edge bundle.

## Release steps after merge

The bump is the only thing in this PR; `version:patch` does not tag. On merged `main`:

```bash
git checkout main && git pull
git tag -a v3.2.3 -m "v3.2.3"
git push origin v3.2.3
npm publish   # 2FA
```

`prepublishOnly` runs `verify:tag`, so a forgotten tag fails the publish rather than shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)