### PR TITLE
chore(release): 3.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump only. Ships #303: the browser environment pre-bundles `vite-plugin-react-server/router/client` and `/utils` so flight-reference-only apps no longer hit a cold-cache mid-session re-optimize reload (the reload aborted the in-flight initial flight fetch — "hydrateOrRender: initial payload failed … Failed to fetch" — leaving the page static until manual reload). Plus the e2e dev-server lifecycle hardening (spec servers can no longer leak).

Verified on the fix commit: three cold-cache consumer runs with zero re-optimizes, full e2e 40/40, full gate green both halves.

After merge: tag `v3.4.5`, then `npm publish` (2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)