### PR TITLE
fix(dev): don't mistake link-fetched server CSS for client-owned on hotUpdate

### DIFF
--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -104,16 +104,25 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       // in the CLIENT module graph (the browser fetches it directly and Vite
       // injects it as a <style>), so Vite's native CSS HMR already updates it
       // in place — no reload, no <link> cache-bust. Detect that case by the
-      // presence of client-environment modules for this file and hand the
-      // update back to Vite by returning undefined. This is the dev:ssr
-      // counterpart to the #96 fix in plugin.server.ts: that fix only takes
-      // effect on the dev:rsc main thread (createPluginOrchestrator.server.js
-      // -> plugin.server.ts). dev:ssr loads plugin.client.ts instead, so
-      // without this branch client-graph CSS falls into the `return []`
-      // suppression below and Vite's native CSS HMR never fires — leaving the
-      // edit stuck until a manual refresh.
-      const isClientGraphCss = isCssFile && (ctx.modules?.length ?? 0) > 0;
+      // presence of client-graph IMPORTERS and hand the update back to Vite
+      // by returning undefined. Node presence alone is NOT the signal: a
+      // server-only stylesheet rendered as <link href="/src/….css"> also gets
+      // a client-graph node the moment the browser fetches that URL — but no
+      // importers, so Vite's "native handling" for it is a full reload while
+      // the RSC worker keeps the stale css-module proxy (old class-name
+      // hashes) until a server restart. This is the dev:ssr counterpart to
+      // the #96 fix in plugin.server.ts: that fix only takes effect on the
+      // dev:rsc main thread; dev:ssr loads plugin.client.ts instead.
+      const isClientGraphCss =
+        isCssFile &&
+        (ctx.modules ?? []).some(
+          (m: { importers?: Set<unknown> }) => (m.importers?.size ?? 0) > 0,
+        );
       if (isClientGraphCss) {
+        // Vite owns the visible update, but the RSC worker still holds the
+        // css-module JS proxy — drop it so the next server render agrees
+        // with the new stylesheet's class-name hashes.
+        hmrHandler?.sendHmrUpdate(file);
         return; // let Vite's native client CSS HMR apply the update
       }
 

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -68,11 +68,20 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
         // in the CLIENT module graph (the browser fetches it directly and Vite
         // injects it as a <style>), so Vite's native CSS HMR already updates it
         // in place — no reload, no <link> cache-bust. Detect that case by the
-        // presence of client-environment modules for this file and hand the
-        // update back to Vite. Suppressing it here (the `return []` below) is
-        // what previously left client-graph CSS edits stuck until a manual
+        // presence of client-graph IMPORTERS and hand the update back to
+        // Vite. Node presence alone is not enough: a server-only stylesheet
+        // rendered as <link> also gets a client-graph node from the browser's
+        // fetch of that URL, but with no importers Vite can only full-reload —
+        // that css must stay on the RSC refetch + cache-bust path below.
+        // Suppressing genuinely client-owned css here (the `return []` below)
+        // is what previously left client-graph CSS edits stuck until a manual
         // refresh: the RSC <link> cache-bust never matches a Vite <style>.
-        if (isCssFile && (ctx.modules?.length ?? 0) > 0) {
+        if (
+          isCssFile &&
+          (ctx.modules ?? []).some(
+            (m: { importers?: Set<unknown> }) => (m.importers?.size ?? 0) > 0,
+          )
+        ) {
           return; // let Vite's native client CSS HMR apply the update
         }
 

--- a/test/dev/css-hmr.test.ts
+++ b/test/dev/css-hmr.test.ts
@@ -110,4 +110,41 @@ describe("CSS module handling in dev", () => {
     expect(afterBody).toContain("rgb(0, 0, 255)");
     expect(afterBody).not.toMatch(/color:\s*red/);
   }, 20000);
+
+  it("re-renders flight with class names matching the served CSS after an edit", async () => {
+    // The browser fetches a server-rendered stylesheet as a plain <link>
+    // request, which registers an importer-LESS node for the file in the
+    // client module graph. That node must not be mistaken for client-owned
+    // CSS: when it was, the css edit was handed to Vite (whose only move for
+    // an importer-less sheet is a full reload) and the rsc worker never
+    // dropped its css-module proxy — so the flight kept serving the OLD
+    // class-name hashes against the NEW stylesheet until a server restart.
+    await fetch(`http://localhost:${port}/src/page/test.module.css?direct`);
+    const flightBefore = await (
+      await fetch(`http://localhost:${port}/`, {
+        headers: { Accept: "text/x-component" },
+      })
+    ).text();
+    expect(flightBefore).toMatch(/_test_/);
+
+    await writeFile(
+      cssPath,
+      `.test {color: rgb(7, 7, 7); padding: 9px}\n.shared {background: white}`
+    );
+    await sleep(1500);
+
+    const flightAfter = await (
+      await fetch(`http://localhost:${port}/`, {
+        headers: { Accept: "text/x-component" },
+      })
+    ).text();
+    const classAfter = flightAfter.match(/_test_[a-zA-Z0-9_-]+/)?.[0];
+    const cssAfter = await (
+      await fetch(`http://localhost:${port}/src/page/test.module.css?direct`)
+    ).text();
+    // Content edits move the css-modules hash; the flight must move with
+    // it. A mismatch is the stale-until-restart symptom.
+    expect(classAfter).toBeTruthy();
+    expect(cssAfter).toContain(classAfter!);
+  }, 20000);
 });


### PR DESCRIPTION
## The bug

In dev, editing a CSS module that only server components import (e.g. a wordmark style) did nothing until the dev server was restarted. Repro: starter working tree, `npm run dev`, edit the lockup css — the page full-reloads but renders unstyled, because the re-rendered flight still carries the old css-modules class hashes (`_wordmark_rtsyt_97`) while the served stylesheet has the new ones (`_wordmark_1u1aj_97`).

## Root cause

A server-rendered stylesheet reaches the browser as `<link href="/src/….css">`, and that fetch registers a node for the file in the **client** module graph. Both dev plugins used node **presence** (`ctx.modules.length > 0`) to mean "Vite's client CSS HMR owns this edit" and returned early. But an importer-less node isn't HMR-capable: Vite's only move for it is a full reload, and the early return meant the rsc worker never dropped its cached css-module proxy — so server renders kept the stale class hashes until a restart rebuilt the graph.

The distinction only bit once a project had **no client component importing the stylesheet** — any `"use client"` importer masks it, which is why it went unnoticed.

## The fix

- Detect client-owned CSS by client-graph **importers**, not node presence (both `plugin.client.ts` for dev:ssr and `plugin.server.ts` for dev:rsc).
- When Vite does own the visible update, still send the worker invalidation so the next server render agrees with the new hashes.

## Verification

- New regression test in `test/dev/css-hmr.test.ts`: after an edit, the flight's class names must appear in the served stylesheet. **A/B: fails against main's detection under dev:ssr, passes with the fix**; green in both conditions.
- Real-browser check on the starter with the patched dist: three consecutive edits each applied live (class hash and computed style moving together, custom refetch event instead of full-reload), no restart.
- `test/dev/css-hmr.test.ts` + `test/dev/hmr.test.ts` green under both `test:client` and `test:server` conditions; full gate left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)