### PR TITLE
chore(release): 3.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release bundling four dev-mode fixes. **Merge after** #293, #294, #295, #296 — this PR is the version bump only (`package.json` + `package-lock.json`); tag `v3.4.2` on main after merge, then publish (2FA).

## What ships

- **#293** — `resolveOptions`' creation-time stash returned stale `clientPackages`, so discovered `"use client"` packages (vprs's own `router/client` barrel included) were externalized in the server environment and evaluated under `react-server`: `React.createContext is not a function` on any direct server-side import. Re-syncs the stashed object in place.
- **#294** — on Vite 8 the `hotUpdate` environment lives on the hook context, not the options bag; the react-server orchestrator saw `'unknown'` and never pushed `server-component-update`, so `page.tsx`/`route.tsx` edits under `dev:rsc` needed a manual reload. Reads `this.environment` first.
- **#295** — the browser environment's `optimizeDeps.entries: []` meant a cold cache optimized mid-session (2 passes, 2 forced reloads, transient second React, one-off Invalid hook call). Hands the scanner the auto-discovered client inputs.
- **#296** — the edge bake resolved `react-server-loader` strictly from the consumer, which only works when npm happens to hoist it; a `file:`-linked vprs (the documented release-verification flow) failed with `Cannot find module 'react-server-loader/server.edge'`. Falls back to vprs's own installation.

## Pre-release verification (run on main + all four fixes merged locally)

- `npm test` both halves green (258 + 829 passing), `tsc --noEmit` clean.
- bidoof-template `file:`-linked: `build:preview` clean (including the edge bake, which fails on current main under the link — that failure is what #296 fixes), dev smoke of `/` and `/index.rsc` OK.
- mmc `file:`-linked: `npm run build` clean including its edge bake, dev smoke OK. Restored afterwards.
- Full Playwright e2e against linked bidoof-template: 39/40. The one failure (`dev-client-imported-server-fn`, strict `errors === []` assertion tripped by an aborted initial flight fetch on a freshly-booted spec server) is **pre-existing and flaky on current main** — A/B'd on the released 3.4.1 commit, which fails the same spec 2/40 — so it is not introduced by this release. Tracked for follow-up.
- Packed tarball (`npm pack`) installed into a clean consumer app: dev renders, hydrates, and client-navigates with zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)