### PR TITLE
fix(dev): pre-bundle lazily-referenced vprs subpaths; e2e kills the real server

### DIFF
--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -276,8 +276,26 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
             // leaves a transient second React copy and one-off "Invalid hook
             // call" errors on first load. Pre-declare them so the first
             // optimizer pass bundles (and dedupes react across) the chain.
+            //
+            // The same lazy-discovery gap applies to vprs's OWN browser-facing
+            // subpaths when nothing in the app's SCANNED client code imports
+            // them statically: an app whose client components are reached only
+            // as flight client references (no static barrel import in the
+            // client entry) pulls router/client and /utils through runtime
+            // resolution the scanner can't see, so a cold cache re-optimizes
+            // mid-session — and that reload aborts the in-flight initial
+            // flight fetch ("hydrateOrRender: initial payload failed ...
+            // Failed to fetch"). Pre-declare them for the browser env; an app
+            // that never requests them just carries a bundled-but-unfetched
+            // dep, which is free.
             include: [
               ...(userConfig.optimizeDeps?.include ?? []),
+              ...(consumer === "client"
+                ? [
+                    "vite-plugin-react-server/router/client",
+                    "vite-plugin-react-server/utils",
+                  ]
+                : []),
               ...(consumer === "client" && userOptions.transport === "webpack"
                 ? [
                     "react-server-loader/webpack/runtime",

--- a/test/e2e/dev-client-imported-server-fn.spec.ts
+++ b/test/e2e/dev-client-imported-server-fn.spec.ts
@@ -17,26 +17,13 @@
  * server-function probe (vite-plugin-react-server-demo-official#97).
  */
 import { test, expect } from "@playwright/test";
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnViteDev, stopViteDev, waitForServer } from "./devServer.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const bidoofDir = join(__dirname, "../../../bidoof-template");
-
-async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
-}
 
 const MODES = [
   { label: "dev:ssr (client-first)", condition: "", basePort: 33000 },
@@ -50,18 +37,16 @@ for (const mode of MODES) {
     let server: ChildProcess | undefined;
 
     test.beforeAll(async () => {
-      server = spawn("npx", ["vite", "--port", String(PORT), "--strictPort"], {
-        cwd: bidoofDir,
-        shell: true,
+      server = spawnViteDev({
+        dir: bidoofDir,
+        port: PORT,
         env: {
-          ...process.env,
           NODE_OPTIONS: mode.condition,
           NODE_ENV: "development",
           BASE_URL: "/",
           PUBLIC_ORIGIN: BASE_URL,
           FORCE_COLOR: "1",
         },
-        stdio: ["ignore", "pipe", "pipe"],
       });
       server.stdout?.on("data", (d) => process.stdout.write(`[${mode.label}] ${d}`));
       server.stderr?.on("data", (d) => process.stderr.write(`[${mode.label}] ${d}`));
@@ -69,17 +54,7 @@ for (const mode of MODES) {
     }, 90_000);
 
     test.afterAll(async () => {
-      if (server && server.exitCode === null && server.signalCode === null) {
-        await new Promise<void>((resolve) => {
-          server!.once("exit", () => resolve());
-          server!.kill("SIGTERM");
-          setTimeout(() => {
-            if (server && server.exitCode === null && server.signalCode === null) {
-              server.kill("SIGKILL");
-            }
-          }, 2000);
-        });
-      }
+      await stopViteDev(server);
     });
 
     test("imports a server function directly and calls it (no bare-specifier error)", async ({

--- a/test/e2e/dev-fast-refresh.spec.ts
+++ b/test/e2e/dev-fast-refresh.spec.ts
@@ -23,10 +23,11 @@
  * full-reload and the state-preservation assertions fail.
  */
 import { test, expect, type Page } from "@playwright/test";
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnViteDev, stopViteDev, waitForServer } from "./devServer.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const bidoofDir = join(__dirname, "../../../bidoof-template");
@@ -34,20 +35,6 @@ const counterFile = join(bidoofDir, "src/components/Counter.client.tsx");
 const pageFile = join(bidoofDir, "src/page/page.tsx");
 
 const CONDITION_RE = /Condition mismatch|wrong condition|under the wrong|loaded under/i;
-
-async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
-}
 
 /** Collect condition-guard warnings + uncaught page errors for an assertion. */
 function watchIssues(page: Page): string[] {
@@ -79,15 +66,10 @@ function defineSuite(mode: Mode, port: number) {
     test.beforeAll(async () => {
       origCounter = await readFile(counterFile, "utf-8");
       origPage = await readFile(pageFile, "utf-8");
-      server = spawn("npx", ["vite", "--port", String(port), "--strictPort"], {
-        cwd: bidoofDir,
-        shell: true,
-        // Own process group so afterAll can kill the whole tree (shell -> npx
-        // -> vite -> esbuild); killing just the parent orphans vite and leaks
-        // the port to the next run.
-        detached: true,
+      server = spawnViteDev({
+        dir: bidoofDir,
+        port,
         env: {
-          ...process.env,
           // dev:rsc carries the global react-server condition; dev:ssr does not.
           NODE_OPTIONS: mode === "rsc" ? "--conditions react-server" : "",
           NODE_ENV: "development",
@@ -98,7 +80,6 @@ function defineSuite(mode: Mode, port: number) {
           CHOKIDAR_USEPOLLING: "true",
           CHOKIDAR_INTERVAL: "500",
         },
-        stdio: ["ignore", "pipe", "pipe"],
       });
       server.stdout?.on("data", (d) => {
         serverLog += d;
@@ -122,29 +103,7 @@ function defineSuite(mode: Mode, port: number) {
     test.afterAll(async () => {
       await writeFile(counterFile, origCounter).catch(() => {});
       await writeFile(pageFile, origPage).catch(() => {});
-      // Kill the whole process group (negative pid), wait for the real exit,
-      // escalate to SIGKILL — so vite/esbuild children don't orphan + hold the
-      // port for the next run.
-      const pid = server?.pid;
-      if (pid && server && server.exitCode === null && server.signalCode === null) {
-        await new Promise<void>((resolve) => {
-          server!.once("exit", () => resolve());
-          try {
-            process.kill(-pid, "SIGTERM");
-          } catch {
-            server!.kill("SIGTERM");
-          }
-          setTimeout(() => {
-            if (server && server.exitCode === null && server.signalCode === null) {
-              try {
-                process.kill(-pid, "SIGKILL");
-              } catch {
-                server.kill("SIGKILL");
-              }
-            }
-          }, 2000);
-        });
-      }
+      await stopViteDev(server);
     });
 
     test("first paint renders without condition errors", async ({ page }) => {

--- a/test/e2e/dev-rsc-client-css-hmr.spec.ts
+++ b/test/e2e/dev-rsc-client-css-hmr.spec.ts
@@ -31,10 +31,11 @@
  * try/finally so a failure can't leave the fixture dirty.
  */
 import { test, expect } from "@playwright/test";
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnViteDev, stopViteDev, waitForServer } from "./devServer.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const bidoofDir = join(__dirname, "../../../bidoof-template");
@@ -45,19 +46,6 @@ const clientCssFile = join(bidoofDir, "src/css/counterStyles.module.css");
 const PORT = 33800;
 const BASE_URL = `http://localhost:${PORT}`;
 
-async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
-}
 
 // Serial single-worker suite: spawn exactly one dev:rsc server for both tests.
 test.describe("dev:rsc CSS-module HMR", () => {
@@ -66,15 +54,10 @@ test.describe("dev:rsc CSS-module HMR", () => {
   let server: ChildProcess | undefined;
 
   test.beforeAll(async () => {
-    server = spawn("npx", ["vite", "--port", String(PORT), "--strictPort"], {
-      cwd: bidoofDir,
-      shell: true,
-      // Own process group so afterAll can kill the whole tree (shell -> npx
-      // -> vite -> esbuild); killing just the parent orphans vite and leaks
-      // the port to the next run.
-      detached: true,
+    server = spawnViteDev({
+      dir: bidoofDir,
+      port: PORT,
       env: {
-        ...process.env,
         // dev:rsc carries the global react-server condition.
         NODE_OPTIONS: "--conditions react-server",
         NODE_ENV: "development",
@@ -86,7 +69,6 @@ test.describe("dev:rsc CSS-module HMR", () => {
         CHOKIDAR_USEPOLLING: "true",
         CHOKIDAR_INTERVAL: "500",
       },
-      stdio: ["ignore", "pipe", "pipe"],
     });
     server.stdout?.on("data", (d) => process.stdout.write(`[dev:rsc-css] ${d}`));
     server.stderr?.on("data", (d) => process.stderr.write(`[dev:rsc-css] ${d}`));
@@ -94,29 +76,7 @@ test.describe("dev:rsc CSS-module HMR", () => {
   }, 90_000);
 
   test.afterAll(async () => {
-    // Kill the whole process group (negative pid), wait for the real exit,
-    // escalate to SIGKILL — so vite/esbuild children don't orphan + hold the
-    // port for the next run.
-    const pid = server?.pid;
-    if (pid && server && server.exitCode === null && server.signalCode === null) {
-      await new Promise<void>((resolve) => {
-        server!.once("exit", () => resolve());
-        try {
-          process.kill(-pid, "SIGTERM");
-        } catch {
-          server!.kill("SIGTERM");
-        }
-        setTimeout(() => {
-          if (server && server.exitCode === null && server.signalCode === null) {
-            try {
-              process.kill(-pid, "SIGKILL");
-            } catch {
-              server.kill("SIGKILL");
-            }
-          }
-        }, 2000);
-      });
-    }
+    await stopViteDev(server);
   });
 
   // CONTROL — the working path. A SERVER-component CSS module edit must

--- a/test/e2e/dev-ssr-client-css-hmr.spec.ts
+++ b/test/e2e/dev-ssr-client-css-hmr.spec.ts
@@ -39,10 +39,11 @@
  * try/finally so a failure can't leave the fixture dirty.
  */
 import { test, expect } from "@playwright/test";
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnViteDev, stopViteDev, waitForServer } from "./devServer.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const bidoofDir = join(__dirname, "../../../bidoof-template");
@@ -53,19 +54,6 @@ const clientCssFile = join(bidoofDir, "src/css/counterStyles.module.css");
 const PORT = 33810;
 const BASE_URL = `http://localhost:${PORT}`;
 
-async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
-}
 
 // Serial single-worker suite: spawn exactly one dev:ssr server for both tests.
 test.describe("dev:ssr CSS-module HMR", () => {
@@ -74,15 +62,10 @@ test.describe("dev:ssr CSS-module HMR", () => {
   let server: ChildProcess | undefined;
 
   test.beforeAll(async () => {
-    server = spawn("npx", ["vite", "--port", String(PORT), "--strictPort"], {
-      cwd: bidoofDir,
-      shell: true,
-      // Own process group so afterAll can kill the whole tree (shell -> npx
-      // -> vite -> esbuild); killing just the parent orphans vite and leaks
-      // the port to the next run.
-      detached: true,
+    server = spawnViteDev({
+      dir: bidoofDir,
+      port: PORT,
       env: {
-        ...process.env,
         // dev:ssr is the client-first mode: NO react-server condition.
         NODE_OPTIONS: "",
         NODE_ENV: "development",
@@ -94,7 +77,6 @@ test.describe("dev:ssr CSS-module HMR", () => {
         CHOKIDAR_USEPOLLING: "true",
         CHOKIDAR_INTERVAL: "500",
       },
-      stdio: ["ignore", "pipe", "pipe"],
     });
     server.stdout?.on("data", (d) => process.stdout.write(`[dev:ssr-css] ${d}`));
     server.stderr?.on("data", (d) => process.stderr.write(`[dev:ssr-css] ${d}`));
@@ -102,29 +84,7 @@ test.describe("dev:ssr CSS-module HMR", () => {
   }, 90_000);
 
   test.afterAll(async () => {
-    // Kill the whole process group (negative pid), wait for the real exit,
-    // escalate to SIGKILL — so vite/esbuild children don't orphan + hold the
-    // port for the next run.
-    const pid = server?.pid;
-    if (pid && server && server.exitCode === null && server.signalCode === null) {
-      await new Promise<void>((resolve) => {
-        server!.once("exit", () => resolve());
-        try {
-          process.kill(-pid, "SIGTERM");
-        } catch {
-          server!.kill("SIGTERM");
-        }
-        setTimeout(() => {
-          if (server && server.exitCode === null && server.signalCode === null) {
-            try {
-              process.kill(-pid, "SIGKILL");
-            } catch {
-              server.kill("SIGKILL");
-            }
-          }
-        }, 2000);
-      });
-    }
+    await stopViteDev(server);
   });
 
   // CONTROL — the working path. A SERVER-component CSS module edit must

--- a/test/e2e/dev-ssr-css-hmr.spec.ts
+++ b/test/e2e/dev-ssr-css-hmr.spec.ts
@@ -21,10 +21,11 @@
  * Same self-contained-server pattern as dev-ssr-server-actions.spec.ts.
  */
 import { test, expect } from "@playwright/test";
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnViteDev, stopViteDev, waitForServer } from "./devServer.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const bidoofDir = join(__dirname, "../../../bidoof-template");
@@ -38,29 +39,14 @@ const BASE_URL = `http://localhost:${PORT}`;
 let server: ChildProcess | undefined;
 let originalCss: string | undefined;
 
-async function waitForServer(url: string, timeoutMs = 30_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
-}
-
 test.beforeAll(async () => {
   originalCss = await readFile(cssFile, "utf-8");
 
   // dev:ssr-equivalent: NO --conditions react-server in NODE_OPTIONS.
-  server = spawn("npx", ["vite", "--port", String(PORT), "--strictPort"], {
-    cwd: bidoofDir,
-    shell: true,
+  server = spawnViteDev({
+    dir: bidoofDir,
+    port: PORT,
     env: {
-      ...process.env,
       NODE_OPTIONS: "",
       NODE_ENV: "development",
       BASE_URL: "/",
@@ -72,7 +58,6 @@ test.beforeAll(async () => {
       CHOKIDAR_USEPOLLING: "true",
       CHOKIDAR_INTERVAL: "500",
     },
-    stdio: ["ignore", "pipe", "pipe"],
   });
   server.stdout?.on("data", (d) => process.stdout.write(`[dev:ssr-css] ${d}`));
   server.stderr?.on("data", (d) => process.stderr.write(`[dev:ssr-css] ${d}`));
@@ -94,28 +79,7 @@ test.afterAll(async () => {
   if (originalCss !== undefined) {
     await writeFile(cssFile, originalCss);
   }
-  // `server.killed` only tracks "did kill() get called", not "did the
-  // process actually exit". A SIGTERM that lands while the vite child
-  // is mid-request, mid-restart, or stuck in worker spawn never reaches
-  // the handler; the 2s budget expires; the afterAll returns; and the
-  // vite child is now an orphan that survives the playwright run. On a
-  // single test pass that's one stray process; iterating builds up.
-  //
-  // Wait for the actual `exit` event before resolving. After the SIGTERM
-  // grace runs out, escalate to SIGKILL and wait again — the kernel
-  // can't ignore SIGKILL, so the second wait is guaranteed to land.
-  if (server && server.exitCode === null && server.signalCode === null) {
-    await new Promise<void>((resolve) => {
-      const onExit = () => resolve();
-      server!.once("exit", onExit);
-      server!.kill("SIGTERM");
-      setTimeout(() => {
-        if (server && server.exitCode === null && server.signalCode === null) {
-          server.kill("SIGKILL");
-        }
-      }, 2000);
-    });
-  }
+  await stopViteDev(server);
 });
 
 // bd-5rk regression: in dev:ssr the SSR worker imports compiled CSS modules

--- a/test/e2e/dev-ssr-server-actions.spec.ts
+++ b/test/e2e/dev-ssr-server-actions.spec.ts
@@ -18,9 +18,10 @@
  * one stays on the dev:rsc path for the existing HMR/navigation specs.
  */
 import { test, expect } from "@playwright/test";
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess } from "node:child_process";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnViteDev, stopViteDev, waitForServer } from "./devServer.js";
 import { DatabaseSync } from "node:sqlite";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -64,37 +65,21 @@ function readTodos(): { id: number; title: string }[] {
   }
 }
 
-async function waitForServer(url: string, timeoutMs = 30_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url);
-      if (res.status < 500) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 250));
-  }
-  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
-}
-
 test.beforeAll(async () => {
   // dev:ssr-equivalent: NO --conditions react-server in NODE_OPTIONS.
   // The plugin runs in client-mode and spawns the RSC worker with the
   // condition flipped — that worker is the one that previously cached
   // props across requests and silently dropped action effects.
-  server = spawn("npx", ["vite", "--port", String(PORT), "--strictPort"], {
-    cwd: bidoofDir,
-    shell: true,
+  server = spawnViteDev({
+    dir: bidoofDir,
+    port: PORT,
     env: {
-      ...process.env,
       NODE_OPTIONS: "",
       NODE_ENV: "development",
       BASE_URL: "/",
       PUBLIC_ORIGIN: BASE_URL,
       FORCE_COLOR: "1",
     },
-    stdio: ["ignore", "pipe", "pipe"],
   });
   server.stdout?.on("data", (d) => process.stdout.write(`[dev:ssr] ${d}`));
   server.stderr?.on("data", (d) => process.stderr.write(`[dev:ssr] ${d}`));
@@ -106,22 +91,7 @@ test.beforeAll(async () => {
 }, 90_000);
 
 test.afterAll(async () => {
-  // See dev-ssr-css-hmr.spec.ts for the rationale. `server.killed` only
-  // tracks "did kill() get called"; rely on the `exit` event with a
-  // SIGKILL escalation so a stuck vite child can't outlive the test
-  // suite and orphan into the agent session.
-  if (server && server.exitCode === null && server.signalCode === null) {
-    await new Promise<void>((resolve) => {
-      const onExit = () => resolve();
-      server!.once("exit", onExit);
-      server!.kill("SIGTERM");
-      setTimeout(() => {
-        if (server && server.exitCode === null && server.signalCode === null) {
-          server.kill("SIGKILL");
-        }
-      }, 2000);
-    });
-  }
+  await stopViteDev(server);
 });
 
 test.describe("server actions persist under dev:ssr (bd-5xu)", () => {

--- a/test/e2e/devServer.ts
+++ b/test/e2e/devServer.ts
@@ -1,0 +1,66 @@
+/**
+ * Shared dev-server lifecycle for the e2e specs.
+ *
+ * Every spec used to `spawn("npx", ["vite", …], { shell: true })` and kill the
+ * returned handle on teardown — but that handle is the WRAPPER SHELL, not vite:
+ * SIGTERM may not propagate and SIGKILL definitely orphans the node child. A
+ * failing spec then leaks a live dev server (100% CPU file-watcher loops were
+ * observed hours later), and enough leaked servers starve every later suite
+ * into worker-ready timeouts.
+ *
+ * spawnViteDev launches vite's real JS entry with the current node — no npx,
+ * no shell — so the returned handle IS the dev-server process and kill()
+ * reaches it. stopViteDev escalates SIGTERM → SIGKILL and always awaits exit.
+ * Call it in afterAll unconditionally: it is a no-op for a process that never
+ * started or already exited.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { join } from "node:path";
+
+export function spawnViteDev(options: {
+  dir: string;
+  port: number;
+  env?: Record<string, string | undefined>;
+  stdio?: "inherit" | "pipe";
+}): ChildProcess {
+  const { dir, port, env = {}, stdio = "pipe" } = options;
+  return spawn(
+    process.execPath,
+    [join(dir, "node_modules/vite/bin/vite.js"), "--port", String(port), "--strictPort"],
+    {
+      cwd: dir,
+      env: { ...process.env, ...env },
+      stdio: stdio === "inherit" ? "inherit" : ["ignore", "pipe", "pipe"],
+    }
+  );
+}
+
+export async function stopViteDev(server: ChildProcess | undefined): Promise<void> {
+  if (!server || server.exitCode !== null || server.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    const killTimer = setTimeout(() => {
+      if (server.exitCode === null && server.signalCode === null) {
+        server.kill("SIGKILL");
+      }
+    }, 2000);
+    server.once("exit", () => {
+      clearTimeout(killTimer);
+      resolve();
+    });
+    server.kill("SIGTERM");
+  });
+}
+
+export async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Server at ${url} did not become ready within ${timeoutMs}ms`);
+}

--- a/test/e2e/server.ts
+++ b/test/e2e/server.ts
@@ -4,9 +4,9 @@
  * 
  * This script starts bidoof-template's dev:rsc server on port 3200.
  */
-import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnViteDev, stopViteDev } from './devServer.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -17,14 +17,15 @@ const bidoofDir = join(__dirname, '../../../bidoof-template');
 async function main() {
   console.log('Starting bidoof-template dev server for e2e tests...');
   console.log('Directory:', bidoofDir);
-  
-  // Start vite directly with proper env vars (npm script chain mangles port args)
-  const proc = spawn('npx', ['vite', '--port', '3200', '--strictPort'], {
-    cwd: bidoofDir,
+
+  // spawnViteDev launches vite's real JS entry directly (no npx, no shell), so
+  // the signal forwarding below reaches the actual dev-server process instead
+  // of a wrapper shell that may orphan it (the leaked-spec-server class).
+  const proc = spawnViteDev({
+    dir: bidoofDir,
+    port: 3200,
     stdio: 'inherit',
-    shell: true,
     env: {
-      ...process.env,
       NODE_OPTIONS: '--conditions react-server',
       NODE_ENV: 'development',
       BASE_URL: '/',
@@ -34,21 +35,17 @@ async function main() {
       CHOKIDAR_INTERVAL: '500',
     },
   });
-  
+
   proc.on('error', (err) => {
     console.error('Failed to start server:', err);
     process.exit(1);
   });
-  
-  process.on('SIGINT', () => {
-    proc.kill('SIGINT');
-    process.exit(0);
-  });
-  
-  process.on('SIGTERM', () => {
-    proc.kill('SIGTERM');
-    process.exit(0);
-  });
+
+  const shutdown = () => {
+    void stopViteDev(proc).then(() => process.exit(0));
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## The flake, both halves

The `dev-client-imported-server-fn` e2e spec (and its CSS-HMR siblings) flaked with `[vprs] hydrateOrRender: initial payload failed; staying static TypeError: Failed to fetch` on freshly-booted spec servers — and each failing run leaked a live dev server. After a weekend of runs, nine leaked servers sat at 100% CPU, starving later suites into worker-ready timeouts and inflating every flake measurement.

## Half 1 — the fetch abort (plugin fix, user-facing)

The cold-boot entries fix (3.4.2) hands Vite's dep scanner the auto-discovered client modules — but an app whose client components are reached **only as flight client references** never statically imports `vite-plugin-react-server/router/client` or `/utils` in scanned code. The scanner can't see runtime reference resolution, so a cold cache still discovered those mid-session: `optimized dependencies changed → reloading`, and that reload aborts the in-flight initial flight fetch. The demo app is exactly this shape, and the failing spec's server log shows the re-optimize at the failure timestamp.

Fix: pre-declare both subpaths in the browser environment's `optimizeDeps.include` — the same precedent as the webpack flight-client chain pre-include directly below it. An app that never requests them carries a bundled-but-unfetched dep, which is free.

## Half 2 — the leak (test infra)

Six specs plus the global webServer spawned vite via `spawn("npx", …, { shell: true })` and killed the returned handle on teardown — that handle is the wrapper shell: SIGTERM may not propagate, SIGKILL definitely orphans the node child. Three specs had already half-fixed this with `detached` + group kills; all seven now use a shared `test/e2e/devServer.ts` helper that launches vite's real JS entry with the current node (no npx, no shell) so the handle **is** the dev server, with SIGTERM→SIGKILL escalation that always awaits exit. Net −131 lines.

## Verification (local build linked into the demo app)

- Three cold-cache runs of the flaky spec: exit 0, **zero** mid-session re-optimizes (previously every cold boot), zero failed fetches.
- Full e2e suite: **40/40** — the first fully green run across this weekend's many attempts (prior runs: 37–39/40).
- Zero leaked processes and zero listeners on the spec-port range after the suite.
- Full gate green on both condition halves (260 + 831), `tsc --noEmit` clean. Demo repo restored and synced afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)