### PR TITLE
fix(config): stale resolveOptions stash drops discovered clientPackages in dev

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -136,6 +136,20 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   // Return stashed options if available
   const stashedOptions = getStashedUserOptions(envId);
   if (stashedOptions && !forceResolve) {
+    // The stash is written at plugin-creation time, BEFORE
+    // clientPackagesDiscoveryPlugin's async `config` hook merges auto-detected
+    // packages into the shared raw options object. Re-sync the field on the
+    // stashed object in place (preserving the shared reference) so the
+    // noExternal / optimizeDeps merges in resolveUserConfig see the discovered
+    // list. Without this, a server component importing a "use client" package
+    // (vprs's own router/client barrel included) is externalized in dev and
+    // evaluated under react-server: React.createContext is not a function.
+    if (
+      options.clientPackages !== undefined &&
+      stashedOptions.clientPackages !== options.clientPackages
+    ) {
+      stashedOptions.clientPackages = options.clientPackages;
+    }
     return {
       type: "success",
       userOptions: stashedOptions as never,

--- a/test/unit/clientPackages.test.ts
+++ b/test/unit/clientPackages.test.ts
@@ -6,6 +6,7 @@ import {
   discoverClientPackages,
 } from "../../plugin/clientPackages/index.js";
 import { clientPackagesDiscoveryPlugin } from "../../plugin/clientPackages/plugin.js";
+import { resolveOptions } from "../../plugin/config/resolveOptions.js";
 import type { Plugin } from "vite";
 
 describe("clientPackages/buildClientPackagesPattern", () => {
@@ -181,6 +182,47 @@ describe("clientPackages/clientPackagesDiscoveryPlugin", () => {
     await plugin.config({}, { command: "serve" });
     expect(userOptions.clientPackages).toEqual(
       expect.arrayContaining(["@user/pkg"])
+    );
+  });
+});
+
+describe("clientPackages × resolveOptions stash ordering", () => {
+  // Plugin factories call resolveOptions() at CREATION time (when the user's
+  // vite.config evaluates the plugin), which resolves and stashes a userOptions
+  // copy. clientPackagesDiscoveryPlugin's merge runs later, in its async
+  // `config` hook, mutating the shared RAW options object — the stash predates
+  // it. A later resolveOptions() call (createEnvironmentPlugin's config hook)
+  // returns the stash, so without re-syncing, the discovered list never reaches
+  // resolveUserConfig's noExternal merge: the server environment externalizes
+  // "use client" packages (vprs's own router/client barrel included) and dev
+  // crashes with "React.createContext is not a function" in the RSC worker.
+  it("a stashed resolve picks up clientPackages merged into the raw options after the stash was written", async () => {
+    const raw: { clientPackages?: readonly string[] } = {};
+
+    // 1. Creation-time resolve — stashes a copy with no clientPackages.
+    const first = resolveOptions(raw as never);
+    expect(first.type).toBe("success");
+    if (first.type !== "success") return;
+
+    // 2. Discovery's config hook merges into the shared raw object.
+    const plugin = clientPackagesDiscoveryPlugin(
+      Object.assign(raw, { clientPackages: ["@my-org/internal-ui"] })
+    ) as Plugin & {
+      config: (config: unknown, env: { command: string }) => Promise<unknown>;
+    };
+    await plugin.config({}, { command: "serve" });
+    expect(raw.clientPackages).toEqual(
+      expect.arrayContaining(["@my-org/internal-ui"])
+    );
+
+    // 3. A later resolve of the SAME raw object returns the stashed copy —
+    //    which must now carry the merged list, on the same shared reference.
+    const second = resolveOptions(raw as never);
+    expect(second.type).toBe("success");
+    if (second.type !== "success") return;
+    expect(second.userOptions).toBe(first.userOptions);
+    expect(second.userOptions.clientPackages).toEqual(
+      expect.arrayContaining(["@my-org/internal-ui"])
     );
   });
 });


### PR DESCRIPTION
## Bug

A server component importing `vite-plugin-react-server/router/client` directly crashes dev on every render:

```
TypeError: React.createContext is not a function
    at .../dist/plugin/router/router-react.js:9:29
```

The page hangs empty. Repro: add `import { Link } from "vite-plugin-react-server/router/client"` to any server `page.tsx` and load a route in dev. Build is unaffected.

The blast radius is wider than the barrel: the same mechanism silently broke dev for **every** node_modules `"use client"` package imported from a server component (`@chakra-ui/react` and friends), which the clientPackages machinery exists to handle.

## Root cause

Plugin factories call `resolveOptions()` at plugin-creation time (when the user's `vite.config` evaluates the plugin), which resolves and stashes a userOptions copy. `clientPackagesDiscoveryPlugin` merges auto-detected packages into the shared **raw** options object later, in its async `config` hook — after the stash was written. Subsequent `resolveOptions()` calls (notably `createEnvironmentPlugin`'s `config` hook) return the stale stash, so `resolveUserConfig`'s `mergedNoExternal` never contains the discovered packages. The server environment then externalizes them, the ModuleRunner falls back to a native node import under the `react-server` condition, and module-scope `React.createContext` throws.

The transformer already defends against exactly this hazard (its whitelist reads `userOptions.clientPackages` lazily per transform call); the stash path had no such defense.

## Fix

On the stashed-return path, `resolveOptions` re-syncs `clientPackages` from the incoming raw options onto the stashed object **in place**, preserving the shared reference every stash consumer holds.

## Verification

- New regression test mirrors the real ordering (creation-time resolve → discovery merge → stashed resolve must see the list, on the same reference). Fails without the fix.
- Full gate green: `npm test` (both condition halves), `test:unit`, `tsc --noEmit`.
- End-to-end with a packed tarball in a consumer app: the direct barrel import in a server `page.tsx` renders in dev — the barrel becomes a hosted client reference (`I["/node_modules/vite-plugin-react-server/dist/plugin/router/client.js", …, "Link"]`) — and a real-browser Playwright pass confirms hydration and client-side `<Link>` navigation with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)