### PR TITLE
chore(release): 3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch: one behavior fix in the client router path, no new public surface beyond a hook re-export. Main is v3.2.3 plus exactly this.

## What's in it

- **[#274](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/274)** — `fix(router)`: the flight root is no longer keyed by route, so client-side navigation reconciles the page tree instead of unmounting and remounting all of it. Shared structure (headers, logos, nav) is preserved in place — CSS animations keep their clock, client-component state survives where the surrounding structure matches. Consumers that leaned on remount-per-route for mount-time reads should subscribe to the router; `useOptionalRouter` is now exported from `router/client` as the prerender-safe spelling. Verified across the starter (DOM-identity + animation-clock probes on the per-request edge server), bidoof's Playwright e2e, and mmc's gate.

## Release steps after merge

The bump is the only thing in this PR; `version:patch` does not tag. On merged `main`:

```bash
git checkout main && git pull
git tag -a v3.2.4 -m "v3.2.4"
git push origin v3.2.4
npm publish   # 2FA
```

`prepublishOnly` runs `verify:tag`, so a forgotten tag fails the publish rather than shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)