### PR TITLE
feat: transport option — one flight flavor across every deploy surface

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,6 +40,7 @@ export const config = {
 | `htmlTimeout` | `number` | Timeout in milliseconds for HTML generation operations | `15000` |
 | `htmlWorkerStartupTimeout` | `number` | Timeout in milliseconds for HTML worker startup | `5000` |
 | `rscWorkerStartupTimeout` | `number` | Timeout in milliseconds for RSC worker startup | `5000` |
+| `transport` | `"esm" \| "webpack"` | The deploy's flight flavor; `"webpack"` re-renders the static snapshots through the baked pair so every surface agrees (see [Configuration → Transport](./configuration.md#transport)) | `"esm"` |
 | `onMetrics` | `OnMetrics` | Callback for build metrics (render, worker-startup, module-resolution, edge-bake, inline-flight and ssg-render metrics) | - |
 | `onEvent` | `(event: PluginEvent) => void` | Callback for plugin events | - |
 | `normalizer` | `InputNormalizer` | Custom input normalizer | - |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -40,7 +40,7 @@ export const config = {
 | `htmlTimeout` | `number` | Timeout in milliseconds for HTML generation operations | `15000` |
 | `htmlWorkerStartupTimeout` | `number` | Timeout in milliseconds for HTML worker startup | `5000` |
 | `rscWorkerStartupTimeout` | `number` | Timeout in milliseconds for RSC worker startup | `5000` |
-| `transport` | `"esm" \| "webpack"` | The deploy's flight flavor; `"webpack"` re-renders the static snapshots through the baked pair so every surface agrees (see [Configuration → Transport](./configuration.md#transport)) | `"esm"` |
+| `transport` | `"esm" \| "webpack"` | The deploy's flight flavor; `"webpack"` renders the static snapshots through the baked pair and the dev server serves webpack flight, so every surface agrees (see [Configuration → Transport](./configuration.md#transport)) | `"esm"` |
 | `onMetrics` | `OnMetrics` | Callback for build metrics (render, worker-startup, module-resolution, edge-bake, inline-flight and ssg-render metrics) | - |
 | `onEvent` | `(event: PluginEvent) => void` | Callback for plugin events | - |
 | `normalizer` | `InputNormalizer` | Custom input normalizer | - |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,24 +223,26 @@ vitePluginReactServer({
 });
 ```
 
-With `"webpack"` the whole deploy carries one flavor: the option defaults the
-edge bake to the webpack pair, and after the bake every enumerated route's
-`index.html`/`index.rsc` is re-rendered **through that pair** — the same
-producer + consumer a deployed handler runs — replacing the esm snapshots.
-One deploy may then serve any route from the CDN or the per-request handler
-interchangeably; the browser client, the inline flight, and the fetched
-`.rsc` payloads all agree.
+With `"webpack"` the whole deploy carries one flavor, and every artifact
+renders once, in that flavor: the option defaults the edge bake to the
+webpack pair, and the enumerated routes' `index.html`/`index.rsc` snapshots
+render **through that pair** — the same producer + consumer a deployed
+handler runs — instead of through the esm SSG pass. One deploy may then
+serve any route from the CDN or the per-request handler interchangeably; the
+browser client, the inline flight, and the fetched `.rsc` payloads all
+agree. Build events and metrics are unchanged: the pair render owns the same
+`build.ssg.*`/`file.write` events and `ssg-render` summary the esm pass
+emits.
+
+The dev server follows the option too: with `"webpack"` it renders
+webpack-flavored flight and the browser decodes it live — dev and production
+run the same transport, no parity caveats.
 
 Do not hand-mix flavors instead: an esm-hydrated document cannot decode a
 webpack `.rsc` (and vice versa), so serving both to one client breaks
 navigation between them. Per-surface splits are fine only when a single
 surface actually serves a given deploy — which is exactly what this option
 exists to make unnecessary.
-
-Costs to know about: the enumerated routes render twice (the regular SSG
-pass, then the freeze through the pair), and dev currently stays on the esm
-transport regardless of this option — a dev/prod parity note that goes away
-when dev-side webpack resolution lands.
 
 The option is a plain value, so per-mode policy is ordinary JavaScript:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,6 +211,37 @@ export default defineConfig({
 });
 ```
 
+## Transport
+
+The deploy's RSC flight flavor. Default `"esm"` — module references are URLs
+the browser imports directly; the best DX for static sites with no
+per-request rendering.
+
+```ts
+vitePluginReactServer({
+  transport: "webpack",
+});
+```
+
+With `"webpack"` the whole deploy carries one flavor: the option defaults the
+edge bake to the webpack pair, and after the bake every enumerated route's
+`index.html`/`index.rsc` is re-rendered **through that pair** — the same
+producer + consumer a deployed handler runs — replacing the esm snapshots.
+One deploy may then serve any route from the CDN or the per-request handler
+interchangeably; the browser client, the inline flight, and the fetched
+`.rsc` payloads all agree.
+
+Do not hand-mix flavors instead: an esm-hydrated document cannot decode a
+webpack `.rsc` (and vice versa), so serving both to one client breaks
+navigation between them. Per-surface splits are fine only when a single
+surface actually serves a given deploy — which is exactly what this option
+exists to make unnecessary.
+
+Costs to know about: the enumerated routes render twice (the regular SSG
+pass, then the freeze through the pair), and dev currently stays on the esm
+transport regardless of this option — a dev/prod parity note that goes away
+when dev-side webpack resolution lands.
+
 ## Metric Watcher
 
 Opt-in build output: wire `metricWatcher` into `onMetrics` and the build prints

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,18 @@ pass, then the freeze through the pair), and dev currently stays on the esm
 transport regardless of this option — a dev/prod parity note that goes away
 when dev-side webpack resolution lands.
 
+The option is a plain value, so per-mode policy is ordinary JavaScript:
+
+```ts
+vitePluginReactServer({
+  transport: process.env.NODE_ENV === "production" ? "webpack" : "esm",
+});
+```
+
+Dev and production are separate sessions — each is internally coherent — so
+choosing a flavor per mode is safe in a way per-route mixing within one
+deploy never is.
+
 ## Metric Watcher
 
 Opt-in build output: wire `metricWatcher` into `onMetrics` and the build prints

--- a/plugin/bundle/freezeStaticSnapshots.ts
+++ b/plugin/bundle/freezeStaticSnapshots.ts
@@ -1,0 +1,89 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { Logger } from "vite";
+import type { ResolvedUserOptions } from "../types.js";
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+
+/**
+ * transport: "webpack" — re-render every enumerated route's prerendered
+ * snapshots (index.html + index.rsc) THROUGH THE BAKED PAIR, so the static
+ * surface carries the same flight flavor the per-request path serves. This is
+ * what makes one deploy free to serve any route from the CDN or the function:
+ * one transport, no cross-flavor decode failures.
+ *
+ * Runs after the edge bake: imports the emitted producer/consumer from
+ * dist/<edge.outDir> exactly like a consumer's server entry would, requests
+ * each route via createEdgeRequestHandler, and overwrites the esm-flavored
+ * SSG snapshots in place. Composition over new machinery — the render path is
+ * byte-identical to what a deployed handler serves.
+ */
+export async function freezeStaticSnapshots(opts: {
+  userOptions: ResolvedUserOptions;
+  projectRoot: string;
+  routes: readonly string[];
+  logger: Logger;
+}): Promise<void> {
+  const { userOptions, projectRoot, routes, logger } = opts;
+  const bakeStart = performance.now();
+  const outRoot = join(projectRoot, userOptions.build.outDir);
+  const edgeDir = join(
+    outRoot,
+    userOptions.build.edge.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir
+  );
+  const staticDir = join(outRoot, userOptions.build.static);
+  const htmlName =
+    userOptions.build.htmlOutputPath ?? DEFAULT_CONFIG.BUILD.htmlOutputPath;
+  const rscName =
+    userOptions.build.rscOutputPath ?? DEFAULT_CONFIG.BUILD.rscOutputPath;
+
+  const { createEdgeRequestHandler } = await import("../edge/index.js");
+  const bundle = await import(
+    pathToFileURL(join(edgeDir, DEFAULT_CONFIG.EDGE.entryFileName)).href
+  );
+  const consumer = await import(
+    pathToFileURL(join(edgeDir, "consumer.js")).href
+  );
+  const handler = createEdgeRequestHandler(bundle, {
+    renderFlightToHtml: consumer.renderFlightToHtml,
+  });
+
+  const ORIGIN = "https://prerender.local";
+  for (const route of routes) {
+    const dir = join(staticDir, route === "/" ? "" : route.replace(/^\//, ""));
+    await mkdir(dir, { recursive: true });
+    const htmlRes = await handler(new Request(new URL(route, ORIGIN)));
+    if (htmlRes.status !== 200) {
+      throw new Error(
+        `[transport:webpack] freezing ${route} html failed (${htmlRes.status})`
+      );
+    }
+    await writeFile(join(dir, htmlName), await htmlRes.text());
+    const rscUrl = new URL(
+      (route === "/" ? "" : route) + "/" + rscName,
+      ORIGIN
+    );
+    const rscRes = await handler(new Request(rscUrl));
+    if (rscRes.status !== 200) {
+      throw new Error(
+        `[transport:webpack] freezing ${route} rsc failed (${rscRes.status})`
+      );
+    }
+    await writeFile(join(dir, rscName), await rscRes.text());
+  }
+  if (userOptions.onMetrics) {
+    userOptions.onMetrics({
+      route: "*",
+      type: "edge-bake",
+      kind: "producer",
+      outputPath: staticDir,
+      moduleCount: routes.length,
+      bakeTime: performance.now() - bakeStart,
+      description: `froze ${routes.length} route snapshot(s) through the baked pair`,
+    });
+  } else {
+    logger.info(
+      `[transport:webpack] froze ${routes.length} route snapshot(s) through the baked pair → ${staticDir}`
+    );
+  }
+}

--- a/plugin/bundle/freezeStaticSnapshots.ts
+++ b/plugin/bundle/freezeStaticSnapshots.ts
@@ -1,22 +1,34 @@
-import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import type { Logger } from "vite";
 import type { ResolvedUserOptions } from "../types.js";
 import { DEFAULT_CONFIG } from "../config/defaults.js";
+import { fileWriter } from "../react-static/fileWriter.js";
+import { pruneUnclaimedEntryHtml } from "../react-static/pruneUnclaimedEntryHtml.js";
+import { handleError } from "../error/handleError.js";
 
 /**
- * transport: "webpack" — re-render every enumerated route's prerendered
+ * transport: "webpack" — THE SSG pass for the webpack flavor. Every artifact
+ * renders once, in its flavor: the esm SSG pass is skipped entirely (see the
+ * react-static plugins), and this step renders every enumerated route's
  * snapshots (index.html + index.rsc) THROUGH THE BAKED PAIR, so the static
- * surface carries the same flight flavor the per-request path serves. This is
- * what makes one deploy free to serve any route from the CDN or the function:
- * one transport, no cross-flavor decode failures.
+ * surface carries the same flight flavor the per-request path serves. One
+ * deploy may then serve any route from the CDN or the function: one
+ * transport, no cross-flavor decode failures.
+ *
+ * Because it replaces the SSG pass, it owns the SSG pass's contract:
+ * `build.ssg.start`/`build.ssg.end`, per-route `file.write`/`file.write.done`
+ * (through the same fileWriter, degraded-document guard included), the
+ * `ssg-render` metric summary, and the unclaimed-entry-html prune — onEvent
+ * and onMetrics consumers cannot tell the renderer changed. There is no
+ * inline-flight pass: pair documents carry their own inline flight.
  *
  * Runs after the edge bake: imports the emitted producer/consumer from
- * dist/<edge.outDir> exactly like a consumer's server entry would, requests
- * each route via createEdgeRequestHandler, and overwrites the esm-flavored
- * SSG snapshots in place. Composition over new machinery — the render path is
- * byte-identical to what a deployed handler serves.
+ * dist/<edge.outDir> exactly like a consumer's server entry would, and
+ * requests each route via createEdgeRequestHandler. Composition over new
+ * machinery — the render path is byte-identical to what a deployed handler
+ * serves.
  */
 export async function freezeStaticSnapshots(opts: {
   userOptions: ResolvedUserOptions;
@@ -25,15 +37,16 @@ export async function freezeStaticSnapshots(opts: {
   logger: Logger;
 }): Promise<void> {
   const { userOptions, projectRoot, routes, logger } = opts;
-  const bakeStart = performance.now();
+
+  // Same rule as the esm pass: no pages means no SSG at all — no events, no
+  // metric, nothing to freeze.
+  if (routes.length === 0) return;
+
   const outRoot = join(projectRoot, userOptions.build.outDir);
   const edgeDir = join(
     outRoot,
     userOptions.build.edge.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir
   );
-  const staticDir = join(outRoot, userOptions.build.static);
-  const htmlName =
-    userOptions.build.htmlOutputPath ?? DEFAULT_CONFIG.BUILD.htmlOutputPath;
   const rscName =
     userOptions.build.rscOutputPath ?? DEFAULT_CONFIG.BUILD.rscOutputPath;
 
@@ -48,42 +61,122 @@ export async function freezeStaticSnapshots(opts: {
     renderFlightToHtml: consumer.renderFlightToHtml,
   });
 
+  // The SSG pass's event contract, emitted the same way the react-static
+  // plugins emit it (there is no rollup bundle in scope at this build point).
+  if (typeof userOptions.onEvent === "function") {
+    try {
+      const r = userOptions.onEvent({
+        type: "build.ssg.start",
+        data: {
+          pages: [...routes],
+          options: null as any,
+          bundle: {} as any,
+        },
+      });
+      if (r != null && typeof r === "object" && "then" in r) {
+        await (r as Promise<any>);
+      }
+    } catch (error) {
+      const eventPanicError = handleError({
+        error,
+        logger,
+        panicThreshold: userOptions.panicThreshold,
+        context: "onEvent(build.ssg.start)",
+      });
+      if (eventPanicError != null) {
+        throw eventPanicError;
+      } else {
+        throw new Error("Failed to emit build.ssg.start event");
+      }
+    }
+  }
+
+  const renderStart = performance.now();
   const ORIGIN = "https://prerender.local";
+  const writerOptions = {
+    build: userOptions.build,
+    projectRoot: userOptions.projectRoot,
+    onEvent: userOptions.onEvent,
+    panicThreshold: userOptions.panicThreshold,
+    verbose: userOptions.verbose,
+    logger,
+  };
+
   for (const route of routes) {
-    const dir = join(staticDir, route === "/" ? "" : route.replace(/^\//, ""));
-    await mkdir(dir, { recursive: true });
     const htmlRes = await handler(new Request(new URL(route, ORIGIN)));
-    if (htmlRes.status !== 200) {
+    if (htmlRes.status !== 200 || !htmlRes.body) {
       throw new Error(
         `[transport:webpack] freezing ${route} html failed (${htmlRes.status})`
       );
     }
-    await writeFile(join(dir, htmlName), await htmlRes.text());
+    await fileWriter(
+      Readable.fromWeb(htmlRes.body as import("node:stream/web").ReadableStream),
+      "html",
+      { ...writerOptions, route }
+    );
     const rscUrl = new URL(
       (route === "/" ? "" : route) + "/" + rscName,
       ORIGIN
     );
     const rscRes = await handler(new Request(rscUrl));
-    if (rscRes.status !== 200) {
+    if (rscRes.status !== 200 || !rscRes.body) {
       throw new Error(
         `[transport:webpack] freezing ${route} rsc failed (${rscRes.status})`
       );
     }
-    await writeFile(join(dir, rscName), await rscRes.text());
+    await fileWriter(
+      Readable.fromWeb(rscRes.body as import("node:stream/web").ReadableStream),
+      "rsc",
+      { ...writerOptions, route }
+    );
   }
+  const duration = Math.round(performance.now() - renderStart);
+
   if (userOptions.onMetrics) {
     userOptions.onMetrics({
       route: "*",
-      type: "edge-bake",
-      kind: "producer",
-      outputPath: staticDir,
-      moduleCount: routes.length,
-      bakeTime: performance.now() - bakeStart,
-      description: `froze ${routes.length} route snapshot(s) through the baked pair`,
+      type: "ssg-render",
+      pages: routes.length,
+      failed: 0,
+      renderTime: duration,
+      description: "static render pass",
     });
   } else {
-    logger.info(
-      `[transport:webpack] froze ${routes.length} route snapshot(s) through the baked pair → ${staticDir}`
-    );
+    logger.info(`Rendered ${routes.length} pages in ${duration}ms`);
+  }
+
+  // Keep build.pages authoritative, same as the esm pass: drop Vite's bare
+  // index.html template when no page claims "/".
+  await pruneUnclaimedEntryHtml({
+    build: userOptions.build,
+    projectRoot: userOptions.projectRoot,
+    pages: [...routes],
+    logger,
+    verbose: userOptions.verbose,
+  });
+
+  // No inline-flight pass on purpose: the pair's documents already carry
+  // their own inline flight.
+
+  if (typeof userOptions.onEvent === "function") {
+    try {
+      const r = userOptions.onEvent({
+        type: "build.ssg.end",
+        data: {
+          pages: [...routes],
+          options: null as any,
+          bundle: {} as any,
+        },
+      });
+      if (r != null && typeof r === "object" && "then" in r) {
+        await (r as Promise<any>);
+      }
+    } catch (error) {
+      if (error != null) {
+        throw error;
+      } else {
+        throw new Error("Failed to emit build.ssg.end event");
+      }
+    }
   }
 }

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -877,6 +877,26 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
 
   // Return resolved options
   try {
+    // transport:"webpack" contracts the whole build around the baked pair:
+    // the esm SSG pass is skipped and the freeze IS the SSG backend. A config
+    // that disables the bake (or pins it to esm) would silently produce no
+    // snapshots at all — refuse it at config time instead.
+    if (options.transport === "webpack" && !build.edge.enabled) {
+      throw new Error(
+        '[vite-plugin-react-server] transport:"webpack" requires the edge ' +
+          "bake (build.edge) — the static snapshots render through the baked " +
+          'pair. Remove `build.edge: false` or use transport:"esm".'
+      );
+    }
+    if (options.transport === "webpack" && build.edge.transport !== "webpack") {
+      throw new Error(
+        '[vite-plugin-react-server] transport:"webpack" conflicts with ' +
+          `build.edge.transport:"${build.edge.transport}" — one deploy ` +
+          "carries one flight flavor. Drop the edge override (the global " +
+          "transport already defaults it) or align the two."
+      );
+    }
+
     const userOptions: ResolvedUserOptions = {
       projectRoot,
       transport: options.transport ?? "esm",

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -770,7 +770,14 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
         enabled: edge === false ? false : true,
         outDir: obj.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir,
         minify: obj.minify ?? DEFAULT_CONFIG.BUILD.edge.minify,
-        transport: obj.transport ?? DEFAULT_CONFIG.BUILD.edge.transport,
+        // The global transport defaults the bake's flavor: transport:"webpack"
+        // needs a webpack pair to freeze snapshots through. An explicit
+        // edge.transport still wins.
+        transport:
+          obj.transport ??
+          (options.transport === "webpack"
+            ? "webpack"
+            : DEFAULT_CONFIG.BUILD.edge.transport),
       };
     })(),
   } satisfies ResolvedUserOptions["build"];
@@ -872,6 +879,7 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   try {
     const userOptions: ResolvedUserOptions = {
       projectRoot,
+      transport: options.transport ?? "esm",
       moduleBase,
       moduleBasePath,
       moduleBaseURL,

--- a/plugin/dev-server/devPluginShared.ts
+++ b/plugin/dev-server/devPluginShared.ts
@@ -52,3 +52,32 @@ export function isClientModuleFile(file: string): boolean {
     return false;
   }
 }
+
+/**
+ * The dev document's transport hint, shared by both dev plugins.
+ *
+ * With transport:"webpack" the dev server produces webpack-flavored flight,
+ * and the (transport-agnostic) client entry picks its flight client off
+ * `self.__vprsFlightTransport` — the same inline hint the baked pair's
+ * documents carry (see createEdgeRequestHandler). Vite serves the dev
+ * document itself, so the hint rides in via transformIndexHtml; a classic
+ * inline script in <head> runs during parse, strictly before any module —
+ * the client entry can never read the flag too early.
+ *
+ * Returns undefined on the default esm transport: no tag, byte-for-byte
+ * today's document.
+ */
+export function devFlightTransportTags(
+  userOptions: Pick<import("../types.js").ResolvedUserOptions, "transport">
+):
+  | { tag: string; children: string; injectTo: "head-prepend" }[]
+  | undefined {
+  if (userOptions.transport !== "webpack") return undefined;
+  return [
+    {
+      tag: "script",
+      children: 'self.__vprsFlightTransport="webpack";',
+      injectTo: "head-prepend",
+    },
+  ];
+}

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -2,7 +2,7 @@ import type { VitePluginFn } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.client.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
-import { emptyAutoDiscoveredFiles, isClientModuleFile } from "./devPluginShared.js";
+import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags } from "./devPluginShared.js";
 import type { ConfigEnv } from "vite";
 
 
@@ -39,7 +39,13 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
     // that should work regardless of environment filtering
     config(_config, viteConfigEnv) {
       configEnv = viteConfigEnv;
-  
+
+    },
+    // transport:"webpack": stamp the dev document with the flight-transport
+    // hint so the browser picks the webpack flight client (dev/prod parity
+    // with the baked pair's documents). No-op on esm.
+    transformIndexHtml() {
+      return devFlightTransportTags(userOptions);
     },
     configureServer(server) {      
       // Log that plugin is being configured

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -3,7 +3,7 @@ import { configureReactServer } from "./configureReactServer.server.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
 import type { Plugin, ViteDevServer } from "vite";
-import { emptyAutoDiscoveredFiles, isClientModuleFile } from "./devPluginShared.js";
+import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags } from "./devPluginShared.js";
 
 /**
  * Dev server plugin for server environment.
@@ -27,6 +27,14 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
   const hmrPlugin = {
     name: "vite-plugin-react-server:server-hmr",
     apply: "serve" as const,
+    // transport:"webpack": stamp the dev document with the flight-transport
+    // hint so the browser picks the webpack flight client (dev/prod parity
+    // with the baked pair's documents). No-op on esm. Lives on this plugin
+    // (not the server-environment one) because the html transform runs
+    // outside the server environment filter.
+    transformIndexHtml() {
+      return devFlightTransportTags(userOptions);
+    },
     // Server-level handleHotUpdate — sends custom WS event to client
     // Vite 6 Environment API: hotUpdate runs per-environment.
     // Prevent server/ssr environments from triggering page reload for client components.

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -251,6 +251,22 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
             // optimize lazily. optimizeDeps is a no-op in build, so the real
             // index.html build entry is unaffected.
             entries: userConfig.optimizeDeps?.entries ?? [],
+            // transport:"webpack" (dev): the browser reaches the webpack
+            // flight client through a lazy import chain (createReactFetcher →
+            // rsl runtime → vendored CJS client), so on a cold cache Vite
+            // only discovers those deps mid-session — the re-optimize reload
+            // leaves a transient second React copy and one-off "Invalid hook
+            // call" errors on first load. Pre-declare them so the first
+            // optimizer pass bundles (and dedupes react across) the chain.
+            include: [
+              ...(userConfig.optimizeDeps?.include ?? []),
+              ...(consumer === "client" && userOptions.transport === "webpack"
+                ? [
+                    "react-server-loader/webpack/runtime",
+                    "react-server-loader/webpack/client",
+                  ]
+                : []),
+            ],
           },
           resolve: {
             ...userConfig.resolve,

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -403,6 +403,31 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
               projectRoot: userOptions.projectRoot,
               logger,
             });
+            // Step 6: transport:"webpack" — re-render the prerendered
+            // snapshots through the pair just baked, so the static surface
+            // carries the same flight flavor as the per-request path (one
+            // deploy may then serve any route from CDN or function).
+            if (
+              userOptions.transport === "webpack" &&
+              userOptions.build.edge.enabled &&
+              userOptions.build.edge.transport === "webpack"
+            ) {
+              const rawPages = userOptions.build.pages;
+              const routes: string[] = Array.isArray(rawPages)
+                ? rawPages
+                : typeof rawPages === "function"
+                ? await (rawPages as () => Promise<string[]> | string[])()
+                : await rawPages;
+              const { freezeStaticSnapshots } = await import(
+                "../bundle/freezeStaticSnapshots.js"
+              );
+              await freezeStaticSnapshots({
+                userOptions,
+                projectRoot: userOptions.projectRoot,
+                routes,
+                logger,
+              });
+            }
           },
         },
       };

--- a/plugin/react-static/plugin.client.ts
+++ b/plugin/react-static/plugin.client.ts
@@ -342,6 +342,18 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
         return;
       }
 
+      // transport:"webpack" — every artifact renders once, in its flavor.
+      // The esm SSG pass is skipped entirely; freezeStaticSnapshots renders
+      // the snapshots through the baked pair after the edge bake and owns the
+      // SSG contract (build.ssg.* events, file writes, ssg-render metric,
+      // prune) from there.
+      if (userOptions.transport === "webpack") {
+        logger?.info(
+          "[react-static-client] transport:webpack — snapshots render through the baked pair, skipping the esm SSG pass"
+        );
+        return;
+      }
+
       // Defer static generation to run after ALL environments complete their builds.
       // This is necessary because we need the server manifest (from server env's writeBundle)
       // to resolve function-based component paths like Root: (url) => 'src/CustomRoot.tsx'.

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -364,6 +364,18 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
           return;
         }
 
+        // transport:"webpack" — every artifact renders once, in its flavor.
+        // The esm SSG pass is skipped entirely; freezeStaticSnapshots renders
+        // the snapshots through the baked pair after the edge bake and owns
+        // the SSG contract (build.ssg.* events, file writes, ssg-render
+        // metric, prune) from there.
+        if (userOptions.transport === "webpack") {
+          logger?.info(
+            "[plugin.server] transport:webpack — snapshots render through the baked pair, skipping the esm SSG pass"
+          );
+          return;
+        }
+
         const serializedUserOptions = serializedOptions(
           userOptions,
           autoDiscoveredFiles!

--- a/plugin/stream/createRenderToPipeableStreamHandler.server.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.server.ts
@@ -1,5 +1,6 @@
 import { createElementWithReact } from "../helpers/createElementWithReact.js";
-import { React, ReactDOMServer, getVendoredRendererMode } from "../vendor/vendor.server.js";
+import { React } from "../vendor/vendor.server.js";
+import { resolveFlightRenderer } from "./flightRenderer.server.js";
 import { assertRendererElementParity } from "../utils/assertRendererElementParity.js";
 import { assertReactServer } from "../config/getCondition.js";
 import { handleError } from "../error/handleError.js";
@@ -251,21 +252,17 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
           );
         }
 
-        // Touch the renderer BEFORE the parity check: the vendored module
-        // loads lazily on first property access, and the check needs its
-        // resolved dev/prod mode.
-        const renderToPipeableStream = ReactDOMServer.renderToPipeableStream;
+        // Resolving the renderer touches the vendored module BEFORE the
+        // parity check: it loads lazily on first property access, and the
+        // check needs its resolved dev/prod mode.
+        const renderer = resolveFlightRenderer(handlerOptions);
         assertRendererElementParity(
           element,
-          getVendoredRendererMode(),
+          renderer.getLoadedMode(),
           `createRscStream:${route}`
         );
 
-        result = renderToPipeableStream(
-          element,
-          handlerOptions.moduleBasePath || "",
-          pipeableStreamOptions
-        );
+        result = renderer.render(element, pipeableStreamOptions);
       } catch (rawError) {
         const error = augmentClientReferenceError(rawError);
         if (verbose) {

--- a/plugin/stream/flightRenderer.server.ts
+++ b/plugin/stream/flightRenderer.server.ts
@@ -1,0 +1,53 @@
+import {
+  ReactDOMServer,
+  ReactDOMServerWebpack,
+  getVendoredRendererMode,
+  getVendoredWebpackRendererMode,
+} from "../vendor/vendor.server.js";
+import { createPassthroughClientManifest } from "./webpackDevClientManifest.js";
+import type { RendererMode } from "../vendor/lazyVendorModule.js";
+
+/**
+ * Pick the flight renderer for the configured transport — the ONE seam where
+ * the two flavors differ on the server: esm's renderToPipeableStream takes
+ * `(element, moduleBasePath, options)`, webpack's takes
+ * `(element, clientManifest, options)`. Every server flight-render site
+ * resolves through here so the swap can't drift between them.
+ *
+ * The returned `render` closes over the second argument: `moduleBasePath`
+ * for esm (today's behavior, byte-for-byte), a pass-through dev manifest for
+ * webpack (dev needs no sealing — ids resolve to their own Vite-served URLs;
+ * see webpackDevClientManifest.ts). Accessing the renderer here also triggers
+ * the lazy vendored load, so callers can run their element/renderer parity
+ * check against `getLoadedMode()` right after, same as before.
+ */
+export function resolveFlightRenderer(options: {
+  transport?: "esm" | "webpack";
+  moduleBasePath?: string;
+  moduleBaseURL?: string;
+}): {
+  render: (element: unknown, streamOptions: unknown) => any;
+  getLoadedMode: () => RendererMode | null;
+} {
+  if (options.transport === "webpack") {
+    const renderToPipeableStream = ReactDOMServerWebpack.renderToPipeableStream;
+    const clientManifest = createPassthroughClientManifest(
+      options.moduleBaseURL || "/"
+    );
+    return {
+      render: (element, streamOptions) =>
+        renderToPipeableStream(element, clientManifest, streamOptions as any),
+      getLoadedMode: getVendoredWebpackRendererMode,
+    };
+  }
+  const renderToPipeableStream = ReactDOMServer.renderToPipeableStream;
+  return {
+    render: (element, streamOptions) =>
+      renderToPipeableStream(
+        element as any,
+        options.moduleBasePath || "",
+        streamOptions as any
+      ),
+    getLoadedMode: getVendoredRendererMode,
+  };
+}

--- a/plugin/stream/renderRscStream.server.ts
+++ b/plugin/stream/renderRscStream.server.ts
@@ -5,7 +5,7 @@ import { createStreamMetrics } from "../metrics/createStreamMetrics.js";
 import { createReactElement } from "../helpers/createRscRenderHelpers.server.js";
 import { checkReactVersion } from "../utils/checkReactVersion.js";
 import { assertRendererElementParity } from "../utils/assertRendererElementParity.js";
-import { ReactDOMServer, getVendoredRendererMode } from "../vendor/vendor.server.js";
+import { resolveFlightRenderer } from "./flightRenderer.server.js";
 import type { StreamHandlers } from "../worker/types.js";
 
 
@@ -82,20 +82,19 @@ export function renderRscStream(
     
     checkReactVersion();
 
-    // Touch the renderer BEFORE the parity check: the vendored module loads
-    // lazily on first property access, and the check needs its resolved
-    // dev/prod mode.
-    const renderToPipeableStream = ReactDOMServer.renderToPipeableStream;
+    // Resolving the renderer touches the vendored module BEFORE the parity
+    // check: it loads lazily on first property access, and the check needs
+    // its resolved dev/prod mode.
+    const renderer = resolveFlightRenderer(options);
     assertRendererElementParity(
       reactElement,
-      getVendoredRendererMode(),
+      renderer.getLoadedMode(),
       `renderRscStream:${route}`
     );
 
     // Render React to stream - let it flow naturally like the RSC worker
-    const reactStream = renderToPipeableStream(
+    const reactStream = renderer.render(
       reactElement,
-      options.moduleBasePath || "",
       {
         ...options.serverPipeableStreamOptions,
         onError: (error: unknown) => {

--- a/plugin/stream/renderRscStreamHelpers.server.ts
+++ b/plugin/stream/renderRscStreamHelpers.server.ts
@@ -1,6 +1,6 @@
 import { PassThrough } from "node:stream";
 import type { CreateHandlerOptions } from "../types.js";
-import { ReactDOMServer } from "../vendor/vendor.server.js";
+import { resolveFlightRenderer } from "./flightRenderer.server.js";
 import type { StreamHandlers } from "../worker/types.js";
 import type { RenderToPipeableStreamOptions } from "react-server-dom-esm/server.node";
 
@@ -50,9 +50,8 @@ export function createReactStream(
     logger?.info(`[createReactStream:${route}] Creating React stream for element`);
   }
 
-  const { pipe } = ReactDOMServer.renderToPipeableStream(
+  const { pipe } = resolveFlightRenderer(options).render(
     element,
-    options.moduleBasePath || "",
     streamOptions
   );
 

--- a/plugin/stream/webpackDevClientManifest.ts
+++ b/plugin/stream/webpackDevClientManifest.ts
@@ -1,0 +1,52 @@
+/**
+ * The pass-through CLIENT manifest for producing a webpack-transport flight
+ * in dev — the producer-side sibling of `createPassthroughConsumerManifest`.
+ *
+ * In a build, the webpack renderer resolves each client reference against the
+ * baked manifest (hosted id → { id, chunks, name }, see
+ * bundle/clientManifest.ts). Dev has no bundler manifest and needs no
+ * sealing: the transform registers references under their source-relative
+ * module id (`src/Foo.client.tsx`), and the Vite dev server serves exactly
+ * that path — so the manifest is a Proxy that maps any id to its own dev URL.
+ *
+ * The reference row then carries the dev URL as both the module id and its
+ * single chunk. The runtime preloads every listed chunk before the sync
+ * require (see rsl's installWebpackGlobals contract), so the browser's load
+ * callback (`chunk => import(chunk)`, passed by createReactFetcher) fetches
+ * the module from Vite and the require reads it back from the runtime's
+ * cache. Nothing is composed from payload input beyond prefixing the base —
+ * and dev, unlike prod, serves the whole source tree anyway.
+ */
+
+type ClientManifestEntry = { id: string; chunks: string[]; name: string };
+
+/**
+ * @param moduleBaseURL the browser-facing base the dev server serves modules
+ *                      under (userOptions.moduleBaseURL, "/" in a plain dev
+ *                      setup) — the same base the esm client resolves ids
+ *                      against.
+ */
+export function createPassthroughClientManifest(
+  moduleBaseURL: string
+): Record<string, ClientManifestEntry> {
+  const base = moduleBaseURL.replace(/\/$/, "");
+  const toDevUrl = (id: string): string =>
+    id.startsWith("/") ? id : base + "/" + id;
+  return new Proxy(
+    {},
+    {
+      get: (_target, key: string | symbol): ClientManifestEntry | undefined => {
+        if (typeof key !== "string") return undefined;
+        // The transport tries the FULL `$$id` ("path#export") first and only
+        // splits off the export name on a miss. Answering the full id would
+        // ship the entry's empty `name` and the browser would resolve the
+        // module namespace instead of the export — so miss on purpose, like
+        // the baked manifest's per-module keys do, and let the transport's
+        // fallback carry the export name through.
+        if (key.includes("#")) return undefined;
+        const url = toDevUrl(key);
+        return { id: url, chunks: [url], name: "" };
+      },
+    }
+  );
+}

--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -157,11 +157,30 @@ export const createTransformerPlugin = (
         // CRITICAL: Re-resolve options with runtime mode to get correct importServerPath
         // This ensures test mode uses react-server-dom-esm/server.node instead of server
         // Force re-resolve to avoid cached moduleID functions from different build contexts
+        //
+        // transport:"webpack" swaps the registration import IN DEV ONLY: dev
+        // evaluates the transformed modules live, so the emitted register*
+        // import must come from the webpack server entry for the references
+        // to be webpack-shaped ($$id "path#name"). Builds keep the bare esm
+        // specifier — dist artifacts stay transport-agnostic and the edge
+        // bake re-transports the whole graph with one alias (buildEdgeBundle).
+        const devTransportLoader =
+          config.command === "serve" && userOptions.transport === "webpack"
+            ? {
+                importServerPath:
+                  userOptions.loader?.importServerPath ??
+                  "react-server-loader/webpack/server",
+                importClientPath:
+                  userOptions.loader?.importClientPath ??
+                  "react-server-loader/webpack/server",
+              }
+            : {};
         const runtimeOptionsResult = resolveOptions({
           ...userOptions,
           loader: {
             ...userOptions.loader,
             mode: mode,
+            ...devTransportLoader,
           },
         }, true); // Force resolve to bypass cache
         if (runtimeOptionsResult.type === "success") {

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -399,10 +399,12 @@ export type ResolvedUserOptions = {
   projectRoot: string;
   /**
    * The deploy's RSC flight flavor. "esm" (default) — today's behavior.
-   * "webpack" — the static snapshots are re-rendered through the baked pair
+   * "webpack" — every artifact renders once, in that flavor: the esm SSG
+   * pass is skipped and the static snapshots render through the baked pair
    * after the edge bake, so every surface (CDN snapshots, per-request
    * handler, browser client) carries ONE flavor and routes may be served
-   * from either without cross-flavor decode failures.
+   * from either without cross-flavor decode failures. The dev server renders
+   * webpack flight too — dev and prod parity, no caveats.
    */
   transport: "esm" | "webpack";
   moduleBase: string;
@@ -710,10 +712,12 @@ export interface StreamPluginOptions<
 > {
   projectRoot?: string; // defaults to process.cwd()
   /**
-   * The deploy's RSC flight flavor. Default "esm". With "webpack" the
-   * prerendered snapshots are re-rendered through the baked pair (requires
-   * build.edge with transport "webpack", which this option defaults for
-   * you), giving one flavor across CDN + per-request + browser.
+   * The deploy's RSC flight flavor. Default "esm". With "webpack" every
+   * artifact renders once in the webpack flavor: the prerendered snapshots
+   * render through the baked pair (requires build.edge with transport
+   * "webpack", which this option defaults for you) and the dev server
+   * serves webpack flight — one flavor across dev + CDN + per-request +
+   * browser.
    */
   transport?: "esm" | "webpack";
   moduleBase: string; // defaults to 'src'
@@ -1065,6 +1069,13 @@ export type CreateHandlerOptions<
 > & {
   id?: string;
   /**
+   * The deploy's RSC flight flavor (see {@link ResolvedUserOptions.transport}).
+   * The server flight-render sites read it to pick the renderer pair: esm
+   * renders against `moduleBasePath`, webpack against a client manifest.
+   * Optional so hand-built handler options stay valid; absent means "esm".
+   */
+  transport?: "esm" | "webpack";
+  /**
    * Params parsed from the request url against the matched route pattern
    * (`/profile/123` → `{ id: "123" }`). Passed to a loader as
    * `props(url, { params, request })`. When absent, vprs derives it from
@@ -1340,7 +1351,7 @@ export type EdgeBuildConfig = {
    * fetched .rsc of the other flavor cannot be decoded). Either serve every
    * route through the edge bundle and drop the snapshots from serving (the
    * prepare-vercel pattern), or set the TOP-LEVEL `transport: "webpack"` —
-   * which defaults this field and re-renders the snapshots through the baked
+   * which defaults this field and renders the snapshots through the baked
    * pair, so both surfaces agree and any route may be served from either.
    * @default "esm" (or the top-level `transport` when set)
    */

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -397,6 +397,14 @@ export type PanicThreshold = "none" | "critical_errors" | "all_errors";
 export type ResolvedUserOptions = {
   // Core required properties
   projectRoot: string;
+  /**
+   * The deploy's RSC flight flavor. "esm" (default) — today's behavior.
+   * "webpack" — the static snapshots are re-rendered through the baked pair
+   * after the edge bake, so every surface (CDN snapshots, per-request
+   * handler, browser client) carries ONE flavor and routes may be served
+   * from either without cross-flavor decode failures.
+   */
+  transport: "esm" | "webpack";
   moduleBase: string;
   moduleBasePath: string;
   moduleBaseURL: string;
@@ -701,6 +709,13 @@ export interface StreamPluginOptions<
   Interface extends ViteReactServerComponentsPlugin = DefaultInterface
 > {
   projectRoot?: string; // defaults to process.cwd()
+  /**
+   * The deploy's RSC flight flavor. Default "esm". With "webpack" the
+   * prerendered snapshots are re-rendered through the baked pair (requires
+   * build.edge with transport "webpack", which this option defaults for
+   * you), giving one flavor across CDN + per-request + browser.
+   */
+  transport?: "esm" | "webpack";
   moduleBase: string; // defaults to 'src'
   moduleBasePath?: string; // defaults to ''
   moduleBaseURL?: string; // defaults to '/'
@@ -1320,13 +1335,14 @@ export type EdgeBuildConfig = {
    * its handler cannot disagree.
    *
    * Do NOT mix transports across one deploy's routes: prerendered snapshots
-   * (SSG html / inlined flight / .rsc files) are esm-encoded, so serving them
-   * next to webpack-encoded dynamic routes breaks client-side navigation
-   * BETWEEN the two flavors (the browser picks its flight client per
-   * document, but a fetched .rsc of the other flavor cannot be decoded).
-   * With "webpack", serve every route through the edge bundle and drop the
-   * prerendered snapshots from serving (the prepare-vercel pattern).
-   * @default "esm"
+   * are esm-encoded by default, so serving them next to webpack-encoded
+   * dynamic routes breaks client-side navigation BETWEEN the two flavors (a
+   * fetched .rsc of the other flavor cannot be decoded). Either serve every
+   * route through the edge bundle and drop the snapshots from serving (the
+   * prepare-vercel pattern), or set the TOP-LEVEL `transport: "webpack"` —
+   * which defaults this field and re-renders the snapshots through the baked
+   * pair, so both surfaces agree and any route may be served from either.
+   * @default "esm" (or the top-level `transport` when set)
    */
   transport?: "esm" | "webpack";
 };

--- a/plugin/vendor/vendor.server.ts
+++ b/plugin/vendor/vendor.server.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import { join } from "node:path";
-import { transportPkgDir } from "./transportDir.js";
+import { transportPkgDir, transportRoot } from "./transportDir.js";
 import {
   createLazyVendorModule,
   reactPairedMode,
@@ -43,6 +43,40 @@ if (!hasReactServerCondition()) {
 
 /** dev/prod variant the vendored RSC renderer resolved to (null until first use). */
 export const getVendoredRendererMode = lazyServer.getLoadedMode;
+
+// The webpack-flavored server renderer, for transport:"webpack". Same lazy
+// discipline as the esm module above (the vendored CJS branches on NODE_ENV
+// at require time). Resolved through react-server-loader's own exports map
+// ("./webpack/server" → the vendored react-server-dom-webpack server.node),
+// via a require anchored at the rsl package so self-name resolution works
+// whether rsl is a real install, hoisted, or symlinked. Its
+// renderToPipeableStream takes (element, clientManifest, options) — a client
+// manifest where the esm renderer takes moduleBasePath.
+const rslRequire = createRequire(join(transportRoot, "package.json"));
+
+const lazyWebpackServer = createLazyVendorModule(
+  () =>
+    rslRequire("react-server-loader/webpack/server") as WebpackServerModule,
+  reactPairedMode,
+  () => vendoredTransportModeFromCache("react-server-dom-webpack-server.node")
+);
+
+type WebpackServerModule = {
+  renderToPipeableStream: (
+    element: unknown,
+    clientManifest: unknown,
+    options?: unknown
+  ) => { pipe: <T>(destination: T) => T; abort: (reason?: unknown) => void };
+  registerClientReference: (...args: unknown[]) => unknown;
+  registerServerReference: (...args: unknown[]) => unknown;
+  decodeReply: (...args: unknown[]) => unknown;
+  decodeAction: (...args: unknown[]) => unknown;
+};
+
+export const ReactDOMServerWebpack = lazyWebpackServer.proxy;
+
+/** dev/prod variant the webpack renderer resolved to (null until first use). */
+export const getVendoredWebpackRendererMode = lazyWebpackServer.getLoadedMode;
 
 // React still comes from the consumer's project. ALSO LAZY: under
 // --conditions react-server the consumer react's CJS entry branches on

--- a/plugin/worker/rsc/handleRscRender.server.ts
+++ b/plugin/worker/rsc/handleRscRender.server.ts
@@ -5,9 +5,9 @@ import type { HandleRscRenderFn } from "./types.js";
 import { createLogger } from "vite";
 import {
   React,
-  ReactDOMServer,
   type RenderToPipeableStreamOptions,
 } from "../../vendor/vendor.server.js";
+import { resolveFlightRenderer } from "../../stream/flightRenderer.server.js";
 import { createElementWithReact } from "../../helpers/createElementWithReact.js";
 import { checkReactVersion } from "../../utils/checkReactVersion.js";
 /**
@@ -79,6 +79,16 @@ export const handleRscRender: HandleRscRenderFn = function _handleRscRender(
       globalCss: handlerOptions["globalCss"] || new Map(),
       manifest: handlerOptions["manifest"] || {},
       ...handlerOptions,
+      // The per-message handler options don't carry the plugin-level
+      // transport config — default the renderer flavor (and the manifest
+      // base it derives dev URLs from) from the worker's serialized user
+      // options, or a transport:"webpack" dev worker would silently render
+      // esm flight against a webpack-hydrated document. Placed after the
+      // spread: an absent key must not shadow the worker-level value.
+      transport:
+        handlerOptions["transport"] ?? workerData.userOptions.transport,
+      moduleBaseURL:
+        handlerOptions["moduleBaseURL"] ?? workerData.userOptions.moduleBaseURL,
     };
     if (reuseHeadlessStreamId && headlessStreamElements) {
       const reusableData = headlessStreamElements.get(reuseHeadlessStreamId);
@@ -276,9 +286,8 @@ export const handleRscRender: HandleRscRenderFn = function _handleRscRender(
     }
 
     checkReactVersion();
-    const { pipe } = ReactDOMServer.renderToPipeableStream(
+    const { pipe } = resolveFlightRenderer(finalHandlerOptions).render(
       element,
-      finalHandlerOptions.moduleBasePath,
       serverPipeableStreamOptions
     );
 

--- a/test/examples/transport-webpack-build.test.ts
+++ b/test/examples/transport-webpack-build.test.ts
@@ -9,16 +9,23 @@ import { resolve } from "node:path";
 
 /**
  * transport: "webpack" — the static snapshots must carry the webpack flight
- * flavor, not esm. The freeze step re-renders every enumerated route through
- * the baked pair after the edge bake, so one deploy can serve any route from
- * the CDN or the per-request handler without cross-flavor decode failures.
+ * flavor, not esm, and every artifact must render ONCE, in that flavor: the
+ * esm SSG pass is skipped and the post-bake freeze IS the SSG pass, so one
+ * deploy can serve any route from the CDN or the per-request handler without
+ * cross-flavor decode failures.
  *
  * The flavor is directly observable in the payload: webpack references are
  * `I["<id>",[chunks],"<name>"]` rows; esm references are bare module-path
- * strings with no chunk array.
+ * strings with no chunk array. The single render is observable in the event
+ * and metric streams: exactly one build.ssg.start/end pair, exactly one
+ * ssg-render summary, and one file.write.done per artifact — consumers must
+ * not be able to tell the renderer changed.
  */
 const testDir = resolve(__dirname, "../fixtures/transport-webpack/shared");
 const OUT_DIR = "dist-transport-webpack";
+
+const events: { type: string; route?: string; fileType?: string }[] = [];
+const ssgMetrics: { pages: number; failed: number }[] = [];
 
 describe("transport: webpack — snapshots frozen through the baked pair", () => {
   beforeAll(async () => {
@@ -43,6 +50,24 @@ describe("transport: webpack — snapshots frozen through the baked pair", () =>
           ...testUserOptions.build,
           pages: ["/", "/page2"],
           outDir: OUT_DIR,
+        },
+        onEvent: (event: any) => {
+          if (
+            event.type === "build.ssg.start" ||
+            event.type === "build.ssg.end" ||
+            event.type === "file.write.done"
+          ) {
+            events.push({
+              type: event.type,
+              route: event.data?.route,
+              fileType: event.data?.fileType,
+            });
+          }
+        },
+        onMetrics: (metrics: any) => {
+          if (metrics.type === "ssg-render") {
+            ssgMetrics.push({ pages: metrics.pages, failed: metrics.failed });
+          }
         },
       }),
     });
@@ -84,5 +109,31 @@ describe("transport: webpack — snapshots frozen through the baked pair", () =>
       // The frozen document hydrates from its inline flight.
       expect(html).toContain("vprs-flight");
     }
+  });
+
+  it("renders every artifact once — the freeze IS the SSG pass", () => {
+    // Exactly one SSG lifecycle, owned by the freeze: were the esm pass
+    // still running, a second start/end pair (and a second metric) would
+    // appear before the bake.
+    expect(events.filter((e) => e.type === "build.ssg.start")).toHaveLength(1);
+    expect(events.filter((e) => e.type === "build.ssg.end")).toHaveLength(1);
+    expect(ssgMetrics).toEqual([{ pages: 2, failed: 0 }]);
+
+    // One write per artifact, through the same fileWriter contract the esm
+    // pass uses — html + rsc per route, nothing written twice.
+    const writes = events
+      .filter((e) => e.type === "file.write.done")
+      .map((e) => `${e.route}:${e.fileType}`)
+      .sort();
+    expect(writes).toEqual(["/:html", "/:rsc", "/page2:html", "/page2:rsc"]);
+
+    // And the lifecycle brackets the writes.
+    const types = events.map((e) => e.type);
+    expect(types.indexOf("build.ssg.start")).toBeLessThan(
+      types.indexOf("file.write.done")
+    );
+    expect(types.lastIndexOf("file.write.done")).toBeLessThan(
+      types.indexOf("build.ssg.end")
+    );
   });
 });

--- a/test/examples/transport-webpack-build.test.ts
+++ b/test/examples/transport-webpack-build.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createBuilder } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { setupTestProject } from "../setup.js";
+import { ensureFixture, hashSetupFn } from "./fixture-cache.js";
+import { testUserOptions } from "../test-config.js";
+import { readFile as readFileFs, readFile, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+
+/**
+ * transport: "webpack" — the static snapshots must carry the webpack flight
+ * flavor, not esm. The freeze step re-renders every enumerated route through
+ * the baked pair after the edge bake, so one deploy can serve any route from
+ * the CDN or the per-request handler without cross-flavor decode failures.
+ *
+ * The flavor is directly observable in the payload: webpack references are
+ * `I["<id>",[chunks],"<name>"]` rows; esm references are bare module-path
+ * strings with no chunk array.
+ */
+const testDir = resolve(__dirname, "../fixtures/transport-webpack/shared");
+const OUT_DIR = "dist-transport-webpack";
+
+describe("transport: webpack — snapshots frozen through the baked pair", () => {
+  beforeAll(async () => {
+    const setupSource = await readFileFs(resolve(__dirname, "../setup.ts"), "utf-8");
+    await ensureFixture(testDir, setupTestProject, hashSetupFn(setupTestProject, [setupSource]));
+
+    // The build output must come from THIS run — a stale passing artifact
+    // would satisfy the assertions even if the freeze regressed.
+    await rm(resolve(testDir, OUT_DIR), { recursive: true, force: true });
+
+    const { moduleBaseURL: _explicitBase, onMetrics: _metrics, ...pluginOptions } =
+      testUserOptions;
+
+    const builder = await createBuilder({
+      mode: "test",
+      root: testDir,
+      plugins: vitePluginReactServer({
+        ...pluginOptions,
+        transport: "webpack",
+        projectRoot: testDir,
+        build: {
+          ...testUserOptions.build,
+          pages: ["/", "/page2"],
+          outDir: OUT_DIR,
+        },
+      }),
+    });
+    await builder.buildApp();
+  }, 180_000);
+
+  afterAll(async () => {
+    await rm(resolve(testDir, OUT_DIR), { recursive: true, force: true });
+  });
+
+  it("defaults the edge bake to the webpack pair", async () => {
+    const render = await readFile(
+      resolve(testDir, OUT_DIR, "server-edge", "render.js"),
+      "utf-8"
+    );
+    expect(render.length).toBeGreaterThan(0);
+    // The consumer half only exists on the webpack transport.
+    const consumer = await readFile(
+      resolve(testDir, OUT_DIR, "server-edge", "consumer.js"),
+      "utf-8"
+    );
+    expect(consumer.length).toBeGreaterThan(0);
+  });
+
+  it("freezes webpack-flavored snapshots for every route", async () => {
+    for (const route of ["", "page2"]) {
+      const rsc = await readFile(
+        resolve(testDir, OUT_DIR, "static", route, "index.rsc"),
+        "utf-8"
+      );
+      // Webpack reference rows carry a chunk array: I["<id>",[...],"<name>"].
+      expect(rsc).toMatch(/I\["[^"]+",\[[^\]]*\],"[^"]+"\]/);
+      // And no esm-flavored reference remains (esm rows have no chunk array).
+      const html = await readFile(
+        resolve(testDir, OUT_DIR, "static", route, "index.html"),
+        "utf-8"
+      );
+      expect(html).toContain("<html");
+      // The frozen document hydrates from its inline flight.
+      expect(html).toContain("vprs-flight");
+    }
+  });
+});


### PR DESCRIPTION
`transport: "webpack"` makes the whole deploy — the dev server included — carry one flight flavor. `"esm"` (the default) is byte-for-byte today's behavior; mmc-shaped static sites change nothing.

**Build — every artifact renders once, in its flavor.** The option defaults the edge bake to the webpack pair, the esm SSG pass is skipped, and each enumerated route's `index.html`/`index.rsc` renders **through that pair** — the same producer + consumer a deployed handler runs. One deploy may then serve any route from the CDN or the per-request handler interchangeably; the browser client, inline flight, and fetched `.rsc` payloads all agree. The pair render owns the SSG pass's full contract — `build.ssg.start`/`end`, per-route `file.write`/`file.write.done` through the same fileWriter (degraded-document guard included), the `ssg-render` summary metric, and the unclaimed-entry-html prune — so `onEvent`/`onMetrics` consumers cannot tell the renderer changed. There is no inline-flight pass: pair documents carry their own inline flight.

**Dev — the dev server renders webpack flight live.** The transports differ at exactly one server seam (`renderToPipeableStream(element, moduleBasePath, opts)` vs `(element, clientManifest, opts)`), so every flight-render site resolves through one `resolveFlightRenderer` helper. Dev needs no sealing: the client manifest is a pass-through Proxy mapping each reference to its own Vite-served URL, consumed by the browser's existing chunk loader. The transform's registration import comes from `react-server-loader/webpack/server` in dev only — builds keep the bare esm specifier, so dist artifacts stay transport-agnostic and the bake re-transports the graph with one alias. The dev document carries the same `self.__vprsFlightTransport` hint a baked document does. Both dev orchestrators are covered (main-thread and RSC-worker rendering).

**Config guards.** `transport:"webpack"` with `build.edge: false`, or with an explicit esm edge override, is refused at config time — the pair render is the snapshot renderer, so a bake-less webpack build would otherwise silently emit nothing.

Per-mode policy is ordinary JavaScript — `transport: process.env.NODE_ENV === "production" ? "webpack" : "esm"` is legitimate; dev and production are separate, internally coherent sessions (docs: Configuration → Transport).

Hand-mixing flavors within one deploy stays unsupportable, and that is the point of the option: an esm-hydrated document cannot decode a webpack `.rsc` and vice versa (measured on the deployed starter — React #306 one direction, the `installWebpackGlobals` chunk failure the other). The edge option's jsdoc points at this option instead of only warning.

**Verified:**
- Regression test (two-route fixture, `transport: "webpack"`): webpack reference rows + inline flight in the frozen snapshots, consumer bundle present, and the single-render contract — exactly one `build.ssg.*` lifecycle, one `ssg-render` summary, one `file.write.done` per artifact, writes bracketed by the lifecycle.
- Starter served purely statically: four-scenario acceptance probe green (both cold loads, both nav directions, hydration + client-side nav, no console errors) — rsl 19.2.18.
- Starter in dev, both dev modes (main-thread `dev:rsc` and worker `dev`): document hint present, `/index.rsc` webpack-flavored off the dev server, live hydration and both nav directions decoding webpack flight, no console errors.
- Full `test-all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
