### PR TITLE
chore(release): 3.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump only (`package.json` + `package-lock.json`). Ships #299: SSG shell-render error surfacing — no silent hang, no exit-0 degraded deploy.

**Release note worth calling out**: builds that previously completed with exit 0 while emitting shell-only documents (a `"use client"` component throwing during the server-side shell render, e.g. a router hook outside its provider) now FAIL with the component error under the default production `panicThreshold` (`all_errors`). That is the bug fix working as intended; `panicThreshold: "critical_errors"` or `"none"` restores degrade-and-continue, loudly logged.

Verified on the fix commit: full gate green on both condition halves (260 + 831), consumer-app probes on all three build paths surface the real component error with exit 1, healthy builds unaffected.

After merge: tag `v3.4.3` on main, then `npm publish` (2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)