### PR TITLE
docs(troubleshooting): stable-train snapshot pitfalls — title #418, missing charset

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -84,6 +84,24 @@ Keep every transitive dependency on that same React with npm overrides:
 
 `$react` means "the version my own dependencies declare", so all deps dedupe onto your React. Mixing channels (experimental transport on stable React, or vice versa) crashes on internals skew — the exact peer pin exists to stop that.
 
+## Static Snapshot Hydration Throws #418 on `<title>` (Stable React)
+
+**Symptoms:** Every cold load of a prerendered (frozen) page logs `Minified React error #418` with args `text,` — and afterwards the document has **two** `<title>` elements. The same page served per-request (dev, `npm run edge`, a server) hydrates clean.
+
+**This is a stable-React hydration bug against frozen snapshots, and it's cosmetic.** React 19.2.x stable fails to adopt the snapshot's hoistable `<title>` during hydration: it reports the mismatch and inserts its own title next to the server one. The page still hydrates and islands work. Removing the `<title>` removes the error, but the right fix is the experimental channel — the adoption bug is already fixed there (same install recipe as the preload section above). Verified against 3.4.6 snapshots: stable errors on every load, the experimental train is clean.
+
+## Mojibake on Static Hosts (Missing `charset`)
+
+**Symptoms:** On some static hosts, non-ASCII text in a prerendered page (`…`, `—`, curly quotes) renders as `â€¦`-style garbage. The same build looks fine on GH Pages or Vercel.
+
+A snapshot contains exactly the head your app renders — nothing injects a charset for you. When the file server also omits `charset=utf-8` from `Content-Type` (GH Pages and Vercel send it; bare servers often don't), the browser falls back to Latin-1. Declare it in the app:
+
+```tsx
+<meta charSet="utf-8" />
+```
+
+React hoists it to first-in-head with charset precedence, so the snapshot is self-describing on any host.
+
 ## `"use server"` Not Working
 
 - File-level: must be first line


### PR DESCRIPTION
Two stable-React pitfalls surfaced while probing frozen snapshots on a bare static server, documented next to the existing preload-warning section since the remedy is the same experimental-train recipe:

- **`<title>` hydration #418**: stable 19.2.x fails to adopt a frozen snapshot's hoistable title — every cold load logs #418 (`text,`) and the document ends up with two title elements. Per-request rendering of the same page is clean, so this only shows on the static path. Cosmetic (hydration completes, islands work); fixed on the experimental channel.
- **Missing charset**: snapshots contain exactly the head the app renders; with no `<meta charSet>` and a file server that omits `charset=utf-8` (GH Pages/Vercel send it, bare servers often don't), the browser parses Latin-1 and non-ASCII text mojibakes. The doc now tells apps to render `<meta charSet="utf-8" />`, which React hoists first-in-head.

Both verified against 3.4.6 snapshots: stable errors on every cold load, the experimental exact-pin train is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)