### PR TITLE
fix(stream): stop RSC_END truncating data chunks still queued on the data port

### DIFF
--- a/plugin/stream/createRscWorkerStream.ts
+++ b/plugin/stream/createRscWorkerStream.ts
@@ -79,17 +79,26 @@ export function createRscWorkerStream(options: RscWorkerStreamOptions): {
     highWaterMark: 64 * 1024 // 64KB buffer
   });
   
+  // The data port's `null` signal is the only ordered end-of-stream authority
+  // (it queues behind every chunk on the same port). RSC_END arrives on the
+  // control port, and cross-port delivery order is NOT guaranteed — ending
+  // from RSC_END can truncate chunks still queued on the data port (notably
+  // the in-band `$E` frame after a render failure). RSC_END only ends the
+  // stream as a delayed fallback for a worker that died before posting `null`.
+  let dataEndedReceived = false;
+
   // Data port - ONLY for raw RSC stream data
   (dataPort1 as any).onmessage = (event: any) => {
     const data = event.data;
-    
+
     if (data === null) {
       // End of stream
       if (verbose) {
         logger?.info(`[createRscWorkerStream] End of RSC stream via dataPort`);
       }
+      dataEndedReceived = true;
       rscStream.end();
-      
+
       // Note: We don't close ports here - let the stream consumer manage port lifecycle
       // This ensures ReactDOMClient.createFromNodeStream() can fully consume the stream
     } else {
@@ -97,7 +106,9 @@ export function createRscWorkerStream(options: RscWorkerStreamOptions): {
       if (verbose) {
         logger?.info(`[createRscWorkerStream] Writing raw RSC data to stream: ${data.length} bytes`);
       }
-      rscStream.write(data);
+      if (!rscStream.writableEnded) {
+        rscStream.write(data);
+      }
     }
   };
   
@@ -114,7 +125,14 @@ export function createRscWorkerStream(options: RscWorkerStreamOptions): {
         if (verbose) {
           logger?.info(`[createRscWorkerStream] RSC stream ended by control message`);
         }
-        rscStream.end();
+        // See the dataEndedReceived note above: only a fallback end.
+        if (!dataEndedReceived) {
+          setTimeout(() => {
+            if (!dataEndedReceived) {
+              rscStream.end();
+            }
+          }, 100).unref?.();
+        }
         break;
       case 'ERROR':
         if (verbose) {

--- a/plugin/stream/handleRscStream.client.ts
+++ b/plugin/stream/handleRscStream.client.ts
@@ -49,6 +49,21 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
     // controlPort1 too early would silently drop those messages, which is
     // exactly the cross-condition leak bd-6pi was hunting.
     let controlEndedReceived = false;
+    // The data port's `null` signal is the only ordered end-of-stream
+    // authority: it queues behind every data chunk on the same port. RSC_END
+    // arrives on the control port, and cross-port delivery order is NOT
+    // guaranteed — under load it can be processed while data chunks (notably
+    // the in-band `$E` error frame after a render failure) are still queued
+    // on the data port. Ending the stream from RSC_END truncated the response
+    // to the leading `:N<timeOrigin>` chunk — a silent 200, the exact
+    // swallowed-error case rsc-stream-error-surface guards against. RSC_END
+    // therefore only ends the stream as a delayed fallback for a worker that
+    // died before posting `null`.
+    let dataEndedReceived = false;
+    const endDataStream = () => {
+      dataEndedReceived = true;
+      rscStream.end();
+    };
     const cleanupPorts = () => {
       try {
         dataPort1.removeListener("message", dataMessageHandler);
@@ -80,9 +95,17 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
           if (options.verbose) {
             options.logger?.info(`[client] RSC render ended for ${message.id}`);
           }
-          // Now it's safe to end the stream
           controlEndedReceived = true;
-          rscStream.end();
+          // Do not end the data stream here — see the dataEndedReceived note
+          // above. Fall back to ending only if the data port's `null` never
+          // arrives (worker died between chunks and its onEnd).
+          if (!dataEndedReceived) {
+            setTimeout(() => {
+              if (!dataEndedReceived) {
+                endDataStream();
+              }
+            }, 100).unref?.();
+          }
           break;
         case "ERROR": {
           // Always log: this is an RSC render error from the worker. Without
@@ -118,7 +141,7 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
           options.logger?.info(`[client] Received end signal via dataPort - completing stream`);
         }
         // Signal that the stream is complete so React can finish consuming
-        rscStream.end();
+        endDataStream();
       } else if (data && data.type === 'ERROR') {
         // Stream error via data port
         if (options.verbose) {
@@ -134,8 +157,12 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
             `[client] Received RSC chunk via dataPort: ${data.length} bytes`
           );
         }
-        // Write the Uint8Array directly without conversion - keep it as raw bytes
-        rscStream.write(data);
+        // Write the Uint8Array directly without conversion - keep it as raw bytes.
+        // A chunk can still arrive after the RSC_END fallback ended the stream;
+        // dropping it beats ERR_STREAM_WRITE_AFTER_END tearing down the response.
+        if (!rscStream.writableEnded) {
+          rscStream.write(data);
+        }
       } else {
         // Unknown data format - log and ignore
         if (options.verbose) {

--- a/test/unit/rsc-stream-end-ordering.test.ts
+++ b/test/unit/rsc-stream-end-ordering.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Worker } from "node:worker_threads";
+import { handleRscStream } from "../../dist/plugin/stream/handleRscStream.client.js";
+import { createRscWorkerStream } from "../../dist/plugin/stream/createRscWorkerStream.js";
+
+/**
+ * RSC_END arrives on the control port while data chunks may still be queued
+ * on the data port — the two ports have no cross-port delivery-order
+ * guarantee. Ending the stream directly from RSC_END truncated in-flight
+ * chunks, most visibly the in-band `$E` error frame after a render failure:
+ * the response became a committed 200 carrying only the leading
+ * `:N<timeOrigin>` chunk, i.e. a silently swallowed error. This suite pins
+ * the legal-but-unlucky interleaving deterministically: RSC_END is processed
+ * BEFORE the remaining data chunks and the data port's `null` end-signal.
+ * Only the `null` may end the stream eagerly; RSC_END is a fallback.
+ *
+ * Imports target the concrete dist modules (not the conditional package
+ * entry) so both implementations are pinned regardless of the condition the
+ * suite runs under.
+ */
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+const chunkPreamble = () => new Uint8Array(Buffer.from(":N1784985134984.08\n"));
+const chunkErrorFrame = () =>
+  new Uint8Array(Buffer.from('1:E{"message":"intentional-render-failure"}\n'));
+
+function createCapturingWorker() {
+  const posted: any[] = [];
+  const worker = {
+    postMessage: vi.fn((msg: any) => {
+      posted.push(msg);
+    }),
+    on: vi.fn(),
+    off: vi.fn(),
+    removeListener: vi.fn(),
+  } as unknown as Worker;
+  return { worker, posted };
+}
+
+async function readAll(reader: ReadableStreamDefaultReader<Uint8Array>) {
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return out;
+    out += Buffer.from(value!).toString();
+  }
+}
+
+describe("RSC_END vs data-port ordering (handleRscStream.client)", () => {
+  it("keeps chunks that arrive after RSC_END was processed", async () => {
+    const { worker, posted } = createCapturingWorker();
+
+    const stream = handleRscStream({
+      options: {
+        worker,
+        id: "req-1",
+        route: "/",
+        url: "/",
+        projectRoot: "/",
+        build: { pages: [], outDir: "dist", server: "server" },
+        verbose: false,
+      } as any,
+      handlers: {} as any,
+    });
+
+    // The transferred ports from the INIT message are the worker's ends.
+    const { dataPort, controlPort } = posted[0];
+    const reader = stream.getReader();
+
+    // First chunk flushes (this is what commits the HTTP 200 in dev).
+    dataPort.postMessage(chunkPreamble());
+    const first = await reader.read();
+    expect(Buffer.from(first.value!).toString()).toContain(":N");
+
+    // RSC_END lands and gets processed while the error frame + null are
+    // still on their way over the data port.
+    controlPort.postMessage({ type: "RSC_END", id: "req-1" });
+    await tick();
+    await tick();
+
+    dataPort.postMessage(chunkErrorFrame());
+    dataPort.postMessage(null);
+
+    const rest = await readAll(reader);
+    expect(rest).toContain("intentional-render-failure");
+  });
+
+  it("still ends the stream via RSC_END when the null end-signal never arrives", async () => {
+    const { worker, posted } = createCapturingWorker();
+
+    const stream = handleRscStream({
+      options: {
+        worker,
+        id: "req-2",
+        route: "/",
+        url: "/",
+        projectRoot: "/",
+        build: { pages: [], outDir: "dist", server: "server" },
+        verbose: false,
+      } as any,
+      handlers: {} as any,
+    });
+
+    const { dataPort, controlPort } = posted[0];
+    const reader = stream.getReader();
+
+    dataPort.postMessage(chunkPreamble());
+    await reader.read();
+
+    // Worker dies after RSC_END without ever posting the data-port null.
+    controlPort.postMessage({ type: "RSC_END", id: "req-2" });
+
+    const done = await Promise.race([
+      reader.read().then((r) => r.done),
+      new Promise<string>((r) => setTimeout(() => r("timeout"), 1000)),
+    ]);
+    expect(done).toBe(true);
+  });
+});
+
+describe("RSC_END vs data-port ordering (createRscWorkerStream)", () => {
+  it("keeps chunks that arrive after RSC_END was processed", async () => {
+    const { worker, posted } = createCapturingWorker();
+
+    const { stream } = createRscWorkerStream({
+      worker,
+      route: "/",
+      url: "/",
+      projectRoot: "/",
+      moduleBasePath: "/",
+      moduleBaseURL: "/",
+      moduleRootPath: "/",
+      serverPipeableStreamOptions: {},
+    } as any);
+
+    const { dataPort, controlPort } = posted[0];
+
+    const received: Buffer[] = [];
+    const ended = new Promise<void>((r) => stream.on("end", r));
+    stream.on("data", (c: Buffer) => received.push(c));
+
+    dataPort.postMessage(chunkPreamble());
+    await tick();
+
+    controlPort.postMessage({ type: "RSC_END", id: "/" });
+    await tick();
+    await tick();
+
+    dataPort.postMessage(chunkErrorFrame());
+    dataPort.postMessage(null);
+    await ended;
+
+    const body = Buffer.concat(received).toString();
+    expect(body).toContain(":N");
+    expect(body).toContain("intentional-render-failure");
+  });
+});


### PR DESCRIPTION
## Problem

Seen as a CI flake on #290: `rsc-stream-error-surface` intermittently got a committed 200 whose whole body was `:N<timestamp>` — the swallowed-error case the test guards against.

The worker signals end-of-render on two channels: an ordered `null` end-signal on the **data port** (queued behind every chunk) and `RSC_END` on the **control port**. Cross-port delivery order is not guaranteed, and both main-thread consumers (`handleRscStream.client`, `createRscWorkerStream`) called `rscStream.end()` immediately on `RSC_END`. Under load, `RSC_END` can be processed while chunks are still queued on the data port — most visibly the in-band `$E` error frame after a render failure, which is exactly what makes a failed render visible to the client. The worker-side half of this race was fixed earlier (see the onError comment in `handleRscRender.server.ts`); this is the main-thread half.

## Fix

- Only the data port's `null` ends the stream eagerly — it is the only end-signal ordered relative to the chunks.
- `RSC_END` arms a 100ms fallback end for the abnormal case where the worker died without posting `null`.
- A chunk arriving after a fallback end is dropped instead of raising `ERR_STREAM_WRITE_AFTER_END` into the response.

## Verification

- New unit suite `rsc-stream-end-ordering` pins the unlucky interleaving deterministically by driving the transferred MessagePorts directly (RSC_END processed before the error frame + `null`). Both truncation tests fail against the previous code; the worker-died fallback test passes on both.
- The originally flaky e2e test is green 8/8 consecutive client-condition runs with the fix.
- Full gate green under both conditions: 824 passed / 42 skipped (server), 254 passed / 12 skipped (client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)