### PR TITLE
chore(deps): react-server-loader 19.2.18 + experimental .1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.17 || 0.0.0-experimental-172742b4-20260716",
+        "react-server-loader": "^19.2.18 || 0.0.0-experimental-172742b4-20260716.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -6437,9 +6437,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.17.tgz",
-      "integrity": "sha512-XrmiJi2gPp1Fk0s9Bq8Fs+82WCYv+TDH7GLZQqNTvYU3caaOCOoVCyMw6YEYn8JQzNukvie2QsHqQcOvQUsHoA==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.18.tgz",
+      "integrity": "sha512-grrUSq8rVeI4eBnY1Uv9pu+IgCwQiLGJkCHVyhZ6rihwfpPa7KNl8mosaJDQZGqddYWmBH9D2IRifddKxuzpFQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -441,7 +441,7 @@
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
-    "react-server-loader": "^19.2.17 || 0.0.0-experimental-172742b4-20260716",
+    "react-server-loader": "^19.2.18 || 0.0.0-experimental-172742b4-20260716.1",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }

--- a/plugin/config/flightBindings.ts
+++ b/plugin/config/flightBindings.ts
@@ -59,16 +59,22 @@ const targetConfigs: Record<FlightTarget, Partial<FlightConfig>> = {
   webpack: {
     rsc: {
       client: {
+        // Explicit per-environment variants, matching the esm bindings above.
+        // The bare "react-server-dom-webpack/client" relies on resolve
+        // conditions, and the client ENVIRONMENT of the --app build resolves
+        // with node-flavored conditions — so the browser bundle pulled the
+        // Node cjs build ("Module util has been externalized" on every build)
+        // instead of client.browser.
         browser: {
-          production: "react-server-dom-webpack/client",
-          development: "react-server-dom-webpack/client",
-          test: "react-server-dom-webpack/client",
+          production: "react-server-dom-webpack/client.browser",
+          development: "react-server-dom-webpack/client.browser",
+          test: "react-server-dom-webpack/client.browser",
           exports: baseConfig.rsc.client.browser.exports
         },
         node: {
-          production: "react-server-dom-webpack/client",
-          development: "react-server-dom-webpack/client",
-          test: "react-server-dom-webpack/client",
+          production: "react-server-dom-webpack/client.node",
+          development: "react-server-dom-webpack/client.node",
+          test: "react-server-dom-webpack/client.node",
           exports: baseConfig.rsc.client.node.exports
         }
       },


### PR DESCRIPTION
Consumes both freshly-published rsl trains:

- **`^19.2.18`** (stable) — the env-resolved webpack client ([rsl #29](https://github.com/nicobrinkkemper/react-server-loader/pull/29)): `createWebpackClient` imports the conditional `react-server-loader/webpack/client`, so each environment bundles exactly its own variant. Measured effect on a webpack-transport consumer's browser build: the `Module "util" externalized` warning gone, webpack chunks reduced from runtime+3 variants to runtime+`client.browser`.
- **`0.0.0-experimental-172742b4-20260716.1`** — the same fix on the experimental train as an rsl revision against the already-published React nightly (no React churn; mmc's `react`/`react-dom` pins stay put).

Second commit: the webpack `flightBindings` entries name explicit per-env variants (`client.browser`/`client.node`), matching the esm bindings' spelling. Inert today — those bindings are unused until the transport option work — but consistent, and it encodes the rule the rsl fix established: variant selection is an environment fact, not a runtime choice.

Release verification (before publish): rsl's full suite + all five transport smokes; vprs's complete gate on the packed tarball; bidoof e2e; mmc gate; starter build with the workerd probe. The release's own verify gate re-ran vprs's suite against the exact published bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)