### PR TITLE
fix(client): module, flight and action URLs follow the SERVING origin

### DIFF
--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -358,12 +358,24 @@ export const resolveUserConfig: ResolveUserConfigFn =
     // (`VITE_PUBLIC_ORIGIN` by default). Setting the bare variable does
     // NOTHING — silently: the build succeeds with the value unbaked, and the
     // first sign is whatever downstream behavior depended on it. Say so at
-    // build time instead of letting it be discovered by absence.
+    // build time instead of letting it be discovered by absence — but ONLY
+    // when the value truly went nowhere: a consumer that reads the bare var
+    // itself and supplies it another way (`base: process.env.BASE_URL` in the
+    // Vite config, or the `publicOrigin` plugin option) has a working setup
+    // and must not be nagged.
     if (configEnv.command === "build" && primaryPrefix !== "") {
+      const bareWentNowhere: Record<"PUBLIC_ORIGIN" | "BASE_URL", boolean> = {
+        // publicOrigin resolves to "" when nothing supplied it — falsy check,
+        // not null: a bare env value with an empty effective origin means the
+        // value went nowhere.
+        PUBLIC_ORIGIN: !effectivePublicOrigin,
+        BASE_URL: config.base == null && !userOptions.moduleBaseURLExplicit,
+      };
       for (const key of ["PUBLIC_ORIGIN", "BASE_URL"] as const) {
         if (
           process.env[key] != null &&
           getEnvValue(key, primaryPrefix) == null &&
+          bareWentNowhere[key] &&
           !warnedUnprefixedEnv.has(key)
         ) {
           warnedUnprefixedEnv.add(key);

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -30,6 +30,9 @@ import { createRollupLikeHash } from "./createRollupLikeHash.js";
 
 const stashedUserConfig: Record<string, ResolvedUserConfig | null> = {};
 let originalConfig: UserConfig | null = null;
+// Once per process, not once per environment pass (resolveUserConfig runs for
+// each of client/ssr/server).
+const warnedUnprefixedEnv = new Set<string>();
 export type ResolveUserConfigProps = {
   condition: ReactCondition;
   config: UserConfig;
@@ -350,6 +353,29 @@ export const resolveUserConfig: ResolveUserConfigFn =
     const envPublicOrigin = getEnvValue("PUBLIC_ORIGIN", primaryPrefix);
     const effectivePublicOrigin =
       envPublicOrigin != null ? envPublicOrigin : userOptions.publicOrigin;
+
+    // Quality-of-life: the plugin reads these via the Vite env PREFIX
+    // (`VITE_PUBLIC_ORIGIN` by default). Setting the bare variable does
+    // NOTHING — silently: the build succeeds with the value unbaked, and the
+    // first sign is whatever downstream behavior depended on it. Say so at
+    // build time instead of letting it be discovered by absence.
+    if (configEnv.command === "build" && primaryPrefix !== "") {
+      for (const key of ["PUBLIC_ORIGIN", "BASE_URL"] as const) {
+        if (
+          process.env[key] != null &&
+          getEnvValue(key, primaryPrefix) == null &&
+          !warnedUnprefixedEnv.has(key)
+        ) {
+          warnedUnprefixedEnv.add(key);
+          const logger = config.customLogger ?? createLogger();
+          logger.warn(
+            `[vite-plugin-react-server] ${key} is set in the environment but the ` +
+              `plugin reads ${primaryPrefix}${key} — the unprefixed value is ignored. ` +
+              `Set ${primaryPrefix}${key} (or pass the option in the plugin config).`
+          );
+        }
+      }
+    }
 
     // Single source of truth for the build/runtime mode.
     //

--- a/plugin/utils/urls.ts
+++ b/plugin/utils/urls.ts
@@ -224,16 +224,31 @@ export const parseURL = (
   | { type: "success"; url: URL; error?: never; base?: never }
   | { type: "error"; url: string; base: string; error: Error } => {
   try {
-    // If base is empty or not a valid absolute URL, use window.location.origin as fallback (browser only)
+    // In a BROWSER the document's own origin always wins over the baked
+    // PUBLIC_ORIGIN. These URLs name same-origin assets of the page being
+    // served — client-component chunks, index.rsc, the action endpoint — and
+    // resolving them against a baked origin splits them off the document the
+    // moment the app is served from anywhere else (a different port,
+    // 127.0.0.1 vs localhost, a preview deploy): the page's scripts come from
+    // origin A, the flight-loaded chunks from origin B, two module graphs
+    // bundle TWO REACTS, and hydration dies with a null dispatcher deep in a
+    // client component — no 404, no warning. PUBLIC_ORIGIN is for absolute
+    // URLs in metadata (canonical, og:image — see createAbsoluteURL), not for
+    // module loading. An explicitly absolute `url` (a CDN moduleBaseURL the
+    // consumer passed on purpose) still passes through below.
     let effectiveBase = base;
-    if (!effectiveBase || effectiveBase === "/" || !isAbsoluteURL(effectiveBase)) {
-      if (typeof window !== "undefined" && window.location) {
-        effectiveBase = window.location.origin;
-      } else if (!effectiveBase) {
-        effectiveBase = "http://localhost"; // Fallback for non-browser environments
-      }
+    if (typeof window !== "undefined" && window.location) {
+      effectiveBase = window.location.origin;
+    } else if (
+      (!effectiveBase || effectiveBase === "/" || !isAbsoluteURL(effectiveBase)) &&
+      !effectiveBase
+    ) {
+      // Non-browser with an EMPTY base only: neutral placeholder. An invalid
+      // non-empty base deliberately keeps its value so `new URL` throws and
+      // the caller's relative-URL fallback applies (pre-existing contract).
+      effectiveBase = "http://localhost";
     }
-    
+
     // If url is already absolute, use it directly
     if (isAbsoluteURL(url)) {
       return {
@@ -241,7 +256,7 @@ export const parseURL = (
         url: new URL(url),
       };
     }
-    
+
     return {
       type: "success",
       url: new URL(url, effectiveBase),

--- a/test/unit/urls.test.ts
+++ b/test/unit/urls.test.ts
@@ -157,4 +157,42 @@ describe('URL utilities', () => {
       expect(result.moduleBaseURL).toBe('http://localhost:5173/');
     });
   });
-}); 
+
+  describe('createPageURL in a browser (origin-split regression)', () => {
+    // The bug this pins: a baked PUBLIC_ORIGIN resolved module/rsc URLs onto
+    // an ABSOLUTE origin. Served from any other origin (port collision,
+    // 127.0.0.1 vs localhost, a preview deploy), the document's scripts and
+    // the flight-loaded chunks came from different origins — two module
+    // graphs, TWO REACTS, and hydration died with a null dispatcher instead
+    // of any visible error. In a browser the document's own origin must win;
+    // the baked origin remains for metadata URLs (createAbsoluteURL) and for
+    // non-browser contexts (covered by the block above, which runs without a
+    // window).
+    const fakeWindow = {
+      location: { origin: 'http://127.0.0.1:4174' },
+    };
+
+    it('resolves moduleBaseURL and indexRSC on the SERVING origin, not the baked one', () => {
+      (globalThis as { window?: unknown }).window = fakeWindow;
+      try {
+        const pageURL = createPageURL('/', 'http://localhost:4173');
+        const result = pageURL('/todos/');
+        expect(result.moduleBaseURL).toBe('http://127.0.0.1:4174/');
+        expect(result.indexRSC).toBe('http://127.0.0.1:4174/todos/index.rsc');
+      } finally {
+        delete (globalThis as { window?: unknown }).window;
+      }
+    });
+
+    it('keeps an explicitly absolute moduleBaseURL verbatim (CDN escape hatch)', () => {
+      (globalThis as { window?: unknown }).window = fakeWindow;
+      try {
+        const pageURL = createPageURL('https://cdn.example.com/assets/', 'http://localhost:4173');
+        const result = pageURL('/todos/');
+        expect(result.moduleBaseURL).toBe('https://cdn.example.com/assets/');
+      } finally {
+        delete (globalThis as { window?: unknown }).window;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Bug

Building with a baked `PUBLIC_ORIGIN` resolved the browser's module-loading URLs onto that **absolute origin**: the flight decoder's `moduleBaseURL` (client-component chunk imports), the `index.rsc` fetch, and `createCallServer`'s action endpoint. Serve the app from any other origin — a port collision bumping `vite preview` to the next port, `127.0.0.1` vs `localhost`, a preview deploy — and the document's scripts come from origin A while the flight-loaded chunks come from origin B. Two origins → two module graphs → **two Reacts**, and hydration dies with a null dispatcher deep inside a client component. No 404, no warning; it reads exactly like an app bug and has burned real debugging time twice.

esm transport only — the webpack transport's baked chunk manifest is path-relative and was never affected.

## Fix

In a **browser**, the document's own origin always wins for these URLs (they name same-origin assets of the page being served). Scoped to `parseURL`:

- explicitly absolute `moduleBaseURL` input still passes through verbatim — the deliberate-CDN escape hatch;
- non-browser contexts keep their exact behavior, including the invalid-base → relative-URL fallback contract;
- `PUBLIC_ORIGIN` remains the source for absolute **metadata** URLs (`createAbsoluteURL`: canonical, `og:image`) — its legitimate job.

The bead's fallback suggestion (a startup origin-mismatch warning) is deliberately not included: with this fix an origin mismatch is a normal production topology (baked `https://example.com`, served from an internal preview host), not an error.

## Quality-of-life rider

Discovered while reproducing: `PUBLIC_ORIGIN=… vite build` **silently does nothing** — the plugin reads the prefixed `VITE_PUBLIC_ORIGIN`. Builds now warn once per variable (`PUBLIC_ORIGIN`, `BASE_URL`), naming the exact variable to set — but **only when the value truly went nowhere**: consumers that supply it another way (the demo repos pass `base: process.env.BASE_URL` in their Vite configs and carry `VITE_`-prefixed twins in `.env`) stay silent. Verified against bidoof's real `build:preview`: zero warnings; a bare-only setup: warns for both; prefixed env: silent.

## Verification

A/B on a static esm build with `VITE_PUBLIC_ORIGIN=http://localhost:4173` baked, served simultaneously from `localhost:4173` and `127.0.0.1:4517`, loaded via the second (Playwright, request-origin tracking):

| | cross-origin loads | dispatcher errors | hydrated client-nav |
|---|---|---|---|
| registry (pre-fix) | `index.rsc` + every client chunk | `null (reading 'useContext')` | broken |
| this branch | none | none | works |

Same-origin serving unaffected. New browser-context regression tests in `urls.test.ts` (origin-split + CDN passthrough); the pre-existing node-context contract tests all pass unchanged. Full gate green on both condition halves (260 + 833), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)