### PR TITLE
chore(release): 3.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.6",
+      "version": "3.4.7",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release. Ships:

- #311 — fix(dev): server-only CSS modules hot-update again — client-owned CSS is now detected by client-graph importers, not node presence, and the rsc worker's css-module proxy is invalidated so flight class hashes track the served stylesheet (was: stale until dev-server restart)
- #309 — fix(error): panic flag survives the worker boundary
- #307 — fix(client): hydrateOrRender reports a user-abort as an abort instead of "staying static"
- #310 — docs: stable-train snapshot pitfalls (title #418, missing charset)
- #308 — docs audit batch

Full gate on main pre-bump: test:server 839 passed / test:client 261 passed, exit 0 both halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)