### PR TITLE
chore(release): 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.2.4",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Minor rather than patch: the default build output changes shape (#276) and `OnMetrics` gains new public metric types (#277). Main is v3.2.4 plus exactly these two.

## What's in it

- **[#276](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/276)** — `chore(logs)`: default build output is summaries only. The bare unprefixed worker lines and the edge bake's progress narration go behind `verbose`; the worker's unknown-message case becomes a prefixed warn.
- **[#277](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/277)** — `feat(metrics)`: the cold-start-honest metrics overhaul. Warm-up first batch (the cold module load is paid once by one route instead of echoing across the whole first batch — measurably slightly faster); resolve/run split with wall-clock timestamps on both load paths; cross-thread clock skew fixed via `StreamMetrics.startAt`; per-batch overview lines (wall vs sum, parallel factor); one consolidated `index.{rsc,html}` line per route with a modules/route split; Vite-style relative paths; new additive metric types `edge-bake`, `inline-flight`, `ssg-render` rendered by `metricWatcher` (raw lines stay for consumers without `onMetrics`).

## Release steps after merge

The bump is the only thing in this PR; `version:minor` does not tag. On merged `main`:

```bash
git checkout main && git pull
git tag -a v3.3.0 -m "v3.3.0"
git push origin v3.3.0
npm publish   # 2FA
```

`prepublishOnly` runs `verify:tag`, so a forgotten tag fails the publish rather than shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)