### PR TITLE
fix(dev): load in-page props on cached-Page renders in the rsc worker

### DIFF
--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -332,11 +332,14 @@ async function loadComponentsWithCache(options: {
         );
       }
 
-      if (propsPath && !resolvedPageProps) {
+      if (!resolvedPageProps) {
         // Props are intentionally NOT cached across requests — see comment
         // above. Drop any pre-existing cache entry from older versions, then
-        // fall through to the separate-load path below.
-        const propsId = `${propsPath}#${propsExportName}@${normalizedUrl}`;
+        // fall through to the separate-load path below. No propsPath gate:
+        // props may live in the page module itself (resolvePageAndProps falls
+        // back to pagePath), and gating on propsPath dropped those on every
+        // cached-Page render — first dev render had props, refresh lost them.
+        const propsId = `${propsPath || pagePath}#${propsExportName}@${normalizedUrl}`;
         if (hasCachedComponent(propsId)) {
           clearCachedComponent(propsId);
         }
@@ -360,8 +363,8 @@ async function loadComponentsWithCache(options: {
       }
       
       // Also clear props cache if page is invalidated
-      if (propsPath && isPageInvalidated) {
-        const propsId = `${propsPath}#${propsExportName}@${normalizedUrl}`;
+      if (isPageInvalidated) {
+        const propsId = `${propsPath || pagePath}#${propsExportName}@${normalizedUrl}`;
         if (hasCachedComponent(propsId)) {
           clearCachedComponent(propsId);
         }
@@ -446,8 +449,10 @@ async function loadComponentsWithCache(options: {
       }
     }
     
-    // If Page was cached but props for this URL weren't, load props separately
-    if (needToLoadProps && propsPath) {
+    // If Page was cached but props for this URL weren't, load props separately.
+    // Runs with propsPath undefined too: resolvePageAndProps then reads the
+    // props export off the page module.
+    if (needToLoadProps) {
       if (verbose) {
         logger?.info(
           `[rsc-worker] Loading props separately for URL: ${url} (Page was cached)`


### PR DESCRIPTION
## Problem

A route can keep its `props` loader in the page module itself instead of a sibling props file — `resolvePageAndProps` supports this by falling back to reading the props export off `pagePath` when `propsPath` is undefined.

In plain dev, that fallback only ran on the *first* render of a route. Every props-load site in the rsc worker was gated on `propsPath` being set, so as soon as the Page component was cached, props resolution was skipped and the route re-rendered with `undefined` props.

**Symptom:** a route with in-page props renders correctly on first visit and loses all of its props on refresh (empty title, missing loader data). Build, edge, and `dev:rsc` call the resolver unconditionally, so only the plain-dev worker path misbehaved.

## Fix

- Gate the separate props load on `!resolvedPageProps` instead of `propsPath && !resolvedPageProps`; `resolvePageAndProps` already handles the `propsPath: undefined` case.
- Key the (clear-only) props cache entries by `propsPath || pagePath` to match the resolver's fallback.

## Verification

- Reproduced against a starter app whose home route exports `props` from `page.tsx`: with registry 3.4.0, first dev load renders title + tagline, every refresh after that renders them empty. With this patch (packed tarball, clean install), first load, two hard reloads, and a navigate-away-and-back all render full props.
- Full test gate green under both conditions: 821 passed / 42 skipped (server), client suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrwSYkEhqJVtj2JmswhZAy