### PR TITLE
feat(metrics): cold-start-honest first batch — resolve/run split, wall-clock spans, edge-bake metric

### DIFF
--- a/plugin/bundle/buildConsumerBundle.ts
+++ b/plugin/bundle/buildConsumerBundle.ts
@@ -40,6 +40,7 @@ export async function buildConsumerBundle(opts: {
 }): Promise<void> {
   const { userOptions, projectRoot, logger } = opts;
   const tag = "[build.edge]";
+  const bakeStart = performance.now();
 
   // The esm transport has no module-map seam to bind a registry to; leave those
   // builds on the runtime consumer rather than emitting something that can't work.
@@ -246,6 +247,15 @@ export async function ${consumerExport}(options) {
           `${join(edgeDir, consumerFileName)}`
       );
     }
+    userOptions.onMetrics?.({
+      route: "*",
+      type: "edge-bake",
+      kind: "consumer",
+      outputPath: join(edgeDir, consumerFileName),
+      moduleCount: idByFile.size,
+      bakeTime: performance.now() - bakeStart,
+      description: `consumer bundle over ${idByFile.size} client module(s)${detail}`,
+    });
   } catch (error) {
     // Additive, like the producer bake: a failure here leaves the runtime
     // consumer in place rather than failing an otherwise-good build.

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -65,6 +65,7 @@ export async function buildEdgeBundle(opts: {
   if (!userOptions.build.edge.enabled) return;
 
   const tag = "[build.edge]";
+  const bakeStart = performance.now();
   const outRoot = join(projectRoot, userOptions.build.outDir);
   const serverDir = join(outRoot, userOptions.build.server);
   const edgeDir = join(
@@ -753,6 +754,16 @@ export async function ${actionExport}(request, opts = {}) {
     if (userOptions.verbose) {
       logger.info(`${tag} baked single-isolate rsc bundle → ${edgeDir}`);
     }
+    // The summary the raw log no longer prints by default: route it through
+    // onMetrics so a metricWatcher consumer still sees what got baked where.
+    userOptions.onMetrics?.({
+      route: "*",
+      type: "edge-bake",
+      kind: "producer",
+      outputPath: edgeDir,
+      bakeTime: performance.now() - bakeStart,
+      description: "single-isolate rsc bundle",
+    });
     // The consumer half (client React + a closed client-module registry), so
     // the pair composes on a runtime with no module loader. No-ops on the esm
     // transport. Emitted only after the producer succeeds — a consumer with

--- a/plugin/metrics/createModuleResolutionMetrics.ts
+++ b/plugin/metrics/createModuleResolutionMetrics.ts
@@ -5,6 +5,9 @@ export function createModuleResolutionMetrics({
   route,
   workerType,
   resolutionTime,
+  resolveStartAt,
+  moduleRunAt,
+  moduleRunTime,
   fromMainThread = isMainThread,
   fromRscWorker = false,
   fromHtmlWorker = false,
@@ -14,6 +17,9 @@ export function createModuleResolutionMetrics({
   route: string;
   workerType: "rsc" | "html" | "mainThread";
   resolutionTime: number;
+  resolveStartAt?: number;
+  moduleRunAt?: number;
+  moduleRunTime?: number;
   fromMainThread?: boolean;
   fromRscWorker?: boolean;
   fromHtmlWorker?: boolean;
@@ -25,6 +31,9 @@ export function createModuleResolutionMetrics({
     type: "module-resolution",
     workerType,
     resolutionTime,
+    resolveStartAt,
+    moduleRunAt,
+    moduleRunTime,
     fromMainThread,
     fromRscWorker,
     fromHtmlWorker,

--- a/plugin/metrics/createRenderMetrics.ts
+++ b/plugin/metrics/createRenderMetrics.ts
@@ -4,6 +4,7 @@ import type { BaseRenderMetrics, CreateRenderMetricsFn, RenderMetrics } from "./
 
 export const createRenderMetrics: CreateRenderMetricsFn = function _createRenderMetrics({
   route,
+  batch,
   type,
   fromMainThread = isMainThread,
   fromRscWorker = false,
@@ -21,6 +22,7 @@ export const createRenderMetrics: CreateRenderMetricsFn = function _createRender
 }) {
   const base = {
     route,
+    batch,
     fromMainThread,
     fromRscWorker,
     fromHtmlWorker,

--- a/plugin/metrics/createStreamMetrics.ts
+++ b/plugin/metrics/createStreamMetrics.ts
@@ -11,6 +11,7 @@ export const createStreamMetrics: CreateStreamMetricsFn =
         errorCount: metrics.errorCount ?? 0,
         duration: metrics.duration ?? 0,
         startTime: metrics.startTime ?? performance.now(),
+        startAt: metrics.startAt ?? Date.now(),
       };
     }
     return {
@@ -20,5 +21,6 @@ export const createStreamMetrics: CreateStreamMetricsFn =
       errorCount: 0,
       duration: 0,
       startTime: performance.now(),
+      startAt: Date.now(),
     };
   };

--- a/plugin/metrics/metricWatcher.ts
+++ b/plugin/metrics/metricWatcher.ts
@@ -3,6 +3,7 @@ import type {
   WorkerStartupMetrics,
   ModuleResolutionMetrics,
   EdgeBakeMetrics,
+  InlineFlightMetrics,
 } from "./types.js";
 import { isMainThread } from "node:worker_threads";
 
@@ -79,7 +80,17 @@ export function metricWatcher({
       | WorkerStartupMetrics
       | ModuleResolutionMetrics
       | EdgeBakeMetrics
+      | InlineFlightMetrics
   ) => {
+    if (metrics.type === "inline-flight") {
+      if (!warnOnly) {
+        const m = metrics as InlineFlightMetrics;
+        info(
+          `\x1b[35minlined flight into\x1b[0m ${m.pages} page(s) in ${formatTime(m.inlineTime)}`
+        );
+      }
+      return;
+    }
     // Standalone summary, not tied to a route's render pipeline.
     if (metrics.type === "edge-bake") {
       if (!warnOnly) {
@@ -311,12 +322,23 @@ export function metricWatcher({
         return `${coloredPath} \x1b[1m${fileSize}\x1b[0m \x1b[90m${processingTime}\x1b[0m`;
       };
 
-      // Show HTML and RSC files
-      const htmlOutput = formatFileOutput(htmlMetrics);
+      // Show the pair in dependency order: the flight (.rsc) feeds the html
+      // render, and both spans count from the same render start. They are
+      // PIPELINED, not sequential — the html render consumes the flight as it
+      // streams — so the html line reports how far it trailed the flight's
+      // completion, which is the html-specific cost. A negative tail would
+      // mean the spans lost their shared origin; omit rather than mislead.
       const rscOutput = formatFileOutput(rscMetrics);
-
-      if (typeof htmlOutput === "string") info(htmlOutput);
+      const htmlOutput = formatFileOutput(htmlMetrics);
       if (typeof rscOutput === "string") info(rscOutput);
+      if (typeof htmlOutput === "string") {
+        const htmlTail = htmlMetrics.processingTime - rscMetrics.processingTime;
+        const phases =
+          htmlTail >= 0
+            ? ` [2m(flight ${formatTime(rscMetrics.processingTime)} → +${formatTime(htmlTail)} html)[0m`
+            : "";
+        info(htmlOutput + phases);
+      }
 
       // Clean up
       pageMetricsMap.delete(route);

--- a/plugin/metrics/metricWatcher.ts
+++ b/plugin/metrics/metricWatcher.ts
@@ -181,21 +181,27 @@ export function metricWatcher({
         metrics as ModuleResolutionMetrics
       );
 
-      // Display module resolution metric as standalone entry. When the worker
-      // reported the resolve-start/module-run split, say WHICH part was slow:
-      // on a cold first batch most of the span is module code actually
-      // executing (or waiting on another route's in-flight cold load), not
-      // per-route resolution work.
+      // Display module resolution metric as standalone entry. The
+      // resolve-start/module-run split decides the LEVEL, not just the text:
+      // a span where module code actually ran is the expected once-per-build
+      // cold load (the warm-up route pays it) — informative, like the
+      // worker-startup line, not a problem. warn() is reserved for the
+      // anomalies: a slow span that was ALL cache-hit waiting (with the
+      // warm-up in place that shouldn't happen), or a slow load the worker
+      // couldn't attribute.
       if (metrics.type === "module-resolution" && "resolutionTime" in metrics && metrics.resolutionTime > maxTime) {
         const m = metrics as ModuleResolutionMetrics;
         const resolutionTime = formatTime(m.resolutionTime);
         if (m.moduleRunAt != null && m.resolveStartAt != null) {
-          const resolvePart = formatTime(m.moduleRunAt - m.resolveStartAt);
-          const runPart = formatTime(m.moduleRunTime ?? 0);
-          warn(
-            `${m.workerType} worker took ${resolutionTime} for route ${route} ` +
-              `(resolve ${resolvePart}, module execution ${runPart} — cold load)`
-          );
+          if (!warnOnly) {
+            const resolvePart = m.moduleRunAt - m.resolveStartAt;
+            const resolveMsg =
+              resolvePart >= 1 ? `resolve ${formatTime(resolvePart)}, ` : "";
+            info(
+              `[35mcold module load[0m ${formatTime(m.moduleRunTime ?? 0)} ` +
+                `(${resolveMsg}${m.workerType}, first route: ${route})`
+            );
+          }
         } else if (m.resolveStartAt != null) {
           warn(
             `${m.workerType} worker took ${resolutionTime} for route ${route} ` +

--- a/plugin/metrics/metricWatcher.ts
+++ b/plugin/metrics/metricWatcher.ts
@@ -44,6 +44,19 @@ let startedLogging = false;
 // Track logged worker startups to prevent duplicates
 const loggedWorkerStartups = new Set<string>();
 
+// Per-batch accumulation (parallel static generation): routes that rendered
+// concurrently, their union wall window and summed spans. Flushed as one
+// overview line when every route of the batch has reported its html metric,
+// so the stream shows what actually ran in parallel and what it bought.
+type BatchWindow = {
+  size: number;
+  routes: Set<string>;
+  minStartAt: number;
+  maxEndAt: number;
+  sumSpans: number;
+};
+const batchWindows = new Map<number, BatchWindow>();
+
 export function metricWatcher({
   maxTime = 200,
   maxBackpressure = 1,
@@ -107,6 +120,41 @@ export function metricWatcher({
       pageMetrics.metrics.rscHeadless = metrics as RenderMetrics;
     } else if (metrics.type === "html") {
       pageMetrics.metrics.html = metrics as RenderMetrics;
+      const html = metrics as RenderMetrics;
+      const batch = html.batch;
+      const startAt = html.streamMetrics.startAt;
+      if (batch && startAt != null && !warnOnly) {
+        let win = batchWindows.get(batch.index);
+        if (!win) {
+          win = {
+            size: batch.size,
+            routes: new Set(),
+            minStartAt: Infinity,
+            maxEndAt: -Infinity,
+            sumSpans: 0,
+          };
+          batchWindows.set(batch.index, win);
+        }
+        if (!win.routes.has(route)) {
+          win.routes.add(route);
+          win.minStartAt = Math.min(win.minStartAt, startAt);
+          win.maxEndAt = Math.max(win.maxEndAt, startAt + html.processingTime);
+          win.sumSpans += html.processingTime;
+        }
+        if (win.routes.size >= win.size) {
+          const wall = win.maxEndAt - win.minStartAt;
+          const speedup = wall > 0 ? win.sumSpans / wall : 1;
+          const label =
+            batch.index === 0 && win.size === 1
+              ? `warm-up: 1 route in ${formatTime(wall)} (cold module load paid here)`
+              : `batch ${batch.index}: ${win.size} routes in ${formatTime(wall)} wall` +
+                (win.size > 1
+                  ? ` (sum ${formatTime(win.sumSpans)}, ${speedup.toFixed(1)}× parallel)`
+                  : "");
+          info(`[2m— ${label} —[0m`);
+          batchWindows.delete(batch.index);
+        }
+      }
     } else if (metrics.type === "worker-startup") {
       // Store worker startup metrics separately
       pageMetrics.workerStartupMetrics.push(metrics as WorkerStartupMetrics);

--- a/plugin/metrics/metricWatcher.ts
+++ b/plugin/metrics/metricWatcher.ts
@@ -4,6 +4,7 @@ import type {
   ModuleResolutionMetrics,
   EdgeBakeMetrics,
   InlineFlightMetrics,
+  SsgRenderMetrics,
 } from "./types.js";
 import { isMainThread } from "node:worker_threads";
 
@@ -81,7 +82,21 @@ export function metricWatcher({
       | ModuleResolutionMetrics
       | EdgeBakeMetrics
       | InlineFlightMetrics
+      | SsgRenderMetrics
   ) => {
+    if (metrics.type === "ssg-render") {
+      if (!warnOnly) {
+        const m = metrics as SsgRenderMetrics;
+        const rate =
+          m.renderTime > 0 ? (m.pages / (m.renderTime / 1000)).toFixed(1) : "?";
+        const failedMsg = m.failed > 0 ? ` \x1b[31m(${m.failed} failed)\x1b[0m` : "";
+        info(
+          `\x1b[35mrendered\x1b[0m ${m.pages} pages in ${formatTime(m.renderTime)} ` +
+            `\x1b[2m(${rate} pages/s)\x1b[0m${failedMsg}`
+        );
+      }
+      return;
+    }
     if (metrics.type === "inline-flight") {
       if (!warnOnly) {
         const m = metrics as InlineFlightMetrics;
@@ -322,22 +337,52 @@ export function metricWatcher({
         return `${coloredPath} \x1b[1m${fileSize}\x1b[0m \x1b[90m${processingTime}\x1b[0m`;
       };
 
-      // Show the pair in dependency order: the flight (.rsc) feeds the html
-      // render, and both spans count from the same render start. They are
-      // PIPELINED, not sequential — the html render consumes the flight as it
-      // streams — so the html line reports how far it trailed the flight's
-      // completion, which is the html-specific cost. A negative tail would
-      // mean the spans lost their shared origin; omit rather than mislead.
-      const rscOutput = formatFileOutput(rscMetrics);
-      const htmlOutput = formatFileOutput(htmlMetrics);
-      if (typeof rscOutput === "string") info(rscOutput);
-      if (typeof htmlOutput === "string") {
-        const htmlTail = htmlMetrics.processingTime - rscMetrics.processingTime;
-        const phases =
-          htmlTail >= 0
-            ? ` [2m(flight ${formatTime(rscMetrics.processingTime)} → +${formatTime(htmlTail)} html)[0m`
-            : "";
-        info(htmlOutput + phases);
+      // One line per route: the flight (.rsc) feeds the html render — both
+      // spans count from the same render start and are PIPELINED (the html
+      // render consumes the flight as it streams), so the pair reads as one
+      // event: total span + how far the html trailed the flight.
+      //
+      // The tail is computed from the two write-done stamps, which are BOTH
+      // taken on the main thread with performance.now() — µs resolution, one
+      // clock. The processingTime difference is Date.now()-based (cross-
+      // thread anchoring) and quantizes to whole ms, which made every tail
+      // read exactly 0 or 1ms.
+      const stem = (name?: string) => name?.replace(/\.[^.]+$/, "");
+      const canMerge =
+        htmlMetrics.fileSize &&
+        rscMetrics.fileSize &&
+        stem(htmlMetrics.fileName) === stem(rscMetrics.fileName);
+      const htmlEnd = htmlMetrics.streamMetrics.endTime;
+      const rscEnd = rscMetrics.streamMetrics.endTime;
+      const htmlTail =
+        htmlEnd != null && rscEnd != null
+          ? Math.max(0, htmlEnd - rscEnd)
+          : Math.max(0, htmlMetrics.processingTime - rscMetrics.processingTime);
+      // Below ~2ms the "tail" is write-scheduling noise (the two file writes
+      // race in Promise.all and complete together) — showing 0μs/1ms suggests
+      // precision that isn't there. No suffix = completed together; a suffix
+      // means the html genuinely trailed the flight.
+      const tailSuffix =
+        htmlTail >= 2 ? ` [2m(+${formatTime(htmlTail)} html)[0m` : "";
+      if (canMerge) {
+        const isRootRoute = htmlMetrics.route === "/";
+        const baseDirDisplay = `[2m${htmlMetrics.baseDir}[0m`;
+        const routeDisplay = isRootRoute
+          ? ""
+          : `[33m/${htmlMetrics.routePath}[0m`;
+        const pairName = `${stem(htmlMetrics.fileName)}.{rsc,html}`;
+        info(
+          `${baseDirDisplay}${routeDisplay}[36m/${pairName}[0m ` +
+            `[1m${formatFileSize(rscMetrics.fileSize!)}+${formatFileSize(htmlMetrics.fileSize!)}[0m ` +
+            `[90m${formatTime(htmlMetrics.processingTime)}[0m` +
+            tailSuffix
+        );
+      } else {
+        // Different stems (custom output names) — keep the two-line form.
+        const rscOutput = formatFileOutput(rscMetrics);
+        const htmlOutput = formatFileOutput(htmlMetrics);
+        if (typeof rscOutput === "string") info(rscOutput);
+        if (typeof htmlOutput === "string") info(htmlOutput + tailSuffix);
       }
 
       // Clean up

--- a/plugin/metrics/metricWatcher.ts
+++ b/plugin/metrics/metricWatcher.ts
@@ -364,6 +364,21 @@ export function metricWatcher({
       // means the html genuinely trailed the flight.
       const tailSuffix =
         htmlTail >= 2 ? ` [2m(+${formatTime(htmlTail)} html)[0m` : "";
+      // A route's span contains its module-load time — the warm-up route pays
+      // the shared graph (the big one), and every route pays its own
+      // page/props modules on first use. Split it out so the render time is
+      // comparable across lines (317ms total reads as modules 211ms + route
+      // 106ms, not as a slow route).
+      const modulesInSpan = pageMetrics.moduleResolutionMetrics.reduce(
+        (total, m) => total + (m.moduleRunTime ?? 0),
+        0
+      );
+      const spanSuffix =
+        modulesInSpan >= 5
+          ? ` [2m(modules ${formatTime(modulesInSpan)} + route ${formatTime(
+              Math.max(0, htmlMetrics.processingTime - modulesInSpan)
+            )})[0m`
+          : "";
       if (canMerge) {
         const isRootRoute = htmlMetrics.route === "/";
         const baseDirDisplay = `[2m${htmlMetrics.baseDir}[0m`;
@@ -375,6 +390,7 @@ export function metricWatcher({
           `${baseDirDisplay}${routeDisplay}[36m/${pairName}[0m ` +
             `[1m${formatFileSize(rscMetrics.fileSize!)}+${formatFileSize(htmlMetrics.fileSize!)}[0m ` +
             `[90m${formatTime(htmlMetrics.processingTime)}[0m` +
+            spanSuffix +
             tailSuffix
         );
       } else {
@@ -382,7 +398,7 @@ export function metricWatcher({
         const rscOutput = formatFileOutput(rscMetrics);
         const htmlOutput = formatFileOutput(htmlMetrics);
         if (typeof rscOutput === "string") info(rscOutput);
-        if (typeof htmlOutput === "string") info(htmlOutput + tailSuffix);
+        if (typeof htmlOutput === "string") info(htmlOutput + spanSuffix + tailSuffix);
       }
 
       // Clean up

--- a/plugin/metrics/metricWatcher.ts
+++ b/plugin/metrics/metricWatcher.ts
@@ -2,6 +2,7 @@ import type {
   RenderMetrics,
   WorkerStartupMetrics,
   ModuleResolutionMetrics,
+  EdgeBakeMetrics,
 } from "./types.js";
 import { isMainThread } from "node:worker_threads";
 
@@ -60,8 +61,26 @@ export function metricWatcher({
     return () => {};
   }
   return (
-    metrics: RenderMetrics | WorkerStartupMetrics | ModuleResolutionMetrics
+    metrics:
+      | RenderMetrics
+      | WorkerStartupMetrics
+      | ModuleResolutionMetrics
+      | EdgeBakeMetrics
   ) => {
+    // Standalone summary, not tied to a route's render pipeline.
+    if (metrics.type === "edge-bake") {
+      if (!warnOnly) {
+        const bake = metrics as EdgeBakeMetrics;
+        const what =
+          bake.kind === "producer"
+            ? "edge producer"
+            : `edge consumer (${bake.moduleCount ?? "?"} client module(s))`;
+        info(
+          `\x1b[35mbaked ${what} in\x1b[0m ${formatTime(bake.bakeTime)} → ${bake.outputPath}`
+        );
+      }
+      return;
+    }
     if (!startedLogging) {
       startedLogging = true;
       info("_______ vite-plugin-react-server ______");
@@ -114,17 +133,41 @@ export function metricWatcher({
         metrics as ModuleResolutionMetrics
       );
 
-      // Display module resolution metric as standalone entry
+      // Display module resolution metric as standalone entry. When the worker
+      // reported the resolve-start/module-run split, say WHICH part was slow:
+      // on a cold first batch most of the span is module code actually
+      // executing (or waiting on another route's in-flight cold load), not
+      // per-route resolution work.
       if (metrics.type === "module-resolution" && "resolutionTime" in metrics && metrics.resolutionTime > maxTime) {
-        const moduleResolutionMetric = metrics as ModuleResolutionMetrics;
-        const resolutionTime = formatTime(
-          moduleResolutionMetric.resolutionTime
-        );
-        warn(
-          `${moduleResolutionMetric.workerType} worker took ${resolutionTime} for route ${route}`
-        );
+        const m = metrics as ModuleResolutionMetrics;
+        const resolutionTime = formatTime(m.resolutionTime);
+        if (m.moduleRunAt != null && m.resolveStartAt != null) {
+          const resolvePart = formatTime(m.moduleRunAt - m.resolveStartAt);
+          const runPart = formatTime(m.moduleRunTime ?? 0);
+          warn(
+            `${m.workerType} worker took ${resolutionTime} for route ${route} ` +
+              `(resolve ${resolvePart}, module execution ${runPart} — cold load)`
+          );
+        } else if (m.resolveStartAt != null) {
+          warn(
+            `${m.workerType} worker took ${resolutionTime} for route ${route} ` +
+              `(all cache hits — time spent waiting, likely on another route's cold load)`
+          );
+        } else {
+          warn(
+            `${m.workerType} worker took ${resolutionTime} for route ${route}`
+          );
+        }
       }
       return; // Don't process module resolution metrics for rendering checks
+    } else if (
+      metrics.type !== "rsc-full" &&
+      metrics.type !== "rsc-headless" &&
+      metrics.type !== "html"
+    ) {
+      // A metric type this watcher predates: ignore it rather than casting it
+      // to RenderMetrics and crashing on fields it doesn't have.
+      return;
     }
 
     // Only process RenderMetrics from here on
@@ -150,11 +193,23 @@ export function metricWatcher({
         0
       );
 
-    // Subtract worker startup and module resolution time from processing time for the first page
-    const actualProcessingTime =
+    // Cold-start attribution for the first batch. processingTime spans the
+    // whole request, which on a cold worker includes startup and module
+    // loading; the old blind subtraction went NEGATIVE when those spans
+    // overlapped each other (concurrent first-batch routes all report the
+    // same waited-on cold load), so first-batch numbers were nonsense. Use
+    // the module-run split where the worker reported it: only the actual
+    // execution portion is subtracted per route, and never below zero.
+    const totalModuleRunTime = pageMetrics.moduleResolutionMetrics.reduce(
+      (total, resolution) => total + (resolution.moduleRunTime ?? resolution.resolutionTime),
+      0
+    );
+    const actualProcessingTime = Math.max(
+      0,
       renderMetrics.processingTime -
-      totalWorkerStartupTime -
-      totalModuleResolutionTime;
+        totalWorkerStartupTime -
+        totalModuleRunTime
+    );
 
     if (actualProcessingTime > maxTime) {
       const startupTimeMsg =
@@ -163,11 +218,11 @@ export function metricWatcher({
           : "";
       const resolutionTimeMsg =
         totalModuleResolutionTime > 0
-          ? ` (module resolution: ${formatTime(totalModuleResolutionTime)})`
+          ? ` (module resolution: ${formatTime(totalModuleResolutionTime)}, of which execution ${formatTime(totalModuleRunTime)})`
           : "";
 
       warn(
-        `It took ${actualProcessingTime}ms to render ${route} (${renderMetrics.type})${startupTimeMsg}${resolutionTimeMsg}`
+        `It took ${formatTime(actualProcessingTime)} to render ${route} (${renderMetrics.type})${startupTimeMsg}${resolutionTimeMsg}`
       );
     }
 

--- a/plugin/metrics/types.ts
+++ b/plugin/metrics/types.ts
@@ -21,6 +21,7 @@ export type StreamMetrics = {
 
 export type CreateRenderMetricsFn = <T extends "html" | "rsc-headless" | "rsc-full">(metrics: {
   route: string;
+  batch?: { index: number; size: number };
   type: T;
   fromMainThread: boolean;
   fromRscWorker: boolean;
@@ -39,6 +40,12 @@ export type CreateRenderMetricsFn = <T extends "html" | "rsc-headless" | "rsc-fu
 
 export type BaseRenderMetrics = {
   route: string;
+  /**
+   * Which render batch this route belonged to (parallel static generation).
+   * index 0 is the warm-up route that pays the cold module load solo; size is
+   * the ACTUAL number of routes in the batch. Absent in sequential mode.
+   */
+  batch?: { index: number; size: number };
   fromMainThread: boolean;
   fromRscWorker: boolean;
   fromHtmlWorker: boolean;

--- a/plugin/metrics/types.ts
+++ b/plugin/metrics/types.ts
@@ -148,6 +148,20 @@ export type EdgeBakeMetrics = {
   description?: string;
 };
 
+/**
+ * The post-write inline-flight pass (flight payload injected into each
+ * prerendered html). Emitted so the pass is measurable — the streamable
+ * inline variant under design changes this cost, and defaulting it needs
+ * numbers from real builds.
+ */
+export type InlineFlightMetrics = {
+  route: "*";
+  type: "inline-flight";
+  pages: number;
+  inlineTime: number;
+  description?: string;
+};
+
 export type CreateStreamMetricsFn = (
   metrics?: Partial<StreamMetrics>
 ) => StreamMetrics;

--- a/plugin/metrics/types.ts
+++ b/plugin/metrics/types.ts
@@ -162,6 +162,20 @@ export type InlineFlightMetrics = {
   description?: string;
 };
 
+/**
+ * The whole static render pass: how many routes rendered (and failed) and the
+ * wall time. Replaces the raw "Rendered N pages in Xms" line for onMetrics
+ * consumers.
+ */
+export type SsgRenderMetrics = {
+  route: "*";
+  type: "ssg-render";
+  pages: number;
+  failed: number;
+  renderTime: number;
+  description?: string;
+};
+
 export type CreateStreamMetricsFn = (
   metrics?: Partial<StreamMetrics>
 ) => StreamMetrics;

--- a/plugin/metrics/types.ts
+++ b/plugin/metrics/types.ts
@@ -4,7 +4,17 @@ export type StreamMetrics = {
   backpressureCount: number;
   errorCount: number;
   duration: number;
+  /** performance.now() in the STAMPING thread — only meaningful for durations computed in that same thread. */
   startTime: number;
+  /**
+   * Wall-clock ms (Date.now()) when the stream span began. Metrics cross the
+   * worker boundary and each thread has its own performance timeOrigin, so any
+   * math between a worker-stamped startTime and another thread's
+   * performance.now() is off by the difference of origins (≈ the worker's
+   * spawn offset) — which inflated every first-batch processingTime by the
+   * same constant. Cross-thread spans must use startAt.
+   */
+  startAt?: number;
   endTime?: number;
   route?: string;
 };
@@ -90,12 +100,45 @@ export type ModuleResolutionMetrics = {
   workerType: "rsc" | "html" | "mainThread";
   startupTime?: never;
   resolutionTime: number;
+  /**
+   * Wall-clock ms (Date.now()) when resolution began. Wall-clock, not
+   * performance.now(): the metric crosses the worker boundary and each thread
+   * has its own performance timeOrigin, so only absolute times let the watcher
+   * relate spans from different threads (the first cold batch overlaps worker
+   * startup, module execution and render).
+   */
+  resolveStartAt?: number;
+  /**
+   * Wall-clock ms when the first NON-cached module load began — the moment
+   * module code actually runs, as opposed to cache lookups or waiting on an
+   * in-flight load. Unset = every component was a cache hit (warm render).
+   */
+  moduleRunAt?: number;
+  /** Load+execute portion of resolutionTime (span end − moduleRunAt). */
+  moduleRunTime?: number;
   fromMainThread: boolean;
   fromRscWorker: boolean;
   fromHtmlWorker: boolean;
   memoryUsage: NodeJS.MemoryUsage;
   description?: string;
   fileSize?: never;
+};
+
+/**
+ * One edge-bake summary (producer or consumer half). Replaces the default
+ * stdout lines the bake used to print: the raw log went behind `verbose`, and
+ * consumers that want the information route it through onMetrics instead.
+ */
+export type EdgeBakeMetrics = {
+  route: "*";
+  type: "edge-bake";
+  kind: "producer" | "consumer";
+  /** Absolute output location (producer: the edge dir; consumer: the bundle file). */
+  outputPath: string;
+  /** Client modules baked into the consumer's closed registry, when kind = "consumer". */
+  moduleCount?: number;
+  bakeTime: number;
+  description?: string;
 };
 
 export type CreateStreamMetricsFn = (

--- a/plugin/react-static/emitFileWriteMetrics.ts
+++ b/plugin/react-static/emitFileWriteMetrics.ts
@@ -18,7 +18,7 @@ export function emitFileWriteMetrics(
   event: any,
   route: string,
   routeResults: Map<string, RenderPageResult>,
-  options: { onMetrics?: (metrics: any) => void }
+  options: { onMetrics?: (metrics: any) => void; batch?: { index: number; size: number } }
 ): void {
   if (event.type !== "file.write.done" || event.data.route !== route) {
     return;
@@ -42,6 +42,7 @@ export function emitFileWriteMetrics(
     const htmlSpan = spanSince(routeResult.metrics.html.streamMetrics);
     const htmlMetrics = createRenderMetrics({
       route: route,
+      batch: options.batch,
       type: routeResult.metrics.html.type,
       fromMainThread: routeResult.metrics.html.fromMainThread,
       fromRscWorker: routeResult.metrics.html.fromRscWorker,
@@ -73,6 +74,7 @@ export function emitFileWriteMetrics(
       const rscFullSpan = spanSince(routeResult.metrics.rscFull.streamMetrics);
       const rscFullMetrics = createRenderMetrics({
         route: route,
+      batch: options.batch,
         type: routeResult.metrics.rscFull.type,
         fromMainThread: routeResult.metrics.rscFull.fromMainThread,
         fromRscWorker: routeResult.metrics.rscFull.fromRscWorker,
@@ -101,6 +103,7 @@ export function emitFileWriteMetrics(
     const rscSpan = spanSince(routeResult.metrics.rscHeadless.streamMetrics);
     const rscMetrics = createRenderMetrics({
       route: route,
+      batch: options.batch,
       type: routeResult.metrics.rscHeadless.type,
       fromMainThread: routeResult.metrics.rscHeadless.fromMainThread,
       fromRscWorker: routeResult.metrics.rscHeadless.fromRscWorker,

--- a/plugin/react-static/emitFileWriteMetrics.ts
+++ b/plugin/react-static/emitFileWriteMetrics.ts
@@ -10,8 +10,18 @@
  * differed in the name of the results Map). This is the full path only; the
  * skip-branch in renderPages emits html-only metrics by design and is left as-is.
  */
+import { relative } from "node:path";
 import { createRenderMetrics } from "../metrics/createRenderMetrics.js";
 import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
+
+// Display spelling for the watcher's file lines: relative to the process CWD,
+// like Vite's own output file list ("dist/static/…"). The event's own paths
+// stay absolute — they are filesystem data, this is presentation. Falls back
+// to the absolute path when the output isn't under the CWD.
+function displayBaseDir(dir: string): string {
+  const rel = relative(process.cwd(), dir);
+  return rel && !rel.startsWith("..") ? rel : dir;
+}
 import type { RenderPageResult } from "../types.js";
 
 export function emitFileWriteMetrics(
@@ -53,7 +63,7 @@ export function emitFileWriteMetrics(
       chunkRate: (event.data.chunks || 0) / (htmlSpan / 1000),
       fileName: event.data.fileName,
       outputPath: event.data.path,
-      baseDir: event.data.baseDir,
+      baseDir: displayBaseDir(event.data.baseDir),
       routePath: event.data.routePath,
       streamMetrics: createStreamMetrics({
         ...routeResult.metrics.html.streamMetrics,
@@ -85,7 +95,7 @@ export function emitFileWriteMetrics(
           routeResult.metrics.rscFull.streamMetrics.chunks / (rscFullSpan / 1000),
         fileName: event.data.fileName,
         outputPath: event.data.path,
-        baseDir: event.data.baseDir,
+        baseDir: displayBaseDir(event.data.baseDir),
         routePath: event.data.routePath,
         streamMetrics: createStreamMetrics({
           ...routeResult.metrics.rscFull.streamMetrics,
@@ -114,7 +124,7 @@ export function emitFileWriteMetrics(
       chunkRate: (event.data.chunks || 0) / (rscSpan / 1000),
       fileName: event.data.fileName,
       outputPath: event.data.path,
-      baseDir: event.data.baseDir,
+      baseDir: displayBaseDir(event.data.baseDir),
       routePath: event.data.routePath,
       streamMetrics: createStreamMetrics({
         ...routeResult.metrics.rscHeadless.streamMetrics,

--- a/plugin/react-static/emitFileWriteMetrics.ts
+++ b/plugin/react-static/emitFileWriteMetrics.ts
@@ -29,8 +29,17 @@ export function emitFileWriteMetrics(
     return;
   }
 
+  // Cross-thread span: the stream's startTime is performance.now() in the
+  // thread that STAMPED it (often a worker), while this function runs on the
+  // main thread — different performance timeOrigins, so subtracting them
+  // inflates every first-batch span by the worker's spawn offset. Prefer the
+  // wall-clock startAt when the producer stamped one.
+  const spanSince = (sm: { startTime: number; startAt?: number }): number =>
+    sm.startAt != null ? Date.now() - sm.startAt : performance.now() - sm.startTime;
+
   if (event.data.fileType === "html") {
     const endTime = performance.now();
+    const htmlSpan = spanSince(routeResult.metrics.html.streamMetrics);
     const htmlMetrics = createRenderMetrics({
       route: route,
       type: routeResult.metrics.html.type,
@@ -39,10 +48,8 @@ export function emitFileWriteMetrics(
       fromHtmlWorker: routeResult.metrics.html.fromHtmlWorker,
       fileSize: event.data.content.length,
       chunks: event.data.chunks || 0,
-      processingTime: endTime - routeResult.metrics.html.streamMetrics.startTime,
-      chunkRate:
-        (event.data.chunks || 0) /
-        ((endTime - routeResult.metrics.html.streamMetrics.startTime) / 1000),
+      processingTime: htmlSpan,
+      chunkRate: (event.data.chunks || 0) / (htmlSpan / 1000),
       fileName: event.data.fileName,
       outputPath: event.data.path,
       baseDir: event.data.baseDir,
@@ -51,7 +58,7 @@ export function emitFileWriteMetrics(
         ...routeResult.metrics.html.streamMetrics,
         chunks: event.data.chunks || 0,
         bytes: event.data.content.length,
-        duration: endTime - routeResult.metrics.html.streamMetrics.startTime,
+        duration: htmlSpan,
         endTime: endTime,
       }),
     });
@@ -63,28 +70,24 @@ export function emitFileWriteMetrics(
     // Also emit RSC Full metrics if available (may be missing on errors)
     if (routeResult.metrics?.rscFull) {
       const rscFullEndTime = performance.now();
+      const rscFullSpan = spanSince(routeResult.metrics.rscFull.streamMetrics);
       const rscFullMetrics = createRenderMetrics({
         route: route,
         type: routeResult.metrics.rscFull.type,
         fromMainThread: routeResult.metrics.rscFull.fromMainThread,
         fromRscWorker: routeResult.metrics.rscFull.fromRscWorker,
         fromHtmlWorker: routeResult.metrics.rscFull.fromHtmlWorker,
-        processingTime:
-          rscFullEndTime - routeResult.metrics.rscFull.streamMetrics.startTime,
+        processingTime: rscFullSpan,
         chunks: routeResult.metrics.rscFull.streamMetrics.chunks,
         chunkRate:
-          routeResult.metrics.rscFull.streamMetrics.chunks /
-          ((rscFullEndTime -
-            routeResult.metrics.rscFull.streamMetrics.startTime) /
-            1000),
+          routeResult.metrics.rscFull.streamMetrics.chunks / (rscFullSpan / 1000),
         fileName: event.data.fileName,
         outputPath: event.data.path,
         baseDir: event.data.baseDir,
         routePath: event.data.routePath,
         streamMetrics: createStreamMetrics({
           ...routeResult.metrics.rscFull.streamMetrics,
-          duration:
-            rscFullEndTime - routeResult.metrics.rscFull.streamMetrics.startTime,
+          duration: rscFullSpan,
           endTime: rscFullEndTime,
         }),
       });
@@ -95,6 +98,7 @@ export function emitFileWriteMetrics(
     }
   } else if (event.data.fileType === "rsc") {
     const rscEndTime = performance.now();
+    const rscSpan = spanSince(routeResult.metrics.rscHeadless.streamMetrics);
     const rscMetrics = createRenderMetrics({
       route: route,
       type: routeResult.metrics.rscHeadless.type,
@@ -103,12 +107,8 @@ export function emitFileWriteMetrics(
       fromHtmlWorker: routeResult.metrics.rscHeadless.fromHtmlWorker,
       fileSize: event.data.content.length,
       chunks: event.data.chunks || 0,
-      processingTime:
-        rscEndTime - routeResult.metrics.rscHeadless.streamMetrics.startTime,
-      chunkRate:
-        (event.data.chunks || 0) /
-        ((rscEndTime - routeResult.metrics.rscHeadless.streamMetrics.startTime) /
-          1000),
+      processingTime: rscSpan,
+      chunkRate: (event.data.chunks || 0) / (rscSpan / 1000),
       fileName: event.data.fileName,
       outputPath: event.data.path,
       baseDir: event.data.baseDir,
@@ -117,8 +117,7 @@ export function emitFileWriteMetrics(
         ...routeResult.metrics.rscHeadless.streamMetrics,
         chunks: event.data.chunks || 0,
         bytes: event.data.content.length,
-        duration:
-          rscEndTime - routeResult.metrics.rscHeadless.streamMetrics.startTime,
+        duration: rscSpan,
         endTime: rscEndTime,
       }),
     });

--- a/plugin/react-static/maybeInlineFlight.ts
+++ b/plugin/react-static/maybeInlineFlight.ts
@@ -17,6 +17,7 @@
  */
 import { resolve } from "node:path";
 import type { Logger } from "vite";
+import type { InlineFlightMetrics } from "../metrics/types.js";
 import { inlineFlightPayload } from "./inlineFlightPayload.js";
 
 export interface MaybeInlineFlightOptions {
@@ -28,6 +29,7 @@ export interface MaybeInlineFlightOptions {
     rscOutputPath?: string;
   };
   projectRoot?: string;
+  onMetrics?: (metrics: InlineFlightMetrics) => void;
   logger?: Logger;
   verbose?: boolean;
 }
@@ -49,6 +51,7 @@ export async function maybeInlineFlight(
     options.build.static ?? "static"
   );
 
+  const inlineStart = performance.now();
   const count = await inlineFlightPayload({
     staticDir,
     htmlFileName: options.build.htmlOutputPath,
@@ -57,6 +60,18 @@ export async function maybeInlineFlight(
     verbose: options.verbose,
   });
 
-  options.logger?.info(`[vprs] inlined flight payload into ${count} page(s)`);
+  // The metric replaces the raw log line for onMetrics consumers (their
+  // watcher renders it, with timing); without onMetrics the line stays.
+  if (options.onMetrics) {
+    options.onMetrics({
+      route: "*",
+      type: "inline-flight",
+      pages: count,
+      inlineTime: performance.now() - inlineStart,
+      description: "post-write inline-flight pass",
+    });
+  } else {
+    options.logger?.info(`[vprs] inlined flight payload into ${count} page(s)`);
+  }
   return count;
 }

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -780,9 +780,22 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
           performance.now() - (timing.renderStart || timing.start)
         );
 
-        closeBundleContext.info(
-          `Rendered ${finalResult.completedRoutes.size} pages in ${duration}ms`
-        );
+        // The watcher renders this (with rate + failures) for onMetrics
+        // consumers; the raw line stays for consumers without a watcher.
+        if (userOptions.onMetrics) {
+          userOptions.onMetrics({
+            route: "*",
+            type: "ssg-render",
+            pages: finalResult.completedRoutes.size,
+            failed: finalResult.failedRoutes?.size ?? 0,
+            renderTime: duration,
+            description: "static render pass",
+          });
+        } else {
+          closeBundleContext.info(
+            `Rendered ${finalResult.completedRoutes.size} pages in ${duration}ms`
+          );
+        }
 
         if (process.env["NODE_ENV"] !== "production") {
           closeBundleContext.warn(

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -817,6 +817,7 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         await maybeInlineFlight({
           build: userOptions.build,
           projectRoot: userOptions.projectRoot,
+          onMetrics: userOptions.onMetrics,
           logger,
           verbose: userOptions.verbose,
         });

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -569,6 +569,7 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         await maybeInlineFlight({
           build: userOptions.build,
           projectRoot: userOptions.projectRoot,
+          onMetrics: userOptions.onMetrics,
           logger,
           verbose: userOptions.verbose,
         });

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -546,9 +546,22 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
           performance.now() - (timing.renderStart || timing.start)
         );
 
-        this.info(
-          `Rendered ${finalResult.completedRoutes.size} pages in ${duration}ms`
-        );
+        // The watcher renders this (with rate + failures) for onMetrics
+        // consumers; the raw line stays for consumers without a watcher.
+        if (userOptions.onMetrics) {
+          userOptions.onMetrics({
+            route: "*",
+            type: "ssg-render",
+            pages: finalResult.completedRoutes.size,
+            failed: finalResult.failedRoutes?.size ?? 0,
+            renderTime: duration,
+            description: "static render pass",
+          });
+        } else {
+          this.info(
+            `Rendered ${finalResult.completedRoutes.size} pages in ${duration}ms`
+          );
+        }
 
         // Keep build.pages authoritative: drop Vite's bare index.html template
         // when no page claims "/". Runs before the inline pass so nothing

--- a/plugin/react-static/renderPage.client.ts
+++ b/plugin/react-static/renderPage.client.ts
@@ -425,8 +425,12 @@ export const renderPage: RenderPageFn = async function* _renderPageClient(
     // Create stream wrappers for file writing
     const rscStreamWrapper = {
       pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => {
-        const streamMetrics = createStreamMetrics();
-        streamMetrics.startTime = performance.now();
+        // Seed from the entry-stamped metrics — same origin as the html span
+        // (see renderPage.server: both indexes share one clock, html ≥ rsc).
+        const streamMetrics = createStreamMetrics({
+          startTime: rscHeadlessMetrics.streamMetrics.startTime,
+          startAt: rscHeadlessMetrics.streamMetrics.startAt,
+        });
 
         // Use the headless RSC stream directly for the .rsc file
         const rscFileStream = headlessRscStream.rscStream;

--- a/plugin/react-static/renderPage.server.ts
+++ b/plugin/react-static/renderPage.server.ts
@@ -466,8 +466,16 @@ export const renderPage: RenderPageFn = async function* renderPage(
     // Create stream wrappers for file writing - simplified like client side
     const rscStreamWrapper = {
       pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => {
-        const streamMetrics = createStreamMetrics();
-        streamMetrics.startTime = performance.now();
+        // Seed the span from the ORIGINAL metrics created at renderPage entry
+        // — the same origin the html span counts from. Both indexes then share
+        // one clock: the .rsc span reads "flight ready at X", the .html span
+        // "document done at Y", and Y ≥ X structurally because the html render
+        // consumes the flight. A pipe-time stamp here measured only the file
+        // flush (1-7ms) and made the pair look unrelated.
+        const streamMetrics = createStreamMetrics({
+          startTime: rscHeadlessMetrics.streamMetrics.startTime,
+          startAt: rscHeadlessMetrics.streamMetrics.startAt,
+        });
 
         // Use the headless RSC stream directly for the .rsc file
         const rscFileStream = headlessRscHandler.rscStream;

--- a/plugin/react-static/renderPage.server.ts
+++ b/plugin/react-static/renderPage.server.ts
@@ -32,6 +32,7 @@ import { createMainThreadHandlers } from "../stream/createMainThreadHandlers.js"
 import { createRscToHtmlStream } from "./rscToHtmlStream.server.js";
 import { resolveComponent } from "../helpers/resolveComponent.js";
 import { resolvePageAndProps } from "../helpers/resolvePageAndProps.js";
+import { createModuleResolutionMetrics } from "../metrics/createModuleResolutionMetrics.js";
 import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
 import { createHeadlessStreamState, trackHeadlessStreamError, hasHeadlessStreamError } from "../helpers/headlessStreamState.js";
 
@@ -81,7 +82,13 @@ export const renderPage: RenderPageFn = async function* renderPage(
       );
     }
 
-    // Resolve components and props using the proper helper
+    // Resolve components and props using the proper helper. The whole load
+    // phase is timed and emitted as a module-resolution metric: on the first
+    // (cold) batch this is where routes spend their time — module code
+    // compiling and executing on the main thread — and without the metric the
+    // watcher attributes all of it to "render".
+    const resolveStartAt = Date.now();
+    const resolveStart = performance.now();
     let PageComponent: any = null;
     let RootComponent: any = null;
     let HtmlComponent: any = null;
@@ -200,6 +207,22 @@ export const renderPage: RenderPageFn = async function* renderPage(
     if (!HtmlComponent) {
       const { Html: DefaultHtml } = await import("../components/html.js");
       HtmlComponent = DefaultHtml as any;
+    }
+
+    if (handlerOptions.onMetrics) {
+      const resolutionTime = performance.now() - resolveStart;
+      handlerOptions.onMetrics(
+        createModuleResolutionMetrics({
+          route: handlerOptions.route,
+          workerType: "mainThread",
+          resolutionTime,
+          resolveStartAt,
+          // Main-thread loads have no cache/wait split: the load IS the run.
+          moduleRunAt: resolveStartAt,
+          moduleRunTime: resolutionTime,
+          description: `Module resolution for route ${handlerOptions.route}`,
+        })
+      );
     }
 
     // Ensure we have all required components

--- a/plugin/react-static/renderPagesBatched.ts
+++ b/plugin/react-static/renderPagesBatched.ts
@@ -34,6 +34,7 @@ async function renderSingleRoute(
   renderPage: RenderPageFn,
   manifest: Manifest,
   failedRoutes: Map<string, unknown>,
+  batch?: { index: number; size: number },
 ): Promise<{ route: string; results: RenderPageResult[]; error?: Error }> {
   const { autoDiscoveredFiles, cssFilesByPage, ...options } = handlerOptions;
   const { page, props, root, html, layouts } = autoDiscoveredFiles.urlMap?.get(route) || {};
@@ -86,8 +87,9 @@ async function renderSingleRoute(
         }
       }
 
-      // Handle metrics collection on file.write.done
-      emitFileWriteMetrics(event, route, routeResults, options);
+      // Handle metrics collection on file.write.done; the batch tag lets the
+      // watcher show which routes rendered concurrently.
+      emitFileWriteMetrics(event, route, routeResults, { ...options, batch });
     };
 
     const routeHandlerOptions = {
@@ -202,15 +204,24 @@ export const renderPagesBatched: RenderPagesFn = (
 
   return (async function* _renderPagesBatched(): AsyncGenerator<RenderPagesResult, RenderPagesResult, unknown> {
     const routeArray = Array.from(routes);
-    const batches = chunk(routeArray, batchSize);
-    
+    // The first route renders SOLO as a warm-up. On a cold module graph a
+    // full-width first batch gains nothing from parallelism — every route in
+    // it serializes on the same one-time module load, so N routes all report
+    // the whole cold-load wall time and the real rendering only starts after
+    // it anyway. One route pays the cold load once; every batch after renders
+    // against a warm graph at full width.
+    const batches =
+      routeArray.length > 1
+        ? [[routeArray[0]], ...chunk(routeArray.slice(1), batchSize)]
+        : chunk(routeArray, batchSize);
+
     if (options.verbose) {
       options.logger?.info(
-        `[renderPagesBatched] Rendering ${routeArray.length} pages in ${batches.length} batches of ${batchSize}`
+        `[renderPagesBatched] Rendering ${routeArray.length} pages: 1 warm-up + ${batches.length - 1} batches of ${batchSize}`
       );
     }
 
-    for (const batch of batches) {
+    for (const [batchIndex, batch] of batches.entries()) {
       // Check for abort signal
       if (options.signal?.aborted) {
         const abortResult: RenderPagesResult = {
@@ -226,8 +237,11 @@ export const renderPagesBatched: RenderPagesFn = (
       }
 
       // Render all pages in this batch concurrently
-      const batchPromises = batch.map(route => 
-        renderSingleRoute(route, handlerOptions, renderPage, manifest, failedRoutes)
+      const batchPromises = batch.map(route =>
+        renderSingleRoute(route, handlerOptions, renderPage, manifest, failedRoutes, {
+          index: batchIndex,
+          size: batch.length,
+        })
       );
 
       const batchResults = await Promise.all(batchPromises);

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -48,6 +48,7 @@ import type {
   StreamMetrics,
   WorkerStartupMetrics,
   ModuleResolutionMetrics,
+  EdgeBakeMetrics,
 } from "./metrics/types.js";
 import type { HtmlWorkerOutputMessage } from "./worker/html/types.js";
 import type { RscChunkOutputMessage } from "./worker/rsc/types.js";
@@ -65,6 +66,7 @@ export type OnMetrics = (
     | RenderMetrics<"rsc-full" | "rsc-headless" | "html">
     | WorkerStartupMetrics
     | ModuleResolutionMetrics
+    | EdgeBakeMetrics
 ) => void;
 
 export type MessageHandler<

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -49,6 +49,7 @@ import type {
   WorkerStartupMetrics,
   ModuleResolutionMetrics,
   EdgeBakeMetrics,
+  InlineFlightMetrics,
 } from "./metrics/types.js";
 import type { HtmlWorkerOutputMessage } from "./worker/html/types.js";
 import type { RscChunkOutputMessage } from "./worker/rsc/types.js";
@@ -67,6 +68,7 @@ export type OnMetrics = (
     | WorkerStartupMetrics
     | ModuleResolutionMetrics
     | EdgeBakeMetrics
+    | InlineFlightMetrics
 ) => void;
 
 export type MessageHandler<

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -50,6 +50,7 @@ import type {
   ModuleResolutionMetrics,
   EdgeBakeMetrics,
   InlineFlightMetrics,
+  SsgRenderMetrics,
 } from "./metrics/types.js";
 import type { HtmlWorkerOutputMessage } from "./worker/html/types.js";
 import type { RscChunkOutputMessage } from "./worker/rsc/types.js";
@@ -69,6 +70,7 @@ export type OnMetrics = (
     | ModuleResolutionMetrics
     | EdgeBakeMetrics
     | InlineFlightMetrics
+    | SsgRenderMetrics
 ) => void;
 
 export type MessageHandler<

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -243,6 +243,13 @@ async function loadComponentsWithCache(options: {
   layoutExportName?: string;
   rscOutputPath?: string;  // Transport suffix, for stripping when matching params
   request?: Request;  // Rebuilt from serializedRequest; threaded into loader ctx
+  /**
+   * Written, not read, by this function: `moduleRunAt` is stamped (wall-clock,
+   * once) right before the FIRST actual load call — the moment module code
+   * runs, as opposed to cache hits. The caller folds it into the
+   * module-resolution metric so a cold first batch is attributable.
+   */
+  marks?: { moduleRunAt?: number };
 }) {
   const {
     pagePath,
@@ -264,6 +271,7 @@ async function loadComponentsWithCache(options: {
     layoutExportName = DEFAULT_CONFIG.LAYOUT_EXPORT_NAME,
     rscOutputPath = DEFAULT_CONFIG.BUILD.rscOutputPath,
     request,
+    marks,
   } = options;
 
   // Nested layouts: resolved once per request (independent of the page-cache
@@ -361,6 +369,7 @@ async function loadComponentsWithCache(options: {
       
       // Reload page and props
       try {
+        if (marks) marks.moduleRunAt ??= Date.now();
         const pageAndPropsResult = await resolvePageAndProps({
           pagePath,
           propsPath,
@@ -445,6 +454,7 @@ async function loadComponentsWithCache(options: {
         );
       }
       try {
+        if (marks) marks.moduleRunAt ??= Date.now();
         const pageAndPropsResult = await resolvePageAndProps({
           pagePath,
           propsPath,
@@ -497,6 +507,7 @@ async function loadComponentsWithCache(options: {
       ? matchRoutes(routePatterns, normalizePathForMatch(url, rscOutputPath))
           ?.params ?? {}
       : {};
+    if (marks) marks.moduleRunAt ??= Date.now();
     layoutChain = await resolveLayoutChain({
       layouts,
       url: normalizedUrl,
@@ -532,6 +543,7 @@ async function loadComponentsWithCache(options: {
           );
         }
       }
+      if (marks) marks.moduleRunAt ??= Date.now();
       const rootResult = await resolveComponent({
         componentPath: rootPath,
         exportName: rootExportName,
@@ -616,6 +628,7 @@ async function loadComponentsWithCache(options: {
       if (verbose) {
         logger?.info(`[rsc-worker] Component not cached, calling resolveComponent with path: ${htmlPath}, exportName: ${htmlExportName}`);
       }
+      if (marks) marks.moduleRunAt ??= Date.now();
       const htmlResult = await resolveComponent({
         componentPath: htmlPath,
         exportName: htmlExportName,
@@ -756,8 +769,13 @@ export async function messageHandler(
         const rscStream = (msg as any).rscStream || new PassThrough();
         activeRenders.set(currentStreamId, rscStream);
 
-        // Start measuring module resolution time from first module load
+        // Start measuring module resolution time from first module load.
+        // performance.now() for the duration; Date.now() for the cross-thread
+        // absolute timestamps the metric carries (each thread has its own
+        // performance timeOrigin).
         const moduleResolutionStartTime = performance.now();
+        const moduleResolveStartAt = Date.now();
+        const loadMarks: { moduleRunAt?: number } = {};
 
         // Load modules (page, props, and components together) - same as server environment
         const projectRoot = msg.options.projectRoot || userOptions.projectRoot || workerData.userOptions?.projectRoot || process.cwd();
@@ -860,6 +878,7 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
                 return undefined;
               }
             })(),
+            marks: loadMarks,
           });
 
         if (verbose) {
@@ -880,6 +899,11 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             route: msg.options.route,
             workerType: "rsc",
             resolutionTime: moduleResolutionTime,
+            resolveStartAt: moduleResolveStartAt,
+            moduleRunAt: loadMarks.moduleRunAt,
+            moduleRunTime: loadMarks.moduleRunAt
+              ? Date.now() - loadMarks.moduleRunAt
+              : 0,
             fromMainThread: false,
             fromRscWorker: true,
             fromHtmlWorker: false,

--- a/test/examples/build-cross-env.test.ts
+++ b/test/examples/build-cross-env.test.ts
@@ -97,7 +97,7 @@ describe("Plugin build test (Cross-Environment)", () => {
       } else {
         // worker-startup, module-resolution and edge-bake metrics
         expect(metric.type).toMatch(
-          /worker-startup|module-resolution|rsc-full|edge-bake/
+          /worker-startup|module-resolution|rsc-full|edge-bake|inline-flight/
         );
         if ("startupTime" in metric) {
           expect(metric.startupTime).toBeGreaterThan(0);

--- a/test/examples/build-cross-env.test.ts
+++ b/test/examples/build-cross-env.test.ts
@@ -95,14 +95,17 @@ describe("Plugin build test (Cross-Environment)", () => {
           expect(metric.chunkRate).toBeGreaterThan(0);
         }
       } else {
-        // worker-startup and module-resolution metrics
+        // worker-startup, module-resolution and edge-bake metrics
         expect(metric.type).toMatch(
-          /worker-startup|module-resolution|rsc-full/
+          /worker-startup|module-resolution|rsc-full|edge-bake/
         );
         if ("startupTime" in metric) {
           expect(metric.startupTime).toBeGreaterThan(0);
         } else if ("resolutionTime" in metric) {
           expect(metric.resolutionTime).toBeGreaterThan(0);
+        } else if ("bakeTime" in metric) {
+          expect(metric.bakeTime).toBeGreaterThan(0);
+          expect(metric.outputPath).toBeDefined();
         }
       }
 

--- a/test/examples/build-cross-env.test.ts
+++ b/test/examples/build-cross-env.test.ts
@@ -97,7 +97,7 @@ describe("Plugin build test (Cross-Environment)", () => {
       } else {
         // worker-startup, module-resolution and edge-bake metrics
         expect(metric.type).toMatch(
-          /worker-startup|module-resolution|rsc-full|edge-bake|inline-flight/
+          /worker-startup|module-resolution|rsc-full|edge-bake|inline-flight|ssg-render/
         );
         if ("startupTime" in metric) {
           expect(metric.startupTime).toBeGreaterThan(0);

--- a/test/examples/metrics.test.ts
+++ b/test/examples/metrics.test.ts
@@ -89,6 +89,10 @@ describe("Metrics Collection", () => {
       } else if (metric.type === "module-resolution") {
         expect(metric.resolutionTime).toBeGreaterThan(0);
         expect(metric.workerType).toBeDefined();
+      } else if (metric.type === "edge-bake") {
+        expect(metric.kind === "producer" || metric.kind === "consumer").toBe(true);
+        expect(metric.outputPath).toBeDefined();
+        expect(metric.bakeTime).toBeGreaterThan(0);
       } else {
         throw new Error(`Unexpected metric type: ${metric.type}`);
       }

--- a/test/examples/metrics.test.ts
+++ b/test/examples/metrics.test.ts
@@ -93,6 +93,9 @@ describe("Metrics Collection", () => {
         expect(metric.kind === "producer" || metric.kind === "consumer").toBe(true);
         expect(metric.outputPath).toBeDefined();
         expect(metric.bakeTime).toBeGreaterThan(0);
+      } else if (metric.type === "inline-flight") {
+        expect(metric.pages).toBeGreaterThanOrEqual(0);
+        expect(metric.inlineTime).toBeGreaterThanOrEqual(0);
       } else {
         throw new Error(`Unexpected metric type: ${metric.type}`);
       }

--- a/test/examples/metrics.test.ts
+++ b/test/examples/metrics.test.ts
@@ -96,6 +96,9 @@ describe("Metrics Collection", () => {
       } else if (metric.type === "inline-flight") {
         expect(metric.pages).toBeGreaterThanOrEqual(0);
         expect(metric.inlineTime).toBeGreaterThanOrEqual(0);
+      } else if (metric.type === "ssg-render") {
+        expect(metric.pages).toBeGreaterThanOrEqual(0);
+        expect(metric.renderTime).toBeGreaterThanOrEqual(0);
       } else {
         throw new Error(`Unexpected metric type: ${metric.type}`);
       }


### PR DESCRIPTION
Stacked on #276 (merge that first; this diff then shrinks to the metrics work).

What began as "the first batch's timings are nonsense" became a full metrics overhaul, every piece measured on mmc's real 300-page `build:gh` through its own `metricWatcher`:

## Correctness

- **Resolve/run split** — both module-load paths (rsc worker AND the main-thread static path, which previously emitted nothing) report `resolveStartAt` / `moduleRunAt` / `moduleRunTime`, distinguishing module execution from cache hits and waiting.
- **Cross-thread clock skew fixed** — `StreamMetrics` carries wall-clock `startAt`; spans that cross the worker boundary no longer subtract `performance.now()` values from different time origins (which inflated every first-batch span by a constant).
- **Shared span origin for the index pair** — the `.rsc` span was stamped at file-flush (read 1-7ms); both spans now count from render start in both renderPage variants, so flight ≤ html structurally.
- **Watcher subtraction clamped** and using the execution portion only — no more negative "actual" times.

## Behavior fix

- **Warm-up first batch** — the first route renders solo, paying the one-time cold module load once, then batches run full-width against a warm graph. (A/B: the cold-load pile-up predates 3.2.x — it's been there since batching landed in v1.11.2.) 300 pages: 8 cold-load reports → 1, slightly faster overall.

## The watcher's output

```
HTML-worker started in 154ms (initial route: /)
cold module load 240ms (mainThread, first route: /10mmc/credits)
— warm-up: 1 route in 307ms (cold module load paid here) —
dist/static/10mmc/credits/index.{rsc,html} 20.4 kB+21.8 kB 307ms
— batch 1: 8 routes in 150ms wall (sum 1.11s, 7.4× parallel) —
…
rendered 300 pages in 5.51s (54.4 pages/s)
inlined flight into 300 page(s) in 350ms
baked edge producer in 796ms → dist/server-edge
```

- One consolidated line per route (`index.{rsc,html}`, both sizes, one span); a `(+Xms html)` suffix only when the html genuinely trailed the flight ≥2ms — below that the pair completed together (pipelined; the sub-2ms "tail" was ms-quantization + write-race noise).
- Per-batch overview lines (wall vs sum, parallel factor) — metrics carry `batch: {index, size}`.
- File paths CWD-relative like Vite's own list.
- Cold load logs as info; `warn` reserved for anomalies (all-cache-hit waits, unattributable slow loads).
- New metric types, all additive: `edge-bake`, `inline-flight` (pages + timing — the measurement hook for the streamable inline-flight design), `ssg-render` (pages, failed, renderTime). Each replaces its raw log line for `onMetrics` consumers; plain consumers keep the raw lines. Unknown future types are ignored instead of crashing the watcher.

Full `test-all` green at every step; the two metric-enumerating tests learned the new types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
