### PR TITLE
chore(release): 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release shipping #289: in-page props (no sibling props file) survive cached-Page renders in the plain-dev rsc worker. Before the fix, a route exporting `props` from `page.tsx` rendered correctly on first dev visit and lost all props on every refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)