### PR TITLE
fix(client): say "aborted" for a departing document, reword the static fallback

### DIFF
--- a/plugin/utils/hydrateOrRender.ts
+++ b/plugin/utils/hydrateOrRender.ts
@@ -44,13 +44,37 @@ export function hydrateOrRender(
   getInitialNode: () => ReactNode | PromiseLike<ReactNode>,
   options: HydrateOrRenderOptions = {}
 ): void {
+  // A document being NAVIGATED AWAY FROM (a reload interrupting a reload, a
+  // link clicked mid-load) has its in-flight module imports and fetches
+  // aborted by the browser — those rejections land here, but they describe a
+  // document that is already being discarded, not a hydration failure on the
+  // page the user ends up on (which loads fine). Track departure via
+  // `pagehide` and say so plainly instead of raising an error; the browser's
+  // own "Loading failed for the module…" reports are not ours to suppress.
+  // Registered lazily so this module stays import-safe outside the browser.
+  let departing = false;
+  if (typeof window !== "undefined") {
+    window.addEventListener("pagehide", () => (departing = true), {
+      once: true,
+    });
+  }
   const onError =
     options.onError ??
-    ((error: unknown) =>
+    ((error: unknown) => {
+      if (departing) {
+        console.info(
+          "[vprs] hydrateOrRender: load aborted — the page was reloaded or " +
+            "navigated away before hydration finished"
+        );
+        return;
+      }
       console.error(
-        "[vprs] hydrateOrRender: initial payload failed; staying static",
+        "[vprs] hydrateOrRender: could not load the initial payload — leaving " +
+          "the server-rendered HTML as-is (no hydration; links fall back to " +
+          "full-page navigation)",
         error
-      ));
+      );
+    });
 
   // Resolve the node and import react-dom/client concurrently; mount only once
   // BOTH are ready. Promise.all consumes both, so a rejection on either path

--- a/test/unit/hydrateOrRender.test.ts
+++ b/test/unit/hydrateOrRender.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+// Straight off dist like the worker tests: the utils barrel is condition-split
+// and this browser-side helper isn't reachable through the server barrel.
+import { hydrateOrRender } from "../../dist/plugin/utils/hydrateOrRender.js";
+
+/**
+ * The default onError wording contract (user report, 2026-07-28):
+ * - a document being navigated away from (reload interrupting a reload) gets
+ *   its in-flight loads aborted — say it was ABORTED, as info, not an error;
+ * - a genuine initial-payload failure logs an error that says what the page
+ *   will do (stay server-rendered, links full-page), replacing the old
+ *   "staying static" wording.
+ */
+describe("hydrateOrRender default onError", () => {
+  let pagehide: (() => void) | undefined;
+  const fakeRoot = { hasChildNodes: () => true } as unknown as Element;
+
+  beforeEach(() => {
+    pagehide = undefined;
+    (globalThis as { window?: unknown }).window = {
+      addEventListener: (ev: string, fn: () => void) => {
+        if (ev === "pagehide") pagehide = fn;
+      },
+    };
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+    vi.restoreAllMocks();
+  });
+
+  const flush = () => new Promise((r) => setTimeout(r, 50));
+
+  it("says ABORTED (info, not error) when the document departed before settling", async () => {
+    hydrateOrRender(fakeRoot, () => Promise.reject(new Error("aborted import")));
+    pagehide?.(); // the navigation-away happens before the rejection lands
+    await flush();
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.info).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(console.info).mock.calls[0][0])).toMatch(/aborted/i);
+  });
+
+  it("logs a real error (with the new wording) when the document stayed", async () => {
+    hydrateOrRender(fakeRoot, () => Promise.reject(new Error("server down")));
+    await flush();
+    expect(console.info).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    const msg = String(vi.mocked(console.error).mock.calls[0][0]);
+    expect(msg).toMatch(/could not load the initial payload/);
+    expect(msg).not.toMatch(/staying static/);
+  });
+
+  it("a custom onError overrides the default entirely", async () => {
+    const onError = vi.fn();
+    hydrateOrRender(fakeRoot, () => Promise.reject(new Error("x")), { onError });
+    pagehide?.();
+    await flush();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(console.info).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What the user sees today

Hard-reloading again while a page is still loading aborts the abandoned document's in-flight module imports. Those rejections land in `hydrateOrRender`'s default handler, which logs:

```
[vprs] hydrateOrRender: initial payload failed; staying static TypeError: error loading dynamically imported module: …
```

That reads like a real hydration failure — but it describes the *discarded* document; the page the user actually lands on loads and hydrates fine (verified against the live consumer site with an interrupted-reload probe: final document has zero errors and working client-side navigation).

## Change

The default `onError` now registers a `pagehide` listener:

- **Departing document** → one plain `console.info`: `load aborted — the page was reloaded or navigated away before hydration finished`. Says what happened instead of raising a scary error (and instead of staying silent).
- **Genuine failure** → reworded error that states the consequence: `could not load the initial payload — leaving the server-rendered HTML as-is (no hydration; links fall back to full-page navigation)`. The odd "staying static" phrasing is gone.
- A custom `onError` overrides everything, unchanged.

The browser's own "Loading failed for the module …" reports for the aborted fetches are not ours to suppress and remain.

## Verification

- Unit tests (3): departed → info with "aborted" and no error; stayed → error with the new wording and the old wording asserted absent; custom `onError` bypasses both.
- Interrupted-reload Playwright probe against a static consumer build: final document hydrates, client-nav works, no error-level vprs lines. (Chromium tears abandoned documents down before their handlers run, so the new info line is mainly observable in Firefox — where the original report came from.)
- Full gate green on both condition halves (260 + 836), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)