### PR TITLE
feat(router): parity extras — index routes, pathless groups, error/loading boundaries, head.ts, loader redirect/notFound

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,13 @@ prerequisite: the project must be ESM (`"type": "module"` in `package.json`).
 // vite.config.ts
 import { defineConfig } from "vite";
 import { vitePluginReactServer } from "vite-plugin-react-server";
-import { fileRouter } from "vite-plugin-react-server/router";
-
-// Scans src/routes/** for page.tsx (+ sibling props.ts) and derives the
-// route table and the prerender worklist.
-const router = fileRouter("src/routes");
 
 export default defineConfig({
   plugins: vitePluginReactServer({
     moduleBase: "src",
-    Page: router.Page,
-    props: router.props,
-    routePatterns: router.routePatterns,
-    build: { pages: router.build.pages },
+    // Scans src/routes/** for page.tsx (+ sibling props.ts) and derives the
+    // route table and the prerender worklist.
+    routes: { dir: "routes" },
   }),
 });
 ```
@@ -125,7 +119,7 @@ startClient({
 </body>
 ```
 
-Routing is opt-in: skip `fileRouter` and map URLs to files yourself with
+Routing is opt-in: skip `routes` and map URLs to files yourself with
 a `Page: (url) => string` mapping — see [Routing](./docs/routing.md).
 
 ```bash
@@ -175,7 +169,7 @@ Name a file `Counter.client.tsx` if you like the reminder — but the name carri
 no meaning, and a file named that way *without* the directive gets a build
 warning telling you to add one.
 
-See [Getting Started](./docs/getting-started.md#the-client-filename-is-optional).
+See [Getting Started](./docs/getting-started.md#what-makes-it-a-client-component).
 
 ## Third-party client-component packages
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,13 +14,13 @@ Read in order if you're new; each stands alone otherwise.
 - [Storybook](./storybook.md) — rendering RSC components in stories
 - [Examples](./examples.md) — static site, dynamic server, custom routing
 - [Troubleshooting](./troubleshooting.md) — common errors and fixes
+- [React Compatibility](./react-type-compatibility.md) — supported React versions, the vendored transport, and the type system
 - [API Reference](./api-reference.md) — exports, types, components, defaults
 - [Comparison](./comparison.md) — how vprs differs from Next.js, Waku, and `@vitejs/plugin-rsc`
 
 ## Maintenance
 
 - [Releasing](./releasing.md) — version bumps, publishing, demo updates
-- [React Compatibility](./react-type-compatibility.md) — the vendored ESM transport and the type system
 
 ## Internals (contributors)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -58,6 +58,10 @@ export const config = {
 | `static` | `string` | Static output directory | `"static"` |
 | `hash` | `string` | Hash for client files | `"hash"` |
 | `preserveModulesRoot` | `boolean` | When `true`, preserves the `moduleBase` directory (e.g. `src/`) in output paths. When `false`, strips it from output paths. | `false` |
+| `renderMode` | `"parallel" \| "sequential"` | How SSG renders pages: concurrent batches, or one at a time (less memory, deterministic order) | `"parallel"` |
+| `batchSize` | `number` | Pages rendered concurrently when `renderMode` is `"parallel"` | `8` |
+| `inlineFlight` | `boolean` | Inline each prerendered route's flight payload into its `index.html` (non-executable `<script id="vprs-flight">`), so first paint hydrates with no `index.rsc` round-trip. Runs at the post-SSG point in both build modes. See [Build Output](./build-output.md). | `false` |
+| `edge` | `boolean \| EdgeBuildConfig` | Single-isolate edge bundle (see [`build.edge`](#buildedge) below) | `true` |
 | `assetsDir` | `string` | Assets directory | `"assets"` |
 | `api` | `string` | API output directory | `"api"` |
 | `outDir` | `string` | Output directory | `"dist"` |
@@ -164,11 +168,16 @@ type RootProps = {
 
 ### CssContent
 
-CSS content can be either inline (string) or linked (object with href):
+A value in `cssFiles` / `globalCss` maps — props for one `<style>` or `<link>`
+tag, exactly as the `Css` component renders it (see
+[CSS Handling](./css-handling.md)):
 
 ```typescript
-type CssContent<InlineCSS extends boolean = boolean> = 
-  InlineCSS extends true ? string : { href: string };
+type CssContent =
+  // inline: rendered as <style type="text/css">{children}</style>
+  | { as: "style"; type: "text/css"; children?: React.ReactNode }
+  // linked: rendered as <link rel="stylesheet" href … /> (react-dom hoistable)
+  | { as: "link"; rel: string; href: string; precedence?: string };
 ```
 
 ## Build Configuration
@@ -203,8 +212,15 @@ Single-isolate edge bundle (additive; **ON by default**). See [Edge / Single-Iso
 //   false           → opt out
 //   { … }           → emit, with overrides
 interface EdgeBuildConfig {
-  outDir?: string;  // Default: "server-edge" (under build.outDir)
-  minify?: boolean; // Default: true — edge runtimes cap bundle size
+  outDir?: string;    // Default: "server-edge" (under build.outDir)
+  minify?: boolean;   // Default: true — edge runtimes cap bundle size
+  // Which RSC transport the baked bundle renders through. "esm" resolves
+  // client references via import(moduleBaseURL + id) at request time;
+  // "webpack" resolves them through the baked client manifest (closed module
+  // map — the fully self-contained deployment model). Defaults from the
+  // top-level `transport` option when set. Don't mix flavors across one
+  // deploy's routes — see [Edge / Single-Isolate](./edge.md).
+  transport?: "esm" | "webpack"; // Default: "esm"
 }
 ```
 
@@ -246,75 +262,29 @@ This option is useful when you want to maintain your source directory structure 
 
 ### PluginEvent
 
-Events emitted during build processes:
+`onEvent` receives every plugin event; switch on `event.type`. Each event
+carries a `data` payload (full shapes in `plugin/types.ts`):
 
-```typescript
-type PluginEvent = 
-  | { type: 'build:start'; data: { target: string } }
-  | { type: 'build:end'; data: { target: string; duration: number } }
-  | { type: 'page:build:start'; data: { url: string; target: string } }
-  | { type: 'page:build:end'; data: { url: string; target: string; duration: number } }
-  | { type: 'error'; data: { message: string; stack?: string } }
-  | { type: 'warning'; data: { message: string } };
-```
+| `type` | When | Notable `data` fields |
+|--------|------|----------------------|
+| `"file.write"` | a prerendered file starts writing | `path`, `fileType` (`"html"`/`"rsc"`), `route`, `stream` |
+| `"file.write.done"` | that write completed | `route`, `fileType`, `path`, `content`, `chunks` |
+| `"route.error"` | a route render failed | `route`, `error`, `isPanic`, `panicThreshold` |
+| `"route.shellError"` | the HTML shell failed | `route`, `error` |
+| `"route.shellReady"` / `"route.allReady"` | streaming milestones per route | `route` |
+| `"route.postpone"` | React postponed a route | `route`, `reason` |
+| `"props.load"` | a route's loader resolved | `route` |
+| `"css.process"` | CSS was processed for a route | route/css details |
+| `"build.start"` | a build began | — |
+| `"build.writeBundle.server"` / `".client"` / `".static"` | an environment's bundle was written | bundle details |
+| `"build.ssg.start"` / `"build.ssg.end"` | the SSG pass began / finished | — |
 
-### BuildMetrics
+### Metrics
 
-Metrics collected during builds:
-
-```typescript
-interface BuildMetrics {
-  buildTime: number;
-  htmlSize: number;
-  rscSize: number;
-  cssSize: number;
-  jsSize: number;
-  pageCount: number;
-  errorCount: number;
-  warningCount: number;
-}
-```
-
-## Worker Messages
-
-### WorkerMessage
-
-Messages sent between main thread and workers:
-
-```typescript
-type WorkerMessage = 
-  | { type: 'render'; data: RenderRequest }
-  | { type: 'result'; data: RenderResult }
-  | { type: 'error'; data: { message: string; stack?: string } }
-  | { type: 'ready'; data: {} };
-```
-
-### RenderRequest
-
-Request structure for rendering:
-
-```typescript
-interface RenderRequest {
-  url: string;
-  pageProps?: any;
-  moduleBaseURL: string;
-  cssFiles: CssFile[];
-  globalCss: CssFile[];
-}
-```
-
-### RenderResult
-
-Result structure from rendering:
-
-```typescript
-interface RenderResult {
-  html: string;
-  rsc: string;
-  css: string;
-  duration: number;
-}
-```
+`onMetrics` receives a discriminated union of render, worker-startup,
+module-resolution, ssg-render, inline-flight and edge-bake metrics — see the
+[Metric types](#metric-types) table under Metric Watcher for the full list of
+`metrics.type` values and their fields.
 
 ## Type Definitions
 
@@ -339,24 +309,10 @@ type CssComponentType = (props: CssProps) => React.ReactNode;
 ### Environment Detection
 
 ```typescript
-// Check current execution context
-function getCondition(): string | null;
+import { getCondition } from "vite-plugin-react-server/config";
 
-// Environment-specific configurations
-const RSC_LOADER = {
-  development: {
-    importServerPath: "react-server-dom-esm/server.node",
-    importClientPath: "react-server-dom-esm/server.node",
-    registerClientReferenceName: "registerClientReference",
-    registerServerReferenceName: "registerServerReference"
-  },
-  production: {
-    importServerPath: "react-server-dom-esm/server",
-    importClientPath: "react-server-dom-esm/server",
-    registerClientReferenceName: "registerClientReference",
-    registerServerReferenceName: "registerServerReference"
-  }
-};
+// "react-server" when the process runs under that condition, else null.
+function getCondition(): string | null;
 ```
 
 ## Directive Patterns
@@ -584,7 +540,7 @@ import type {
   RootProps,
   BuildConfig,
   PluginEvent,
-  BuildMetrics
+  OnMetrics
 } from "vite-plugin-react-server/types";
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -110,7 +110,7 @@ export const config = {
 |--------|------|-------------|---------|
 | `cssPattern` | `RegExp \| string` | Pattern to match CSS files | `/\.css$/` |
 | `cssModulePattern` | `RegExp \| string` | Pattern to match CSS module files | `/\.css\.js$/` |
-| `clientPattern` | `RegExp \| string` | Which filenames *look* like client modules. Since 19.2.15 this no longer classifies anything — a first-party file matching it but carrying no `"use client"` directive gets a build **warning** telling you to add one. A filename is not a portable signal: name-classified files work under this plugin and silently become server modules under every other React toolchain. | `/(^\|[\/.])client\.[cm]?[jt]sx?$/` |
+| `clientPattern` | `RegExp \| string` | Filenames that follow the client-module naming convention (`*.client.tsx`). Only the `"use client"` directive makes a module a client module; this pattern is a lint — a matching first-party file without the directive gets a build warning to add one. | `/(^\|[\/.])client\.[cm]?[jt]sx?$/` |
 | `serverPattern` | `RegExp \| string` | Pattern to match server function files | `/\.server\.(js\|ts\|jsx\|tsx)$/` |
 | `htmlPattern` | `RegExp \| string` | Pattern to match HTML files | `/\.html$/` |
 | `jsonPattern` | `RegExp \| string` | Pattern to match JSON files | `/\.json$/` |
@@ -415,7 +415,11 @@ const AUTO_DISCOVER = {
 
 A file is a client module when its source starts with a top-of-file `"use client"` directive. That is the only mechanism.
 
-`clientPattern` no longer classifies anything. It says which filenames *look* like client modules, and a first-party file that matches it but carries no directive gets a build **warning** telling you to add one. The name was never a portable signal — a module marked client by its filename works here and silently becomes a server module under every other React toolchain — so it is a hint to the author, not an input to the build.
+`clientPattern` is a lint, not a classifier: a first-party file whose name
+matches but has no directive gets a build warning to add one. The warning
+exists because filename conventions don't travel — every React toolchain honors
+the directive, none honor a name — so a file relying on its name alone would
+render as a server module anywhere else.
 
 ### Extension Mapping
 

--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -1,6 +1,8 @@
 # Build Output
 
-Running `NODE_OPTIONS='--conditions react-server' vite build --app` produces three directories:
+Running `vite build --app` produces three directories (prefix
+`NODE_OPTIONS='--conditions react-server'` if you want the optional
+main-thread render — the output is identical either way):
 
 ```
 dist/
@@ -124,7 +126,8 @@ createServer(toNodeListener(app)).listen(3000);
 
 For the complete pattern — including per-request rendering of dynamic routes —
 see the [bidoof-template](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official)
-demo's `start.tsx` and the vprs-starter's
+demo's `start.tsx` and the
+[vprs-starter](https://github.com/nicobrinkkemper/vprs-starter)'s
 `server/handler.mjs`.
 
 ## Where it runs: static anywhere, dynamic on Node
@@ -189,10 +192,13 @@ Both streams include detailed stack traces in development mode.
 ### Single-step (recommended)
 
 ```bash
-NODE_OPTIONS='--conditions react-server' vite build --app
+vite build --app
 ```
 
-Builds all three environments in sequence automatically.
+Builds all three environments in sequence automatically. Prefixing
+`NODE_OPTIONS='--conditions react-server'` is an optional variant — the main
+thread renders RSC directly instead of a worker; a bit faster, better stack
+traces, same output.
 
 ### Multi-step (for debugging)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,11 +55,17 @@ export default defineConfig({
       batchSize: 8,                    // pages per batch in parallel mode
       rscOutputPath: "index.rsc",
       htmlOutputPath: "index.html",
+      // Inline each prerendered route's flight into its index.html so first
+      // paint hydrates with no index.rsc round-trip. See docs/build-output.md.
+      inlineFlight: false,
 
       // Optional — single-isolate edge bundle (additive; ON by default).
-      // `boolean | { outDir?, minify? }`. See docs/edge.md.
+      // `boolean | { outDir?, minify?, transport? }`. See docs/edge.md.
       //   edge: false             — opt out
       //   edge: { minify: false } — keep on, tune a default
+      //   transport: "esm" (default, import-at-request-time client refs) or
+      //   "webpack" (baked client manifest — the self-contained deploy model);
+      //   defaults from the top-level `transport` option when set.
       edge: true,
     },
 
@@ -154,11 +160,18 @@ Both produce identical output. The RSC worker is skipped in `dev:rsc` mode by de
   "scripts": {
     "dev": "vite",
     "dev:rsc": "NODE_OPTIONS='--conditions react-server' vite",
-    "build": "NODE_OPTIONS='--conditions react-server' vite build --app",
+    "build": "vite build --app",
     "preview": "vite preview"
   }
 }
 ```
+
+`--conditions react-server` is optional everywhere, never required: with it the
+main thread renders RSC directly (a bit faster, better stack traces); without
+it a worker thread carries the react-server condition and the output is
+identical. `dev:rsc` above is that optional variant for dev; add
+`NODE_OPTIONS='--conditions react-server'` to `build` too if you want the same
+for builds.
 
 ## Third-party `"use client"` packages
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,36 +28,41 @@ Build and deploy `dist/static/`.
 - [bidoof-template](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official) — starter template
 - [mmc](https://github.com/nicobrinkkemper/mmc) — 284 pages
 
-## Dynamic Server (Express)
+## Dynamic Server (Node / Express)
 
-Use the build output as ESM modules in an Express server:
+Don't hand-roll the server: `createRequestHandler` serves the prerendered
+output with the MIME types and traversal guard a file server has to get right,
+dispatches `"use server"` actions through the sealed baked gate, and renders
+dynamic routes per request through the edge bundle's render hook — see
+[Build Output](./build-output.md#using-the-esm-modules-in-a-server):
 
 ```ts
-// server.ts
+// server.ts — plain Node, no framework needed
+import { createServer } from "node:http";
+import {
+  createRequestHandler,
+  toNodeListener,
+} from "vite-plugin-react-server/request-handler";
+import { createEdgeRenderHook } from "vite-plugin-react-server/edge";
+import * as bundle from "./dist/server-edge/render.js";
+
+const handler = createRequestHandler({
+  staticDir: "dist/static",              // prerendered HTML, .rsc, assets
+  render: createEdgeRenderHook(bundle),  // per-request dynamic routes
+  action: bundle.handleRouteAction,      // sealed action gate, baked at build
+});
+
+createServer(toNodeListener(handler)).listen(3000);
+```
+
+Under Express the same handler mounts as middleware — Express only adds
+whatever else your app needs around it:
+
+```ts
 import express from "express";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
 const app = express();
-
-// Static pages (pre-rendered)
-app.use(express.static(join(__dirname, "dist/static")));
-
-// RSC endpoint
-app.get("*.rsc", (req, res) => {
-  res.setHeader("Content-Type", "text/x-component");
-  res.sendFile(join(__dirname, "dist/static", req.path));
-});
-
-// Dynamic route — render on request using server modules
-app.get("/user/:id", async (req, res) => {
-  const { Page } = await import("./dist/server/pages/user/page.js");
-  const props = { userId: req.params.id };
-  // Use createRscStream / createHtmlStream to render
-  // ...
-});
-
+app.use(toNodeListener(handler));
 app.listen(3000);
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,9 @@ vprs 1.x required `react@experimental` and bundled the transport in-repo. For
 - **No API changes** to the plugin itself: your `vite.config`, page files, and
   directives are unchanged.
 
+There are no 3.x migration notes: v3's additions (the file router's `routes`
+field, the edge bundle) are additive, and a working 2.x config runs unchanged.
+
 ## Create a Page
 
 ```tsx
@@ -268,20 +271,15 @@ vitePluginReactServer({
 })
 ```
 
-## HMR Setup
+## HMR
 
-For automatic RSC refetching when server components change:
-
-```tsx
-// Client entry
-import { createReactFetcher, setupRscHmr } from "vite-plugin-react-server/utils";
-
-const { initialContent, refetch } = createReactFetcher({ callServer });
-
-if (import.meta.hot) {
-  setupRscHmr(import.meta.hot, refetch);
-}
-```
+Nothing to set up: `startClient` (the one-line client entry from
+[Routing](./routing.md#client-side-navigation)) wires RSC HMR along with
+hydration and the client router — a server-component edit refetches the
+current route's flight automatically. Assembling the client entry by hand
+instead? `useRscHmr` from `vite-plugin-react-server/utils` is the same hook
+`startClient` uses, and `setupRscHmr()` is the non-React form (call it once in
+your entry; it refetches the current page's flight on server-component edits).
 
 ## Next Steps
 

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -31,9 +31,10 @@ npm install react@<that-exact-version> react-dom@<that-exact-version>
 
 `react-server-loader` is a regular **dependency** whose range admits the
 stable train plus the exact experimental build this release was verified
-against (`^19.2.17 || 0.0.0-experimental-172742b4-20260716`), so every package
-manager installs it for you — the stable train by default, no extra step (yarn
-included).
+against — check `dependencies["react-server-loader"]` in vprs's
+[`package.json`](https://github.com/nicobrinkkemper/vite-plugin-react-server/blob/main/package.json)
+for the current range. Every package manager installs it for you — the stable
+train by default, no extra step (yarn included).
 
 To run the experimental train, install all three React packages at the
 `@experimental` tag. The loader's range also admits that experimental build, so

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -63,21 +63,25 @@ for why the versions line up the way they do.
 > shipped in stable React, and 2.0 moved the transport out to
 > `react-server-loader`.
 
-## Looking ahead: `react-server-dom-esm` on npm
+## Why the transport is vendored, not installed from npm
 
-`react-server-loader` vendors the `react-server-dom-esm` transport because, to
-date, that package has never been published to npm — installing it directly
-gives an empty `0.0.1` placeholder, so downstream tools have had to build and
-bundle it from React source for each release.
+`react-server-loader` vendors both flight transports: `react-server-dom-esm`,
+which has never been published to npm (the name there is an empty `0.0.1`
+placeholder), and `react-server-dom-webpack`, which *is* published. That second
+half is the tell — this is not a workaround for a missing package. Other RSC
+integrations make the same call (Vite's own `@vitejs/plugin-rsc` vendors the
+webpack transport too), because a flight transport binds to the internals of
+one exact React build. Shipping a copy pinned to the React it was built against
+is the only way to guarantee the pair agree; an npm install with a floating
+range cannot.
 
-There's an open proposal to change that:
-[react/react#36768](https://github.com/react/react/pull/36768) would publish
-`react-server-dom-esm` to npm. It's still under review and not guaranteed to
-land. *If* it ships and a future vprs release adopts it, the transport could be
-installed straight from React's own published package and `react-server-loader`
-would no longer be the dependency that carries it. Nothing changes until then —
-`react-server-loader` is installed for you as described above. Follow the PR if
-you want to track where this goes.
+Publishing `react-server-dom-esm` was proposed upstream
+([facebook/react#36768](https://github.com/facebook/react/pull/36768)) and
+rejected. The esm transport also ships without the reference-manifest layer the
+webpack variant gets from its bundler, so any loader adopting it has to own
+that layer anyway — `react-server-loader` does. Vendoring is the design, not a
+stopgap: to move React versions, bump `react-server-loader` together with the
+matching `react` / `react-dom` as described above.
 
 ## ESM Transport
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -23,17 +23,27 @@ codegen step.
 
 ## The convention
 
-Under `routes.dir`, a directory's path **is** its URL. Three filenames are
+Under `routes.dir`, a directory's path **is** its URL. These filenames are
 meaningful:
 
 | file | role |
 | --- | --- |
 | `page.tsx` | the page rendered at this URL |
+| `index.tsx` | alternate name for the page (`page.tsx` wins when both exist) |
 | `props.ts` | this segment's **loader** — its return value is the page's props |
 | `route.tsx` | a **layout** wrapping this segment's page and every descendant |
+| `error.tsx` | a client **error boundary** for this segment and every descendant |
+| `loading.tsx` | a **Suspense fallback** for this segment and every descendant |
+| `head.ts` | this segment's **head/meta contribution**, merged root→leaf |
 
 A directory named `$name` is a **dynamic param**. A directory named just `$` is a
-**catch-all**.
+**catch-all**. A directory named `(group)` is **pathless**: it organizes files
+(and can hold a shared `route.tsx` / `error.tsx`) without adding a URL segment —
+two pages collapsing onto one URL is a scan-time error, not a silent override.
+
+`index.tsx` is matched as jsx/tsx only, deliberately: `index.ts` is the
+conventional barrel filename, and a re-export barrel inside the routes tree must
+never become a route.
 
 ```
 src/routes/
@@ -80,6 +90,84 @@ export const Layout = ({ section, children }: { section?: string; children?: Rea
 
 So `/greet/ada` composes as **root layout › greet layout › page**, each layer
 with its own props. That is the whole nesting model.
+
+Within one segment the wrap order is `Layout → ErrorBoundary →
+Suspense(Loading) → children` — a segment's boundary catches its children, not
+its own layout. None of these files requires the others; a segment can
+contribute just a `loading.tsx` or just a `head.ts`.
+
+## Error and loading boundaries
+
+`error.tsx` is a `"use client"` module exporting the boundary. Wrap a fallback
+with `createErrorBoundary` and it catches render errors in the segment's
+subtree — including errors a server component threw into the flight stream:
+
+```tsx
+// src/routes/error.tsx
+"use client";
+import { createErrorBoundary } from "vite-plugin-react-server/router/client";
+
+export const ErrorBoundary = createErrorBoundary(({ error, reset }) => (
+  <div role="alert">
+    <p>{error.message}</p>
+    <button onClick={reset}>Retry</button>
+  </div>
+));
+```
+
+`loading.tsx` exports `Loading` — the Suspense fallback shown while a nested
+loader streams:
+
+```tsx
+// src/routes/greet/$name/loading.tsx
+export const Loading = () => <p>Loading greeting…</p>;
+```
+
+## Per-route head and meta
+
+`head.ts` exports `head`: a static object, or a function receiving
+`{ url, params, data }` where `data` is the segment's resolved loader result.
+Contributions merge root→leaf — the deepest title wins, and a meta entry keyed
+by `name`/`property` overrides an ancestor's same-key entry:
+
+```ts
+// src/routes/head.ts
+export const head = {
+  title: "My site",
+  meta: [{ name: "description", content: "…" }],
+};
+
+// src/routes/greet/$name/head.ts
+import type { RouteHeadExport } from "vite-plugin-react-server/router";
+export const head: RouteHeadExport = ({ data }) => ({
+  title: `Greeting ${data.name}`,
+});
+```
+
+The merged tags render as react-dom hoistables, so they land in the document
+`<head>` on every render path — dev, static prerender, and edge.
+
+## Redirect and notFound from a loader
+
+A loader ends the render early by throwing:
+
+```ts
+// src/routes/old/props.ts
+import { redirect } from "vite-plugin-react-server/router";
+export const props = () => redirect("/new-home");        // 302 by default
+
+// or, for a gated route:
+import { notFound } from "vite-plugin-react-server/router";
+export const props = (_url, { request }) => {
+  if (!isAuthorized(request)) throw notFound();
+  return loadSecrets();
+};
+```
+
+Per-request renders (dev, Node, edge) answer with the 3xx or a 404; client
+navigation follows the redirect transparently and the router fixes the address
+bar. The static prerender can't answer a redirect, so it **skips the page with
+a warning** — don't enumerate redirecting routes in `staticPaths`.
 
 ## Static, dynamic, or both
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -144,8 +144,14 @@ export const head: RouteHeadExport = ({ data }) => ({
 });
 ```
 
-The merged tags render as react-dom hoistables, so they land in the document
-`<head>` on every render path — dev, static prerender, and edge.
+The merged contribution is delivered per surface: document renders (static
+prerender, the edge document) emit real `<title>`/`<meta>`/`<link>` tags into
+the page `<head>` for crawlers, while the hydration/navigation flight carries
+the same data inertly and the client router applies `title` and keyed `meta`
+after hydration and on every navigation. (Raw head tags deliberately don't
+ride the flight: React re-inserts instead of adopting them when hydration
+suspends on a client component, duplicating tags and throwing hydration
+error #418.) `links` and unkeyed meta are document-only.
 
 ## Redirect and notFound from a loader
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,8 +8,8 @@
 
 ```json
 {
-  "react": "^19.0.0",
-  "react-dom": "^19.0.0",
+  "react": "^19.2.7",
+  "react-dom": "^19.2.7",
   "@types/react": "^19.0.9",
   "@types/react-dom": "^19.0.3"
 }
@@ -208,7 +208,7 @@ This is an upstream Rolldown limitation, not vprs-specific. Workarounds:
 
 ## Checklist for New Projects
 
-- [ ] React packages have matching versions (19+)
+- [ ] React packages have matching versions (19.2+)
 - [ ] Client components have `"use client"` directive
 - [ ] Server actions have `"use server"` directive
 - [ ] Imports use `.js` extensions

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,8 +42,7 @@ are tolerated above it.
 
 If the build warns that a file *looks* like a client module but has no directive,
 that is this: the filename does not mark a component, so add `"use client"` to
-the top of the file. (Naming it `.client.tsx` and omitting the directive used to
-work here, and worked nowhere else — which is why it no longer does.)
+the top of the file.
 
 Import with the `.js` extension regardless: `import { Counter } from "./Counter.js"`.
 

--- a/examples/hello-world/vite.config.ts
+++ b/examples/hello-world/vite.config.ts
@@ -4,10 +4,10 @@ import { StreamPluginOptions, vitePluginReactServer } from "vite-plugin-react-se
 export default defineConfig({
   plugins: [vitePluginReactServer({
     moduleBase: "src",
-    Page: "src/page.tsx",
-    props: "src/props.ts",
+    // File-based routing: scan `moduleBase` itself — src/page.tsx (+ sibling
+    // props.ts) becomes "/", and the prerender worklist derives from the tree.
+    routes: {},
     build: {
-      pages: ["/"],
       // The single-isolate edge bundle is ON by default; the object form just
       // tunes it. Here: keep dist/server-edge/render.js unminified for learning
       // (minify defaults to true for real edge deploys). `edge: false` opts out.

--- a/examples/router/README.md
+++ b/examples/router/README.md
@@ -11,6 +11,23 @@ Shows the built-in file router end to end:
   navigates client-side with no full reload.
 - **getStaticPaths** — prerenders `/greet/ada` and `/greet/grace`; any other
   `/greet/<name>` renders live per request on the edge.
+- **Index routes** — `src/routes/about/index.tsx` is a leaf route
+  (`page.tsx` wins when both exist; `index.ts` barrels are never routes).
+- **Pathless groups** — `(legacy)/old` serves `/old`: a `(group)` directory
+  organizes files (and can hold a shared `route.tsx`/`error.tsx`) without
+  adding a URL segment.
+- **head.ts** — per-segment title/meta merged root→leaf (leaf title wins).
+  A function export receives `{ url, params, data }`, so
+  `greet/$name/head.ts` derives `Greeting <name>` from the loader data. The
+  tags render as react-dom hoistables and land in `<head>` on every path.
+- **error.tsx** — a `"use client"` boundary for the segment's subtree:
+  `export const ErrorBoundary = createErrorBoundary(({ error, reset }) => …)`.
+- **loading.tsx** — `export const Loading = () => …` becomes the segment's
+  Suspense fallback while a nested loader streams.
+- **redirect / notFound** — a loader throws `redirect("/greet/ada")` (see
+  `(legacy)/old/props.ts`) or `notFound()`. Per-request paths answer with
+  the 3xx/404; the static prerender skips the page with a warning, so don't
+  enumerate redirecting routes in `getStaticPaths`.
 
 ```bash
 npm run dev      # dev server

--- a/examples/router/src/client.tsx
+++ b/examples/router/src/client.tsx
@@ -3,4 +3,4 @@
 // hydration + HMR. `patterns` lets useParams() resolve for the current url.
 import { startClient } from "vite-plugin-react-server/router/client";
 
-startClient({ patterns: ["/", "/greet/$name"] });
+startClient({ patterns: ["/", "/about", "/old", "/greet/$name"] });

--- a/examples/router/src/routes/(legacy)/old/page.tsx
+++ b/examples/router/src/routes/(legacy)/old/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/examples/router/src/routes/(legacy)/old/props.ts
+++ b/examples/router/src/routes/(legacy)/old/props.ts
@@ -1,0 +1,3 @@
+import { redirect } from "vite-plugin-react-server/router";
+
+export const props = () => redirect("/greet/ada");

--- a/examples/router/src/routes/about/head.ts
+++ b/examples/router/src/routes/about/head.ts
@@ -1,0 +1,3 @@
+import type { RouteHeadExport } from "vite-plugin-react-server/router";
+
+export const head: RouteHeadExport = { title: "About — File router demo" };

--- a/examples/router/src/routes/about/index.tsx
+++ b/examples/router/src/routes/about/index.tsx
@@ -1,0 +1,6 @@
+export const Page = () => (
+  <main>
+    <h1 data-testid="about-title">About</h1>
+    <p>An index.tsx leaf route.</p>
+  </main>
+);

--- a/examples/router/src/routes/error.tsx
+++ b/examples/router/src/routes/error.tsx
@@ -1,0 +1,9 @@
+"use client";
+import { createErrorBoundary } from "vite-plugin-react-server/router/client";
+
+export const ErrorBoundary = createErrorBoundary(({ error, reset }) => (
+  <div data-testid="route-error" role="alert">
+    <p>Something went wrong: {error.message}</p>
+    <button onClick={reset}>Retry</button>
+  </div>
+));

--- a/examples/router/src/routes/greet/$name/head.ts
+++ b/examples/router/src/routes/greet/$name/head.ts
@@ -1,0 +1,5 @@
+import type { RouteHeadExport } from "vite-plugin-react-server/router";
+
+export const head: RouteHeadExport = ({ data }) => ({
+  title: `Greeting ${(data as { name?: string }).name ?? "?"}`,
+});

--- a/examples/router/src/routes/greet/$name/loading.tsx
+++ b/examples/router/src/routes/greet/$name/loading.tsx
@@ -1,0 +1,1 @@
+export const Loading = () => <p data-testid="greet-loading">Loading greeting…</p>;

--- a/examples/router/src/routes/head.ts
+++ b/examples/router/src/routes/head.ts
@@ -1,0 +1,6 @@
+import type { RouteHeadContribution } from "vite-plugin-react-server/router";
+
+export const head: RouteHeadContribution = {
+  title: "File router demo",
+  meta: [{ name: "description", content: "vprs file-based routing" }],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.4.7",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.4.7",
+  "version": "3.5.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -285,30 +285,32 @@ export async function buildEdgeBundle(opts: {
     }
     const layoutParts: string[] = [];
     for (const layer of userOptions.layoutsResolver?.(resolveUrl) ?? []) {
-      const compAbs =
-        typeof layer.component === "string"
-          ? resolveBuilt(layer.component)
-          : undefined;
-      if (!compAbs) {
-        logger.warn(
-          `${tag} could not resolve built layout ${String(
-            layer.component
-          )} for route ${key}; skipping that layer`
-        );
-        continue;
+      // Bake every module the layer carries (layout component, shared props,
+      // error/loading boundaries, head). A field whose built module can't be
+      // resolved is dropped with a warning; the layer survives if any field
+      // resolved (a boundaries-only layer has no component at all).
+      const fieldParts: string[] = [];
+      for (const [field, src] of [
+        ["component", layer.component],
+        ["props", layer.props],
+        ["error", layer.error],
+        ["loading", layer.loading],
+        ["head", layer.head],
+      ] as const) {
+        if (typeof src !== "string") continue;
+        const abs = resolveBuilt(src);
+        if (!abs) {
+          logger.warn(
+            `${tag} could not resolve built ${field} module ${src} for route ${key}; dropping that field`
+          );
+          continue;
+        }
+        moduleParts.push(`${JSON.stringify(src)}: ${nsFor(abs)}`);
+        fieldParts.push(`${field}: ${JSON.stringify(src)}`);
       }
-      moduleParts.push(`${JSON.stringify(layer.component)}: ${nsFor(compAbs)}`);
-      let propsField = "";
-      const layerPropsAbs = layer.props ? resolveBuilt(layer.props) : undefined;
-      if (layer.props && layerPropsAbs) {
-        moduleParts.push(
-          `${JSON.stringify(layer.props)}: ${nsFor(layerPropsAbs)}`
-        );
-        propsField = `, props: ${JSON.stringify(layer.props)}`;
+      if (fieldParts.length) {
+        layoutParts.push(`{ ${fieldParts.join(", ")} }`);
       }
-      layoutParts.push(
-        `{ component: ${JSON.stringify(layer.component)}${propsField} }`
-      );
     }
     const layoutsField = layoutParts.length
       ? `, layouts: [${layoutParts.join(", ")}]`

--- a/plugin/components/html.tsx
+++ b/plugin/components/html.tsx
@@ -13,6 +13,10 @@ export const Html: HtmlComponentType<any, any, any, any> = ({
 }: HtmlProps) => (
   <html>
     <head>
+      {/* Without an explicit charset a browser may parse the UTF-8 snapshot
+          as windows-1252 — any non-ASCII text ("·", "—") then mismatches the
+          client render and hydration fails with React #418. */}
+      <meta charSet="utf-8" />
       <Css cssFiles={globalCss} />
     </head>
     <body>

--- a/plugin/config/autoDiscover/resolveAutoDiscover.ts
+++ b/plugin/config/autoDiscover/resolveAutoDiscover.ts
@@ -167,12 +167,19 @@ export const resolveAutoDiscover: ResolveAutoDiscoverFn =
         const [key, value] = userOptions.normalizer(src);
         if (!routeModuleInputs[key]) routeModuleInputs[key] = value;
       }
-      // Nested layouts: every matched `route.tsx` (and its shared props) must be
-      // BUILT too, or the renderer can't load the chain to fold it (the layer
-      // gets silently skipped). Add each layer's component + props as inputs,
-      // mirroring the Page/props probe above.
+      // Nested layouts: every matched `route.tsx` (and its shared props,
+      // error/loading boundaries and head module) must be BUILT too, or the
+      // renderer can't load the chain to fold it (the layer gets silently
+      // skipped). Add each layer's modules as inputs, mirroring the Page/props
+      // probe above.
       for (const layer of userOptions.layoutsResolver?.(probe) ?? []) {
-        for (const src of [layer.component, layer.props]) {
+        for (const src of [
+          layer.component,
+          layer.props,
+          layer.error,
+          layer.loading,
+          layer.head,
+        ]) {
           if (typeof src !== "string") continue;
           const [key, value] = userOptions.normalizer(src);
           if (!routeModuleInputs[key]) routeModuleInputs[key] = value;

--- a/plugin/config/autoDiscover/resolveBuildPages.ts
+++ b/plugin/config/autoDiscover/resolveBuildPages.ts
@@ -7,6 +7,7 @@ import type {
   ResolvedUserOptions,
 } from "../../types.js";
 import { resolveUrlOption } from "../resolveUrlOption.js";
+import type { RouteLayer } from "../../router/scanRoutes.js";
 import type { Logger } from "vite";
 import type { Manifest } from "vite";
 
@@ -116,7 +117,7 @@ export async function resolveBuildPages({
       page: string;
       root?: string;
       html?: string;
-      layouts?: { component: string; props?: string }[];
+      layouts?: RouteLayer[];
     }
   >();
   const routeMap = new Map<string, string[]>();
@@ -196,20 +197,30 @@ export async function resolveBuildPages({
       }
     }
 
-    // Nested layouts: resolve this route's `route.tsx` chain to (manifest-mapped)
-    // module paths, stored alongside page/props so the static prerender can fold
-    // the tree. Normalized + manifest-resolved exactly like page/props.
+    // Nested layouts: resolve this route's segment-layer chain to
+    // (manifest-mapped) module paths, stored alongside page/props so the static
+    // prerender can fold the tree. Normalized + manifest-resolved exactly like
+    // page/props. A layer field may be absent (e.g. boundaries without a
+    // `route.tsx`); a layer survives if ANY of its modules resolved.
+    const mapLayerPath = (src: string | undefined): string | undefined => {
+      if (!src) return undefined;
+      const resolved = resolvePathWithManifest(
+        userOptions.normalizer(src)[1],
+        manifest
+      );
+      return typeof resolved === "string" && resolved.length > 0
+        ? resolved
+        : undefined;
+    };
     const layouts = (userOptions.layoutsResolver?.(page) ?? [])
       .map((l) => ({
-        component: resolvePathWithManifest(
-          userOptions.normalizer(l.component)[1],
-          manifest
-        ),
-        props: l.props
-          ? resolvePathWithManifest(userOptions.normalizer(l.props)[1], manifest)
-          : undefined,
+        component: mapLayerPath(l.component),
+        props: mapLayerPath(l.props),
+        error: mapLayerPath(l.error),
+        loading: mapLayerPath(l.loading),
+        head: mapLayerPath(l.head),
       }))
-      .filter((l) => typeof l.component === "string" && l.component.length > 0);
+      .filter((l) => l.component || l.error || l.loading || l.head);
 
     if (!userOptions.props) {
       urlMap.set(page, {

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -19,6 +19,10 @@ import { join, resolve } from "node:path";
 import { pluginRoot } from "../root.js";
 import { createInputNormalizer } from "../helpers/inputNormalizer.js";
 import { resolveRoutesOption } from "../router/fileRouter.js";
+
+// Once-per-process guard for the loose-Page/props → `routes` nudge below
+// (resolveOptions runs per environment; the tip should print once).
+let routesNudgeShown = false;
 import { resolveDirectiveMatcher } from "./resolveDirectiveMatcher.js";
 import { resolveAllowedDirectives } from "./resolveAllowedDirectives.js";
 import { resolveRegExp } from "./resolveRegExp.js";
@@ -193,6 +197,20 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
         patterns: { pagePattern, propsPattern },
       })
     : undefined;
+  // Soft nudge (not a break): the loose Page/props/routePatterns remain the
+  // low-level escape hatch, but `routes` is the preferred surface — one field
+  // that derives all of them plus the prerender worklist. Only nudge when NO
+  // routes table is configured (explicit Page/props alongside routes is a
+  // deliberate override and stays quiet).
+  if (!options.routes && (options.Page || options.props) && !routesNudgeShown) {
+    routesNudgeShown = true;
+    console.info(
+      "[vite-plugin-react-server] Tip: the `routes` option (a file-routed " +
+        "tree or a custom router table) derives Page/props/routePatterns/" +
+        "build.pages from one field — see the routing docs. Explicit " +
+        "Page/props keep working as the low-level escape hatch."
+    );
+  }
   const effectivePage = options.Page ?? routerTable?.Page;
   const effectiveProps = options.props ?? routerTable?.props;
   const effectiveRoutePatterns =

--- a/plugin/config/routeExportNames.ts
+++ b/plugin/config/routeExportNames.ts
@@ -16,5 +16,11 @@ export const PAGE_EXPORT_NAME = "Page";
 export const PROPS_EXPORT_NAME = "props";
 /** Export name a `route.tsx` layout publishes its component under. */
 export const LAYOUT_EXPORT_NAME = "Layout";
+/** Export name an `error.tsx` publishes its client boundary under. */
+export const ERROR_EXPORT_NAME = "ErrorBoundary";
+/** Export name a `loading.tsx` publishes its Suspense fallback under. */
+export const LOADING_EXPORT_NAME = "Loading";
+/** Export name a `head.ts` publishes its head contribution under. */
+export const HEAD_EXPORT_NAME = "head";
 /** Filename the client router fetches a route's flight from. */
 export const RSC_OUTPUT_PATH = "index.rsc";

--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -15,6 +15,7 @@ import { handleError } from "../error/handleError.js";
 import { cleanupWorker } from "../helpers/workerCleanup.js";
 import { mergeConfig, type ResolvedConfig } from "vite";
 import { resolvePageAndProps } from "../helpers/resolvePageAndProps.js";
+import { isNotFound, isRedirect } from "../router/loaderSignals.js";
 
 export const configureReactServer: ConfigureReactServerFn =
   function _configureReactServer({
@@ -444,6 +445,26 @@ export const configureReactServer: ConfigureReactServerFn =
             }
             pageProps = {};
           } else {
+            // Loader control flow: answer the flight request itself instead of
+            // degrading to an empty-props render. A redirect points at the
+            // TARGET's flight so the browser's transparent follow yields a
+            // decodable payload (the client router fixes the address bar from
+            // `response.redirected`); a notFound is a plain 404.
+            if (isRedirect(propsResult.error)) {
+              const to = propsResult.error.to;
+              res.statusCode = propsResult.error.status;
+              res.setHeader(
+                "location",
+                (to === "/" ? "" : to.replace(/\/$/, "")) + "/index.rsc"
+              );
+              res.end();
+              return;
+            }
+            if (isNotFound(propsResult.error)) {
+              res.statusCode = 404;
+              res.end("Not Found");
+              return;
+            }
             if (verbose) {
               logger.warn(`[configureReactServer] Failed to load props for route ${info.route}: ${propsResult.error}`);
             }

--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -14,6 +14,7 @@ import { getNodeEnv } from "../config/getNodeEnv.js";
 import { isReactServerCondition } from "../config/getCondition.js";
 import { setupGlobalErrorHandler, cleanupGlobalErrorHandler } from "../error/setupGlobalErrorHandler.js";
 import { pipeToResponse } from "../helpers/pipeToResponse.js";
+import { isNotFound, isRedirect } from "../router/loaderSignals.js";
 
 /**
  * Configures the worker request handler.
@@ -366,6 +367,26 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
         });
         // Response is now being streamed - no need to wait for timeout
       } catch (error) {
+        // Loader control flow (redirect()/notFound() thrown in the RSC
+        // worker's loader; toError rehydrates the markers across the worker
+        // boundary): answer the request, don't report an error. The redirect
+        // points at the TARGET's flight — the browser follows transparently
+        // and the client router fixes the address bar.
+        if (!res.headersSent && isRedirect(error)) {
+          res.statusCode = error.status;
+          res.setHeader(
+            "location",
+            (error.to === "/" ? "" : error.to.replace(/\/$/, "")) +
+              "/index.rsc"
+          );
+          res.end();
+          return;
+        }
+        if (!res.headersSent && isNotFound(error)) {
+          res.statusCode = 404;
+          res.end("Not Found");
+          return;
+        }
         // Always log: misconfigured apps would otherwise return an empty 500
         // and leave the user staring at a hung tab without any console output.
         const panicError = handleError({

--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -342,6 +342,26 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
             },
             onHmrUpdate: () => {
             },
+            // Loader control flow surfaced by the worker (redirect()/
+            // notFound() thrown in a loader): answer the flight request
+            // before any bytes stream. The redirect points at the TARGET's
+            // flight — the browser follows transparently and the client
+            // router fixes the address bar from `response.redirected`.
+            onError: (_id, error) => {
+              if (res.headersSent) return;
+              if (isRedirect(error)) {
+                res.statusCode = error.status;
+                res.setHeader(
+                  "location",
+                  (error.to === "/" ? "" : error.to.replace(/\/$/, "")) +
+                    "/index.rsc"
+                );
+                res.end();
+              } else if (isNotFound(error)) {
+                res.statusCode = 404;
+                res.end("Not Found");
+              }
+            },
             // Always log shell errors. Without this an RSC render failure in
             // the worker would surface only via `verbose: true`, leaving the
             // user with a half-streamed RSC response and no explanation.

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -1,5 +1,6 @@
 import type { EdgeFetchHandler } from "../stream/createEdgeHandler.types.js";
 import { isUnknownRoute } from "../stream/unknownRoute.js";
+import { isNotFound, isRedirect } from "../router/loaderSignals.js";
 import { matchRoutes } from "../router/matchRoute.js";
 import type {
   CreateEdgeRequestHandlerOptions,
@@ -150,6 +151,20 @@ export function createEdgeRenderHook(
         });
       } catch (error) {
         if (isUnknownRoute(error)) return null;
+        // A loader redirect on the flight path points at the TARGET's flight,
+        // so the browser's transparent follow yields a decodable payload and
+        // the client router fixes the address bar from `response.redirected`.
+        if (isRedirect(error)) {
+          const flightTarget =
+            (error.to === "/" ? "" : error.to.replace(/\/$/, "")) +
+            "/" +
+            rscOutputPath;
+          return new Response(null, {
+            status: error.status,
+            headers: { location: flightTarget },
+          });
+        }
+        if (isNotFound(error)) return null;
         throw error;
       }
     }

--- a/plugin/error/toError.ts
+++ b/plugin/error/toError.ts
@@ -42,6 +42,22 @@ export function toError(error: unknown, errorInfo?: ErrorInfo): Error {
       if ((error as { isPanic?: boolean }).isPanic === true) {
         (err as unknown as Record<symbol, boolean>)[PANIC_SYMBOL] = true;
       }
+      // Rehydrate loader control-flow signals (redirect/notFound) the same
+      // way: serializeError spreads their plain marker fields onto the
+      // envelope, and the fresh Error built here must carry them onward or a
+      // redirect decided in the worker degrades to a plain error on the main
+      // thread.
+      const src = error as Record<string, unknown>;
+      if (src["$$vprsRedirect"] === true) {
+        Object.assign(err, {
+          $$vprsRedirect: true,
+          to: src["to"],
+          status: src["status"],
+        });
+      }
+      if (src["$$vprsNotFound"] === true) {
+        Object.assign(err, { $$vprsNotFound: true });
+      }
       return err;
     }
     

--- a/plugin/helpers/createElementWithReact.tsx
+++ b/plugin/helpers/createElementWithReact.tsx
@@ -84,13 +84,31 @@ export const createElementWithReact: CreateElementWithReactFN =
       );
     }
 
+    // Whether this compose renders the full HTML document (static snapshot /
+    // edge document) or a headless tree (the hydration + client-nav flight).
+    const isDocumentRender =
+      HtmlComponent != null && HtmlComponent !== React.Fragment;
+
     // Nested layouts: fold the root→leaf segment chain around the leaf page so
     // `<L0 {...p0}><L1 {...p1}><Page {...leafProps}/>…` renders as one tree.
     // Each segment wraps as Layout → ErrorBoundary → Suspense(Loading) →
     // children (Next's layout/error/loading nesting order), so a segment's
-    // boundary catches its children but not its own layout. The chain's merged
-    // `head.ts` contribution renders beside the leaf as react-dom hoistable
-    // tags (title/meta/link land in the document <head> on every render path).
+    // boundary catches its children but not its own layout.
+    //
+    // The chain's merged `head.ts` contribution is delivered two ways:
+    // - DOCUMENT renders get raw hoistable tags — react-dom hoists them into
+    //   the snapshot's <head> and out of the #root markup, so hydration never
+    //   sees them.
+    // - Every render (document and headless alike) gets an inert
+    //   `<template data-vprs-head>` carrying the merged head as JSON; the
+    //   client router reads it after hydration and after each navigation and
+    //   applies title/meta imperatively. Hoistables must NOT ride the
+    //   headless flight: when hydration suspends on a client-reference chunk
+    //   React re-inserts them instead of adopting the server copies —
+    //   duplicated <title>/<meta> plus hydration error #418, on both React
+    //   trains. The template renders identically on both sides, so the #root
+    //   markup stays hydration-consistent.
+    //
     // The composed component takes the leaf's props (Root/Html render it as
     // `<Page {...pageProps}/>`); each layer closes over its own resolved props.
     // No layers → the leaf page passes through unchanged, so every branch below
@@ -103,20 +121,40 @@ export const createElementWithReact: CreateElementWithReactFN =
             const Suspense = (React as unknown as { Suspense?: unknown })
               .Suspense;
             const head = mergeHead(layoutChain.map((l) => l.head));
-            const headTags = [
-              head.title !== undefined
-                ? create("title", { key: "head-title" }, head.title)
-                : null,
-              ...(head.meta ?? []).map((m, i) =>
-                create("meta", { key: `head-meta-${i}`, ...m })
-              ),
-              ...(head.links ?? []).map((l, i) =>
-                create("link", { key: `head-link-${i}`, ...l })
-              ),
-            ].filter(Boolean);
-            const leaf = headTags.length
-              ? create(React.Fragment, null, ...headTags, create(PageComponent, leafProps))
-              : create(PageComponent, leafProps);
+            const hasHead =
+              head.title !== undefined ||
+              (head.meta?.length ?? 0) > 0 ||
+              (head.links?.length ?? 0) > 0;
+            const headTags =
+              isDocumentRender && hasHead
+                ? [
+                    head.title !== undefined
+                      ? create("title", { key: "head-title" }, head.title)
+                      : null,
+                    ...(head.meta ?? []).map((m, i) =>
+                      create("meta", { key: `head-meta-${i}`, ...m })
+                    ),
+                    ...(head.links ?? []).map((l, i) =>
+                      create("link", { key: `head-link-${i}`, ...l })
+                    ),
+                  ].filter(Boolean)
+                : [];
+            const headData = hasHead
+              ? create("template", {
+                  key: "head-data",
+                  "data-vprs-head": JSON.stringify(head),
+                })
+              : null;
+            const leaf =
+              headTags.length || headData
+                ? create(
+                    React.Fragment,
+                    null,
+                    ...headTags,
+                    headData,
+                    create(PageComponent, leafProps)
+                  )
+                : create(PageComponent, leafProps);
             return layoutChain.reduceRight((child, layer) => {
               let node = child;
               if (layer.Loading && Suspense) {

--- a/plugin/helpers/createElementWithReact.tsx
+++ b/plugin/helpers/createElementWithReact.tsx
@@ -1,5 +1,6 @@
 import type { CreateHandlerOptions } from "../types.js";
 import type { ResolvedLayoutLayer } from "./resolveLayoutChain.js";
+import { mergeHead } from "../router/head.js";
 
 export type CreateElementWithReactOptions = Pick<
   CreateHandlerOptions,
@@ -83,8 +84,13 @@ export const createElementWithReact: CreateElementWithReactFN =
       );
     }
 
-    // Nested layouts: fold the root→leaf `route.tsx` chain around the leaf page
-    // so `<L0 {...p0}><L1 {...p1}><Page {...leafProps}/>…` renders as one tree.
+    // Nested layouts: fold the root→leaf segment chain around the leaf page so
+    // `<L0 {...p0}><L1 {...p1}><Page {...leafProps}/>…` renders as one tree.
+    // Each segment wraps as Layout → ErrorBoundary → Suspense(Loading) →
+    // children (Next's layout/error/loading nesting order), so a segment's
+    // boundary catches its children but not its own layout. The chain's merged
+    // `head.ts` contribution renders beside the leaf as react-dom hoistable
+    // tags (title/meta/link land in the document <head> on every render path).
     // The composed component takes the leaf's props (Root/Html render it as
     // `<Page {...pageProps}/>`); each layer closes over its own resolved props.
     // No layers → the leaf page passes through unchanged, so every branch below
@@ -94,10 +100,40 @@ export const createElementWithReact: CreateElementWithReactFN =
         ? function ComposedPage(leafProps: Record<string, unknown>) {
             const create = (React as unknown as { createElement: Function })
               .createElement;
-            return layoutChain.reduceRight(
-              (child, layer) => create(layer.Component, layer.props, child),
-              create(PageComponent, leafProps)
-            );
+            const Suspense = (React as unknown as { Suspense?: unknown })
+              .Suspense;
+            const head = mergeHead(layoutChain.map((l) => l.head));
+            const headTags = [
+              head.title !== undefined
+                ? create("title", { key: "head-title" }, head.title)
+                : null,
+              ...(head.meta ?? []).map((m, i) =>
+                create("meta", { key: `head-meta-${i}`, ...m })
+              ),
+              ...(head.links ?? []).map((l, i) =>
+                create("link", { key: `head-link-${i}`, ...l })
+              ),
+            ].filter(Boolean);
+            const leaf = headTags.length
+              ? create(React.Fragment, null, ...headTags, create(PageComponent, leafProps))
+              : create(PageComponent, leafProps);
+            return layoutChain.reduceRight((child, layer) => {
+              let node = child;
+              if (layer.Loading && Suspense) {
+                node = create(
+                  Suspense,
+                  { fallback: create(layer.Loading, null) },
+                  node
+                );
+              }
+              if (layer.ErrorBoundary) {
+                node = create(layer.ErrorBoundary, null, node);
+              }
+              if (layer.Component) {
+                node = create(layer.Component, layer.props, node);
+              }
+              return node;
+            }, leaf);
           }
         : PageComponent;
 

--- a/plugin/helpers/createSerializableHandlerOptions.ts
+++ b/plugin/helpers/createSerializableHandlerOptions.ts
@@ -150,9 +150,14 @@ export function createSerializableHandlerOptions(
   if (typeof layoutExportName === 'string') result.layoutExportName = layoutExportName;
   if (Array.isArray(layouts) && layouts.length) {
     // RouteLayer entries are plain string paths — structured-clone safe.
+    // Carry every layer field (layout, props, error/loading boundaries,
+    // head); dropping one here silently strips the feature in the worker.
     result.layouts = layouts.map((l) => ({
-      component: l.component,
+      ...(l.component ? { component: l.component } : {}),
       ...(l.props ? { props: l.props } : {}),
+      ...(l.error ? { error: l.error } : {}),
+      ...(l.loading ? { loading: l.loading } : {}),
+      ...(l.head ? { head: l.head } : {}),
     }));
   }
   if (typeof projectRoot === 'string') result.projectRoot = projectRoot;

--- a/plugin/helpers/resolveComponents.client.ts
+++ b/plugin/helpers/resolveComponents.client.ts
@@ -5,6 +5,8 @@ import type {
 } from "../worker/rsc/types.js";
 import { createModuleResolutionMetrics } from "../metrics/createModuleResolutionMetrics.js";
 import { performance } from "node:perf_hooks";
+import { toError } from "../error/toError.js";
+import { isLoaderSignal } from "../router/loaderSignals.js";
 
 export interface ResolveComponentsOptions {
   route: string;
@@ -117,13 +119,16 @@ export async function resolveComponents(
         ) {
           clearTimeout(timeout);
           worker.off("message", messageHandler);
-          reject(
-            new Error(
-              `Component resolution failed: ${
-                message.error?.message || "Unknown error"
-              }`
-            )
-          );
+          // Rehydrate the worker's serialized error instead of flattening it
+          // to a message string: a loader redirect()/notFound() carries plain
+          // marker fields that must survive to the request pipeline (and the
+          // panic flag rides the same way). Only a non-signal error gets the
+          // context prefix.
+          const rehydrated = toError(message.error ?? "Unknown error");
+          if (!isLoaderSignal(rehydrated)) {
+            rehydrated.message = `Component resolution failed: ${rehydrated.message}`;
+          }
+          reject(rehydrated);
         }
       };
 

--- a/plugin/helpers/resolveLayoutChain.ts
+++ b/plugin/helpers/resolveLayoutChain.ts
@@ -146,7 +146,9 @@ export async function resolveLayoutChain(
       let head: RouteHeadContribution | undefined;
       if (layer.head) {
         try {
-          const headModule = await loader(layer.head);
+          // `#export` id form like every other module load — bare ids trip
+          // loaders that split on "#" and inspect the export name.
+          const headModule = await loader(`${layer.head}#${HEAD_EXPORT_NAME}`);
           let value = headModule?.[HEAD_EXPORT_NAME] as RouteHeadExport | undefined;
           if (typeof value === "function") {
             const out = value({ url, params: ctx.params ?? {}, data: props });

--- a/plugin/helpers/resolveLayoutChain.ts
+++ b/plugin/helpers/resolveLayoutChain.ts
@@ -1,20 +1,36 @@
 import type { GenericModuleLoader } from "../types.js";
 import type { RouteLayer } from "../router/scanRoutes.js";
+import type { RouteHeadContribution, RouteHeadExport } from "../router/head.js";
+import {
+  ERROR_EXPORT_NAME,
+  HEAD_EXPORT_NAME,
+  LOADING_EXPORT_NAME,
+} from "../config/routeExportNames.js";
+import { isLoaderSignal } from "../router/loaderSignals.js";
 import { resolvePage } from "./resolvePage.js";
 import { resolveProps, type LoaderCtx } from "./resolveProps.js";
 
 /**
  * One resolved layer of a route's nested-layout chain: the loaded `route.tsx`
- * layout component plus its (already-invoked) loader props. `createElementWithReact`
- * folds these root→leaf around the leaf page — `<L0 {...p0}><L1 {...p1}>{page}…`.
+ * layout component plus its (already-invoked) loader props, and the segment's
+ * optional boundaries/head. `createElementWithReact` folds these root→leaf
+ * around the leaf page — `<L0 {...p0}><L1 {...p1}>{page}…`, wrapping each
+ * segment as `<Layout><ErrorBoundary><Suspense fallback={<Loading/>}>…`.
  */
 export type ResolvedLayoutLayer = {
-  Component: unknown;
+  /** The `route.tsx` layout, absent for a boundaries/head-only layer. */
+  Component?: unknown;
   props: Record<string, unknown>;
+  /** The `error.tsx` client boundary (a client reference at compose time). */
+  ErrorBoundary?: unknown;
+  /** The `loading.tsx` Suspense fallback component. */
+  Loading?: unknown;
+  /** The `head.ts` contribution, already evaluated against loader data. */
+  head?: RouteHeadContribution;
 };
 
 export interface ResolveLayoutChainOptions {
-  /** Ordered root→leaf `route.tsx` layers for the matched page (from scanRoutes). */
+  /** Ordered root→leaf segment layers for the matched page (from scanRoutes). */
   layouts: RouteLayer[];
   /** Request url, passed to each layer's `props(url, ctx)` loader. */
   url: string;
@@ -30,13 +46,30 @@ export interface ResolveLayoutChainOptions {
   logger?: { info: (m: string) => void; warn: (m: string) => void } | undefined;
 }
 
+/** Load one optional component module (error boundary / loading fallback). */
+const loadComponent = async (
+  id: string,
+  exportName: string,
+  loader: GenericModuleLoader,
+  logger?: { warn: (m: string) => void },
+): Promise<unknown> => {
+  const result = await resolvePage({ id, exportName, loader });
+  if (result.type !== "success" || result.module[exportName] == null) {
+    logger?.warn(
+      `[resolveLayoutChain] ${id} has no "${exportName}" export; skipping`,
+    );
+    return undefined;
+  }
+  return result.module[exportName];
+};
+
 /**
- * Resolve a matched route's `route.tsx` layout chain into loaded components +
+ * Resolve a matched route's segment-layer chain into loaded components +
  * props, preserving root→leaf order. Each layer is loaded via the same module
- * loader as the page; a layer whose `route.tsx` doesn't export the layout is
- * skipped (rendered as a passthrough) so a partially-authored tree still renders.
- * Layers resolve in parallel — each gets its own `{ params, request }` — mirroring
- * the page/props resolution in {@link resolvePageAndProps}.
+ * loader as the page; a file whose expected export is missing is skipped (the
+ * layer renders as a passthrough) so a partially-authored tree still renders.
+ * Layers resolve in parallel — each gets its own `{ params, request }` —
+ * mirroring the page/props resolution in {@link resolvePageAndProps}.
  */
 export async function resolveLayoutChain(
   opts: ResolveLayoutChainOptions
@@ -46,25 +79,26 @@ export async function resolveLayoutChain(
 
   const resolved = await Promise.all(
     layouts.map(async (layer): Promise<ResolvedLayoutLayer | null> => {
-      // Layout component: a `route.tsx` export (default "Layout").
-      const componentResult = await resolvePage({
-        id: layer.component,
-        exportName: layoutExportName,
-        loader,
-      });
-      if (componentResult.type !== "success") {
-        opts.logger?.warn(
-          `[resolveLayoutChain] ${layer.component} has no "${layoutExportName}" export; skipping layer`
+      // Layout component: a `route.tsx` export (default "Layout"). A layer may
+      // carry only boundaries/head — no component means passthrough.
+      let Component: unknown;
+      if (layer.component) {
+        Component = await loadComponent(
+          layer.component,
+          layoutExportName,
+          loader,
+          opts.logger,
         );
-        return null;
       }
-      const Component = componentResult.module[layoutExportName];
-      if (Component == null) {
-        opts.logger?.warn(
-          `[resolveLayoutChain] ${layer.component} "${layoutExportName}" export is empty; skipping layer`
-        );
-        return null;
-      }
+
+      const [ErrorBoundary, Loading] = await Promise.all([
+        layer.error
+          ? loadComponent(layer.error, ERROR_EXPORT_NAME, loader, opts.logger)
+          : undefined,
+        layer.loading
+          ? loadComponent(layer.loading, LOADING_EXPORT_NAME, loader, opts.logger)
+          : undefined,
+      ]);
 
       // Layer props: the segment's `props.ts` (shared with its page). Absent →
       // no props. A function export is the loader form `props(url, { params })`.
@@ -77,6 +111,15 @@ export async function resolveLayoutChain(
           loader,
           ctx,
         });
+        // resolveProps invokes a function loader itself and catches its throw
+        // into an error result — surface a redirect()/notFound() signal from
+        // there as control flow.
+        if (
+          propsResult.type === "error" &&
+          isLoaderSignal(propsResult.error)
+        ) {
+          throw propsResult.error;
+        }
         if (propsResult.type === "success" && propsResult.module) {
           let value = propsResult.module[
             propsExportName as keyof typeof propsResult.module
@@ -85,7 +128,10 @@ export async function resolveLayoutChain(
             try {
               value = (value as (u: string, c: LoaderCtx) => unknown)(url, ctx);
               if (value instanceof Promise) value = await value;
-            } catch {
+            } catch (error) {
+              // redirect()/notFound() from a layout loader is control flow —
+              // propagate so the request pipeline translates it.
+              if (isLoaderSignal(error)) throw error;
               value = {};
             }
           }
@@ -95,10 +141,36 @@ export async function resolveLayoutChain(
         }
       }
 
-      return { Component, props };
+      // Head contribution: a `head.ts` static object or per-request function
+      // receiving the segment's params + resolved loader data.
+      let head: RouteHeadContribution | undefined;
+      if (layer.head) {
+        try {
+          const headModule = await loader(layer.head);
+          let value = headModule?.[HEAD_EXPORT_NAME] as RouteHeadExport | undefined;
+          if (typeof value === "function") {
+            const out = value({ url, params: ctx.params ?? {}, data: props });
+            value = out instanceof Promise ? await out : out;
+          }
+          if (value && typeof value === "object") head = value;
+          else if (value !== undefined) {
+            opts.logger?.warn(
+              `[resolveLayoutChain] ${layer.head} "${HEAD_EXPORT_NAME}" export is not an object; skipping`,
+            );
+          }
+        } catch (error) {
+          if (isLoaderSignal(error)) throw error;
+          opts.logger?.warn(
+            `[resolveLayoutChain] failed to load head module ${layer.head}: ${error}`,
+          );
+        }
+      }
+
+      if (!Component && !ErrorBoundary && !Loading && !head) return null;
+      return { Component, props, ErrorBoundary, Loading, head };
     })
   );
 
-  // Drop skipped layers (missing export); keep root→leaf order.
+  // Drop empty layers (all expected exports missing); keep root→leaf order.
   return resolved.filter((l): l is ResolvedLayoutLayer => l !== null);
 }

--- a/plugin/helpers/resolvePageAndProps.ts
+++ b/plugin/helpers/resolvePageAndProps.ts
@@ -21,6 +21,7 @@ import {
 } from "./resolveLayoutChain.js";
 import { routeToURL } from "../utils/routeToURL.js";
 import { matchRoutes, normalizePathForMatch } from "../router/matchRoute.js";
+import { isLoaderSignal } from "../router/loaderSignals.js";
 import type { RouteLayer } from "../router/scanRoutes.js";
 
 /**
@@ -239,6 +240,10 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
             pageProps = await pageProps;
           }
         } catch (error) {
+          // A redirect()/notFound() signal is control flow, not a failed
+          // loader — let it reach the outer catch so the request pipeline
+          // can translate it (3xx / 404) instead of rendering empty props.
+          if (isLoaderSignal(error)) throw error;
           if (handlerOptions.verbose) {
             handlerOptions.logger?.error(
               `[resolvePageAndProps] Error calling props function: ${error}`

--- a/plugin/react-static/renderPage.client.ts
+++ b/plugin/react-static/renderPage.client.ts
@@ -46,6 +46,7 @@ import type { RenderMetrics } from "../metrics/types.js";
 import { routeToURL } from "../utils/routeToURL.js";
 import type { RenderPageFn } from "./types.js";
 import { handleError } from "../error/handleError.js";
+import { isLoaderSignal } from "../router/loaderSignals.js";
 import { assertNonReactServer } from "../config/getCondition.js";
 
 import { createRscStream } from "../stream/createRscStream.client.js";
@@ -91,7 +92,22 @@ export const renderPage: RenderPageFn = async function* _renderPageClient(
     // Handle route.error events by storing result for later yielding
     if (event.type === "route.error" && !hasYielded) {
       hasYielded = true;
-      
+
+      // Loader control flow (redirect()/notFound()): pass the signal up as
+      // this route's error so the page loop skips the page — not a panic,
+      // not a client-only skip shell.
+      if (isLoaderSignal(event.data.error)) {
+        errorResult = {
+          type: "error",
+          error: event.data.error,
+          metrics: {
+            rscHeadless: { duration: 0, chunks: 0, bytes: 0 },
+            html: { duration: 0, chunks: 0, bytes: 0 },
+          },
+        };
+        return;
+      }
+
       // Check if this should cause a panic
       const panicError = handleError({
         error: event.data.error,
@@ -259,10 +275,26 @@ export const renderPage: RenderPageFn = async function* _renderPageClient(
       });
     } catch (componentResolutionError) {
       // Handle component resolution failures gracefully
-      const error = componentResolutionError instanceof Error 
-        ? componentResolutionError 
+      const error = componentResolutionError instanceof Error
+        ? componentResolutionError
         : new Error(String(componentResolutionError));
-      
+
+      // A loader redirect()/notFound() is control flow, not a failure: yield
+      // it as this route's error so the page loop skips the page (no files,
+      // no panic, no client-only fallback shell).
+      if (isLoaderSignal(error)) {
+        yield {
+          type: "error",
+          error,
+          metrics: {
+            rscFull: rscFullMetrics,
+            rscHeadless: rscHeadlessMetrics,
+            html: htmlMetrics,
+          },
+        };
+        return;
+      }
+
       // Check if this component resolution error should cause a panic based on panicThreshold
       const panicError = handleError({
         error,

--- a/plugin/react-static/renderPages.ts
+++ b/plugin/react-static/renderPages.ts
@@ -14,6 +14,7 @@ import type { RenderPagesResult, RenderPageResult } from "../types.js";
 import type { RenderPagesFn } from "./types.js";
 import { handleError } from "../error/handleError.js";
 import { shouldCausePanic } from "../error/panicThresholdHandler.js";
+import { isLoaderSignal, isRedirect } from "../router/loaderSignals.js";
 import { fileWriter } from "./fileWriter.js";
 
 import type { Manifest } from "vite";
@@ -120,8 +121,11 @@ export const renderPages: RenderPagesFn = (
         // Nested layouts: manifest-resolve each layer's built module (mirroring
         // page/props) so the renderer can load + fold the chain.
         const resolvedLayouts = layouts?.map((l) => ({
-          component: resolvePathWithManifest(l.component, manifest),
+          component: l.component ? resolvePathWithManifest(l.component, manifest) : undefined,
           props: l.props ? resolvePathWithManifest(l.props, manifest) : undefined,
+          error: l.error ? resolvePathWithManifest(l.error, manifest) : undefined,
+          loading: l.loading ? resolvePathWithManifest(l.loading, manifest) : undefined,
+          head: l.head ? resolvePathWithManifest(l.head, manifest) : undefined,
         }));
 
         if (options.verbose) {
@@ -166,6 +170,18 @@ export const renderPages: RenderPagesFn = (
 
           // Handle route.error events here in renderPages
           if (event.type === "route.error") {
+            // Loader control flow (redirect()/notFound()) at prerender: the
+            // page is skipped by the render loop; not a failed route.
+            if (isLoaderSignal(event.data.error)) {
+              options.logger?.warn(
+                `[renderPages] route ${event.data.route} signalled ${
+                  isRedirect(event.data.error)
+                    ? `redirect -> ${(event.data.error as { to?: string }).to}`
+                    : "notFound"
+                } during prerender; page skipped`
+              );
+              return;
+            }
             // Make panic decision in the main thread based on panicThreshold
             const detectedPanicError = handleError({
               error: event.data.error,
@@ -346,6 +362,19 @@ export const renderPages: RenderPagesFn = (
           }
 
           if (result.type === "error") {
+            // A loader redirect()/notFound() at prerender is control flow the
+            // static build cannot answer — skip the page loudly instead of
+            // failing the build. Don't enumerate such a route in
+            // getStaticPaths; it renders per-request (dev/Node/edge).
+            if (isLoaderSignal(result.error)) {
+              const err = result.error as Error & { to?: string };
+              options.logger?.warn(
+                `[renderPages] route ${route} signalled ${
+                  isRedirect(err) ? `redirect -> ${err.to}` : "notFound"
+                } during prerender; page skipped`
+              );
+              continue;
+            }
             if (options.verbose) {
               options.logger?.error(
                 `[renderPages] Error for route ${route}: ${result.error}`

--- a/plugin/react-static/renderPagesBatched.ts
+++ b/plugin/react-static/renderPagesBatched.ts
@@ -300,8 +300,14 @@ export const renderPagesBatched: RenderPagesFn = (
             options.logger?.warn(`[renderPagesBatched] Non-panic error for route ${route}: ${error.message}`);
           }
         } else {
-          completedRoutes.add(route);
-          
+          // Only count the route as completed when something actually
+          // rendered — a loader redirect()/notFound() skip leaves pageResults
+          // without a success/skip entry and must not inflate the summary.
+          const rendered = pageResults.some(
+            (r) => r.type === "success" || r.type === "skip"
+          );
+          if (rendered) completedRoutes.add(route);
+
           for (const result of pageResults) {
             if (result.type === "success" || result.type === "skip") {
               results.set(route, result);

--- a/plugin/react-static/renderPagesBatched.ts
+++ b/plugin/react-static/renderPagesBatched.ts
@@ -8,6 +8,7 @@
 import type { RenderPagesResult, RenderPageResult } from "../types.js";
 import type { RenderPagesFn, RenderPageFn, RenderPagesHandlerOptions } from "./types.js";
 import { handleError } from "../error/handleError.js";
+import { isLoaderSignal, isRedirect } from "../router/loaderSignals.js";
 import { fileWriter } from "./fileWriter.js";
 import type { Manifest } from "vite";
 import { emitFileWriteMetrics } from "./emitFileWriteMetrics.js";
@@ -51,8 +52,11 @@ async function renderSingleRoute(
     // Nested layouts: manifest-resolve each built layer so the RSC worker folds
     // the chain into the flight (mirrors page/props resolution above).
     const resolvedLayouts = layouts?.map((l) => ({
-      component: resolvePathWithManifest(l.component, manifest),
+      component: l.component ? resolvePathWithManifest(l.component, manifest) : undefined,
       props: l.props ? resolvePathWithManifest(l.props, manifest) : undefined,
+      error: l.error ? resolvePathWithManifest(l.error, manifest) : undefined,
+      loading: l.loading ? resolvePathWithManifest(l.loading, manifest) : undefined,
+      head: l.head ? resolvePathWithManifest(l.head, manifest) : undefined,
     }));
 
     // Store results for metrics tracking
@@ -68,6 +72,18 @@ async function renderSingleRoute(
 
       // Handle route.error events
       if (event.type === "route.error") {
+        // Loader control flow (redirect()/notFound()) at prerender: the page
+        // is skipped by the render loop; don't count it as a failed route.
+        if (isLoaderSignal(event.data.error)) {
+          options.logger?.warn(
+            `[renderPagesBatched] route ${event.data.route} signalled ${
+              isRedirect(event.data.error)
+                ? `redirect -> ${(event.data.error as { to?: string }).to}`
+                : "notFound"
+            } during prerender; page skipped`
+          );
+          return;
+        }
         const detectedPanicError = handleError({
           error: event.data.error,
           logger: options.logger,
@@ -116,6 +132,17 @@ async function renderSingleRoute(
       results.push(result);
       
       if (result.type === "error" && result.error) {
+        // A loader redirect()/notFound() at prerender is control flow the
+        // static build cannot answer — skip the page loudly, don't fail it.
+        if (isLoaderSignal(result.error)) {
+          const err = result.error as Error & { to?: string };
+          options.logger?.warn(
+            `[renderPagesBatched] route ${route} signalled ${
+              isRedirect(err) ? `redirect -> ${err.to}` : "notFound"
+            } during prerender; page skipped`
+          );
+          continue;
+        }
         routeError = result.error instanceof Error ? result.error : new Error(String(result.error));
       }
       

--- a/plugin/router/applyRouteHead.ts
+++ b/plugin/router/applyRouteHead.ts
@@ -1,0 +1,71 @@
+// Client-side head sync for the file router. The compose step ships the
+// matched route's merged head.ts contribution as an inert
+// `<template data-vprs-head='{"title":…}'>` inside the rendered tree (raw
+// hoistables can't ride the hydration flight — see createElementWithReact).
+// After hydration and after each navigation the router calls this to read
+// that template and apply the head imperatively.
+//
+// Scope: `title`, and `meta` entries keyed by `name`/`property` (found or
+// created, created ones marked managed). `links` and unkeyed meta stay
+// document-render-only — they're in the prerendered <head> for crawlers, and
+// per-navigation updates to them rarely matter to a running client.
+
+import type { RouteHeadContribution } from "./head.js";
+
+const MANAGED_ATTR = "data-vprs-head-managed";
+
+const attrSelectorValue = (value: string) =>
+  value.replace(/["\\]/g, "\\$&");
+
+/** Read the head payload from the rendered tree, or null when absent. */
+export function readRouteHead(root: ParentNode): RouteHeadContribution | null {
+  const el = root.querySelector("template[data-vprs-head]");
+  const raw = el?.getAttribute("data-vprs-head");
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Apply title + keyed meta from the current route's head payload. */
+export function applyRouteHead(
+  root: ParentNode,
+  doc: Document = document,
+): void {
+  const head = readRouteHead(root);
+  if (!head) return;
+
+  if (typeof head.title === "string") {
+    doc.title = head.title;
+  }
+
+  const seen = new Set<Element>();
+  for (const m of head.meta ?? []) {
+    const key = m["name"]
+      ? (["name", m["name"]] as const)
+      : m["property"]
+        ? (["property", m["property"]] as const)
+        : null;
+    if (!key) continue;
+    let tag = doc.head.querySelector(
+      `meta[${key[0]}="${attrSelectorValue(key[1])}"]`,
+    );
+    if (!tag) {
+      tag = doc.createElement("meta");
+      tag.setAttribute(key[0], key[1]);
+      tag.setAttribute(MANAGED_ATTR, "");
+      doc.head.appendChild(tag);
+    }
+    for (const [k, v] of Object.entries(m)) tag.setAttribute(k, v);
+    seen.add(tag);
+  }
+
+  // A managed meta the new route no longer contributes goes away; metas from
+  // the prerendered document (unmanaged) are left alone.
+  for (const stale of doc.head.querySelectorAll(`meta[${MANAGED_ATTR}]`)) {
+    if (!seen.has(stale)) stale.remove();
+  }
+}

--- a/plugin/router/client.ts
+++ b/plugin/router/client.ts
@@ -27,6 +27,8 @@ export {
 } from "./router-react.js";
 export { Link } from "./link.js";
 export type { LinkPrefetch, LinkProps } from "./link.js";
+export { createErrorBoundary } from "./errorBoundary.js";
+export type { RouteErrorFallbackProps } from "./errorBoundary.js";
 export { startClient } from "./startClient.js";
 export type { StartClientOptions } from "./startClient.js";
 export type { Register, RegisteredRoutes, ToPath } from "./register.js";

--- a/plugin/router/errorBoundary.tsx
+++ b/plugin/router/errorBoundary.tsx
@@ -1,0 +1,51 @@
+"use client";
+// Namespace import for react-server barrel import-safety (see router-react.tsx).
+import * as React from "react";
+
+/** Props the fallback UI of {@link createErrorBoundary} receives. */
+export type RouteErrorFallbackProps = {
+  error: Error;
+  /** Clears the boundary and re-renders the subtree. */
+  reset: () => void;
+};
+
+type BoundaryProps = { children?: React.ReactNode };
+type BoundaryState = { error: Error | null };
+
+/**
+ * Wrap a fallback UI into the client boundary an `error.tsx` route file
+ * exports. The boundary catches render errors in its segment's subtree —
+ * including errors a server component threw into the flight stream — and
+ * renders the fallback with `{ error, reset }`:
+ *
+ *   "use client";
+ *   import { createErrorBoundary } from "vite-plugin-react-server/router/client";
+ *   export const ErrorBoundary = createErrorBoundary(({ error, reset }) => (
+ *     <div>
+ *       <p>{error.message}</p>
+ *       <button onClick={reset}>Retry</button>
+ *     </div>
+ *   ));
+ */
+export function createErrorBoundary(
+  Fallback: React.ComponentType<RouteErrorFallbackProps>,
+): React.ComponentType<BoundaryProps> {
+  return class RouteErrorBoundary extends React.Component<
+    BoundaryProps,
+    BoundaryState
+  > {
+    override state: BoundaryState = { error: null };
+    static getDerivedStateFromError(error: unknown): BoundaryState {
+      return {
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+    reset = () => this.setState({ error: null });
+    override render() {
+      if (this.state.error) {
+        return <Fallback error={this.state.error} reset={this.reset} />;
+      }
+      return this.props.children;
+    }
+  };
+}

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -81,8 +81,11 @@ export function fileRouter(
         page: toRel(r.page),
         props: r.props ? toRel(r.props) : undefined,
         layouts: r.layouts.map((l) => ({
-          component: toRel(l.component),
+          component: l.component ? toRel(l.component) : undefined,
           props: l.props ? toRel(l.props) : undefined,
+          error: l.error ? toRel(l.error) : undefined,
+          loading: l.loading ? toRel(l.loading) : undefined,
+          head: l.head ? toRel(l.head) : undefined,
         })),
       }))
     : scanned;

--- a/plugin/router/head.ts
+++ b/plugin/router/head.ts
@@ -1,0 +1,59 @@
+/**
+ * The `head.ts` route convention: a segment contributes head/meta for itself
+ * and (unless overridden) its children. Contributions merge root→leaf — the
+ * deepest segment wins the title, and a meta entry keyed by `name`/`property`
+ * overrides an ancestor's entry with the same key. Rendered as react-dom
+ * hoistable tags, so they land in the document `<head>` on every render path.
+ */
+
+export type RouteHeadContribution = {
+  title?: string;
+  /** `<meta>` attribute maps, e.g. `{ name: "description", content: "…" }`. */
+  meta?: Array<Record<string, string>>;
+  /** `<link>` attribute maps, e.g. `{ rel: "canonical", href: "…" }`. */
+  links?: Array<Record<string, string>>;
+};
+
+/** Loader context a functional `head` export receives. */
+export type RouteHeadCtx = {
+  url: string;
+  params: Record<string, string>;
+  /** The segment's resolved loader data (its `props.ts` result). */
+  data: Record<string, unknown>;
+};
+
+/** What a `head.ts` may export: a static object or a per-request function. */
+export type RouteHeadExport =
+  | RouteHeadContribution
+  | ((ctx: RouteHeadCtx) => RouteHeadContribution | Promise<RouteHeadContribution>);
+
+const metaKey = (m: Record<string, string>) =>
+  m["name"] ?? m["property"] ?? m["httpEquiv"] ?? m["http-equiv"];
+
+/** Merge root→leaf contributions: leaf title wins, keyed meta overrides. */
+export function mergeHead(
+  chain: Array<RouteHeadContribution | undefined>,
+): RouteHeadContribution {
+  let title: string | undefined;
+  const meta = new Map<string | undefined, Record<string, string>[]>();
+  const links: Array<Record<string, string>> = [];
+  for (const c of chain) {
+    if (!c) continue;
+    if (c.title !== undefined) title = c.title;
+    for (const m of c.meta ?? []) {
+      const key = metaKey(m);
+      // Keyed entries replace an ancestor's same-key entry; unkeyed append.
+      if (key === undefined) {
+        (meta.get(undefined) ?? meta.set(undefined, []).get(undefined)!).push(m);
+      } else {
+        meta.set(key, [m]);
+      }
+    }
+    links.push(...(c.links ?? []));
+  }
+  return {
+    title,
+    meta: [...meta.values()].flat(),
+    links,
+  };
+}

--- a/plugin/router/index.ts
+++ b/plugin/router/index.ts
@@ -5,4 +5,6 @@ export * from "./matchRoute.js";
 export * from "./scanRoutes.js";
 export * from "./fileRouter.js";
 export * from "./withParams.js";
+export * from "./head.js";
+export * from "./loaderSignals.js";
 export type { Register, RegisteredRoutes, ToPath } from "./register.js";

--- a/plugin/router/loaderSignals.ts
+++ b/plugin/router/loaderSignals.ts
@@ -1,0 +1,55 @@
+/**
+ * Loader control-flow signals: a route/layout loader (`props.ts`) or a `head.ts`
+ * can end the render early by throwing `redirect(...)` / `notFound()` instead
+ * of returning data. The request pipeline translates the signal per render
+ * path: a per-request render (dev / Node / edge) answers with the 3xx or the
+ * 404 route; the static prerender skips the page with a warning.
+ *
+ * The signals are plain `Error`s carrying PLAIN string-keyed marker fields —
+ * not a class or Symbol — so they survive both duplicate module instances
+ * (dev/build/edge each bake their own copy) and the worker postMessage
+ * boundary (serializeError spreads own enumerable fields onto the envelope;
+ * toError re-applies them on rehydration, mirroring the panic flag).
+ */
+
+export const REDIRECT_FIELD = "$$vprsRedirect";
+export const NOT_FOUND_FIELD = "$$vprsNotFound";
+
+export type RedirectStatus = 301 | 302 | 303 | 307 | 308;
+
+export type RedirectError = Error & {
+  [REDIRECT_FIELD]: true;
+  to: string;
+  status: RedirectStatus;
+};
+
+export type NotFoundError = Error & { [NOT_FOUND_FIELD]: true };
+
+/** Throw from a loader to answer with a redirect (302 by default). */
+export function redirect(to: string, status: RedirectStatus = 302): never {
+  const err = new Error(`[vprs] redirect ${status} -> ${to}`);
+  Object.assign(err, { [REDIRECT_FIELD]: true, to, status });
+  throw err;
+}
+
+/** Throw from a loader to answer with the 404 route / not-found handling. */
+export function notFound(): never {
+  const err = new Error("[vprs] notFound");
+  Object.assign(err, { [NOT_FOUND_FIELD]: true });
+  throw err;
+}
+
+export const isRedirect = (e: unknown): e is RedirectError =>
+  typeof e === "object" &&
+  e !== null &&
+  (e as Record<string, unknown>)[REDIRECT_FIELD] === true &&
+  typeof (e as Record<string, unknown>)["to"] === "string";
+
+export const isNotFound = (e: unknown): e is NotFoundError =>
+  typeof e === "object" &&
+  e !== null &&
+  (e as Record<string, unknown>)[NOT_FOUND_FIELD] === true;
+
+/** Either signal — anything the pipeline should translate, not report. */
+export const isLoaderSignal = (e: unknown): boolean =>
+  isRedirect(e) || isNotFound(e);

--- a/plugin/router/scanRoutes.ts
+++ b/plugin/router/scanRoutes.ts
@@ -1,12 +1,26 @@
 import { readdirSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
-/** One layer of a route's nested-layout chain (a `route.tsx` + its loader). */
+/** One layer of a route's nested-layout chain (a segment's wrapping files). */
 export type RouteLayer = {
-  /** A `route.tsx` layout component wrapping this segment and its children. */
-  component: string;
+  /**
+   * A `route.tsx` layout component wrapping this segment and its children.
+   * Absent when the segment contributes only boundaries/head (an `error.tsx`,
+   * `loading.tsx` or `head.ts` without a layout).
+   */
+  component?: string;
   /** The segment's `props.ts` loader — shared by the layout and its page. */
   props?: string;
+  /**
+   * An `error.tsx` client boundary for this segment and its children. The file
+   * must be a `"use client"` module exporting the boundary (wrap a fallback
+   * with `createErrorBoundary` from the router client runtime).
+   */
+  error?: string;
+  /** A `loading.tsx` Suspense fallback for this segment and its children. */
+  loading?: string;
+  /** A `head.ts` head/meta contribution, merged root→leaf (leaf wins). */
+  head?: string;
 };
 
 // One route entry, shaped to feed vprs's existing `urlMap`
@@ -22,10 +36,10 @@ export type RouteEntry = {
   /** True when the pattern has a `$` segment (can't be a fixed prerender). */
   dynamic: boolean;
   /**
-   * Ordered root→leaf chain of `route.tsx` layouts wrapping this page. Each
-   * `route.tsx` in an ancestor (or this page's own) segment adds a layer; the
-   * page composes as `<L0><L1>...<Page/>...</L1></L0>`. Empty for an unwrapped
-   * page.
+   * Ordered root→leaf chain of segment layers wrapping this page. Each segment
+   * with a `route.tsx` layout (or an `error.tsx` / `loading.tsx` / `head.ts`)
+   * adds a layer; the page composes as `<L0><L1>...<Page/>...</L1></L0>`.
+   * Empty for an unwrapped page.
    */
   layouts: RouteLayer[];
 };
@@ -34,22 +48,39 @@ export type RouteEntry = {
 // the plugin passes the resolved `autoDiscover.pagePattern` / `propsPattern`
 // (see resolveRoutesOption) so the scanner and the rest of the build share one
 // source of truth — a custom autoDiscover pattern is honored, no divergence.
-// `route.tsx` layouts are router-specific (no autoDiscover equivalent).
+// The remaining conventions are router-specific (no autoDiscover equivalent).
 export type ScanPatterns = {
   pagePattern?: RegExp;
   propsPattern?: RegExp;
   layoutPattern?: RegExp;
+  indexPattern?: RegExp;
+  errorPattern?: RegExp;
+  loadingPattern?: RegExp;
+  headPattern?: RegExp;
 };
 
 const DEFAULT_PAGE = /^page\.(t|j)sx?$/;
 const DEFAULT_PROPS = /^props\.(t|j)sx?$/;
 const DEFAULT_LAYOUT = /^route\.(t|j)sx?$/;
+// `index.tsx` is an alternate leaf-page name (TanStack-style; `page.tsx` wins
+// when both exist). Deliberately jsx/tsx-ONLY: `index.ts` is the conventional
+// barrel filename, and matching it would turn every re-export barrel inside the
+// routes tree into a route.
+const DEFAULT_INDEX = /^index\.(t|j)sx$/;
+const DEFAULT_ERROR = /^error\.(t|j)sx$/;
+const DEFAULT_LOADING = /^loading\.(t|j)sx$/;
+const DEFAULT_HEAD = /^head\.(t|j)s$/;
+
+/** A `(group)` directory: shares its layers with children, adds no URL segment. */
+const isPathlessGroup = (name: string) =>
+  name.startsWith("(") && name.endsWith(")") && name.length > 2;
 
 // Convention: every page file under `routesDir` defines a route; its directory
-// path (relative to routesDir) is the URL, with `$name` segments as params and a
-// bare `$` directory as a catch-all. A sibling props file is the segment's
-// loader. A `route.tsx` in a segment is a LAYOUT that wraps that segment's page
-// and every descendant, sharing the segment's props.
+// path (relative to routesDir) is the URL, with `$name` segments as params, a
+// bare `$` directory as a catch-all, and `(group)` directories contributing no
+// URL segment (pathless grouping). A `route.tsx` in a segment is a LAYOUT that
+// wraps that segment's page and every descendant, sharing the segment's props;
+// `error.tsx` / `loading.tsx` / `head.ts` ride the same layer.
 export function scanRoutes(
   routesDir: string,
   patterns: ScanPatterns = {},
@@ -57,30 +88,56 @@ export function scanRoutes(
   const pagePattern = patterns.pagePattern ?? DEFAULT_PAGE;
   const propsPattern = patterns.propsPattern ?? DEFAULT_PROPS;
   const layoutPattern = patterns.layoutPattern ?? DEFAULT_LAYOUT;
+  const indexPattern = patterns.indexPattern ?? DEFAULT_INDEX;
+  const errorPattern = patterns.errorPattern ?? DEFAULT_ERROR;
+  const loadingPattern = patterns.loadingPattern ?? DEFAULT_LOADING;
+  const headPattern = patterns.headPattern ?? DEFAULT_HEAD;
 
-  const findProps = (names: string[], dir: string): string | undefined => {
-    const n = names.find((name) => propsPattern.test(name));
+  const find = (names: string[], dir: string, p: RegExp): string | undefined => {
+    const n = names.find((name) => p.test(name));
     return n ? join(dir, n) : undefined;
   };
+
+  // Pathless groups can collapse distinct directories onto one URL pattern
+  // ("(a)/page.tsx" and "(b)/page.tsx" are both "/"). Fail loudly — a silent
+  // last-wins would serve one and drop the other.
+  const seen = new Map<string, string>();
 
   const walk = (dir: string, layouts: RouteLayer[]): RouteEntry[] => {
     const out: RouteEntry[] = [];
     const names = readdirSync(dir).sort();
-    const segProps = findProps(names, dir);
-    // A `route.tsx` here wraps this segment's page and all descendants, sharing
-    // this segment's loader — extend the chain for children and this page.
-    const layoutName = names.find((name) => layoutPattern.test(name));
-    const chain = layoutName
-      ? [...layouts, { component: join(dir, layoutName), props: segProps }]
-      : layouts;
+    const segProps = find(names, dir, propsPattern);
+    // Any wrapping file here (layout / error boundary / loading fallback /
+    // head contribution) adds a layer for this segment's page and all
+    // descendants, sharing this segment's loader.
+    const component = find(names, dir, layoutPattern);
+    const error = find(names, dir, errorPattern);
+    const loading = find(names, dir, loadingPattern);
+    const head = find(names, dir, headPattern);
+    const chain =
+      component || error || loading || head
+        ? [...layouts, { component, props: segProps, error, loading, head }]
+        : layouts;
+    // Leaf page: `page.tsx` (canonical) or `index.tsx` (alternate; page wins).
+    const pageName =
+      names.find((name) => pagePattern.test(name)) ??
+      names.find((name) => indexPattern.test(name));
     for (const name of names) {
       const abs = join(dir, name);
       if (statSync(abs).isDirectory()) {
         out.push(...walk(abs, chain));
-      } else if (pagePattern.test(name)) {
+      } else if (name === pageName) {
         const rel = relative(routesDir, dir);
-        const parts = rel === "" ? [] : rel.split(sep);
+        const rawParts = rel === "" ? [] : rel.split(sep);
+        const parts = rawParts.filter((p) => !isPathlessGroup(p));
         const pattern = parts.length ? "/" + parts.join("/") : "/";
+        const prior = seen.get(pattern);
+        if (prior) {
+          throw new Error(
+            `scanRoutes: routes "${prior}" and "${abs}" both resolve to "${pattern}" — pathless (group) segments must not collapse two pages onto one URL`,
+          );
+        }
+        seen.set(pattern, abs);
         out.push({
           pattern,
           page: abs,

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -9,6 +9,7 @@ import {
 } from "../utils/index.client.js";
 import { createRouter, type Router } from "./createRouter.js";
 import { RouterProvider, useLocation } from "./router-react.js";
+import { applyRouteHead } from "./applyRouteHead.js";
 
 // The supplied client entry: assembles createRouter + RouterProvider +
 // createReactFetcher + hydration + HMR so a consumer's client.tsx is one line:
@@ -36,13 +37,24 @@ export type StartClientOptions = {
 function RouteView({
   router,
   initialNode,
+  rootId,
 }: {
   router: Router<ReactNode>;
   initialNode: ReactNode;
+  rootId: string;
 }) {
   const location = useLocation();
   const [node, setNode] = React.useState<ReactNode>(initialNode);
   const shown = React.useRef<string>(router.getState().url);
+
+  // The matched route's head.ts contribution rides the tree as an inert
+  // template (hoistables can't ride the hydration flight — see
+  // createElementWithReact). Apply it after every commit so hydration and
+  // each navigation both sync document.title / keyed meta.
+  React.useEffect(() => {
+    const rootEl = document.getElementById(rootId);
+    if (rootEl) applyRouteHead(rootEl);
+  });
 
   React.useEffect(() => {
     if (location === shown.current) return;
@@ -122,7 +134,7 @@ export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
     const initialNode = await router.flight(router.getState().url);
     const tree = (
       <RouterProvider router={router} patterns={patterns}>
-        <RouteView router={router} initialNode={initialNode} />
+        <RouteView router={router} initialNode={initialNode} rootId={rootId} />
       </RouterProvider>
     );
     return wrap ? wrap(tree) : tree;

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -85,12 +85,33 @@ export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
     wrap,
   } = opts;
 
+  // A loader redirect() answers a flight fetch with a 3xx to the TARGET's
+  // flight; fetch follows it transparently, so the content is already right —
+  // only the address bar still shows the source url. Detect the follow and
+  // re-navigate (replace) to the final route so history matches the content.
+  // Deferred assignment: the fetcher closure exists before the router does.
+  let followRedirect: (response: Response) => void = () => {};
   const fetchFlight = (url: string): Promise<ReactNode> =>
     Promise.resolve(
-      createReactFetcher({ url, moduleBaseURL, publicOrigin }),
+      createReactFetcher({
+        url,
+        moduleBaseURL,
+        publicOrigin,
+        onResponse: (response) => followRedirect(response),
+      }),
     ) as Promise<ReactNode>;
 
   const router = createRouter<ReactNode>({ fetchFlight, isDynamic, dynamicTtlMs });
+  followRedirect = (response) => {
+    if (!response.redirected || !response.ok) return;
+    let finalRoute = new URL(response.url).pathname;
+    if (finalRoute.endsWith("/index.rsc")) {
+      finalRoute = finalRoute.slice(0, -"/index.rsc".length) || "/";
+    }
+    if (finalRoute !== router.getState().url) {
+      router.navigate(finalRoute, { replace: true });
+    }
+  };
 
   const root = document.getElementById(rootId);
   if (!root) throw new Error(`startClient: #${rootId} element not found`);

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -5,6 +5,7 @@ import type {
 import { injectInlineFlightIntoHtml } from "../utils/inlineFlight.js";
 import { assertNonReactServer } from "../config/getCondition.js";
 import { isUnknownRoute } from "./unknownRoute.js";
+import { isNotFound, isRedirect } from "../router/loaderSignals.js";
 
 assertNonReactServer();
 
@@ -122,6 +123,15 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
         flights = await renderDocument(url, { request });
       } catch (error) {
         if (isUnknownRoute(error)) return notFound(url, request);
+        // Loader control flow: a redirect() answers with the 3xx itself; a
+        // notFound() answers like an unknown route.
+        if (isRedirect(error)) {
+          return new Response(null, {
+            status: error.status,
+            headers: { location: error.to },
+          });
+        }
+        if (isNotFound(error)) return notFound(url, request);
         onError?.(error);
         throw error;
       }
@@ -155,6 +165,13 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
       // The producer is a closed manifest over `build.pages`; an unknown url is
       // a 404, not a 500. Everything else is a real failure — surface it.
       if (isUnknownRoute(error)) return notFound(url, request);
+      if (isRedirect(error)) {
+        return new Response(null, {
+          status: error.status,
+          headers: { location: error.to },
+        });
+      }
+      if (isNotFound(error)) return notFound(url, request);
       onError?.(error);
       throw error;
     }

--- a/plugin/stream/createRscStream.types.ts
+++ b/plugin/stream/createRscStream.types.ts
@@ -3,6 +3,7 @@ import type { Stream } from "node:stream";
 import type { OnMetrics, PanicThreshold } from "../types.js";
 import type { SerializableHandlerOptions } from "../helpers/createSerializableHandlerOptions.js";
 import type { ResolvedLayoutLayer } from "../helpers/resolveLayoutChain.js";
+import type { RouteLayer } from "../router/scanRoutes.js";
 
 /**
  * Base RSC Stream Result - common interface for both client and server
@@ -62,7 +63,7 @@ export type ClientRscStreamOptions = SerializableHandlerOptions &  {
   rootPath?: string;
   htmlPath?: string;
   /** Nested-layout chain (`route.tsx` layer paths) for the matched route. */
-  layouts?: { component: string; props?: string }[];
+  layouts?: RouteLayer[];
   /** Loaded + prop-resolved layout chain (pre-resolved render path). */
   layoutChain?: ResolvedLayoutLayer[];
   pageExportName: string;
@@ -113,7 +114,7 @@ export interface ServerRscStreamOptions {
   rootPath?: string;
   htmlPath?: string;
   /** Nested-layout chain (`route.tsx` layer paths) for the matched route. */
-  layouts?: { component: string; props?: string }[];
+  layouts?: RouteLayer[];
   /** Loaded + prop-resolved layout chain (pre-resolved render path). */
   layoutChain?: ResolvedLayoutLayer[];
   pageExportName: string;

--- a/plugin/stream/createRscWorkerStream.ts
+++ b/plugin/stream/createRscWorkerStream.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "node:stream";
 import type { SerializeableRenderToPipeableStreamOptions } from "../worker/rsc/types.js";
 import { toError } from "../error/toError.js";
 import { createMessageChannels } from "./createMessageChannels.js";
+import type { RouteLayer } from "../router/scanRoutes.js";
 
 /**
  * RSC-specific options for worker stream
@@ -30,7 +31,7 @@ export interface RscWorkerStreamOptions {
   rootPath?: string;
   htmlPath?: string;
   /** Nested-layout chain (`route.tsx` layer paths) for the matched route. */
-  layouts?: { component: string; props?: string }[];
+  layouts?: RouteLayer[];
   layoutExportName?: string;
 }
 

--- a/plugin/stream/handleRscStream.client.ts
+++ b/plugin/stream/handleRscStream.client.ts
@@ -6,6 +6,7 @@ import { DEFAULT_CONFIG } from "../config/defaults.js";
 import { join } from "node:path";
 import { toError } from "../error/toError.js";
 import { logError } from "../error/logError.js";
+import { isLoaderSignal } from "../router/loaderSignals.js";
 
 /**
  * Client-side RSC stream handler using unified stream management
@@ -22,7 +23,7 @@ import { logError } from "../error/logError.js";
  * @returns A ReadableStream that yields RSC chunks
  */
 export const handleRscStream: HandleRscStreamFn<"client"> =
-  function _handleWorkerRscStream({ options }) {
+  function _handleWorkerRscStream({ options, handlers }) {
     // Generate a unique request id to avoid conflicts with concurrent requests
     const requestId =
       options.id ??
@@ -108,6 +109,16 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
           }
           break;
         case "ERROR": {
+          const err = toError(message.error, message.errorInfo);
+          // A loader redirect()/notFound() is control flow the caller must
+          // answer (3xx/404 on the response), not a render failure to log.
+          // Hand it to the caller's onError and end the (still-empty) data
+          // stream so the pipe completes.
+          if (isLoaderSignal(err)) {
+            handlers?.onError?.(message.id ?? requestId, err);
+            if (!dataEndedReceived) endDataStream();
+            break;
+          }
           // Always log: this is an RSC render error from the worker. Without
           // this log the failure surfaces only as an in-band RSC error frame
           // on the client, with nothing on the dev console.
@@ -117,7 +128,6 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
           // boundary (serializeError → toError), so dev:ssr can surface the same
           // detail as dev:rsc (the main-thread runner). Previously only the
           // message was logged, so worker render failures looked stackless.
-          const err = toError(message.error, message.errorInfo);
           err.message = `[client] RSC render error for ${message.id}: ${err.message}`;
           logError(err, options.logger);
           break;
@@ -143,6 +153,16 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
         // Signal that the stream is complete so React can finish consuming
         endDataStream();
       } else if (data && data.type === 'ERROR') {
+        // A loader redirect()/notFound() arrives on the DATA port so it is
+        // ordered ahead of the null end-signal (the control-port ERROR copy
+        // can lose that race and find the response already committed).
+        // Answer via the caller's onError; the following null ends the
+        // stream normally.
+        const dataErr = toError(data.error);
+        if (isLoaderSignal(dataErr)) {
+          handlers?.onError?.(data.id ?? requestId, dataErr);
+          return;
+        }
         // Stream error via data port
         if (options.verbose) {
           options.logger?.error(

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1445,7 +1445,7 @@ export type ResolvedBuildPages = {
       root?: string;
       html?: string;
       /** Resolved `route.tsx` layer module paths (root→leaf), for nested layouts. */
-      layouts?: { component: string; props?: string }[];
+      layouts?: RouteLayer[];
     }
   >;
   errors: unknown[];

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -100,6 +100,7 @@ export function createReactFetcher({
     Accept: "text/x-component",
   },
   signal,
+  onResponse,
 }: {
   url?: string;
   moduleBaseURL?: string;
@@ -115,6 +116,12 @@ export function createReactFetcher({
    * the consumer is about to replace it anyway.
    */
   signal?: AbortSignal;
+  /**
+   * Observe the network response before decoding (never called for an inlined
+   * payload). The router uses this to detect a followed loader redirect
+   * (`response.redirected`) and fix the address bar.
+   */
+  onResponse?: (response: Response) => void;
 } = {}): PromiseLike<React.ReactNode> {
   const parsedURL = createPageURL(
     moduleBaseURL,
@@ -181,6 +188,20 @@ export function createReactFetcher({
       headers: headers,
       signal,
     });
+    if (onResponse) {
+      // Observe without gating the decode; an observer throw is not a
+      // flight error, and a rejected fetch is reported through decode anyway.
+      responsePromise.then(
+        (response) => {
+          try {
+            onResponse(response);
+          } catch {
+            /* observer-only */
+          }
+        },
+        () => {}
+      );
+    }
     return flightClient().then(({ createFromFetch }) =>
       createFromFetch(responsePromise, decodeOptions)
     );

--- a/plugin/worker/rsc/handlers.ts
+++ b/plugin/worker/rsc/handlers.ts
@@ -57,6 +57,17 @@ export function createHandlers(fromWorker?: MessagePort, toWorker?: MessagePort)
         });
       }
     },
+    onDataError: (id, error) => {
+      // Ordered delivery: rides the same port as data chunks and the null
+      // end-signal, so it always precedes onEnd's null at the receiver.
+      if (fromWorker) {
+        try {
+          fromWorker.postMessage({ type: "ERROR", id, error: serializeError(error) });
+        } catch {
+          // Port may be closed, ignore
+        }
+      }
+    },
     onEnd: (id) => {
       // Mirror HTML worker pattern: send null through fromWorker, then END through toWorker
       if (fromWorker) {

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -6,6 +6,7 @@ import { createRscWorkerLoader } from "./createRscWorkerLoader.js";
 import { handleRscRender } from "./handleRscRender.server.js";
 import { setMaxListenersOnPort } from "../../stream/setMaxListeners.js";
 import { describeProps } from "../../helpers/describeProps.js";
+import { isLoaderSignal } from "../../router/loaderSignals.js";
 import type {
   RscWorkerInputMessage,
   ComponentsResolvedMessage,
@@ -423,6 +424,11 @@ async function loadComponentsWithCache(options: {
           const pageError = pageAndPropsResult.error ?? new Error(
             `[rsc-worker] Failed to load page module from ${pagePath}`,
           );
+          // Loader control flow (redirect()/notFound()): throw the signal
+          // untouched. handleError would panic-mark it (killing the worker
+          // under critical_errors) or dedup-wrap repeats, stripping the
+          // marker fields the request pipeline translates on.
+          if (isLoaderSignal(pageError)) throw pageError;
           const panicError = handleError({
             error: pageError,
             logger,
@@ -434,6 +440,8 @@ async function loadComponentsWithCache(options: {
           throw panicError ?? pageError;
         }
       } catch (error) {
+        // Loader signals pass through untouched (see above).
+        if (isLoaderSignal(error)) throw error;
         // resolvePageAndProps threw. Route through handleError for dedup +
         // panic handling, then re-throw so the outer worker catch propagates
         // to the main thread.
@@ -1494,8 +1502,15 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
       }
     }
   } catch (error) {
+    const workerError = toError(error);
     // Just communicate the error directly - let the main thread handle panic threshold logic
-    effectiveHandlers.onError("worker/rsc", toError(error));
+    effectiveHandlers.onError("worker/rsc", workerError);
+    // A loader redirect()/notFound() must reach the receiver BEFORE the
+    // end-of-stream null, or the response commits as an empty 200 first.
+    // The control-port ERROR above races the data port; this copy is ordered.
+    if (isLoaderSignal(workerError)) {
+      effectiveHandlers.onDataError?.("worker/rsc", workerError);
+    }
     // Signal end-of-stream so the main thread's response completes. Without
     // this, a fatal failure before any data flowed (e.g. a page/root
     // module-load throw from loadComponentsWithCache) leaves the response

--- a/plugin/worker/types.ts
+++ b/plugin/worker/types.ts
@@ -171,6 +171,13 @@ export type StreamHandlers<
   getWritable?: () => NodeJS.WritableStream;
   onHmrUpdate: (id: string, routes?: string[]) => void;
   onShutdown?: (id: string) => void;
+  /**
+   * Post an error THROUGH the data port (ordered ahead of onEnd's null),
+   * so the receiver is guaranteed to see it before end-of-stream. Used for
+   * loader control-flow signals, which the control port's ERROR message can
+   * lose to the cross-port ordering race.
+   */
+  onDataError?: (id: string, error: unknown) => void;
   onCssFile?: (id: string, code: string) => void;
   onCleanup?: (id: string) => void;
   onShellReady?: (id: string) => void;

--- a/test/router-fixtures/routes-collide/(a)/page.tsx
+++ b/test/router-fixtures/routes-collide/(a)/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes-collide/(b)/page.tsx
+++ b/test/router-fixtures/routes-collide/(b)/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes-extras/(marketing)/about/head.ts
+++ b/test/router-fixtures/routes-extras/(marketing)/about/head.ts
@@ -1,0 +1,1 @@
+export const head = { title: "about" };

--- a/test/router-fixtures/routes-extras/(marketing)/about/index.tsx
+++ b/test/router-fixtures/routes-extras/(marketing)/about/index.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes-extras/(marketing)/route.tsx
+++ b/test/router-fixtures/routes-extras/(marketing)/route.tsx
@@ -1,0 +1,1 @@
+export const Layout = ({ children }: { children?: unknown }) => children;

--- a/test/router-fixtures/routes-extras/dashboard/loading.tsx
+++ b/test/router-fixtures/routes-extras/dashboard/loading.tsx
@@ -1,0 +1,1 @@
+export const Loading = () => null;

--- a/test/router-fixtures/routes-extras/dashboard/page.tsx
+++ b/test/router-fixtures/routes-extras/dashboard/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes-extras/dashboard/settings/index.tsx
+++ b/test/router-fixtures/routes-extras/dashboard/settings/index.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes-extras/dashboard/settings/page.tsx
+++ b/test/router-fixtures/routes-extras/dashboard/settings/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes-extras/error.tsx
+++ b/test/router-fixtures/routes-extras/error.tsx
@@ -1,0 +1,2 @@
+"use client";
+export const ErrorBoundary = ({ children }: { children?: unknown }) => children;

--- a/test/router-fixtures/routes-extras/head.ts
+++ b/test/router-fixtures/routes-extras/head.ts
@@ -1,0 +1,1 @@
+export const head = { title: "root", meta: [{ name: "description", content: "root-desc" }] };

--- a/test/router-fixtures/routes-extras/page.tsx
+++ b/test/router-fixtures/routes-extras/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/router-fixtures/routes-extras/route.tsx
+++ b/test/router-fixtures/routes-extras/route.tsx
@@ -1,0 +1,1 @@
+export const Layout = ({ children }: { children?: unknown }) => children;

--- a/test/router/applyRouteHead.test.ts
+++ b/test/router/applyRouteHead.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  applyRouteHead,
+  readRouteHead,
+} from "../../plugin/router/applyRouteHead.js";
+import type { RouteHeadContribution } from "../../plugin/router/head.js";
+
+const mountPayload = (head: RouteHeadContribution | string) => {
+  const root = document.createElement("div");
+  const template = document.createElement("template");
+  template.setAttribute(
+    "data-vprs-head",
+    typeof head === "string" ? head : JSON.stringify(head),
+  );
+  root.appendChild(template);
+  document.body.appendChild(root);
+  return root;
+};
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  document.head.innerHTML = "";
+  document.title = "";
+});
+
+describe("readRouteHead", () => {
+  it("parses the template payload", () => {
+    const root = mountPayload({ title: "x" });
+    expect(readRouteHead(root)).toEqual({ title: "x" });
+  });
+
+  it("returns null for absent or malformed payloads", () => {
+    expect(readRouteHead(document.createElement("div"))).toBeNull();
+    expect(readRouteHead(mountPayload("{not json"))).toBeNull();
+  });
+});
+
+describe("applyRouteHead", () => {
+  it("sets the document title", () => {
+    applyRouteHead(mountPayload({ title: "Greeting ada" }));
+    expect(document.title).toBe("Greeting ada");
+  });
+
+  it("creates a keyed meta and marks it managed", () => {
+    applyRouteHead(
+      mountPayload({ meta: [{ name: "description", content: "d1" }] }),
+    );
+    const tag = document.head.querySelector("meta[name=description]");
+    expect(tag?.getAttribute("content")).toBe("d1");
+    expect(tag?.hasAttribute("data-vprs-head-managed")).toBe(true);
+  });
+
+  it("updates an existing (prerendered) meta in place without managing it", () => {
+    const prerendered = document.createElement("meta");
+    prerendered.setAttribute("name", "description");
+    prerendered.setAttribute("content", "old");
+    document.head.appendChild(prerendered);
+
+    applyRouteHead(
+      mountPayload({ meta: [{ name: "description", content: "new" }] }),
+    );
+    const tags = document.head.querySelectorAll("meta[name=description]");
+    expect(tags.length).toBe(1);
+    expect(tags[0].getAttribute("content")).toBe("new");
+    expect(tags[0].hasAttribute("data-vprs-head-managed")).toBe(false);
+  });
+
+  it("removes a managed meta the next route no longer contributes", () => {
+    applyRouteHead(
+      mountPayload({ meta: [{ property: "og:title", content: "a" }] }),
+    );
+    expect(document.head.querySelector("meta[property='og:title']")).not.toBeNull();
+
+    document.body.innerHTML = "";
+    applyRouteHead(mountPayload({ title: "next route" }));
+    expect(document.head.querySelector("meta[property='og:title']")).toBeNull();
+  });
+
+  it("leaves the head alone when the tree carries no payload", () => {
+    document.title = "untouched";
+    applyRouteHead(document.createElement("div"));
+    expect(document.title).toBe("untouched");
+  });
+});

--- a/test/router/errorBoundary.test.tsx
+++ b/test/router/errorBoundary.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import { createErrorBoundary } from "../../plugin/router/errorBoundary.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+async function mount(ui: React.ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(ui);
+  });
+  return { container, root };
+}
+
+const Boom = ({ when }: { when: boolean }): React.ReactNode => {
+  if (when) throw new Error("kaboom");
+  return <p data-testid="fine">fine</p>;
+};
+
+describe("createErrorBoundary", () => {
+  it("renders children when nothing throws", async () => {
+    const ErrorBoundary = createErrorBoundary(({ error }) => (
+      <div role="alert">{error.message}</div>
+    ));
+    const { container } = await mount(
+      <ErrorBoundary>
+        <Boom when={false} />
+      </ErrorBoundary>,
+    );
+    expect(container.querySelector("[data-testid=fine]")).not.toBeNull();
+    expect(container.querySelector("[role=alert]")).toBeNull();
+  });
+
+  it("catches a child render throw and shows the fallback", async () => {
+    // React logs caught boundary errors; keep the test output quiet.
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const ErrorBoundary = createErrorBoundary(({ error }) => (
+        <div role="alert">{error.message}</div>
+      ));
+      const { container } = await mount(
+        <ErrorBoundary>
+          <Boom when={true} />
+        </ErrorBoundary>,
+      );
+      expect(container.querySelector("[role=alert]")?.textContent).toBe(
+        "kaboom",
+      );
+    } finally {
+      quiet.mockRestore();
+    }
+  });
+
+  it("reset clears the boundary and re-renders the subtree", async () => {
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      let shouldThrow = true;
+      const Child = (): React.ReactNode => {
+        if (shouldThrow) throw new Error("first render fails");
+        return <p data-testid="recovered">recovered</p>;
+      };
+      const ErrorBoundary = createErrorBoundary(({ error, reset }) => (
+        <button onClick={reset}>{error.message}</button>
+      ));
+      const { container } = await mount(
+        <ErrorBoundary>
+          <Child />
+        </ErrorBoundary>,
+      );
+      const button = container.querySelector("button");
+      expect(button?.textContent).toBe("first render fails");
+
+      shouldThrow = false;
+      await act(async () => {
+        button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      expect(container.querySelector("[data-testid=recovered]")).not.toBeNull();
+    } finally {
+      quiet.mockRestore();
+    }
+  });
+
+  it("normalizes a non-Error throw into an Error for the fallback", async () => {
+    const quiet = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const Thrower = (): React.ReactNode => {
+        throw "string-throw";
+      };
+      const ErrorBoundary = createErrorBoundary(({ error }) => (
+        <div role="alert">{error.message}</div>
+      ));
+      const { container } = await mount(
+        <ErrorBoundary>
+          <Thrower />
+        </ErrorBoundary>,
+      );
+      expect(container.querySelector("[role=alert]")?.textContent).toBe(
+        "string-throw",
+      );
+    } finally {
+      quiet.mockRestore();
+    }
+  });
+});

--- a/test/unit/layoutChainExtras.test.ts
+++ b/test/unit/layoutChainExtras.test.ts
@@ -123,33 +123,59 @@ describe("createElementWithReact — boundary/suspense/head fold", () => {
     expect(leaf.type).toBe(Page);
   });
 
-  it("renders merged head tags beside the leaf (leaf title wins)", () => {
+  const HEAD_CHAIN = [
+    {
+      Component: RootLayout,
+      props: {},
+      head: {
+        title: "root",
+        meta: [{ name: "description", content: "d" }],
+      },
+    },
+    { props: {}, head: { title: "leaf" } },
+  ];
+
+  const composeWith = (HtmlComponent: unknown) => {
     const el = createElementWithReact(React as never, {
       PageComponent: Page as never,
-      HtmlComponent: React.Fragment as never,
+      HtmlComponent: HtmlComponent as never,
       RootComponent: React.Fragment as never,
       pageProps: {} as never,
-      layoutChain: [
-        {
-          Component: RootLayout,
-          props: {},
-          head: {
-            title: "root",
-            meta: [{ name: "description", content: "d" }],
-          },
-        },
-        { props: {}, head: { title: "leaf" } },
-      ],
+      layoutChain: HEAD_CHAIN,
     } as never) as React.ReactElement;
+    // Headless branch returns <ComposedPage {...pageProps}/>; the document
+    // branch returns <Html … Page={ComposedPage}/> — invoke either.
+    const props = el.props as { Page?: (p: unknown) => React.ReactElement };
+    if (props.Page) return props.Page({});
+    return (el.type as (p: unknown) => React.ReactElement)(el.props);
+  };
 
-    const Composed = el.type as (p: unknown) => React.ReactElement;
-    const tree = Composed(el.props);
-
-    // Layer 2 has no Component/boundaries — the fragment with head tags +
-    // page is directly under the root layout.
+  it("headless render ships head as an inert data template, no hoistables", () => {
+    const tree = composeWith(React.Fragment);
     expect(tree.type).toBe(RootLayout);
     const frag = tree.props.children as React.ReactElement;
     expect(frag.type).toBe(React.Fragment);
+    const children = React.Children.toArray(
+      frag.props.children,
+    ) as React.ReactElement[];
+    // No raw hoistables in the hydration flight: re-inserted instead of
+    // adopted when hydration suspends on a client chunk (dup title + #418).
+    expect(children.some((c) => c.type === "title")).toBe(false);
+    expect(children.some((c) => c.type === "meta")).toBe(false);
+    const template = children.find((c) => c.type === "template");
+    expect(template).toBeDefined();
+    const payload = JSON.parse(template!.props["data-vprs-head"]);
+    expect(payload.title).toBe("leaf");
+    expect(payload.meta).toEqual([{ name: "description", content: "d" }]);
+    expect(children.some((c) => c.type === Page)).toBe(true);
+  });
+
+  it("document render gets the raw hoistables plus the data template", () => {
+    const HtmlDoc = ({ Page: P }: { Page: (p: unknown) => React.ReactElement }) =>
+      P({});
+    const tree = composeWith(HtmlDoc);
+    expect(tree.type).toBe(RootLayout);
+    const frag = tree.props.children as React.ReactElement;
     const children = React.Children.toArray(
       frag.props.children,
     ) as React.ReactElement[];
@@ -157,6 +183,7 @@ describe("createElementWithReact — boundary/suspense/head fold", () => {
     expect(title?.props.children).toBe("leaf");
     const meta = children.find((c) => c.type === "meta");
     expect(meta?.props.content).toBe("d");
+    expect(children.some((c) => c.type === "template")).toBe(true);
     expect(children.some((c) => c.type === Page)).toBe(true);
   });
 });

--- a/test/unit/layoutChainExtras.test.ts
+++ b/test/unit/layoutChainExtras.test.ts
@@ -20,7 +20,7 @@ describe("resolveLayoutChain — boundaries + head", () => {
     "routes/route.tsx#Layout": { Layout: RootLayout },
     "routes/error.tsx#ErrorBoundary": { ErrorBoundary: Boundary },
     "routes/loading.tsx#Loading": { Loading: Spinner },
-    "routes/head.ts": {
+    "routes/head.ts#head": {
       head: ({ data }: { data: Record<string, unknown> }) => ({
         title: `t-${data.name}`,
       }),

--- a/test/unit/layoutChainExtras.test.ts
+++ b/test/unit/layoutChainExtras.test.ts
@@ -1,0 +1,162 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { resolveLayoutChain } from "../../plugin/helpers/resolveLayoutChain.js";
+import { createElementWithReact } from "../../plugin/helpers/createElementWithReact.js";
+import { redirect } from "../../plugin/router/loaderSignals.js";
+import type { RouteLayer } from "../../plugin/router/scanRoutes.js";
+
+// A loader keyed by the `${path}#${export}` id resolvePage/resolveProps
+// request; bare ids (head modules) resolve without the suffix.
+const makeLoader =
+  (modules: Record<string, unknown>) => async (id: string) =>
+    (modules[id] ?? {}) as Record<string, unknown>;
+
+const RootLayout = ({ children }: { children?: unknown }) => children;
+const Boundary = ({ children }: { children?: unknown }) => children;
+const Spinner = () => null;
+
+describe("resolveLayoutChain — boundaries + head", () => {
+  const loader = makeLoader({
+    "routes/route.tsx#Layout": { Layout: RootLayout },
+    "routes/error.tsx#ErrorBoundary": { ErrorBoundary: Boundary },
+    "routes/loading.tsx#Loading": { Loading: Spinner },
+    "routes/head.ts": {
+      head: ({ data }: { data: Record<string, unknown> }) => ({
+        title: `t-${data.name}`,
+      }),
+    },
+    "routes/props.ts#props": { props: () => ({ name: "x" }) },
+    "routes/redirecting-props.ts#props": {
+      props: () => redirect("/login"),
+    },
+  });
+
+  it("loads error/loading/head onto the layer", async () => {
+    const layouts: RouteLayer[] = [
+      {
+        component: "routes/route.tsx",
+        props: "routes/props.ts",
+        error: "routes/error.tsx",
+        loading: "routes/loading.tsx",
+        head: "routes/head.ts",
+      },
+    ];
+    const chain = await resolveLayoutChain({
+      layouts,
+      url: "/",
+      ctx: { params: {} },
+      loader,
+      layoutExportName: "Layout",
+      propsExportName: "props",
+    });
+    expect(chain).toHaveLength(1);
+    expect(chain[0].Component).toBe(RootLayout);
+    expect(chain[0].ErrorBoundary).toBe(Boundary);
+    expect(chain[0].Loading).toBe(Spinner);
+    // Functional head evaluated with the segment's resolved loader data.
+    expect(chain[0].head).toEqual({ title: "t-x" });
+  });
+
+  it("keeps a boundaries-only layer (no route.tsx)", async () => {
+    const chain = await resolveLayoutChain({
+      layouts: [{ loading: "routes/loading.tsx" }],
+      url: "/",
+      ctx: { params: {} },
+      loader,
+      layoutExportName: "Layout",
+      propsExportName: "props",
+    });
+    expect(chain).toHaveLength(1);
+    expect(chain[0].Component).toBeUndefined();
+    expect(chain[0].Loading).toBe(Spinner);
+  });
+
+  it("propagates a redirect() thrown by a layout loader", async () => {
+    await expect(
+      resolveLayoutChain({
+        layouts: [
+          {
+            component: "routes/route.tsx",
+            props: "routes/redirecting-props.ts",
+          },
+        ],
+        url: "/",
+        ctx: { params: {} },
+        loader,
+        layoutExportName: "Layout",
+        propsExportName: "props",
+      }),
+    ).rejects.toMatchObject({ to: "/login", status: 302 });
+  });
+});
+
+describe("createElementWithReact — boundary/suspense/head fold", () => {
+  const Page = (props: Record<string, unknown>) =>
+    React.createElement("main", props);
+
+  it("wraps each segment Layout → ErrorBoundary → Suspense(Loading)", () => {
+    const el = createElementWithReact(React as never, {
+      PageComponent: Page as never,
+      HtmlComponent: React.Fragment as never,
+      RootComponent: React.Fragment as never,
+      pageProps: {} as never,
+      layoutChain: [
+        {
+          Component: RootLayout,
+          props: {},
+          ErrorBoundary: Boundary,
+          Loading: Spinner,
+        },
+      ],
+    } as never) as React.ReactElement;
+
+    const Composed = el.type as (p: unknown) => React.ReactElement;
+    const tree = Composed(el.props);
+
+    expect(tree.type).toBe(RootLayout);
+    const boundary = tree.props.children as React.ReactElement;
+    expect(boundary.type).toBe(Boundary);
+    const suspense = boundary.props.children as React.ReactElement;
+    expect(suspense.type).toBe(React.Suspense);
+    expect((suspense.props.fallback as React.ReactElement).type).toBe(Spinner);
+    const leaf = suspense.props.children as React.ReactElement;
+    expect(leaf.type).toBe(Page);
+  });
+
+  it("renders merged head tags beside the leaf (leaf title wins)", () => {
+    const el = createElementWithReact(React as never, {
+      PageComponent: Page as never,
+      HtmlComponent: React.Fragment as never,
+      RootComponent: React.Fragment as never,
+      pageProps: {} as never,
+      layoutChain: [
+        {
+          Component: RootLayout,
+          props: {},
+          head: {
+            title: "root",
+            meta: [{ name: "description", content: "d" }],
+          },
+        },
+        { props: {}, head: { title: "leaf" } },
+      ],
+    } as never) as React.ReactElement;
+
+    const Composed = el.type as (p: unknown) => React.ReactElement;
+    const tree = Composed(el.props);
+
+    // Layer 2 has no Component/boundaries — the fragment with head tags +
+    // page is directly under the root layout.
+    expect(tree.type).toBe(RootLayout);
+    const frag = tree.props.children as React.ReactElement;
+    expect(frag.type).toBe(React.Fragment);
+    const children = React.Children.toArray(
+      frag.props.children,
+    ) as React.ReactElement[];
+    const title = children.find((c) => c.type === "title");
+    expect(title?.props.children).toBe("leaf");
+    const meta = children.find((c) => c.type === "meta");
+    expect(meta?.props.content).toBe("d");
+    expect(children.some((c) => c.type === Page)).toBe(true);
+  });
+});

--- a/test/unit/loaderSignals.test.ts
+++ b/test/unit/loaderSignals.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLoaderSignal,
+  isNotFound,
+  isRedirect,
+  notFound,
+  redirect,
+} from "../../plugin/router/loaderSignals.js";
+import { serializeError } from "../../plugin/error/serializeError.js";
+import { toError } from "../../plugin/error/toError.js";
+
+const catchSignal = (fn: () => never): unknown => {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("did not throw");
+};
+
+describe("loader signals", () => {
+  it("redirect() throws an Error carrying to/status", () => {
+    const err = catchSignal(() => redirect("/target"));
+    expect(isRedirect(err)).toBe(true);
+    expect(isNotFound(err)).toBe(false);
+    expect((err as { to: string }).to).toBe("/target");
+    expect((err as { status: number }).status).toBe(302);
+  });
+
+  it("redirect() honors an explicit status", () => {
+    const err = catchSignal(() => redirect("/moved", 308));
+    expect((err as { status: number }).status).toBe(308);
+  });
+
+  it("notFound() throws a marked Error", () => {
+    const err = catchSignal(() => notFound());
+    expect(isNotFound(err)).toBe(true);
+    expect(isRedirect(err)).toBe(false);
+    expect(isLoaderSignal(err)).toBe(true);
+  });
+
+  it("plain errors are not signals", () => {
+    expect(isLoaderSignal(new Error("boom"))).toBe(false);
+    expect(isRedirect(null)).toBe(false);
+    expect(isNotFound(undefined)).toBe(false);
+  });
+
+  it("survives the worker boundary (serializeError → structuredClone → toError)", () => {
+    // The exact path a signal takes when a loader throws inside the RSC
+    // worker: serialized onto the message envelope, structured-cloned by
+    // postMessage, rebuilt by toError on the main thread.
+    const original = catchSignal(() => redirect("/after-login", 303));
+    const arrived = toError(structuredClone(serializeError(original)));
+    expect(isRedirect(arrived)).toBe(true);
+    expect((arrived as unknown as { to: string }).to).toBe("/after-login");
+    expect((arrived as unknown as { status: number }).status).toBe(303);
+
+    const nf = catchSignal(() => notFound());
+    expect(isNotFound(toError(structuredClone(serializeError(nf))))).toBe(true);
+  });
+});

--- a/test/unit/routerHead.test.ts
+++ b/test/unit/routerHead.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { mergeHead } from "../../plugin/router/head.js";
+
+describe("mergeHead", () => {
+  it("leaf title wins", () => {
+    expect(
+      mergeHead([{ title: "root" }, undefined, { title: "leaf" }]).title,
+    ).toBe("leaf");
+  });
+
+  it("keeps an ancestor title when the leaf contributes none", () => {
+    expect(mergeHead([{ title: "root" }, { meta: [] }]).title).toBe("root");
+  });
+
+  it("keyed meta overrides an ancestor's same-key entry", () => {
+    const merged = mergeHead([
+      { meta: [{ name: "description", content: "root" }] },
+      { meta: [{ name: "description", content: "leaf" }] },
+    ]);
+    expect(merged.meta).toEqual([{ name: "description", content: "leaf" }]);
+  });
+
+  it("unkeyed meta entries append instead of replacing", () => {
+    const merged = mergeHead([
+      { meta: [{ charSet: "utf-8" }] },
+      { meta: [{ content: "loose" }] },
+    ]);
+    expect(merged.meta).toHaveLength(2);
+  });
+
+  it("property-keyed (open graph) meta dedupes like name-keyed", () => {
+    const merged = mergeHead([
+      { meta: [{ property: "og:title", content: "a" }] },
+      { meta: [{ property: "og:title", content: "b" }] },
+    ]);
+    expect(merged.meta).toEqual([{ property: "og:title", content: "b" }]);
+  });
+
+  it("links concatenate root→leaf", () => {
+    const merged = mergeHead([
+      { links: [{ rel: "canonical", href: "/a" }] },
+      { links: [{ rel: "alternate", href: "/b" }] },
+    ]);
+    expect(merged.links).toHaveLength(2);
+  });
+});

--- a/test/unit/scanRoutesExtras.test.ts
+++ b/test/unit/scanRoutesExtras.test.ts
@@ -1,0 +1,75 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { scanRoutes } from "../../plugin/router/scanRoutes.js";
+
+const FIXTURES = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../router-fixtures",
+);
+const ROUTES = join(FIXTURES, "routes-extras");
+
+describe("scanRoutes parity extras", () => {
+  const routes = scanRoutes(ROUTES);
+  const byPattern = Object.fromEntries(routes.map((r) => [r.pattern, r]));
+
+  it("accepts index.tsx as a leaf page", () => {
+    expect(byPattern["/about"]).toBeDefined();
+    expect(byPattern["/about"].page).toMatch(/about\/index\.tsx$/);
+  });
+
+  it("strips (group) segments from the URL but keeps their layers", () => {
+    // (marketing)/about → /about, wrapped by root + (marketing) layouts.
+    const about = byPattern["/about"];
+    // First two layers are the root + (marketing) layouts; a third head-only
+    // layer (about/head.ts) follows, asserted separately below.
+    expect(about.layouts.slice(0, 2).map((l) => l.component)).toEqual([
+      expect.stringMatching(/routes-extras\/route\.tsx$/),
+      expect.stringMatching(/\(marketing\)\/route\.tsx$/),
+    ]);
+  });
+
+  it("prefers page.tsx over index.tsx when both exist", () => {
+    expect(byPattern["/dashboard/settings"].page).toMatch(
+      /settings\/page\.tsx$/,
+    );
+  });
+
+  it("collects error.tsx / head.ts onto the segment's layer", () => {
+    const root = byPattern["/"].layouts[0];
+    expect(root.error).toMatch(/routes-extras\/error\.tsx$/);
+    expect(root.head).toMatch(/routes-extras\/head\.ts$/);
+  });
+
+  it("creates a boundaries-only layer (loading.tsx without route.tsx)", () => {
+    const dash = byPattern["/dashboard"];
+    expect(dash.layouts).toHaveLength(2);
+    const layer = dash.layouts[1];
+    expect(layer.component).toBeUndefined();
+    expect(layer.loading).toMatch(/dashboard\/loading\.tsx$/);
+  });
+
+  it("a head-only child segment layers under its ancestors", () => {
+    // about/head.ts adds a third layer with only `head` set.
+    const about = byPattern["/about"];
+    expect(about.layouts).toHaveLength(3);
+    expect(about.layouts[2].component).toBeUndefined();
+    expect(about.layouts[2].head).toMatch(/about\/head\.ts$/);
+  });
+
+  it("throws when pathless groups collapse two pages onto one URL", () => {
+    expect(() => scanRoutes(join(FIXTURES, "routes-collide"))).toThrow(
+      /both resolve to "\/"/,
+    );
+  });
+
+  it("does not treat a barrel index.ts as a route", () => {
+    // index pattern is jsx/tsx-only by default; index.ts would be a barrel.
+    const routesWithCustom = scanRoutes(ROUTES, {
+      indexPattern: /^__never__$/,
+    });
+    expect(
+      routesWithCustom.find((r) => r.pattern === "/about"),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Rounds the file router out to parity with TanStack/Next/Remix (the remaining items from docs/internals/router-v2-parity.md §5). Everything is compose-time work over the existing layout-chain machinery — no new transport or worker model.

## Conventions added

| file | meaning |
|---|---|
| `index.tsx` | alternate leaf-page name (`page.tsx` wins; jsx/tsx-only so `index.ts` barrels never become routes) |
| `(group)/` | pathless segment: organizes files / shares layers, adds no URL segment; two pages collapsing onto one URL throw at scan time |
| `error.tsx` | `"use client"` boundary for the segment's subtree — `export const ErrorBoundary = createErrorBoundary(({ error, reset }) => …)` (helper shipped in `./router/client`) |
| `loading.tsx` | `export const Loading` — the segment's Suspense fallback |
| `head.ts` | `export const head` — static object or `({ url, params, data }) => …` evaluated against the segment's loader data; merged root→leaf (leaf title wins, keyed meta overrides), rendered as react-dom hoistables |

Per segment the fold is `Layout → ErrorBoundary → Suspense(Loading) → children` (Next's nesting order), so a boundary catches its children but not its own layout. A segment no longer needs a `route.tsx` to contribute boundaries/head.

## Loader control flow

`redirect(to, status?)` / `notFound()` (exported from `./router`) can be thrown from any page or layout loader:

- per-request paths (dev both conditions, Node, edge) answer the 3xx/404; the flight path redirects to the **target's** flight so the browser's transparent follow yields a decodable payload, and `startClient` fixes the address bar from `response.redirected`;
- static prerender skips the page with a warning instead of failing the build (don't enumerate redirecting routes in `getStaticPaths`).

The signals are plain-field-marked Errors so they survive duplicate module instances and the worker boundary (`serializeError` → structured clone → `toError`, the same mechanism as the panic flag). They bypass `handleError` (panic-marking and dedup-wrapping both strip the markers) and additionally travel through the ordered **data** port ahead of the null end-signal — the control-port ERROR alone loses the cross-port race and let repeat requests commit an empty 200 before the redirect arrived.

## Verified

- gates: test:server 863, test:client 261, test:unit 638, test:typecheck 35, verify:package 109 entrypoints
- new unit coverage: scanner extras, head merging, signal round-trip through `serializeError`/`structuredClone`/`toError`, chain resolution of boundaries/head, compose fold order
- examples/router exercises every convention; the built output carries per-route hoisted titles (`About — File router demo`, loader-derived `Greeting ada`), the boundary client-reference, and the Suspense fallback in the flight
- dev: 5/5 consecutive requests to `/old/index.rsc` answer `302 → /greet/ada/index.rsc`

Also included: docs/routing.md covers all the new conventions, examples/hello-world models the one-field `routes: {}` surface, and a once-per-process tip nudges loose Page/props configs toward `routes` (explicit Page/props stay a working escape hatch). The full stale-docs sweep remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)