### PR TITLE
fix(router): a page.tsx without a sibling props.ts renders with empty props

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ export const Page = ({ title }: { title: string }) => (
 export const props = () => ({ title: "Hello from the server" });
 ```
 
-A route is a `page.tsx` with a sibling `props.ts`: add
-`src/routes/about/page.tsx` and `src/routes/about/props.ts` the same way and
-`/about` exists — prerendered, and reachable client-side through `Link`
-without a page reload.
+Add `src/routes/about/page.tsx` the same way and `/about` exists —
+prerendered, and reachable client-side through `Link` without a page reload.
+A sibling `props.ts` is optional: add one when the page needs
+server-computed props.
 
 ```tsx
 // src/client.tsx — the whole client entry: hydration + client-side navigation

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -262,13 +262,16 @@ export async function buildEdgeBundle(opts: {
     const pageSrc = routeSource(userOptions.Page, resolveUrl);
     const propsSrc = routeSource(userOptions.props, resolveUrl);
     const pageAbs = resolveBuilt(pageSrc);
-    const propsAbs = resolveBuilt(propsSrc);
-    if (
-      typeof pageSrc !== "string" ||
-      typeof propsSrc !== "string" ||
-      !pageAbs ||
-      !propsAbs
-    ) {
+    // Props are optional by contract: a route may have a page.tsx with no
+    // sibling props file (fileRouter returns undefined). Only a MISSING page
+    // disqualifies the route; a props-less route bakes without a props module
+    // and renders with empty props — the same rule as the static build.
+    const propsAbs =
+      typeof propsSrc === "string" ? resolveBuilt(propsSrc) : undefined;
+    if (typeof pageSrc !== "string" || !pageAbs) {
+      return null;
+    }
+    if (typeof propsSrc === "string" && !propsAbs) {
       return null;
     }
     // Bake this route's `route.tsx` layout chain: each layer's component (and
@@ -276,10 +279,10 @@ export async function buildEdgeBundle(opts: {
     // src path, and a `layouts: [{ component, props }]` array is emitted so the
     // edge folds the nested tree via resolveLayoutChain. A layer whose built
     // module can't be resolved is skipped (the page still renders).
-    const moduleParts = [
-      `${JSON.stringify(pageSrc)}: ${nsFor(pageAbs)}`,
-      `${JSON.stringify(propsSrc)}: ${nsFor(propsAbs)}`,
-    ];
+    const moduleParts = [`${JSON.stringify(pageSrc)}: ${nsFor(pageAbs)}`];
+    if (typeof propsSrc === "string" && propsAbs) {
+      moduleParts.push(`${JSON.stringify(propsSrc)}: ${nsFor(propsAbs)}`);
+    }
     const layoutParts: string[] = [];
     for (const layer of userOptions.layoutsResolver?.(resolveUrl) ?? []) {
       const compAbs =
@@ -310,9 +313,13 @@ export async function buildEdgeBundle(opts: {
     const layoutsField = layoutParts.length
       ? `, layouts: [${layoutParts.join(", ")}]`
       : "";
+    const propsPathField =
+      typeof propsSrc === "string"
+        ? `, propsPath: ${JSON.stringify(propsSrc)}`
+        : "";
     return `  ${JSON.stringify(key)}: { pagePath: ${JSON.stringify(
       pageSrc
-    )}, propsPath: ${JSON.stringify(propsSrc)}, modules: { ${moduleParts.join(
+    )}${propsPathField}, modules: { ${moduleParts.join(
       ", "
     )} }${layoutsField} },`;
   };

--- a/plugin/config/resolveUrlOption.ts
+++ b/plugin/config/resolveUrlOption.ts
@@ -95,11 +95,22 @@ export const resolveUrlOption: ResolvePageAndPropsOptionsFn = async function _re
         if (typeof result === "string") {
           return { type: "success", [configName]: result } as any;
         }
+        if (result === undefined && configName === "props") {
+          // Props are optional by contract — fileRouter types `props` as
+          // `(url) => string | undefined`, and a route directory may carry a
+          // page.tsx with no sibling props file. Treating undefined as an
+          // error here silently DROPPED the route from the build worklist;
+          // it must resolve to "no props" and render with empty props.
+          return { type: "success", props: undefined } as any;
+        }
         if (result instanceof Promise) {
           try {
             const promiseResult = await result;
             if (typeof promiseResult === "string") {
               return { type: "success", [configName]: promiseResult } as any;
+            }
+            if (promiseResult === undefined && configName === "props") {
+              return { type: "success", props: undefined } as any;
             }
           } catch (error) {
             return { type: "error", error: error as Error };

--- a/test/unit/resolveUrlOption-optional-props.test.ts
+++ b/test/unit/resolveUrlOption-optional-props.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { resolveUrlOption } from "../../plugin/config/resolveUrlOption.js";
+
+// Props are optional by contract: fileRouter types `props` as
+// `(url) => string | undefined`, and a route directory may carry a page.tsx
+// with no sibling props file. An undefined return used to resolve to
+// `type: "error"`, which made resolveBuildPages drop the route from the build
+// worklist entirely — the page silently didn't exist in the output.
+describe("resolveUrlOption: optional props", () => {
+  const base = {
+    pageExportName: "Page",
+    propsExportName: "props",
+    rootExportName: "Root",
+    htmlExportName: "Html",
+  } as any;
+
+  it("a props function returning undefined resolves to no-props, not an error", async () => {
+    const result = await resolveUrlOption(
+      { ...base, props: (_url: string) => undefined },
+      "props",
+      "/about"
+    );
+    expect(result.type).toBe("success");
+    expect((result as any).props).toBeUndefined();
+  });
+
+  it("an async props function resolving undefined resolves to no-props", async () => {
+    const result = await resolveUrlOption(
+      { ...base, props: async (_url: string) => undefined },
+      "props",
+      "/about"
+    );
+    expect(result.type).toBe("success");
+    expect((result as any).props).toBeUndefined();
+  });
+
+  it("a props function returning a string still resolves the path", async () => {
+    const result = await resolveUrlOption(
+      { ...base, props: (_url: string) => "src/routes/props.ts" },
+      "props",
+      "/"
+    );
+    expect(result.type).toBe("success");
+    expect((result as any).props).toBe("src/routes/props.ts");
+  });
+
+  it("a Page function returning undefined is still an error (a route needs a page)", async () => {
+    const result = await resolveUrlOption(
+      { ...base, Page: (_url: string) => undefined },
+      "Page",
+      "/about"
+    );
+    expect(result.type).toBe("error");
+  });
+});


### PR DESCRIPTION
Found while verifying the new README lead example end-to-end (#280): adding `src/routes/about/page.tsx` without an `about/props.ts` produced `Rendered 1 pages` — the route silently didn't exist, with only a warning buried in the edge-bake output.

Two seams carried the same refusal:

- **`resolveUrlOption`**: a `props` function returning `undefined` (fileRouter's spelling for a props-less route — it types `props` as `(url) => string | undefined`) fell through to `type: "error"`, and `resolveBuildPages` error-`continue`d, dropping the route from the build worklist.
- **`buildEdgeBundle`'s `routeEntryLine`**: independently required a resolvable props module, omitting props-less routes from the baked route table — a per-request consumer would 404 them.

Both now treat props-less as legitimate: the route renders with **empty props**, bakes without a props module, and the `Page` stays strictly required (a Page function returning `undefined` is still an error — covered by test).

Verified: new unit tests on the resolver contract; end-to-end on a minimal two-route fileRouter project — both pages render, `/about` present in `dist/static` and in the edge bundle's route table, zero omission warnings. Full `test-all` green.

Note: #280's README currently says a route is "a page.tsx **with** a sibling props.ts" — accurate against 3.3.0's behavior, stale once this merges. Follow-up commit on #280 (or after both merge) flips it back to props-optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)