### PR TITLE
chore(release): 3.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump only (`package.json` + `package-lock.json`). Ships #301: worker startup boot-shim heartbeats — the entries signal liveness while their heavy import graphs load, so the startup inactivity watchdog only fires on genuine silence. Fixes the verify-gate `Worker ready timeout after 10000ms of inactivity` flakes under parallel load. No timeout values changed, no public API or worker-path changes.

After merge: tag `v3.4.4` on main, then `npm publish` (2FA). This release's own verify gate doubles as the real-world measurement for the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)