### PR TITLE
chore(release): 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch: one router fix plus the docs wave. Main is v3.3.0 plus exactly these three.

## What's in it

- **[#281](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/281)** — `fix(router)`: a `page.tsx` without a sibling `props.ts` renders with empty props instead of being silently dropped from the build worklist and the baked edge route table. Page stays strictly required.
- **[#280](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/280)** — README leads with the real wiring (fileRouter + props + startClient, verified by scaffolding it verbatim); LICENSE placeholder finally names the author. Publishing also refreshes the npm-displayed README.
- **[#279](https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/279)** — SECURITY.md + docs audit slice 4 (storybook, comparison drift, minor tail).

## Release steps after merge

```bash
git checkout main && git pull
git tag -a v3.3.1 -m "v3.3.1"
git push origin v3.3.1
npm publish   # 2FA
```

`prepublishOnly` runs `verify:tag`, so a forgotten tag fails the publish rather than shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)