### PR TITLE
chore: six small fixes from the docs audit

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -219,8 +219,7 @@ Configuration for CSS handling:
 
 ```typescript
 interface CssConfig {
-  inlineCss?: boolean; // Default: false
-  purgeCss?: boolean; // Default: false
+  inlineCss?: boolean; // Default: undefined = auto (inline files <= inlineThreshold); false disables inlining
   inlineThreshold?: number; // Default: 4096 (4KB)
   inlinePatterns?: RegExp[];
   linkPatterns?: RegExp[];

--- a/docs/internals/transformer.md
+++ b/docs/internals/transformer.md
@@ -93,12 +93,12 @@ Server actions are excluded entirely.
 
 ## Client-Module Classification
 
-The transformer never re-implements directive detection. It calls `detectClientModule({ source, moduleId, parseFn: this.parse })` from `plugin/loader/directives/detectClientModule.ts` — the single source of truth shared with the dev-server file watcher, the worker react-loader, build auto-discover, and the configurable `loader.*` defaults. The `parseFn` argument lets the transformer use Rollup's AST; the other call sites fall through to the parser-free `sourceHasTopLevelClientDirective` scanner. Both paths agree on every well-authored case.
+The transformer never re-implements directive detection. It calls `detectClientModule({ source, moduleId, parseFn })` from `react-server-loader/directives` (vprs's own `./directives` subpath is only a back-compat re-export of that module) — the single source of truth shared with the dev-server file watcher, the worker react-loader, build auto-discover, and the configurable `loader.*` defaults. The `parseFn` argument lets the transformer supply rsl's acorn-based parser; the other call sites fall through to the parser-free `sourceHasTopLevelClientDirective` scanner. Both paths agree on every well-authored case.
 
 The filename half of the classifier:
 
 ```ts
-// plugin/loader/directives/detectClientModule.ts:23
+// react-server-loader: directives/detectClientModule.ts
 const CLIENT_FILENAME_PATTERN = /(^|[\/.])client\.[cm]?[jt]sx?$/;
 ```
 

--- a/plugin/config/defaults.tsx
+++ b/plugin/config/defaults.tsx
@@ -263,8 +263,11 @@ export const DEFAULT_CONFIG = {
     // this is because the rsc-worker is used to stream rsc during development
   },
   CSS: {
+    // undefined = AUTO: inline when the file is at or under inlineThreshold,
+    // link otherwise (inlinePatterns/linkPatterns override per file). `false`
+    // disables inlining entirely. There is no `true` force — set
+    // inlineThreshold: 0 to size-gate nothing, or use inlinePatterns.
     inlineCss: undefined,
-    purgeCss: false,
     inlineThreshold: 4096, // 4KB
     inlinePatterns: [] as RegExp[], // Always inline CSS modules
     linkPatterns: [] as RegExp[], // Always link node_modules CSS

--- a/plugin/helpers/createCssProps.tsx
+++ b/plugin/helpers/createCssProps.tsx
@@ -10,7 +10,6 @@ import { DEFAULT_CONFIG } from "../config/defaults.js";
  * - path is a string
  * - css is an object with the following properties:
  *   - inlineCss: boolean
- *   - purgeCss: boolean
  *   - inlineThreshold: number
  *   - inlinePatterns: RegExp[]
  *   - linkPatterns: RegExp[]

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -13,7 +13,7 @@ import { RouterProvider, useLocation } from "./router-react.js";
 // The supplied client entry: assembles createRouter + RouterProvider +
 // createReactFetcher + hydration + HMR so a consumer's client.tsx is one line:
 //
-//   import { startClient } from "vite-plugin-react-server/router";
+//   import { startClient } from "vite-plugin-react-server/router/client";
 //   startClient({ patterns: ROUTES });
 //
 // Only pages that use client nav ship this; a pure-static page needs no entry.

--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -316,9 +316,11 @@ export const createTransformerPlugin = (
 
           // Robustly determine whether this module is a client reference by a
           // top-of-file `"use client"` DIRECTIVE (not by the `.client.`
-          // filename). `detectClientModule` parses with Rollup's JSX-aware
-          // `this.parse` and reuses `analyzeDirectives` internally; if the
-          // parse fails it falls back to the parser-free char-scanner. We
+          // filename). `detectClientModule` parses with rsl's acorn-based
+          // `rslParse` (passed as parseFn — NOT the bundler's `this.parse`,
+          // whose parser is JS-only under Vite 8/rolldown) and reuses
+          // `analyzeDirectives` internally; if the parse fails it falls back
+          // to the parser-free char-scanner. We
           // pass `source` only (no `moduleId`) so the filename pattern is
           // skipped here — that path is handled downstream in
           // `createModuleID` via the same helper.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,9 +52,9 @@ export default defineConfig({
       // from a react-client process via spawning a react-server worker.
       // The router client suite (Link / RouterProvider) imports
       // react-dom/client, which throws under the react-server condition, so it
-      // runs client-mode only — mirror of the unit/server exclusion above.
+      // runs client-mode only — mirror of the unit exclusion above.
       ...(getCondition() !== "react-server"
-        ? ["test/unit/**/*.test.*", "test/server/**/*.test.*"]
+        ? ["test/unit/**/*.test.*"]
         : ["test/router/**/*.test.*"]),
     ],
   },


### PR DESCRIPTION
The batch pre-scoped by the docs audit — six one-line-ish fixes, no behavior changes:

1. `startClient` example comment: the import path is `/router/client`, not `/router`.
2. **`purgeCss` removed** — it existed only as a default value and a doc mention; never typed, never read anywhere.
3. **`inlineCss` default documented** at the definition and in `api-reference.md`: `undefined` = auto (inline files ≤ `inlineThreshold`, default 4 KB), `false` disables inlining entirely; there is no `true` force (use `inlineThreshold`/`inlinePatterns`).
4. `vitest.config.ts`: dropped the `test/server/**` exclusion glob — the directory doesn't exist. Full gate runs identical test counts before/after.
5. Transformer comment: `detectClientModule` parses with rsl's acorn-based `rslParse` passed as `parseFn` — not the bundler's `this.parse` (JS-only under Vite 8/rolldown).
6. `internals/transformer.md`: directive detection's source of truth is `react-server-loader/directives`; vprs's `./directives` subpath is the back-compat re-export (deliberately kept — it's a public export).

Full gate green on both condition halves (260 + 833), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)