### PR TITLE
chore(release): 3.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.5",
+      "version": "3.4.6",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump only. Ships #305: browser module/flight/action URLs follow the **serving** origin — a baked `PUBLIC_ORIGIN` can no longer split the module graph into two Reacts (the silent null-dispatcher hydration death on any origin mismatch; esm transport). `PUBLIC_ORIGIN` remains the source for metadata URLs, an explicit absolute `moduleBaseURL` still passes through, and builds now warn when a bare `PUBLIC_ORIGIN`/`BASE_URL` env var is set but truly goes nowhere (silent for setups that supply the value another way — verified against the demo repos).

After merge: tag `v3.4.6`, then `npm publish` (2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)