### PR TITLE
fix(ssg): surface shell render errors — no silent hang, no exit-0 degraded deploy

### DIFF
--- a/plugin/bundle/freezeStaticSnapshots.ts
+++ b/plugin/bundle/freezeStaticSnapshots.ts
@@ -57,8 +57,21 @@ export async function freezeStaticSnapshots(opts: {
   const consumer = await import(
     pathToFileURL(join(edgeDir, "consumer.js")).href
   );
+  // Collect render-time errors per route. The freeze only checks the response
+  // STATUS, but the status commits on the first chunk — a component that
+  // throws mid-stream (e.g. a router hook rendered in the HTML shell outside
+  // its provider) degrades that subtree while the stream completes fine, and
+  // the freeze would write a shell-only document with exit 0: a silent bad
+  // deploy. React reports those through onError; route it through handleError
+  // so the default production threshold ("all_errors") fails the build naming
+  // the route and the component error, while a relaxed panicThreshold keeps
+  // the degrade-and-continue behavior — loudly.
+  const renderErrors: unknown[] = [];
   const handler = createEdgeRequestHandler(bundle, {
     renderFlightToHtml: consumer.renderFlightToHtml,
+    onError: (error: unknown) => {
+      renderErrors.push(error);
+    },
   });
 
   // The SSG pass's event contract, emitted the same way the react-static
@@ -103,11 +116,27 @@ export async function freezeStaticSnapshots(opts: {
   };
 
   for (const route of routes) {
+    const errorsBefore = renderErrors.length;
     const htmlRes = await handler(new Request(new URL(route, ORIGIN)));
     if (htmlRes.status !== 200 || !htmlRes.body) {
       throw new Error(
         `[transport:webpack] freezing ${route} html failed (${htmlRes.status})`
       );
+    }
+    // The document render is fully buffered before the Response returns (the
+    // handler awaits the HTML text), so every onError for this route has fired
+    // by now — check BEFORE writing so a degraded document is never emitted.
+    if (renderErrors.length > errorsBefore) {
+      const panicError = handleError({
+        error: renderErrors[errorsBefore],
+        logger,
+        panicThreshold: userOptions.panicThreshold,
+        log: true,
+        context: `[transport:webpack] freezing ${route}: the HTML shell render errored — the document would be missing that subtree`,
+      });
+      if (panicError != null) {
+        throw panicError;
+      }
     }
     await fileWriter(
       Readable.fromWeb(htmlRes.body as import("node:stream/web").ReadableStream),

--- a/plugin/react-static/fileWriter.ts
+++ b/plugin/react-static/fileWriter.ts
@@ -246,6 +246,38 @@ export const fileWriter: FileWriterFn = function _fileWriter(
     contentCollector.on('error', handleError);
     writeStream.on('error', handleError);
 
+    // A render error can destroy the source BEFORE this writer subscribes (the
+    // HTML handler destroys its PassThrough from React's onError, and its own
+    // local 'error' listener marks the event handled) — the 'error' above then
+    // never fires for us, pipe() on the dead stream produces neither data nor
+    // end, and this promise would wait forever (the silent SSG hang on a shell
+    // render error). Same for a destroy that wins the race later: 'close'
+    // without a completed read means the content never fully arrived.
+    const src = sourceStream as NodeJS.ReadableStream & {
+      destroyed?: boolean;
+      errored?: Error | null;
+      readableEnded?: boolean;
+    };
+    if (src.destroyed) {
+      handleError(
+        src.errored ??
+          new Error(
+            `[fileWriter] ${fileType} source stream for route ${options.route} was destroyed before writing started (a render error upstream?)`
+          )
+      );
+      return;
+    }
+    sourceStream.on("close", () => {
+      if (src.readableEnded === false) {
+        handleError(
+          src.errored ??
+            new Error(
+              `[fileWriter] ${fileType} source stream for route ${options.route} closed before it ended (a render error upstream?)`
+            )
+        );
+      }
+    });
+
     // Handle successful completion
     writeStream.on("finish", () => {
       if (signal) {

--- a/plugin/stream/createHtmlStream.server.ts
+++ b/plugin/stream/createHtmlStream.server.ts
@@ -63,6 +63,15 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
 
   // Create the HTML output stream
   const htmlStream = new PassThrough();
+  // A render error destroys this stream (the ERROR message below) — and that
+  // can happen BEFORE the consumer subscribes, e.g. a shell error that fires
+  // while the build is still wiring the fileWriter. destroy(err) emits 'error';
+  // with zero listeners Node treats it as an uncaught exception and kills the
+  // process ("Unhandled 'error' event on PassThrough"), even though the error
+  // is already reported through the onError/handleError channels. This local
+  // listener only absorbs the crash — consumers that subscribed still get the
+  // same event.
+  htmlStream.on("error", () => {});
 
   // Flow control state for HTML output stream backpressure handling
   let isStreamEnded = false;
@@ -324,7 +333,37 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
   // Note: Process-level cleanup is handled by worker shutdown protocol
 
   return {
-    pipe: (destination: any) => htmlStream.pipe(destination),
+    pipe: (destination: any) => {
+      // A render error destroys htmlStream (the worker's ERROR message) — and
+      // that can happen BEFORE the consumer pipes. Piping a dead PassThrough
+      // emits neither data nor end, so a fileWriter waiting on the pipeline
+      // sits until an outer abort timer fires and the REAL component error is
+      // replaced by a generic timeout. Propagate instead: destroy the
+      // destination with the render error (Node emits it on nextTick, after
+      // the caller's synchronously-attached listeners are in place) and
+      // forward any later error the same way — pipe() itself never forwards
+      // errors downstream. Same treatment as the client-side handler.
+      const propagate = (error: unknown) => {
+        const err =
+          error instanceof Error
+            ? error
+            : new Error(String(error ?? `HTML render failed for ${route}`));
+        const dest = destination as NodeJS.WritableStream & {
+          destroy?: (e?: Error) => void;
+        };
+        dest.on?.("error", () => {});
+        if (typeof dest.destroy === "function") dest.destroy(err);
+        else dest.emit?.("error", err);
+      };
+      if (htmlStream.destroyed) {
+        propagate(
+          htmlStream.errored ?? new Error(`HTML render failed for ${route}`)
+        );
+        return destination;
+      }
+      htmlStream.on("error", propagate);
+      return htmlStream.pipe(destination);
+    },
       abort: () => {
     controlPort1.postMessage({ type: "ABORT", reason: "Stream aborted" });
     htmlStream.end();

--- a/plugin/stream/createRenderToPipeableStreamHandler.client.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.client.ts
@@ -79,6 +79,7 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
     }
 
     // Create the React HTML stream using ReactDOMServer.renderToPipeableStream
+    let rendererAborted = false;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream(reactElements, {
       bootstrapModules:
         clientPipeableStreamOptions?.bootstrapModules || [],
@@ -102,7 +103,7 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
             `[createRenderToPipeableStreamHandler.client:${route}] React rendering error: ${error instanceof Error ? error.message : String(error)}`
           );
         }
-        
+
         // Destroy the HTML stream with the error to prevent hanging
         if (verbose) {
           logger?.info(
@@ -110,6 +111,23 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
           );
         }
         htmlStream.destroy(error instanceof Error ? error : new Error(String(error)));
+
+        // The output is dead, so stop React's render too: its work loop keeps
+        // running the orphaned request otherwise (Suspense retries included),
+        // and a retry that throws after the destination is gone has nowhere to
+        // report — it escapes as an UNCAUGHT exception from React's internal
+        // scheduler. Deferred so the current onError pass unwinds first, and
+        // guarded because abort() itself reports through onError.
+        if (!rendererAborted) {
+          rendererAborted = true;
+          setImmediate(() => {
+            try {
+              abort();
+            } catch {
+              // Already settled — nothing left to stop.
+            }
+          });
+        }
         
         // Handle error according to panic threshold
         const panicError = handleError({
@@ -137,6 +155,19 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
               error: error,
             },
           });
+        }
+      },
+      // A SHELL error (thrown outside every Suspense boundary) also reaches
+      // onError above, which destroys htmlStream and routes the panic logic.
+      // This handler must still EXIST: without it React treats the shell error
+      // as unhandled and re-throws it asynchronously from its work loop — an
+      // uncaught exception escaping the whole pipeline even when the build
+      // handled the error.
+      onShellError(error: unknown) {
+        if (verbose) {
+          logger?.error(
+            `[createRenderToPipeableStreamHandler.client:${route}] HTML shell render failed (nothing was piped): ${error instanceof Error ? error.message : String(error)}`
+          );
         }
       },
     });
@@ -196,7 +227,35 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
     return {
       type: "client" as const,
       pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => {
-        // Pipe our PassThrough stream to the destination
+        // A React render error destroys htmlStream (see onError above) — and it
+        // can win the race against the consumer subscribing. Piping a dead
+        // PassThrough emits neither data nor end, so a fileWriter waiting on
+        // the pipeline would hang forever with the render error swallowed (the
+        // silent SSG hang on a shell render error). Propagate instead: destroy
+        // the destination with the render error — Node emits it on nextTick,
+        // after the caller's synchronously-attached 'error' listeners are in
+        // place — and forward any later error the same way (pipe() itself
+        // never forwards errors downstream).
+        const propagate = (error: unknown) => {
+          const err =
+            error instanceof Error
+              ? error
+              : new Error(String(error ?? `HTML render failed for ${route}`));
+          const dest = destination as NodeJS.WritableStream & {
+            destroy?: (e?: Error) => void;
+          };
+          // Absorb the crash if the caller has not subscribed yet (an 'error'
+          // event with zero listeners is an uncaught exception); listeners the
+          // caller does attach still receive the event.
+          dest.on?.("error", () => {});
+          if (typeof dest.destroy === "function") dest.destroy(err);
+          else dest.emit?.("error", err);
+        };
+        if (htmlStream.destroyed) {
+          propagate(htmlStream.errored ?? new Error(`HTML render failed for ${route}`));
+          return destination;
+        }
+        htmlStream.on("error", propagate);
         htmlStream.pipe(destination);
         return destination;
       },

--- a/plugin/stream/renderRscStream.server.ts
+++ b/plugin/stream/renderRscStream.server.ts
@@ -120,20 +120,15 @@ export function renderRscStream(
             });
           }
           
-          // CRITICAL: Don't let the error propagate further - this prevents uncaught exceptions
-          // The error has been handled by our error handler, so we don't need to re-throw it
-          
-          // Ensure stream is ended when error occurs to prevent hanging (like RSC worker does)
-          // Use setImmediate to ensure the error handler completes before ending the stream
-          setImmediate(() => {
-            if (!rscStream.destroyed) {
-              rscStream.end();
-            }
-            // Also abort the React stream to ensure it stops producing data
-            if (reactStream && typeof reactStream.abort === 'function') {
-              reactStream.abort();
-            }
-          });
+          // Do NOT force-end the stream here (same fix as the RSC worker's
+          // handleRscRender): React's flight renderer emits the error in-band
+          // (the `$E` error frame) and closes the destination itself once the
+          // request settles. Ending/aborting from onError races that flush —
+          // under load the manual end can win and truncate the stream, dropping
+          // the `$E` frame, so the consumer sees a silent truncated payload
+          // instead of a surfaced error. Let React own stream completion; the
+          // stream error handlers and the outer catch remain the hang safety
+          // net.
         },
         onPostpone: (reason: string) => {
           if (verbose) {

--- a/plugin/worker/html/handleHtmlRender.client.ts
+++ b/plugin/worker/html/handleHtmlRender.client.ts
@@ -124,7 +124,8 @@ export const handleHtmlRender: HandleHtmlRenderFn = function _handleHtmlRender(
     }
 
     // Create the stream once and pipe directly with onData
-    const { pipe } = ReactDOMServer.renderToPipeableStream(result.children, {
+    let rendererAborted = false;
+    const { pipe, abort } = ReactDOMServer.renderToPipeableStream(result.children, {
       ...mergedPipeableStreamOptions,
       onShellReady() {
         if (verbose) {
@@ -179,11 +180,39 @@ export const handleHtmlRender: HandleHtmlRenderFn = function _handleHtmlRender(
         }
 
         handlers.onError(route, error, errorInfo);
-        if(handlers.onError) {
-          handlers.onError(route, error, errorInfo);
-        }
         if(mergedPipeableStreamOptions?.onError) {
           mergedPipeableStreamOptions.onError(error, errorInfo);
+        }
+      },
+      // A SHELL error (thrown outside every Suspense boundary) means React
+      // never pipes: onShellReady/onAllReady don't fire and the Writable's
+      // `final` never runs — the END message never goes out. React also calls
+      // onError for shell errors, and the main thread destroys its stream on
+      // the resulting ERROR message, so the channel does terminate; this
+      // handler exists to say WHY nothing was piped (always, not just in
+      // verbose) and to forward the shell-error hook a consumer configured.
+      onShellError(error: unknown) {
+        logger.error(
+          `[html-worker:${route}] HTML shell render failed (nothing was piped): ${error}`
+        );
+        if (mergedPipeableStreamOptions?.onShellError) {
+          mergedPipeableStreamOptions.onShellError(error);
+        }
+        // Stop the orphaned render: with the shell failed nothing will ever
+        // pipe, but React's work loop keeps running the request (Suspense
+        // retries included) and a retry that throws with the request dead has
+        // nowhere to report — it escapes the worker as an uncaught exception
+        // and lands on the parent's Worker 'error' channel. Deferred so this
+        // handler unwinds first; guarded because abort() reports via onError.
+        if (!rendererAborted) {
+          rendererAborted = true;
+          setImmediate(() => {
+            try {
+              abort();
+            } catch {
+              // Already settled — nothing left to stop.
+            }
+          });
         }
       },
     });
@@ -211,7 +240,10 @@ export const handleHtmlRender: HandleHtmlRenderFn = function _handleHtmlRender(
       },
     });
 
-    // Pipe the React stream directly to our writable
+    // Pipe the React stream directly to our writable. (Deliberately NOT moved
+    // into onShellReady: delaying the pipe breaks the suspended-render drain
+    // flow the backpressure test guards. A failed shell writing nothing is
+    // handled by onShellError + the ERROR-message destroy on the main thread.)
     pipe(customWritable);
 
     // Set up RSC stream error handling

--- a/test/examples/ssg-shell-error-build.test.ts
+++ b/test/examples/ssg-shell-error-build.test.ts
@@ -1,0 +1,54 @@
+import { expect, test, describe, afterAll } from "vitest";
+import { getSharedBuild, cleanupSharedBuilds } from "./shared-build.js";
+import { setupShellHookErrorTestProject } from "../setup.js";
+
+/**
+ * Regression guard for the silent SSG hang/degrade on a shell render error.
+ *
+ * A "use client" component that throws during the server-side HTML shell
+ * render (e.g. a router hook rendered outside its provider — here simulated
+ * with a deterministic `typeof window === "undefined"` throw) used to either
+ * HANG the static build with no output (the render error destroyed the HTML
+ * stream before the fileWriter subscribed, so it waited forever) or complete
+ * with exit 0 while emitting a shell-only document. The build must instead
+ * surface the component error per panicThreshold.
+ */
+describe("SSG shell render error surfacing", () => {
+  test(
+    'panicThreshold "all_errors": the build FAILS with the component error (no hang, no silent degrade)',
+    { timeout: 90_000 },
+    async () => {
+      await expect(
+        getSharedBuild("shell-hook-error-test-project", "shell-error-panic-all", {
+          setupProject: setupShellHookErrorTestProject,
+          pages: ["/"],
+          panicThreshold: "all_errors",
+          verbose: false,
+          Page: "src/page/page.tsx",
+          props: "src/page/props.ts",
+        })
+      ).rejects.toThrow(/ShellThrow: rendered outside the browser/);
+    }
+  );
+
+  test(
+    'panicThreshold "none": the build completes (degrade-and-continue stays available)',
+    { timeout: 90_000 },
+    async () => {
+      await expect(
+        getSharedBuild("shell-hook-error-test-project", "shell-error-panic-none", {
+          setupProject: setupShellHookErrorTestProject,
+          pages: ["/"],
+          panicThreshold: "none",
+          verbose: false,
+          Page: "src/page/page.tsx",
+          props: "src/page/props.ts",
+        })
+      ).resolves.toBeDefined();
+    }
+  );
+
+  afterAll(async () => {
+    await cleanupSharedBuilds();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -915,3 +915,49 @@ export function ClientErrorComponent({ throwError }: { throwError: boolean }) {
 }`
   );
 }
+
+/**
+ * Fixture for the silent-SSG-hang regression: a "use client" component that
+ * throws ONLY during the server-side HTML shell render (client components DO
+ * render server-side for the shell; the flight pass never executes them, and
+ * the browser has `window`). The build must surface this error according to
+ * panicThreshold — never hang, never emit a degraded document with exit 0.
+ */
+export async function setupShellHookErrorTestProject(testDir: string) {
+  await setupIndexHTML(testDir);
+
+  await mkdir(resolve(testDir, "src/page"), { recursive: true });
+  await writeFile(
+    resolve(testDir, "src/page/page.tsx"),
+    `import React from "react";
+import { ShellThrow } from "../components/ShellThrow.client.js";
+
+export function Page() {
+  return (
+    <div>
+      <h1>Shell hook error test</h1>
+      <ShellThrow />
+    </div>
+  );
+}`
+  );
+
+  await writeFile(
+    resolve(testDir, "src/page/props.ts"),
+    `export const props = (url: string) => ({ url });`
+  );
+
+  await mkdir(resolve(testDir, "src/components"), { recursive: true });
+  await writeFile(
+    resolve(testDir, "src/components/ShellThrow.client.tsx"),
+    `"use client";
+import React from "react";
+
+export function ShellThrow() {
+  if (typeof window === "undefined") {
+    throw new Error("ShellThrow: rendered outside the browser");
+  }
+  return <div data-testid="shell-throw">browser only</div>;
+}`
+  );
+}


### PR DESCRIPTION
## Bug

A `"use client"` component that throws during the server-side HTML shell render — a router hook rendered outside its provider, or any browser-only code — produced one of three silent failures depending on the build path, with the component error reported through React's `onError` but never reaching the build:

1. **client-first SSG: infinite hang, zero output.** `onError` destroyed the handler's PassThrough before the fileWriter subscribed; the already-spent `'error'` event was never re-observed, and piping the dead stream produced neither data nor end. (Bisecting this cost about an hour downstream.)
2. **worker path: the real error replaced by a generic timeout.** Same dead-pipe gap in `createHtmlStream.server` — the component error was known within seconds, but the build sat until the 15s abort and rejected with `TimeoutError` instead.
3. **webpack freeze: silent bad deploy.** The freeze checked only the response status, which commits on the first chunk; a mid-stream throw degraded the subtree while the stream completed, so a shell-only `index.html` shipped with exit 0.

Plus a process-crash variant on all paths: `destroy(err)` on a stream with no `'error'` listener at emit time ("Unhandled 'error' event on PassThrough").

## Fixes

- **Pipe-time propagation** in both stream handlers: a dead/erroring source destroys the destination with the render error (Node emits destroy errors on nextTick, after the caller's synchronously-attached listeners), and later errors are forwarded — `pipe()` itself never forwards errors downstream.
- **fileWriter guards**: rejects when the source is already destroyed at attach, or closes without ending.
- **Freeze checks render errors per route** via `createEdgeRequestHandler`'s `onError`, routed through `handleError` **before** writing: the production default (`all_errors`) fails the build naming the route and the component error; a relaxed `panicThreshold` keeps degrade-and-continue, loudly.
- **Local `'error'` absorbers** at the destroy sites — the error already travels the handled channels; subscribed consumers still receive the event.
- **`onShellError` handlers** on the worker and main-thread renderers (a failed shell now logs why nothing was piped), and **orphaned renders are aborted** once their output stream is dead so React's work loop stops retrying against a dead request.
- **`renderRscStream.server.ts` no longer force-ends the flight on error** — parity with 0f03197; the `setImmediate` end/abort raced React's own `$E` error-frame flush and could truncate the stream.

Deliberately **not** moved: the worker still pipes immediately rather than from `onShellReady` — delaying the pipe breaks the suspended-render drain flow the backpressure test guards (verified: that variant fails `html-backpressure-build`).

## Verification

- New `test/examples/ssg-shell-error-build.test.ts` + fixture (a client component that throws only when `window` is undefined): `all_errors` must reject with the component error — a hang regression times the test out — and `none` must complete. Green on both condition halves with zero unhandled errors, standalone and in-suite.
- Full gate green on both halves (260 + 831 passing), `tsc --noEmit` clean.
- Consumer-app probes on a packed tarball: all three build paths (client-first esm, server-first, webpack freeze) now exit 1 with the actual `RouterProvider` error surfaced; healthy builds unaffected on all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)