### PR TITLE
fix(dev): read hotUpdate environment from the hook context, not the options bag

### DIFF
--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -62,15 +62,18 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
         resolvedConfig: server.config,
       });
     },
-    hotUpdate(ctx: any) {
+    hotUpdate(this: any, ctx: any) {
       const { file, server } = ctx;
-      const envName = ctx.environment?.name ?? 'unknown';
-      
-      // Run worker invalidation once per change. Real fs-watch tags the call
-      // with the 'client' environment, but a manually-triggered or Vite-8
-      // "global" hotUpdate can arrive with no environment ('unknown') — handle
-      // both, or the RSC worker never hears about the edit. Multiple calls for
-      // the same change are deduped by `isProcessingHmr` below.
+      // The environment lives on the hook context (`this.environment`); on
+      // Vite 8 `ctx.environment` is undefined. Keep both fallbacks.
+      const envName =
+        this?.environment?.name ?? ctx.environment?.name ?? 'unknown';
+
+      // Run worker invalidation once per change, from the client-environment
+      // call. A manually-triggered hotUpdate can still arrive with no
+      // environment ('unknown') — handle both, or the RSC worker never hears
+      // about the edit. Multiple calls for the same change are deduped by
+      // `isProcessingHmr` below.
       if (envName !== 'client' && envName !== 'unknown') return;
       
       // Prevent recursive HMR updates

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -38,9 +38,15 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
     // Server-level handleHotUpdate — sends custom WS event to client
     // Vite 6 Environment API: hotUpdate runs per-environment.
     // Prevent server/ssr environments from triggering page reload for client components.
-    hotUpdate(ctx: any) {
+    hotUpdate(this: any, ctx: any) {
       const { file, server } = ctx;
-      const envName = ctx.environment?.name ?? 'unknown';
+      // The environment lives on the HOOK CONTEXT (`this.environment`), not on
+      // the options bag — on Vite 8 `ctx.environment` is undefined, so reading
+      // only ctx left every call as 'unknown': the client branch (which pushes
+      // the server-component-update event to the browser) never ran, and dev:rsc
+      // edits to page/route.tsx were suppressed without a refetch push.
+      const envName =
+        this?.environment?.name ?? ctx.environment?.name ?? 'unknown';
 
       const moduleBase = userOptions.moduleBase || "src";
       const projectRoot = userOptions.projectRoot || server?.config?.root || '';

--- a/test/dev/hmr.test.ts
+++ b/test/dev/hmr.test.ts
@@ -136,8 +136,19 @@ export const Page = () => <div>Updated Content</div>;`
       "Updated Content"
     );
 
-    console.log('Captured events:', events.map(e => ({ type: e.type, event: e.event })));
     expect(afterContent).toContain("Updated Content");
+
+    // The browser only refetches on receipt of this custom event (useRscHmr) —
+    // server-side invalidation alone is a false pass where every open tab keeps
+    // showing pre-edit content until a manual reload. Regression guard: on
+    // Vite 8 the environment moved off the hotUpdate options bag onto the hook
+    // context, which silenced this push under the react-server orchestrator.
+    const updateEvents = events.filter(
+      (e) =>
+        e.type === "custom" &&
+        e.event === "vite-plugin-react-server:server-component-update"
+    );
+    expect(updateEvents.length).toBeGreaterThan(0);
   }, 15000);
 
   it("should return updated content after file change", async () => {


### PR DESCRIPTION
## Bug

Under `dev:rsc` (react-server condition on the main thread, direct rendering), editing `page.tsx` or `route.tsx` never updates the browser. Server-side invalidation works — a manual reload or a fresh fetch of the RSC endpoint serves the new content — but the `vite-plugin-react-server:server-component-update` push that `useRscHmr` refetches on is never sent. Plain dev (worker path) hot-applies the same edit in seconds.

## Root cause

On Vite 8 the `hotUpdate` hook's environment lives on the hook context (`this.environment`); `ctx.environment` is undefined. `plugin.server.ts` read only the options bag, so under the react-server orchestrator every call resolved to `'unknown'`:

- never matched the `client` branch, which sends the browser push,
- never matched the `server` branch, which invalidates the module graph,
- fell through to `return []`, suppressing Vite's default full reload on top.

Plain dev only worked because `plugin.client.ts` carries a "treat `'unknown'` as the client pass" workaround with its own dedupe.

## Fix

Resolve the environment as `this?.environment?.name ?? ctx.environment?.name ?? 'unknown'` in both dev-server plugins. With real names available, each branch fires exactly once per edit (one push per change instead of relying on dedupe flags).

## Verification

- `test/dev/hmr.test.ts` captured `server.ws.send` payloads but never asserted on them — which is how this slipped through. It now requires the `server-component-update` custom event; that assertion fails on the old read under the react-server test half and passes with the fix.
- Full gate green: `npm test` on both condition halves, `tsc --noEmit`.
- Measured with a Playwright probe (WebSocket frame sniffing + DOM watch after an fs edit) against a consumer app on a packed tarball: dev:rsc went from 0 frames / no hot-apply to exactly 1 frame + DOM hot-applied within the wait window; plain dev unchanged (1 frame, hot-applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)