### PR TITLE
docs: refresh the reference layer to match the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,13 @@ prerequisite: the project must be ESM (`"type": "module"` in `package.json`).
 // vite.config.ts
 import { defineConfig } from "vite";
 import { vitePluginReactServer } from "vite-plugin-react-server";
-import { fileRouter } from "vite-plugin-react-server/router";
-
-// Scans src/routes/** for page.tsx (+ sibling props.ts) and derives the
-// route table and the prerender worklist.
-const router = fileRouter("src/routes");
 
 export default defineConfig({
   plugins: vitePluginReactServer({
     moduleBase: "src",
-    Page: router.Page,
-    props: router.props,
-    routePatterns: router.routePatterns,
-    build: { pages: router.build.pages },
+    // Scans src/routes/** for page.tsx (+ sibling props.ts) and derives the
+    // route table and the prerender worklist.
+    routes: { dir: "routes" },
   }),
 });
 ```
@@ -125,7 +119,7 @@ startClient({
 </body>
 ```
 
-Routing is opt-in: skip `fileRouter` and map URLs to files yourself with
+Routing is opt-in: skip `routes` and map URLs to files yourself with
 a `Page: (url) => string` mapping — see [Routing](./docs/routing.md).
 
 ```bash
@@ -175,7 +169,7 @@ Name a file `Counter.client.tsx` if you like the reminder — but the name carri
 no meaning, and a file named that way *without* the directive gets a build
 warning telling you to add one.
 
-See [Getting Started](./docs/getting-started.md#the-client-filename-is-optional).
+See [Getting Started](./docs/getting-started.md#what-makes-it-a-client-component).
 
 ## Third-party client-component packages
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,13 +14,13 @@ Read in order if you're new; each stands alone otherwise.
 - [Storybook](./storybook.md) — rendering RSC components in stories
 - [Examples](./examples.md) — static site, dynamic server, custom routing
 - [Troubleshooting](./troubleshooting.md) — common errors and fixes
+- [React Compatibility](./react-type-compatibility.md) — supported React versions, the vendored transport, and the type system
 - [API Reference](./api-reference.md) — exports, types, components, defaults
 - [Comparison](./comparison.md) — how vprs differs from Next.js, Waku, and `@vitejs/plugin-rsc`
 
 ## Maintenance
 
 - [Releasing](./releasing.md) — version bumps, publishing, demo updates
-- [React Compatibility](./react-type-compatibility.md) — the vendored ESM transport and the type system
 
 ## Internals (contributors)
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -58,6 +58,10 @@ export const config = {
 | `static` | `string` | Static output directory | `"static"` |
 | `hash` | `string` | Hash for client files | `"hash"` |
 | `preserveModulesRoot` | `boolean` | When `true`, preserves the `moduleBase` directory (e.g. `src/`) in output paths. When `false`, strips it from output paths. | `false` |
+| `renderMode` | `"parallel" \| "sequential"` | How SSG renders pages: concurrent batches, or one at a time (less memory, deterministic order) | `"parallel"` |
+| `batchSize` | `number` | Pages rendered concurrently when `renderMode` is `"parallel"` | `8` |
+| `inlineFlight` | `boolean` | Inline each prerendered route's flight payload into its `index.html` (non-executable `<script id="vprs-flight">`), so first paint hydrates with no `index.rsc` round-trip. Runs at the post-SSG point in both build modes. See [Build Output](./build-output.md). | `false` |
+| `edge` | `boolean \| EdgeBuildConfig` | Single-isolate edge bundle (see [`build.edge`](#buildedge) below) | `true` |
 | `assetsDir` | `string` | Assets directory | `"assets"` |
 | `api` | `string` | API output directory | `"api"` |
 | `outDir` | `string` | Output directory | `"dist"` |
@@ -164,11 +168,16 @@ type RootProps = {
 
 ### CssContent
 
-CSS content can be either inline (string) or linked (object with href):
+A value in `cssFiles` / `globalCss` maps — props for one `<style>` or `<link>`
+tag, exactly as the `Css` component renders it (see
+[CSS Handling](./css-handling.md)):
 
 ```typescript
-type CssContent<InlineCSS extends boolean = boolean> = 
-  InlineCSS extends true ? string : { href: string };
+type CssContent =
+  // inline: rendered as <style type="text/css">{children}</style>
+  | { as: "style"; type: "text/css"; children?: React.ReactNode }
+  // linked: rendered as <link rel="stylesheet" href … /> (react-dom hoistable)
+  | { as: "link"; rel: string; href: string; precedence?: string };
 ```
 
 ## Build Configuration
@@ -203,8 +212,15 @@ Single-isolate edge bundle (additive; **ON by default**). See [Edge / Single-Iso
 //   false           → opt out
 //   { … }           → emit, with overrides
 interface EdgeBuildConfig {
-  outDir?: string;  // Default: "server-edge" (under build.outDir)
-  minify?: boolean; // Default: true — edge runtimes cap bundle size
+  outDir?: string;    // Default: "server-edge" (under build.outDir)
+  minify?: boolean;   // Default: true — edge runtimes cap bundle size
+  // Which RSC transport the baked bundle renders through. "esm" resolves
+  // client references via import(moduleBaseURL + id) at request time;
+  // "webpack" resolves them through the baked client manifest (closed module
+  // map — the fully self-contained deployment model). Defaults from the
+  // top-level `transport` option when set. Don't mix flavors across one
+  // deploy's routes — see [Edge / Single-Isolate](./edge.md).
+  transport?: "esm" | "webpack"; // Default: "esm"
 }
 ```
 
@@ -246,75 +262,29 @@ This option is useful when you want to maintain your source directory structure 
 
 ### PluginEvent
 
-Events emitted during build processes:
+`onEvent` receives every plugin event; switch on `event.type`. Each event
+carries a `data` payload (full shapes in `plugin/types.ts`):
 
-```typescript
-type PluginEvent = 
-  | { type: 'build:start'; data: { target: string } }
-  | { type: 'build:end'; data: { target: string; duration: number } }
-  | { type: 'page:build:start'; data: { url: string; target: string } }
-  | { type: 'page:build:end'; data: { url: string; target: string; duration: number } }
-  | { type: 'error'; data: { message: string; stack?: string } }
-  | { type: 'warning'; data: { message: string } };
-```
+| `type` | When | Notable `data` fields |
+|--------|------|----------------------|
+| `"file.write"` | a prerendered file starts writing | `path`, `fileType` (`"html"`/`"rsc"`), `route`, `stream` |
+| `"file.write.done"` | that write completed | `route`, `fileType`, `path`, `content`, `chunks` |
+| `"route.error"` | a route render failed | `route`, `error`, `isPanic`, `panicThreshold` |
+| `"route.shellError"` | the HTML shell failed | `route`, `error` |
+| `"route.shellReady"` / `"route.allReady"` | streaming milestones per route | `route` |
+| `"route.postpone"` | React postponed a route | `route`, `reason` |
+| `"props.load"` | a route's loader resolved | `route` |
+| `"css.process"` | CSS was processed for a route | route/css details |
+| `"build.start"` | a build began | — |
+| `"build.writeBundle.server"` / `".client"` / `".static"` | an environment's bundle was written | bundle details |
+| `"build.ssg.start"` / `"build.ssg.end"` | the SSG pass began / finished | — |
 
-### BuildMetrics
+### Metrics
 
-Metrics collected during builds:
-
-```typescript
-interface BuildMetrics {
-  buildTime: number;
-  htmlSize: number;
-  rscSize: number;
-  cssSize: number;
-  jsSize: number;
-  pageCount: number;
-  errorCount: number;
-  warningCount: number;
-}
-```
-
-## Worker Messages
-
-### WorkerMessage
-
-Messages sent between main thread and workers:
-
-```typescript
-type WorkerMessage = 
-  | { type: 'render'; data: RenderRequest }
-  | { type: 'result'; data: RenderResult }
-  | { type: 'error'; data: { message: string; stack?: string } }
-  | { type: 'ready'; data: {} };
-```
-
-### RenderRequest
-
-Request structure for rendering:
-
-```typescript
-interface RenderRequest {
-  url: string;
-  pageProps?: any;
-  moduleBaseURL: string;
-  cssFiles: CssFile[];
-  globalCss: CssFile[];
-}
-```
-
-### RenderResult
-
-Result structure from rendering:
-
-```typescript
-interface RenderResult {
-  html: string;
-  rsc: string;
-  css: string;
-  duration: number;
-}
-```
+`onMetrics` receives a discriminated union of render, worker-startup,
+module-resolution, ssg-render, inline-flight and edge-bake metrics — see the
+[Metric types](#metric-types) table under Metric Watcher for the full list of
+`metrics.type` values and their fields.
 
 ## Type Definitions
 
@@ -339,24 +309,10 @@ type CssComponentType = (props: CssProps) => React.ReactNode;
 ### Environment Detection
 
 ```typescript
-// Check current execution context
-function getCondition(): string | null;
+import { getCondition } from "vite-plugin-react-server/config";
 
-// Environment-specific configurations
-const RSC_LOADER = {
-  development: {
-    importServerPath: "react-server-dom-esm/server.node",
-    importClientPath: "react-server-dom-esm/server.node",
-    registerClientReferenceName: "registerClientReference",
-    registerServerReferenceName: "registerServerReference"
-  },
-  production: {
-    importServerPath: "react-server-dom-esm/server",
-    importClientPath: "react-server-dom-esm/server",
-    registerClientReferenceName: "registerClientReference",
-    registerServerReferenceName: "registerServerReference"
-  }
-};
+// "react-server" when the process runs under that condition, else null.
+function getCondition(): string | null;
 ```
 
 ## Directive Patterns
@@ -584,7 +540,7 @@ import type {
   RootProps,
   BuildConfig,
   PluginEvent,
-  BuildMetrics
+  OnMetrics
 } from "vite-plugin-react-server/types";
 ```
 

--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -1,6 +1,8 @@
 # Build Output
 
-Running `NODE_OPTIONS='--conditions react-server' vite build --app` produces three directories:
+Running `vite build --app` produces three directories (prefix
+`NODE_OPTIONS='--conditions react-server'` if you want the optional
+main-thread render — the output is identical either way):
 
 ```
 dist/
@@ -124,7 +126,8 @@ createServer(toNodeListener(app)).listen(3000);
 
 For the complete pattern — including per-request rendering of dynamic routes —
 see the [bidoof-template](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official)
-demo's `start.tsx` and the vprs-starter's
+demo's `start.tsx` and the
+[vprs-starter](https://github.com/nicobrinkkemper/vprs-starter)'s
 `server/handler.mjs`.
 
 ## Where it runs: static anywhere, dynamic on Node
@@ -189,10 +192,13 @@ Both streams include detailed stack traces in development mode.
 ### Single-step (recommended)
 
 ```bash
-NODE_OPTIONS='--conditions react-server' vite build --app
+vite build --app
 ```
 
-Builds all three environments in sequence automatically.
+Builds all three environments in sequence automatically. Prefixing
+`NODE_OPTIONS='--conditions react-server'` is an optional variant — the main
+thread renders RSC directly instead of a worker; a bit faster, better stack
+traces, same output.
 
 ### Multi-step (for debugging)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,11 +55,17 @@ export default defineConfig({
       batchSize: 8,                    // pages per batch in parallel mode
       rscOutputPath: "index.rsc",
       htmlOutputPath: "index.html",
+      // Inline each prerendered route's flight into its index.html so first
+      // paint hydrates with no index.rsc round-trip. See docs/build-output.md.
+      inlineFlight: false,
 
       // Optional — single-isolate edge bundle (additive; ON by default).
-      // `boolean | { outDir?, minify? }`. See docs/edge.md.
+      // `boolean | { outDir?, minify?, transport? }`. See docs/edge.md.
       //   edge: false             — opt out
       //   edge: { minify: false } — keep on, tune a default
+      //   transport: "esm" (default, import-at-request-time client refs) or
+      //   "webpack" (baked client manifest — the self-contained deploy model);
+      //   defaults from the top-level `transport` option when set.
       edge: true,
     },
 
@@ -154,11 +160,18 @@ Both produce identical output. The RSC worker is skipped in `dev:rsc` mode by de
   "scripts": {
     "dev": "vite",
     "dev:rsc": "NODE_OPTIONS='--conditions react-server' vite",
-    "build": "NODE_OPTIONS='--conditions react-server' vite build --app",
+    "build": "vite build --app",
     "preview": "vite preview"
   }
 }
 ```
+
+`--conditions react-server` is optional everywhere, never required: with it the
+main thread renders RSC directly (a bit faster, better stack traces); without
+it a worker thread carries the react-server condition and the output is
+identical. `dev:rsc` above is that optional variant for dev; add
+`NODE_OPTIONS='--conditions react-server'` to `build` too if you want the same
+for builds.
 
 ## Third-party `"use client"` packages
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,36 +28,41 @@ Build and deploy `dist/static/`.
 - [bidoof-template](https://github.com/nicobrinkkemper/vite-plugin-react-server-demo-official) — starter template
 - [mmc](https://github.com/nicobrinkkemper/mmc) — 284 pages
 
-## Dynamic Server (Express)
+## Dynamic Server (Node / Express)
 
-Use the build output as ESM modules in an Express server:
+Don't hand-roll the server: `createRequestHandler` serves the prerendered
+output with the MIME types and traversal guard a file server has to get right,
+dispatches `"use server"` actions through the sealed baked gate, and renders
+dynamic routes per request through the edge bundle's render hook — see
+[Build Output](./build-output.md#using-the-esm-modules-in-a-server):
 
 ```ts
-// server.ts
+// server.ts — plain Node, no framework needed
+import { createServer } from "node:http";
+import {
+  createRequestHandler,
+  toNodeListener,
+} from "vite-plugin-react-server/request-handler";
+import { createEdgeRenderHook } from "vite-plugin-react-server/edge";
+import * as bundle from "./dist/server-edge/render.js";
+
+const handler = createRequestHandler({
+  staticDir: "dist/static",              // prerendered HTML, .rsc, assets
+  render: createEdgeRenderHook(bundle),  // per-request dynamic routes
+  action: bundle.handleRouteAction,      // sealed action gate, baked at build
+});
+
+createServer(toNodeListener(handler)).listen(3000);
+```
+
+Under Express the same handler mounts as middleware — Express only adds
+whatever else your app needs around it:
+
+```ts
 import express from "express";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
 const app = express();
-
-// Static pages (pre-rendered)
-app.use(express.static(join(__dirname, "dist/static")));
-
-// RSC endpoint
-app.get("*.rsc", (req, res) => {
-  res.setHeader("Content-Type", "text/x-component");
-  res.sendFile(join(__dirname, "dist/static", req.path));
-});
-
-// Dynamic route — render on request using server modules
-app.get("/user/:id", async (req, res) => {
-  const { Page } = await import("./dist/server/pages/user/page.js");
-  const props = { userId: req.params.id };
-  // Use createRscStream / createHtmlStream to render
-  // ...
-});
-
+app.use(toNodeListener(handler));
 app.listen(3000);
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,9 @@ vprs 1.x required `react@experimental` and bundled the transport in-repo. For
 - **No API changes** to the plugin itself: your `vite.config`, page files, and
   directives are unchanged.
 
+There are no 3.x migration notes: v3's additions (the file router's `routes`
+field, the edge bundle) are additive, and a working 2.x config runs unchanged.
+
 ## Create a Page
 
 ```tsx
@@ -268,20 +271,15 @@ vitePluginReactServer({
 })
 ```
 
-## HMR Setup
+## HMR
 
-For automatic RSC refetching when server components change:
-
-```tsx
-// Client entry
-import { createReactFetcher, setupRscHmr } from "vite-plugin-react-server/utils";
-
-const { initialContent, refetch } = createReactFetcher({ callServer });
-
-if (import.meta.hot) {
-  setupRscHmr(import.meta.hot, refetch);
-}
-```
+Nothing to set up: `startClient` (the one-line client entry from
+[Routing](./routing.md#client-side-navigation)) wires RSC HMR along with
+hydration and the client router — a server-component edit refetches the
+current route's flight automatically. Assembling the client entry by hand
+instead? `useRscHmr` from `vite-plugin-react-server/utils` is the same hook
+`startClient` uses, and `setupRscHmr()` is the non-React form (call it once in
+your entry; it refetches the current page's flight on server-component edits).
 
 ## Next Steps
 

--- a/docs/react-type-compatibility.md
+++ b/docs/react-type-compatibility.md
@@ -31,9 +31,10 @@ npm install react@<that-exact-version> react-dom@<that-exact-version>
 
 `react-server-loader` is a regular **dependency** whose range admits the
 stable train plus the exact experimental build this release was verified
-against (`^19.2.17 || 0.0.0-experimental-172742b4-20260716`), so every package
-manager installs it for you — the stable train by default, no extra step (yarn
-included).
+against — check `dependencies["react-server-loader"]` in vprs's
+[`package.json`](https://github.com/nicobrinkkemper/vite-plugin-react-server/blob/main/package.json)
+for the current range. Every package manager installs it for you — the stable
+train by default, no extra step (yarn included).
 
 To run the experimental train, install all three React packages at the
 `@experimental` tag. The loader's range also admits that experimental build, so

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,8 +8,8 @@
 
 ```json
 {
-  "react": "^19.0.0",
-  "react-dom": "^19.0.0",
+  "react": "^19.2.7",
+  "react-dom": "^19.2.7",
   "@types/react": "^19.0.9",
   "@types/react-dom": "^19.0.3"
 }
@@ -208,7 +208,7 @@ This is an upstream Rolldown limitation, not vprs-specific. Workarounds:
 
 ## Checklist for New Projects
 
-- [ ] React packages have matching versions (19+)
+- [ ] React packages have matching versions (19.2+)
 - [ ] Client components have `"use client"` directive
 - [ ] Server actions have `"use server"` directive
 - [ ] Imports use `.js` extensions


### PR DESCRIPTION
Applies the docs review — the narrative docs (routing, edge, server-actions, comparison) were accurate; the reference layer had drifted. Stacked on #313 (branch base); retarget to main lands automatically when #313 merges.

## Wrong content fixed
- **getting-started "HMR Setup"** showed a `createReactFetcher({ callServer })` → `{ initialContent, refetch }` API that doesn't exist. Replaced with the truth: `startClient` wires HMR itself; `useRscHmr` / `setupRscHmr()` for hand-rolled entries.
- **api-reference's legacy bottom half**: `PluginEvent` now lists the real `file.write` / `route.*` / `build.*` union from `plugin/types.ts`; the fictional `BuildMetrics` interface (which contradicted the correct Metric-types table in the same file) is a pointer to that table; the internal `WorkerMessage`/`RenderRequest`/`RenderResult` dump and stale `RSC_LOADER` block are removed; `CssContent` matches the real `{ as: "style" }` / `{ as: "link" }` shape css-handling.md documents; the Type Imports example imports `OnMetrics` (`BuildMetrics` doesn't exist).
- **README** broken anchor → `#what-makes-it-a-client-component`.
- **examples.md Express example** (Express-5-incompatible `app.get("*.rsc")`, unguarded `sendFile`, pseudocode dynamic route) rewritten around `createRequestHandler` + `createEdgeRenderHook` + the sealed action gate — the pattern build-output.md already prescribes — with Express reduced to mounting the same handler.

## Consistency
- **One condition story**: `--conditions react-server` is optional, never required. configuration.md's build script and build-output.md's opener/Build Modes now agree with the README and comparison.md.
- **README minimal example** uses `routes: { dir: "routes" }` instead of hand-spreading `fileRouter` into four fields.
- **`build.edge.transport`** documented in configuration.md and api-reference's `EdgeBuildConfig` (was edge.md-only); `inlineFlight`, `renderMode`, `batchSize`, `edge` added to the option tables that omitted them.

## Version strings
- react-type-compatibility points at `package.json` for the loader range instead of quoting an exact range that had already drifted (`^19.2.17` vs the real `^19.2.18 || …716.1`).
- troubleshooting recommends the real `^19.2.7` peer floor (was `^19.0.0`); checklist says 19.2+.
- getting-started notes there are no 3.x migration steps (v3 is additive).
- build-output links the vprs-starter repo; React Compatibility moves from the docs index's Maintenance section to the user docs (getting-started sends readers there for install guidance).

All relative anchors in the touched files verified against their target headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)