### PR TITLE
chore(release): 3.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for the transport release (#286): `transport: "esm" | "webpack"` — one flight flavor across every deploy surface, the dev server included, every artifact rendered once in its flavor.

Flow after merge: tag `v3.4.0` on main (prepublishOnly enforces it), then publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)