### PR TITLE
fix(router): unkey the flight root — client nav reconciles instead of remounting

### DIFF
--- a/plugin/helpers/createElementWithReact.tsx
+++ b/plugin/helpers/createElementWithReact.tsx
@@ -132,8 +132,14 @@ export const createElementWithReact: CreateElementWithReactFN =
         logger?.info(`[createElementWithReact] Returning Root only`);
       }
       return (
+        // Deliberately NO key here. This element is the flight root the client
+        // router swaps on navigation; keying it by route tells React to unmount
+        // and remount the ENTIRE page tree on every client nav — CSS animations
+        // restart, client-component state dies, no DOM is ever preserved.
+        // Unkeyed, React reconciles the old and new trees and structure that
+        // matches across routes (headers, logos, nav) is updated in place. A
+        // page that WANTS a clean remount can key its own subtree.
         <RootComponent
-          key={route}
           as={React.Fragment}
           cssFiles={cssFiles}
           pageProps={pageProps}

--- a/plugin/router/client.ts
+++ b/plugin/router/client.ts
@@ -21,6 +21,7 @@ export type {
 export {
   RouterProvider,
   useLocation,
+  useOptionalRouter,
   useParams,
   useRouter,
 } from "./router-react.js";


### PR DESCRIPTION
Found while chasing why the starter's atom logo restarts its animation and jumps size on every page switch: the raw flight payloads show the root as `["$","$1","/",…]` vs `["$","$1","/about",…]` — a fragment **keyed by route** (`createElementWithReact.tsx`, rode in with the dual-condition refactor with no stated intent). A changed key is an explicit unmount-and-remount instruction, so React never got to reconcile: measured with a DOM-identity probe on the starter's edge server, nothing below `#root` survived a navigation and `document.getAnimations()` clocks reset.

## Change

- Drop the `key={route}` from the Root-only flight element (with a comment stating the invariant). Unkeyed, React reconciles the outgoing and incoming trees: structure that matches by position/type is updated in place; structure that differs remounts naturally. A page that wants a hard remount can key its own subtree.
- Export `useOptionalRouter` from `router/client` — the prerender-safe hook consumers need where they previously leaned on remount-per-route for mount-time reads (active-nav state being the canonical case).

## Semantics note (why this is a behavior change worth a look)

Client components that assumed "fresh mount on every route" now persist wherever the surrounding structure matches. In the starter that was exactly one component (Nav's active-link read), fixed by subscribing to the router. Flight serialization flattens server components to elements, so preservation is element-structural, which is *more* preservation than component-identity routers give — that's what makes shared chrome (logos, headers) continuous for free.

## Verified

- Full `test-all` green, twice self-sabotaged by running `npm pack` mid-gate (prepack wipes dist) — the final clean run has a real exit 0.
- Starter probes on the per-request edge server: logo DOM node survives nav (tagged-element check), `getAnimations()` max clock continues (1317ms → 1700ms across the swap), size change now eases via CSS transition; nav active state flips correctly both directions; the hydration gate (sentinel across nav + content-swap assertion) passes.
- bidoof `npm test` (build + Playwright e2e incl. server actions and flash-free dynamic SSR): 3/3.
- mmc `npm test` against the packed build: green.

Starter follow-up is committed locally and held until this ships in a release (`useOptionalRouter` doesn't exist in registry 3.2.3, a push would break the Vercel build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)