### PR TITLE
docs(readme): lead with the real wiring — fileRouter + props + startClient

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Your Name
+Copyright (c) 2024 Nico Brinkkemper
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -60,24 +60,75 @@ upgrading from 1.x, see the
 
 ## Minimal Example
 
+File-based routes, server-computed props, and a one-call client entry — the
+same wiring the [starter](https://github.com/nicobrinkkemper/vprs-starter)
+deploys. One prerequisite: the project must be ESM (`"type": "module"` in
+`package.json`).
+
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite";
 import { vitePluginReactServer } from "vite-plugin-react-server";
+import { fileRouter } from "vite-plugin-react-server/router";
+
+// Scans src/routes/** for page.tsx (+ sibling props.ts) and derives the
+// route table and the prerender worklist.
+const router = fileRouter("src/routes");
 
 export default defineConfig({
   plugins: vitePluginReactServer({
     moduleBase: "src",
-    Page: "src/page.tsx",
-    build: { pages: ["/"] },
+    Page: router.Page,
+    props: router.props,
+    routePatterns: router.routePatterns,
+    build: { pages: router.build.pages },
   }),
 });
 ```
 
 ```tsx
-// src/page.tsx
-export const Page = ({ url }: { url: string }) => <div>Hello from {url}</div>;
+// src/routes/page.tsx — a server component, served at "/"
+import { Link } from "vite-plugin-react-server/router/client";
+
+export const Page = ({ title }: { title: string }) => (
+  <main>
+    <h1>{title}</h1>
+    <Link to="/about">About</Link>
+  </main>
+);
 ```
+
+```ts
+// src/routes/props.ts — runs on the server; its result is the Page's props
+export const props = () => ({ title: "Hello from the server" });
+```
+
+A route is a `page.tsx` with a sibling `props.ts`: add
+`src/routes/about/page.tsx` and `src/routes/about/props.ts` the same way and
+`/about` exists — prerendered, and reachable client-side through `Link`
+without a page reload.
+
+```tsx
+// src/client.tsx — the whole client entry: hydration + client-side navigation
+"use client";
+import { startClient } from "vite-plugin-react-server/router/client";
+
+startClient({
+  moduleBaseURL: import.meta.env.BASE_URL,
+  publicOrigin: import.meta.env.PUBLIC_ORIGIN,
+});
+```
+
+```html
+<!-- index.html -->
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/client.tsx"></script>
+</body>
+```
+
+Routing is opt-in: skip `fileRouter` and map URLs to files yourself with
+a `Page: (url) => string` mapping — see [Routing](./docs/routing.md).
 
 ```bash
 # Dev server


### PR DESCRIPTION
The Minimal Example still taught the pre-router spelling: a hand-mapped `Page`, no props, no client entry — a static page with no hydration or navigation story. It now shows what consumers actually deploy, lifted from the starter's real files: `fileRouter` over `src/routes`, a server `props.ts` feeding the Page, `Link` navigation, the one-call `startClient` entry, and the `index.html` mount. The manual `Page` mapping stays as the one-line no-router escape hatch.

**Every snippet was verified by scaffolding the example verbatim into a fresh project and building it.** That surfaced two truths the text now states plainly:

- the project must be ESM (`"type": "module"` in package.json — without it the config load dies on `ERR_REQUIRE_ASYNC_MODULE`);
- a route is a `page.tsx` **with a sibling `props.ts`** — a props-less page is silently omitted from the build with only a warning buried in the edge-bake output. Filed as a fix candidate (default to empty props, or fail loud).

Also: `LICENSE` said `Copyright (c) 2024 Your Name` — the template placeholder has shipped in every npm tarball to date. Now the actual author.

Note: the README now links `vprs-starter`, which is still a private repo — merge after flipping it public (it's housekeeping-ready: LICENSE, metadata, description all in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)