### PR TITLE
test(dev): cover cached-Page re-renders across props patterns

### DIFF
--- a/test/dev/props-variations.test.ts
+++ b/test/dev/props-variations.test.ts
@@ -12,8 +12,10 @@ let server,
   port = 3103,
   pageURL,
   pageURL2,
+  pageURL3,
   response: RSCStreamResponse,
-  response2: RSCStreamResponse;
+  response2: RSCStreamResponse,
+  response3: RSCStreamResponse;
 const testDir = resolve(__dirname, "../fixtures/props-variations.test");
 
 // Capture every error/warn log the plugin emits during this test's lifecycle.
@@ -50,12 +52,18 @@ describe("RSC Server", () => {
           ...testUserOptions,
           projectRoot: testDir,
           Page: (id) =>
-            !id.includes('page2')
-              ? join("src", "page", "page.tsx")
-              : join("src", "page2", "page.tsx"),
-          props: undefined, // no props
+            id.includes('page3')
+              ? join("src", "page3", "page.tsx")
+              : id.includes('page2')
+                ? join("src", "page2", "page.tsx")
+                : join("src", "page", "page.tsx"),
+          // Mixed per-route props shapes, like a fileRouter project:
+          // "/" keeps its props loader in page.tsx (propsPath undefined),
+          // "/page2" has no props at all, "/page3" uses a sibling props file.
+          props: (id) =>
+            id.includes('page3') ? join("src", "page3", "props.ts") : undefined,
           build: {
-            pages: ["/", "/page2"],
+            pages: ["/", "/page2", "/page3"],
           },
         }),
       ],
@@ -72,8 +80,10 @@ describe("RSC Server", () => {
     }
     pageURL = `http://localhost:${port}/index.rsc`;
     pageURL2 = `http://localhost:${port}/page2/index.rsc`;
+    pageURL3 = `http://localhost:${port}/page3/index.rsc`;
     response = await handleRSCStream(pageURL);
     response2 = await handleRSCStream(pageURL2);
+    response3 = await handleRSCStream(pageURL3);
   });
 
   afterAll(async () => {
@@ -138,6 +148,43 @@ describe("RSC Server", () => {
     // Verify the response contains page content
     expect(response2.result).toContain("Home Page for");
     // Server environment shows undefined values as $undefined in RSC stream, which is expected
+  });
+
+  it("should handle props from a sibling props file", async () => {
+    expect(response3.ok).toBe(true);
+    expect(response3.statusCode).toBe(200);
+    expect(response3.result).toContain("Page3 Page");
+    expect(response3.result).toContain("sibling-props-loaded");
+  });
+
+  // The cached-Page re-render tests below re-request each route after its
+  // Page component is already cached in the rsc worker. Props are resolved
+  // on a separate path in that case, and the in-page pattern regressed there
+  // once (#289): first dev render had props, every refresh lost them. A
+  // single fetch per route cannot catch that class of bug.
+
+  it("in-page props survive a cached-Page re-render (refresh)", async () => {
+    expect(response.result).toContain("in-page-props-loaded");
+    const refreshed = await handleRSCStream(pageURL);
+    expect(refreshed.ok).toBe(true);
+    expect(refreshed.statusCode).toBe(200);
+    expect(refreshed.result).toContain("Home Page");
+    expect(refreshed.result).toContain("in-page-props-loaded");
+  });
+
+  it("sibling-file props survive a cached-Page re-render (refresh)", async () => {
+    const refreshed = await handleRSCStream(pageURL3);
+    expect(refreshed.ok).toBe(true);
+    expect(refreshed.statusCode).toBe(200);
+    expect(refreshed.result).toContain("Page3 Page");
+    expect(refreshed.result).toContain("sibling-props-loaded");
+  });
+
+  it("no-props route stays clean on a cached-Page re-render (refresh)", async () => {
+    const refreshed = await handleRSCStream(pageURL2);
+    expect(refreshed.ok).toBe(true);
+    expect(refreshed.statusCode).toBe(200);
+    expect(refreshed.result).toContain("Home Page for");
   });
 
   it("does not emit RSC render error logs for the sub-route request (bd-w4t regression)", () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -649,12 +649,13 @@ export async function setupTestProjectPropsVariations(testDir: string) {
     resolve(testDir, "src", "page", "page.tsx"),
     `import React from "react";
 export function props(){
-    return import.meta.env;
+    return {...import.meta.env, propsMarker: "in-page-props-loaded"};
 }
 export function Page(propsEnv) {
 return (
   <div>
     <h1>Home Page</h1>
+    <p>Marker: {propsEnv.propsMarker}</p>
     <p>Base URL: {propsEnv.BASE_URL}</p>
     <p>Public: {propsEnv.PUBLIC_ORIGIN}</p>
     <p>Mode: {import.meta.env.MODE}</p>
@@ -691,6 +692,28 @@ return (
     <p>SSR: {import.meta.env.SSR}</p>
     <p>URL: {import.meta.env.BASE_URL}</p>
     <p>Public Origin: {import.meta.env.PUBLIC_ORIGIN}</p>
+  </div>
+);
+}`
+  );
+  // Third pattern: props in a sibling props file (propsPath set), alongside
+  // the in-page-props and no-props routes above, so one server covers the
+  // mixed per-route shapes a fileRouter project can produce.
+  await mkdir(resolve(testDir, "src/page3"), { recursive: true });
+  await writeFile(
+    resolve(testDir, "src", "page3", "props.ts"),
+    `export function props() {
+  return { title: "Page3", propsMarker: "sibling-props-loaded" };
+}`
+  );
+  await writeFile(
+    resolve(testDir, "src", "page3", "page.tsx"),
+    `import React from "react";
+export function Page({ title, propsMarker }) {
+return (
+  <div>
+    <h1>{title + " Page"}</h1>
+    <p>Marker: {propsMarker}</p>
   </div>
 );
 }`


### PR DESCRIPTION
## Why

#289 fixed in-page props being dropped on cached-Page renders in the plain-dev rsc worker, but shipped without tests. The existing props-variations suite fetched each route exactly once, so the separate props-load path that runs when the Page component is already cached had zero coverage — which is how the bug regressed invisibly.

## What

- The fixture now covers the three per-route props shapes a project can mix: props exported from `page.tsx` itself (`propsPath` undefined), a sibling `props.ts`, and no props at all, using a per-route `props` function like a fileRouter would produce.
- Each route is re-fetched after its Page is cached, with marker strings that only render when props actually resolved.
- The existing no-error-logs assertion now runs after the re-fetches too.

## Verification

- With the #289 fix reverted and rebuilt, the new in-page cached-refresh test fails; everything else passes. Only the client condition exercises this path — under the react-server condition dev renders directly with no worker, so a server-condition-only run can never catch this class of bug.
- Full gate green under both conditions: 825 passed / 42 skipped (server), 258 passed / 12 skipped (client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)