### PR TITLE
docs: SECURITY.md + audit slice 4 — storybook, comparison drift, minor tail

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+| ------- | --------- |
+| 3.3.x   | Yes — receives security fixes |
+| < 3.3   | Best effort only |
+
+The latest minor release receives security fixes. Fixes for older minors are
+best-effort. Check `package.json` on `main` for the current version.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately through GitHub Security
+Advisories on this repository: open the **Security** tab and use **Report a
+vulnerability**.
+
+Please do **not** open a public issue for a suspected vulnerability. Public
+issues are indexed immediately and give users no time to update before details
+are visible.
+
+Include what you can: affected version, a minimal reproduction, and the impact
+you believe it has. You will get an acknowledgement in the advisory thread.
+
+## Scope
+
+### In scope
+
+- **Server-action reference resolution (the production trust boundary).**
+  In production, server-action POSTs resolve the client-supplied id through a
+  sealed allowlist built from Vite's emitted server manifest
+  (`plugin/references/createSealedServerReferenceGate.server.ts`, used by
+  `plugin/helpers/handleServerAction.server.ts`). Ids the build never emitted
+  must be rejected before any import, module loading must never derive a path
+  from the incoming id, and a missing manifest must fail closed. Any bypass of
+  this gate — resolving an unregistered id, importing a path derived from the
+  request, or reaching the unsealed dev resolver under production — is a
+  vulnerability.
+- **Path traversal in file serving** — the static/preview request handlers and
+  the loaders (e.g. `plugin/helpers/createRequestHandler.server.ts`,
+  `plugin/react-static/configurePreviewServer.ts`) must never serve files
+  outside their configured root.
+- **Worker message injection** — the RSC/HTML render workers
+  (`plugin/worker/`) act on structured messages; crafted messages that cause
+  code execution or file access outside the intended render are in scope.
+
+### Out of scope
+
+- **The dev server exposed to untrusted networks.** Dev mode serves live
+  source through an open resolver by design and is not a security boundary.
+  Do not expose a Vite dev server to networks you do not trust.
+- Content of verbose/debug logging.
+- Vulnerabilities in consumer application code (your pages, actions, and
+  server code), or in dependencies of your application.
+
+## Disclosure
+
+Disclosure is coordinated: we prepare and release a fix before details are
+made public, and publish the advisory once a fixed version is available.
+Reporters are credited in the advisory unless they prefer otherwise.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -26,7 +26,7 @@ an implementation detail, not a knob you tune.
 | Kind | Vite plugin | Vite plugin (official) | Framework | Framework (+ RSC extension) |
 | Imposes routing / app structure | No — file-based router is opt-in (since v3) | No | Yes (file-based pages router) | Yes (file-based) |
 | React target | Stable 19.2+ (default) or experimental | Stable, canary, or experimental (your choice) | React 19 | React 19 |
-| RSC transport | `react-server-dom-esm`, via `react-server-loader` | `react-server-dom-webpack`, vendored (BYO to pin a version) | managed by the framework | managed by the extension |
+| RSC transport | `react-server-dom-esm`, via `react-server-loader` (edge bake can select a vendored webpack transport) | `react-server-dom-webpack`, vendored (BYO to pin a version) | managed by the framework | managed by the extension |
 | Build output | `static/` + `client/` + `server/` portable ESM | app bundle via multi-environment build | framework-managed | framework-managed |
 | Host anywhere (static / Express / Hono) | Yes, you wire the server | Yes | Via the framework's server | Via vike-server |
 | Node `--conditions react-server` | Optional; works either way (see [below](#the-react-server-condition-is-optional)) | Used internally | Managed | Managed |
@@ -161,17 +161,22 @@ scope on purpose:
 - **No framework conveniences.** No auth, i18n, head/meta management, image
   optimization, or plugin ecosystem. vprs transforms RSC boundaries, runs the
   workers, and emits ESM; the rest of the app is yours.
-- **No webpack/RSC-bundler transport.** vprs renders through the ESM transport
-  (`react-server-dom-esm`, supplied by `react-server-loader`). If your pipeline
-  needs the webpack transport, use `@vitejs/plugin-rsc`.
+- **No pluggable transport.** vprs renders through the transports
+  `react-server-loader` vendors: the ESM transport (`react-server-dom-esm`)
+  everywhere, plus a vendored webpack transport that only the
+  [edge bake](./edge.md) can select (`build.edge.transport: "webpack"`). If
+  your pipeline needs to bring its own transport build, use
+  `@vitejs/plugin-rsc`.
 - **No deployment/hosting layer.** The build emits ESM and a static directory;
   wiring them into a host (static CDN, Express, Hono, serverless) is up to you.
   The static output runs anywhere (including the edge). Dynamic SSR has two
   shapes: the default worker-based build (Node, `worker_threads`) and the
   [single-isolate edge bundle](./edge.md), which needs no workers and no
-  `--conditions` flag — but its render still imports built modules off disk, so
-  it targets Node-flavored serverless functions, not literal V8-isolate edge
-  runtimes. See
+  `--conditions` flag. How far that bundle reaches is set by its transport
+  (`build.edge.transport`): the default `"esm"` render imports built modules
+  off disk, so it targets Node-compatible hosts; `"webpack"` bakes a closed
+  module map plus a consumer bundle with no `node:` imports, which is what
+  filesystem-less runtimes (Cloudflare Workers, Deno Deploy) require. See
   [Build Output → Where it runs](./build-output.md#where-it-runs-static-anywhere-dynamic-on-node).
 - **Two React trains, not any React build.** vprs pins React through
   `react-server-loader`, which ships a stable train and an experimental train;

--- a/docs/css-handling.md
+++ b/docs/css-handling.md
@@ -40,8 +40,8 @@ export const Root = ({ cssFiles, Page, pageProps, ...props }) => (
 
 ```ts
 css: {
-  inlineCss: true,            // enable inlining (default: true)
-  inlineThreshold: 4096,      // files < 4KB are inlined
+  inlineCss: true,            // inline small files (default: enabled; only `false` disables)
+  inlineThreshold: 4096,      // files up to 4096 bytes are inlined (default)
   inlinePatterns: [],          // RegExp[] — always inline matching files
   linkPatterns: [],            // RegExp[] — always link matching files
 }
@@ -62,7 +62,7 @@ Each entry in `cssFiles` is either:
 { as: "style", type: "text/css", id: string, children: string }
 
 // Linked (large file)
-{ as: "link", id: string, rel: "stylesheet", href: string }
+{ as: "link", id: string, rel: "stylesheet", href: string, precedence: "high" }
 ```
 
 ## CSS Modules

--- a/docs/maintenance/README.md
+++ b/docs/maintenance/README.md
@@ -18,6 +18,7 @@ Filenames are in backticks so markdown doesn't italicize the `_` in names like
 | [`workers.md`](../internals/workers.md) | Worker system (RSC + HTML workers) |
 | [`advanced-topics.md`](../internals/advanced-topics.md) | Custom workers, message system, extending the plugin |
 | [`module-resolution-escape-hatches.md`](../internals/module-resolution-escape-hatches.md) | Module-resolution escape hatches |
+| [`router-v2-parity.md`](../internals/router-v2-parity.md) | Router v2 parity spec and conventions |
 | [`MESSAGE_PORTS_ANALYSIS.md`](../internals/MESSAGE_PORTS_ANALYSIS.md) | Worker communication architecture |
 | [`COMMON_ISSUES.md`](../internals/COMMON_ISSUES.md) | Frequently encountered problems and solutions |
 | [`DEBUGGING.md`](../internals/DEBUGGING.md) | Debugging techniques and tools |
@@ -30,16 +31,16 @@ Filenames are in backticks so markdown doesn't italicize the `_` in names like
 The plugin has two execution modes:
 
 ### Dev Mode (default)
-- RSC rendering on main thread via Vite's Environment API (`server.environments['server'].runner`)
-- No workers or MessagePorts
-- HMR via `hotUpdate` hook (Vite 6 Environment API)
+- RSC rendering in a dedicated RSC worker by default (`DEV.useRscWorker`); when Vite itself runs under `--conditions react-server`, rendering happens on the main thread via Vite's Environment API (`server.environments['server'].runner`)
+- No HTML worker (`DEV.useHtmlWorker: false` — the browser renders the HTML)
+- HMR via `hotUpdate` hook (Vite Environment API)
 - Client components → `@vitejs/plugin-react` Fast Refresh
 - Server components → RSC refetch via custom WS event
 - CSS → RSC refetch (inlined in stream)
 
 ### Production Build
 - Worker-based parallel rendering (batch size 8 by default)
-- `react-server-dom-esm` vendored (symlink auto-created in `configResolved`)
+- `react-server-dom-esm` vendored via `react-server-loader` (symlink auto-created in `configResolved`)
 - Static HTML + RSC output per page
 
 ## Releasing

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -29,14 +29,16 @@ npm view react-server-loader@experimental peerDependencies
 npm install react@<that-exact-version> react-dom@<that-exact-version>
 ```
 
-`react-server-loader` is a regular **dependency** whose range admits both
-trains (`^19.2.10 || >=0.0.0-0 <0.0.1`), so every package manager installs it
-for you — the stable train by default, no extra step (yarn included).
+`react-server-loader` is a regular **dependency** whose range admits the
+stable train plus the exact experimental build this release was verified
+against (`^19.2.17 || 0.0.0-experimental-172742b4-20260716`), so every package
+manager installs it for you — the stable train by default, no extra step (yarn
+included).
 
 To run the experimental train, install all three React packages at the
-`@experimental` tag. The loader's range also admits experimental, so npm
-collapses to a single copy alongside your experimental React — no `overrides`,
-no duplicate in the tree:
+`@experimental` tag. The loader's range also admits that experimental build, so
+npm collapses to a single copy alongside your experimental React — no
+`overrides`, no duplicate in the tree:
 
 ```bash
 npm install react@experimental react-dom@experimental react-server-loader@experimental
@@ -86,8 +88,8 @@ The plugin consumes a vendored build of `react-server-dom-esm` from the
 
 1. The transport ships inside `react-server-loader` (`node_modules/react-server-loader/vendor/react-server-dom-esm/`); a single `transportDir` helper resolves it via the package.
 2. A Vite alias plugin resolves all `react-server-dom-esm/*` imports to that copy.
-3. In dev mode, a `node_modules/react-server-dom-esm` symlink is auto-created (via `configResolved`) so Vite's module runner and the RSC worker resolve the bare specifier natively.
-4. Server-side entries are marked external during builds and resolved at runtime via `createRequire`.
+3. A `node_modules/react-server-dom-esm` symlink is auto-created (via `configResolved`, on every Vite startup) so Vite's module runner and the RSC worker resolve the bare specifier natively.
+4. Server-side entries are marked external during builds under the bare specifier and resolved at runtime through that symlink (or the RSC worker's loader hook).
 
 ### Runtime Usage Outside Vite
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,7 @@ The unit/integration suite alone is not sufficient — the plugin can pass its o
 cd ~/code/vite-plugin-react-server
 
 # 1a. Full plugin suite — both halves must be green.
-npm test                 # runs test:client and test:server in sequence
+npm test                 # test:both — the suite in the client env, then again under --conditions react-server
 
 # 1b. Build the package.
 npm run build
@@ -48,16 +48,8 @@ done
 # 1d. Playwright e2e (runs against bidoof-template per playwright.config.ts).
 npx playwright test test/e2e/hmr.spec.ts
 
-# All 9 tests should pass:
-# - page content is visible
-# - server component RSC refetch (preserves client state)
-# - server component updates todos page
-# - useRscHmr listener is active
-# - import.meta.hot preserved in library build
-# - CSS HMR preserves client state
-# - client component does not trigger RSC refetch
-# - server action works
-# - todo toggle persists
+# Every test in the spec must pass (10 as of 3.3.0): page render, RSC refetch
+# vs Fast Refresh routing, CSS HMR, server actions, client-state persistence.
 ```
 
 **If any of 1a–1d fails, do not publish.** File an issue and bisect to the introducing commit. A regression that is already on `main` but not yet released is still a release-blocker — it ships to consumers the moment you `npm publish`.
@@ -92,10 +84,13 @@ npm publish   # requires 2FA (human step)
 ```
 
 This tag step is manual and has been missed before (v3.1.7 shipped untagged and
-needed backfilling; v3.1.9 nearly did). `prepublishOnly` runs `verify:tag`, which
+needed backfilling; v3.1.9 nearly did). `prepublishOnly` runs `verify:tag`, then
+`build`, then `verify:package` (publint + entrypoint checks). `verify:tag`
 refuses to publish unless `v<version>` exists and points at `HEAD` — a forgotten
 tag now fails the publish instead of shipping. For a deliberate untagged publish,
-set `VPRS_SKIP_TAG_CHECK=1`.
+set `VPRS_SKIP_TAG_CHECK=1`. After `prepublishOnly`, npm's `prepack` step
+rebuilds `dist` with plain `tsc` (`rm -rf dist && tsc -p tsconfig.json`), so the
+tarball's `dist` is the tsc output.
 
 For pre-releases, hand-edit the version (e.g. `3.2.0-alpha.0`), tag it the same
 way, then `npm publish --tag alpha`.
@@ -185,7 +180,7 @@ The plugin's `configResolved` hook auto-creates the `react-server-dom-esm` symli
 - [ ] `bidoof-template` linked via `file:../vite-plugin-react-server` — `npm run build:preview` AND dev server (`vite`) both succeed; home page returns 200 with content
 - [ ] `mmc` linked via `file:../vite-plugin-react-server` — `npm run build` succeeds; dev server starts cleanly
 - [ ] Both demo repos restored to their committed `package.json`/`package-lock.json` afterwards
-- [ ] `npx playwright test test/e2e/hmr.spec.ts` — 9/9 pass
+- [ ] `npx playwright test test/e2e/hmr.spec.ts` — all pass
 - [ ] `npm run version:<type>` — commit `package.json` + `package-lock.json`, PR, merge
 - [ ] `git tag -a v<version> -m "v<version>" && git push origin v<version>` — on merged `main`
 - [ ] `npm publish` (2FA — human step; `verify:tag` blocks an untagged publish)

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -1,65 +1,66 @@
 # Storybook
 
-vprs ships a Storybook preset so your RSC app's components build and render in
-Storybook with one line.
+vprs ships a Storybook preset (`vite-plugin-react-server/storybook`) for the
+`@storybook/react-vite` framework:
 
 ```ts
 // .storybook/main.ts
-import type { StorybookConfig } from "@storybook/react-vite";
-
-const config: StorybookConfig = {
-  stories: ["../src/**/*.stories.@(ts|tsx)"],
+export default {
   framework: { name: "@storybook/react-vite", options: {} },
   addons: ["vite-plugin-react-server/storybook"],
 };
-
-export default config;
 ```
 
-Requires vprs ≥ 1.9.0. Use the `@storybook/react-vite` framework.
+## Default: the plugin stays active, RSC works
 
-## Why it's needed
+By default the preset keeps the vprs plugin in Storybook's builder config. The
+RSC dev server runs inside Storybook and Server Components stream for real —
+the `.rsc` routes are served, so a story can render the live app via
+`createReactFetcher`. No launch flag is needed: the plugin sets the
+`react-server` condition per-environment and the RSC worker sets it for
+itself, so plain `storybook dev` is enough.
 
-A vprs app can't be bundled by Storybook out of the box. The Vite plugin assumes
-RSC entry points (`Page`/`props`/`Html`) and intercepts `/`, so Storybook has to
-strip it — but stripping it also removes the resolver for the bare
-`react-server-dom-esm/client.browser` import that vprs's RSC-client utilities
-emit (`react-server-dom-esm` is vendored inside vprs, not a standalone npm
-package). Without help, the bare import is unresolvable and the Storybook build
-fails. The preset re-creates exactly the configuration you'd otherwise hand-roll
-in `viteFinal`.
+In this mode the preset changes one thing: it silences the
+`MODULE_LEVEL_DIRECTIVE` warning Rollup emits for every `"use client"` /
+`"use server"` file when bundling UI libraries (Chakra, Ark, MUI, …). It
+preserves any `onwarn` you've configured.
 
-## What the preset does
+## Opt-out: `rsc: false` for a client-only build
 
-- **Strips** the `vite-plugin-react-server` plugin from Storybook's builder config.
-- **Resolves** `react-server-dom-esm/client.browser` to the ESM build shipped by
-  the `react-server-loader` dependency at `react-server-loader/client.browser`.
-- **Externalizes** `virtual:react-server/hmr` (only the stripped plugin provides it).
-- **Silences** the `MODULE_LEVEL_DIRECTIVE` warning Rollup emits for every
-  `"use client"` / `"use server"` file when bundling UI libraries (Chakra, Ark,
-  MUI, …). It preserves any `onwarn` you've configured.
+```ts
+// .storybook/main.ts
+export default {
+  framework: { name: "@storybook/react-vite", options: {} },
+  addons: [{ name: "vite-plugin-react-server/storybook", options: { rsc: false } }],
+};
+```
+
+This is the lighter, no-RSC-worker build for projects that only story client
+components. The preset strips every `vite-plugin-react-server` plugin from the
+builder config and re-adds the shims the stripped plugin would otherwise have
+provided:
+
+- **Resolves** `react-server-dom-esm/client.browser` to the ESM build shipped
+  by the `react-server-loader` dependency at
+  `react-server-loader/client.browser` (`react-server-dom-esm` is vendored
+  inside `react-server-loader`, not a standalone npm package — without the
+  shim the bare import is unresolvable).
+- **Stubs** `virtual:react-server/hmr` with a browser-safe no-op module that
+  mirrors the real virtual's export shape (`RSC_HMR_EVENT`, `useRscHmr`,
+  `setupRscHmr`). The real provider lives in the stripped dev-server plugin;
+  stories don't talk to a vprs dev server, so a no-op is the correct
+  semantics. It is a resolve+load stub, not a Rollup `external` — a
+  `virtual:` URL left external would fail to fetch in the browser.
+- **Drops** `react-server-dom-esm` entries from `optimizeDeps.include`.
+
+The directive-warning silencing applies in this mode too.
 
 ## What it does not do
 
-- It does **not** render React Server Components via the RSC wire protocol.
-  Write stories for the **client** components your app composes — the preset
-  makes the build resolve, it isn't a server-render shim.
-- It does **not** configure your UI library's theme. Add your provider as a
-  decorator in `.storybook/preview`:
-
-```tsx
-// .storybook/preview.tsx
-import type { Preview } from "@storybook/react-vite";
-import { MyThemeProvider } from "../src/theme";
-
-const preview: Preview = {
-  decorators: [(Story) => <MyThemeProvider><Story /></MyThemeProvider>],
-};
-
-export default preview;
-```
+The preset does not configure your UI library's theme — add your provider as a
+decorator in `.storybook/preview` as you would in any Storybook project.
 
 ## Related
 
-- [Third-party `"use client"` packages](../README.md#third-party-use-client-packages)
+- [Third-party `"use client"` packages](./configuration.md#third-party-use-client-packages)
   — how vprs detects UI libraries that ship directives.


### PR DESCRIPTION
Slice 4 of the docs audit, plus the repo's first `SECURITY.md`.

- **SECURITY.md** (new, 61 lines): supported versions (latest minor), private reporting via GitHub Security Advisories only, and a scope section grounded in the actual architecture — the sealed server-reference gate as the production trust boundary (any bypass is a vulnerability), path traversal in the static/preview handlers, worker message injection; dev mode explicitly out of scope as a security boundary. Coordinated disclosure with reporter credit.
- **storybook.md**: rewritten against the preset source. Keeping the vprs plugin is the *default* (RSC streams inside Storybook, no launch flag); `rsc: false` is the client-only opt-out; the preset's default-mode job is silencing Rollup's `MODULE_LEVEL_DIRECTIVE` noise while preserving a configured `onwarn`.
- **comparison.md**: verify-then-patch — only the claims the dual-transport work made stale. The edge bundle's reach now follows `build.edge.transport`: `esm` imports built modules off disk (Node-flavored hosts), `webpack` bakes a closed module map + consumer bundle for filesystem-less runtimes.
- **css-handling / react-type-compatibility / releasing / maintenance README**: targeted minor-stale corrections (`inlineCss` default semantics, the `precedence` field, the exact `react-server-loader` range, symlink timing, real release-script names).

Process: four writer agents in parallel, then one adversarial verifier that re-checked every changed claim against source (zero corrections needed). All snippets lifted from real code. `internals/*` deliberately untouched — several are deletion candidates awaiting maintainer calls.

Note for after merge: GitHub private vulnerability reporting must be enabled in the repo's security settings for the SECURITY.md flow to work (Settings → Code security → Private vulnerability reporting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)