### PR TITLE
fix(dev): server-env invalidation reads the environment from the hook context too

### DIFF
--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -101,10 +101,11 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
       // Server components are handled by the RSC refetch event sent above
       // Invalidate the server module so next RSC request gets fresh content
       if (envName === 'server') {
-        const mod = ctx.environment?.moduleGraph?.getModulesByFile(file);
+        const environment = this?.environment ?? ctx.environment;
+        const mod = environment?.moduleGraph?.getModulesByFile(file);
         if (mod) {
           for (const m of mod) {
-            ctx.environment.moduleGraph.invalidateModule(m);
+            environment.moduleGraph.invalidateModule(m);
           }
         }
       }


### PR DESCRIPTION
Follow-up to #294, same wrong-object read one branch further down: the server-environment branch of `hotUpdate` still read `ctx.environment?.moduleGraph` for its explicit module invalidation. On Vite 8 `ctx.environment` is undefined, so the loop was a silent no-op (masked by Vite's own watcher invalidation, which is why content still refreshed). Reads the environment from the hook context with the ctx fallback, matching the envName fix.

This was pushed to the #294 branch during review but landed after the squash-merge, so it needs its own PR.

`tsc --noEmit` clean; `test/dev/hmr.test.ts` green on the react-server half with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)