### PR TITLE
fix(error): carry the panic flag across the worker boundary faithfully

### DIFF
--- a/plugin/error/serializeError.ts
+++ b/plugin/error/serializeError.ts
@@ -1,4 +1,4 @@
-import { PANIC_SYMBOL } from "./shouldPanic.js";
+import { PANIC_SYMBOL, isPanic } from "./shouldPanic.js";
 
 export function serializeError(error: unknown): {
   message?: string;
@@ -7,6 +7,13 @@ export function serializeError(error: unknown): {
   environment?: string;
   cause?: unknown;
   breadcrumbs?: string[];
+  /**
+   * The panic flag as a PLAIN field: the real flag lives on a Symbol key,
+   * which (a) the old string-key read here never found and (b) postMessage's
+   * structured clone drops anyway. This field is what actually crosses the
+   * worker boundary; toError re-applies the Symbol on rehydration.
+   */
+  isPanic?: boolean;
   [PANIC_SYMBOL]?: boolean;
 } {
   if (error instanceof Error) {
@@ -18,8 +25,8 @@ export function serializeError(error: unknown): {
       cause: cause,
       breadcrumbs:
         (error as Error & { breadcrumbs: string[] })["breadcrumbs"] ?? [],
-      [PANIC_SYMBOL]:
-        (error as Error & { PANIC_SYMBOL: boolean })["PANIC_SYMBOL"] ?? false,
+      isPanic: isPanic(error),
+      [PANIC_SYMBOL]: isPanic(error),
       ...rest,
     };
   }
@@ -29,6 +36,7 @@ export function serializeError(error: unknown): {
       stack: undefined,
       name: "Unknown React Stream Error",
       breadcrumbs: [],
+      isPanic: false,
       [PANIC_SYMBOL]: false,
     };
   }
@@ -45,7 +53,8 @@ export function serializeError(error: unknown): {
       stack: stack,
       name: name,
       breadcrumbs: [],
-      [PANIC_SYMBOL]: false,
+      isPanic: isPanic(error),
+      [PANIC_SYMBOL]: isPanic(error),
       ...rest,
     };
   }

--- a/plugin/error/toError.ts
+++ b/plugin/error/toError.ts
@@ -1,4 +1,6 @@
 // React types are imported from vendor system at runtime
+import { PANIC_SYMBOL } from "./shouldPanic.js";
+
 type ErrorInfo = {
   componentStack?: string;
 };
@@ -31,6 +33,14 @@ export function toError(error: unknown, errorInfo?: ErrorInfo): Error {
       } else {
         // If no stack trace available, capture one at this point
         // Error.captureStackTrace(err, toError);
+      }
+      // Rehydrate the panic classification: serializeError carries it as the
+      // plain `isPanic` field because the Symbol key does not survive
+      // postMessage's structured clone. Panic decided in the worker stays
+      // panic on the main thread instead of being re-derived from
+      // panicThreshold downstream.
+      if ((error as { isPanic?: boolean }).isPanic === true) {
+        (err as unknown as Record<symbol, boolean>)[PANIC_SYMBOL] = true;
       }
       return err;
     }

--- a/test/unit/panicAcrossWorkerBoundary.test.ts
+++ b/test/unit/panicAcrossWorkerBoundary.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { serializeError } from "../../dist/plugin/error/serializeError.js";
+import { toError } from "../../dist/plugin/error/toError.js";
+import { PANIC_SYMBOL, isPanic } from "../../dist/plugin/error/shouldPanic.js";
+
+/**
+ * The panic flag must survive the worker message boundary. Two historical
+ * defects, both pinned here:
+ * - serializeError read the STRING key "PANIC_SYMBOL" while handleError sets
+ *   a Symbol key — the read was always false;
+ * - even a Symbol-keyed field on the envelope is dropped by postMessage's
+ *   structured clone. The envelope therefore carries a plain `isPanic`, and
+ *   toError re-applies the Symbol on rehydration.
+ * structuredClone() simulates the postMessage boundary faithfully.
+ */
+describe("panic flag across the worker boundary", () => {
+  it("a panic error round-trips serializeError → structuredClone → toError as panic", () => {
+    const err = new Error("boom");
+    (err as unknown as Record<symbol, boolean>)[PANIC_SYMBOL] = true;
+
+    const envelope = serializeError(err);
+    expect(envelope.isPanic).toBe(true);
+
+    const arrived = structuredClone(envelope);
+    // The Symbol key is gone after the clone — only the plain field survives.
+    expect((arrived as Record<symbol, unknown>)[PANIC_SYMBOL]).toBeUndefined();
+
+    const rehydrated = toError(arrived);
+    expect(isPanic(rehydrated)).toBe(true);
+    expect(rehydrated.message).toBe("boom");
+  });
+
+  it("a non-panic error round-trips as non-panic", () => {
+    const envelope = serializeError(new Error("ordinary"));
+    expect(envelope.isPanic).toBe(false);
+    const rehydrated = toError(structuredClone(envelope));
+    expect(isPanic(rehydrated)).toBe(false);
+  });
+});


### PR DESCRIPTION
From the docs audit (`internals/ERROR_HANDLING.md`, MEDIUM): the panic classification made inside a worker never reached the main thread.

## Two defects, one dropped flag

1. `serializeError` read the **string** key `"PANIC_SYMBOL"` — but `handleError` marks errors with a **Symbol** key (`Symbol.for('vite-plugin-react-server.panic')`), so the read was always `false`.
2. Even if it had read the Symbol, a Symbol-keyed property on the message envelope is dropped by `postMessage`'s structured clone.

Downstream code papered over this by re-deriving panic from `panicThreshold === 'all_errors'` instead of trusting the classification made at the error site.

## Fix

- The envelope carries a plain `isPanic: boolean` (read via the real `isPanic()` helper); the Symbol-keyed field remains for same-thread consumers.
- `toError` re-applies `PANIC_SYMBOL` when rehydrating a serialized worker error carrying `isPanic: true`.

## Verification

Round-trip unit test simulates the boundary with `structuredClone`: panic error → envelope has `isPanic: true`, clone drops the Symbol (asserted), rehydration restores `isPanic(err) === true`; a non-panic error round-trips false. Full gate green on both condition halves (260 + 835), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)