### PR TITLE
fix(dev): scan auto-discovered client modules so cold boot optimizes once

### DIFF
--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -247,10 +247,28 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
             // dev that resolves to the static `index.html`, which an RSC dev
             // server never serves, so the scan fails and logs (per re-optimize)
             // "failed to resolve rolldownOptions.input value: index.html".
-            // An explicit empty entries list skips the html crawl; deps still
-            // optimize lazily. optimizeDeps is a no-op in build, so the real
-            // index.html build entry is unaffected.
-            entries: userConfig.optimizeDeps?.entries ?? [],
+            // An explicit entries list skips the html crawl. For the BROWSER
+            // environment, an EMPTY list means nothing is scanned up front and
+            // every dep (react, react/jsx-dev-runtime, the router/client
+            // barrel) is discovered lazily on the first request — each
+            // mid-session optimize pass forces a reload and leaves a transient
+            // second React copy (one-off "Invalid hook call" / null-dispatcher
+            // errors on a cold cache). Hand the scanner the auto-discovered
+            // client modules instead so the first optimizer pass sees the real
+            // browser graph. Server/ssr environments keep the empty list.
+            // optimizeDeps is a no-op in build, so the real index.html build
+            // entry is unaffected.
+            entries:
+              userConfig.optimizeDeps?.entries ??
+              (consumer === "client" && envConfig.name === "client"
+                ? Object.values(
+                    autoDiscoveredFiles.clientInputs ?? {}
+                  ).flatMap((v) =>
+                    typeof v === "string" && /\.[cm]?[jt]sx?$/.test(v)
+                      ? [v.replace(/^\/+/, "")]
+                      : []
+                  )
+                : []),
             // transport:"webpack" (dev): the browser reaches the webpack
             // flight client through a lazy import chain (createReactFetcher →
             // rsl runtime → vendored CJS client), so on a cold cache Vite


### PR DESCRIPTION
## Bug

On a cold optimizer cache, the first dev page load is noisy and double-reloads: Vite discovers `vite-plugin-react-server/router/client`, then `react` + `react/jsx-dev-runtime`, in two mid-session optimize passes. Each pass forces an "optimized dependencies changed, reloading" reload and leaves a transient second React copy — one-off `Invalid hook call` and `Cannot read properties of null (reading 'useState')` console errors on every cold boot. Warm sessions are clean. Identical on esm and webpack transports.

## Root cause

The browser environment sets `optimizeDeps.entries: []` to skip Vite 8's `index.html` crawl (an RSC dev server never serves the static `index.html`, so the crawl fails with "failed to resolve rolldownOptions.input value: index.html"). But an empty list also means *nothing* is scanned up front, so every browser dep is discovered lazily on the first request. The webpack flight-client chain was already pre-declared via `optimizeDeps.include` for exactly this reason; the rest of the client graph wasn't.

## Fix

Hand the scanner the auto-discovered client inputs as `optimizeDeps.entries` for the browser environment — the same set the build already treats as client inputs (the explicit client entry plus directive-detected `"use client"` modules; client-ness comes from the directive, not from any filename convention). The first optimizer pass then sees the real client graph and bundles everything once. Server/ssr environments keep the empty list; a user-supplied `entries` still wins; build is unaffected (optimizeDeps is dev-only).

## Verification

Playwright cold-boot probe against a consumer app on a packed tarball (fresh cache dir per run):

| | optimize passes | forced reloads | console errors |
|---|---|---|---|
| before | 2 | 2 | 3 (Invalid hook call ×2, null-dispatcher useState) |
| after | 0 | 0 | 0 |

The `index.html` crawl warning does not return, the HMR push still applies edits, and the full gate is green on both condition halves plus `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)