### PR TITLE
docs: drop links to the private starter repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,8 @@ upgrading from 1.x, see the
 
 ## Minimal Example
 
-File-based routes, server-computed props, and a one-call client entry — the
-same wiring the [starter](https://github.com/nicobrinkkemper/vprs-starter)
-deploys. One prerequisite: the project must be ESM (`"type": "module"` in
-`package.json`).
+File-based routes, server-computed props, and a one-call client entry. One
+prerequisite: the project must be ESM (`"type": "module"` in `package.json`).
 
 ```ts
 // vite.config.ts

--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -124,7 +124,7 @@ createServer(toNodeListener(app)).listen(3000);
 
 For the complete pattern — including per-request rendering of dynamic routes —
 see the [bidoof-template](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official)
-demo's `start.tsx` and the [vprs-starter](https://github.com/nicobrinkkemper/vprs-starter)'s
+demo's `start.tsx` and the vprs-starter's
 `server/handler.mjs`.
 
 ## Where it runs: static anywhere, dynamic on Node


### PR DESCRIPTION
The starter is deliberately private while the edge/webpack surface it demonstrates is not yet a stable API. The two hyperlinks to it (README's Minimal Example intro, build-output.md) 404 for everyone else — the prose stays, the links go. Re-add when it goes public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)