### PR TITLE
fix(edge): resolve react-server-loader from vprs itself when the consumer lacks it

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -365,8 +365,23 @@ export async function buildEdgeBundle(opts: {
   // to the consumer project (the same react the build used).
   const projectRequire = createRequire(join(projectRoot, "package.json"));
   const reactDir = dirname(projectRequire.resolve("react/package.json"));
-  const serverEdge = projectRequire.resolve("react-server-loader/server.edge");
-  const serverNode = projectRequire.resolve("react-server-loader/server.node");
+  // react-server-loader is vprs's OWN dependency, not the consumer's. A
+  // registry install hoists it into the consumer's node_modules so the
+  // consumer-rooted resolve finds it, but a `file:`-linked vprs (the
+  // releasing-doc verification flow) keeps its deps in its own node_modules —
+  // npm does not install a link's transitive deps into the consumer. Resolve
+  // from the consumer first (keeps the hoisted copy authoritative), fall back
+  // to vprs's own installation.
+  const selfRequire = createRequire(import.meta.url);
+  const resolveRsl = (id: string): string => {
+    try {
+      return projectRequire.resolve(id);
+    } catch {
+      return selfRequire.resolve(id);
+    }
+  };
+  const serverEdge = resolveRsl("react-server-loader/server.edge");
+  const serverNode = resolveRsl("react-server-loader/server.node");
 
   // Which RSC transport the bundle renders through. The transformed modules in
   // dist/server import the esm transport by ABSOLUTE path (their register*
@@ -378,7 +393,7 @@ export async function buildEdgeBundle(opts: {
   const transport = userOptions.build.edge.transport;
   const flightServerEntry =
     transport === "webpack"
-      ? projectRequire.resolve("react-server-loader/webpack/server.edge")
+      ? resolveRsl("react-server-loader/webpack/server.edge")
       : serverEdge;
 
   // Webpack bakes only: stub the `node:` modules whose only reachable uses are


### PR DESCRIPTION
## Bug

Following `docs/releasing.md` step 1c — linking the local build into a demo repo via `file:../vite-plugin-react-server` — fails the edge bake:

```
Error: Cannot find module 'react-server-loader/server.edge'
```

Any consumer app whose tree doesn't end up with a hoisted `react-server-loader` copy hits the same wall.

## Root cause

`buildEdgeBundle` resolved `react-server-loader/server.edge`, `server.node`, and the webpack server entry strictly from the consumer project's `package.json`. `react-server-loader` is vprs's own dependency, not the consumer's: a registry install happens to hoist it into the consumer's `node_modules`, so the consumer-rooted resolve finds it by accident of hoisting. A `file:`-linked vprs keeps its deps in its own `node_modules` (npm does not install a link's transitive deps into the consumer), so the resolve has nothing to find.

## Fix

Resolve rsl from the consumer first (a hoisted copy stays authoritative, identical to today's registry behavior), and fall back to vprs's own installation. React is deliberately left consumer-resolved: it's a peer dependency and must match the React the build used.

## Verification

- Repro: `file:`-link the local build into bidoof-template, `npm install`, `npm run build:preview` → fails with the error above on current `main` (pre-existing, unrelated to the other open fix PRs — A/B'd).
- With this fix: same linked `build:preview` completes (exit 0, all pages prerendered, edge bundle baked).
- `tsc --noEmit` clean; the combined release-verification branch runs the full test gate over this change together with #293/#294/#295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)