### PR TITLE
docs: state the third-party client-package contract (reachability + provider wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,16 @@ See [Getting Started](./docs/getting-started.md#what-makes-it-a-client-component
 
 ## Third-party client-component packages
 
-Component libraries like Chakra UI, MUI, Mantine, react-aria, and framer-motion are **client-only** — their components rely on React context/state and must run inside a client boundary, the same constraint they carry under Next.js's App Router. Use them within a `"use client"` component (commonly a small provider wrapper); they can't be imported directly into a server component. This isn't a vprs limitation — e.g. [Chakra's own Next.js App Router guide](https://v2.chakra-ui.com/getting-started/nextjs-app-guide) requires wrapping `ChakraProvider` in a `'use client'` component.
+Component libraries like Chakra UI, MUI, Mantine, react-aria, and framer-motion ship per-file `"use client"` directives in their compiled output. vprs detects these packages and preserves the directives, so the server build turns each directive module into a client reference instead of executing it under the `react-server` condition (which would throw on `createContext`/`useState`).
 
-vprs auto-detects these so they're treated correctly at build start: any package with `react` in its `peerDependencies` is classified as a client package (using [`vitefu.crawlFrameworkPkgs`](https://github.com/svitejs/vitefu)). Two escape hatches if needed:
+Two rules govern using them:
+
+- **The package must be reachable from the client graph.** The client build only emits (hosts) package modules that some first-party `"use client"` module imports; a client reference recorded by the server build dangles at render time (`ERR_MODULE_NOT_FOUND`) if nothing client-side pulls the package in. With such an importer in place, server components can import the package's components directly.
+- **Providers need a `"use client"` wrapper.** Props crossing the server→client boundary must be serializable, and a provider's value typically isn't (`ChakraProvider` takes a system object full of functions). This is an RSC constraint, not a vprs one: [Chakra's App Router guide](https://chakra-ui.com/docs/get-started/frameworks/next-app) ships that wrapper as its CLI-generated `provider.tsx` snippet.
+
+In practice the provider wrapper satisfies both rules at once: it is the client-side importer that gets the package hosted.
+
+Detection is automatic at build start: any package with `react` in its `peerDependencies` is classified as a client package (using [`vitefu.crawlFrameworkPkgs`](https://github.com/svitejs/vitefu)). Two escape hatches if needed:
 
 ```ts
 vitePluginReactServer({

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -175,9 +175,9 @@ for builds.
 
 ## Third-party `"use client"` packages
 
-Libraries like Chakra UI, MUI, Mantine, react-aria, and framer-motion ship per-file `"use client"` directives in their compiled output. vprs picks them up automatically so they can be imported directly in server components — same as Next.js's App Router.
+Libraries like Chakra UI, MUI, Mantine, react-aria, and framer-motion ship per-file `"use client"` directives in their compiled output. vprs picks them up automatically: the server build converts each directive module into a client reference instead of executing it under the `react-server` condition, so server components can import the package's components directly — provided the package is also reachable from the client graph. The client build only hosts package modules that some first-party `"use client"` module imports (commonly the provider wrapper); a reference with no client-side importer dangles at SSG render (`ERR_MODULE_NOT_FOUND`). See the README's "Third-party client-component packages" section for the usage rules.
 
-Detection runs once at config-time via [`vitefu.crawlFrameworkPkgs`](https://github.com/svitejs/vitefu): any package with `react` in `peerDependencies` is added to the bundle's `noExternal` list, has its directives preserved through esbuild's pre-bundle (`optimizeDeps.exclude`), and gets each `"use client"` module emitted as its own client chunk so the html-worker can resolve client references at SSG render time.
+Detection runs once at config-time via [`vitefu.crawlFrameworkPkgs`](https://github.com/svitejs/vitefu): any package with `react` in `peerDependencies` is added to the bundle's `noExternal` list and has its directives preserved through esbuild's pre-bundle (`optimizeDeps.exclude`); client-graph-reachable `"use client"` modules are emitted as their own client chunks so the html-worker can resolve client references at SSG render time.
 
 | Option | Type | Default | Purpose |
 |--------|------|---------|---------|

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -465,11 +465,15 @@ export const resolveUserConfig: ResolveUserConfigFn =
     //      aware `resolve.noExternal`) makes Rollup inline these packages
     //      into the server bundle, where our transform converts each
     //      `"use client"` module to a `registerClientReference` stub.
-    //   3. Each `"use client"` module emits as a chunk under
+    //   3. `"use client"` modules reachable from the client graph (via a
+    //      first-party client importer) emit as chunks under
     //      `dist/client/node_modules/<pkg>/...` thanks to Vite's natural
     //      preserved-modules handling — those paths match the moduleIDs
     //      we generate in `createTransformerPlugin`, so the html-worker
-    //      can resolve client refs at SSG-render time.
+    //      can resolve client refs at SSG-render time. A reference whose
+    //      package has no client-side importer dangles at render
+    //      (ERR_MODULE_NOT_FOUND); see createDirectiveClientAutoDiscover
+    //      for the router-barrel special case.
     const clientPackages: readonly string[] =
       (userOptions as { clientPackages?: readonly string[] }).clientPackages ??
       [];

--- a/test/examples/client-package-direct-import.test.ts
+++ b/test/examples/client-package-direct-import.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve } from "path";
+import { mkdir, writeFile } from "fs/promises";
+import { setupIndexHTML } from "../setup.js";
+import { getSharedBuild, SharedBuildResult } from "./shared-build.js";
+
+/**
+ * A server component may import a component from a client package directly —
+ * no user-authored `"use client"` wrapper. The package ships per-file
+ * `"use client"` directives in its compiled output (the shape Chakra UI, MUI,
+ * Mantine, react-aria, and framer-motion publish); listing it in
+ * `clientPackages` (or auto-detection via its react peerDep) keeps those
+ * directives visible to the transformer, which converts each directive module
+ * into a client reference instead of executing it under the `react-server`
+ * condition.
+ *
+ * The local package below recreates the installed-dependency shape: an ESM
+ * module under the fixture's `node_modules` whose top line is `"use client"`
+ * and whose body calls a client-only React API (`useState`). Executing it
+ * server-side would throw `react does not provide an export named 'useState'`;
+ * hosting it as a client reference must not.
+ */
+describe("Client package imported directly by a server component", () => {
+  let buildResult: SharedBuildResult;
+
+  beforeAll(async () => {
+    buildResult = await getSharedBuild(
+      "client-package-direct-import",
+      "client-package-direct-import",
+      {
+        setupProject: async (testDir: string) => {
+          await setupIndexHTML(testDir);
+          await mkdir(resolve(testDir, "src/page"), { recursive: true });
+
+          const pkg = resolve(testDir, "node_modules", "fake-ui");
+          await mkdir(pkg, { recursive: true });
+          await writeFile(
+            resolve(pkg, "package.json"),
+            JSON.stringify({
+              name: "fake-ui",
+              version: "1.0.0",
+              type: "module",
+              main: "index.js",
+              exports: { ".": "./index.js" },
+              peerDependencies: { react: "*" },
+            })
+          );
+          await writeFile(
+            resolve(pkg, "index.js"),
+            `"use client";
+import React from "react";
+
+export function FancyButton({ label }) {
+  const [count, setCount] = React.useState(0);
+  return React.createElement(
+    "button",
+    { "data-testid": "fancy-button", onClick: () => setCount(count + 1) },
+    label,
+    " ",
+    count
+  );
+}
+`
+          );
+
+          // First-party client module importing the package: this is what
+          // pulls fake-ui into the CLIENT build graph so its directive module
+          // is emitted (hosted) under dist/*/node_modules/fake-ui/. Without
+          // any client-side importer the server-recorded reference dangles at
+          // SSG render (ERR_MODULE_NOT_FOUND).
+          await mkdir(resolve(testDir, "src/components"), { recursive: true });
+          await writeFile(
+            resolve(testDir, "src/components/Toolbar.client.tsx"),
+            `import React from "react";
+import { FancyButton } from "fake-ui";
+
+export function Toolbar() {
+  return <FancyButton label="toolbar" />;
+}
+`
+          );
+
+          await writeFile(
+            resolve(testDir, "src/page/page.tsx"),
+            `import React from "react";
+import { FancyButton } from "fake-ui";
+import { Toolbar } from "../components/Toolbar.client.js";
+
+export function Page() {
+  return (
+    <div>
+      <h1>Client Package Test</h1>
+      <Toolbar />
+      <FancyButton label="press" />
+    </div>
+  );
+}
+`
+          );
+
+          await writeFile(
+            resolve(testDir, "src/page/props.ts"),
+            `export const props = (url: string) => ({ url });`
+          );
+        },
+        pages: ["/"],
+        // Surface any RSC serialization error as a build failure so the test
+        // fails loudly if direct import regresses.
+        panicThreshold: "all_errors",
+        verbose: false,
+        clientPackages: ["fake-ui"],
+      }
+    );
+  }, 30000);
+
+  it("builds without executing the client package under react-server", () => {
+    expect(buildResult).toBeDefined();
+    const routeErrors = buildResult.events.filter(
+      (e: any) => e.type === "route.error"
+    );
+    expect(routeErrors).toHaveLength(0);
+  });
+
+  it("renders the server shell around the client component slot", () => {
+    const htmlFiles = buildResult.htmlFiles();
+    expect(htmlFiles.length).toBeGreaterThan(0);
+    expect(htmlFiles[0][1]).toContain("Client Package Test");
+  });
+
+  it("serializes the package component as a hosted client reference", () => {
+    const rscContent = buildResult
+      .rscFiles()
+      .map(([, content]) => content)
+      .join("\n");
+    expect(rscContent).toMatch(/I\[/);
+    expect(rscContent).toContain("FancyButton");
+  });
+
+  it("emits the package's directive module as a client chunk", () => {
+    const clientLike = [
+      ...buildResult.clientChunks(),
+      ...buildResult.staticChunks(),
+    ];
+    expect(
+      clientLike.some(([, code]) => /FancyButton/.test(code))
+    ).toBe(true);
+  });
+});
+
+describe("Client package with no client-side importer", () => {
+  it("dangles at SSG render: the reference's module is never hosted", async () => {
+    // Same package, but ONLY a server component imports it — nothing pulls
+    // fake-ui into the client graph, so the client build never emits
+    // node_modules/fake-ui/index.js and the html-worker's import of the
+    // client reference fails. This pins the reachability rule the docs state;
+    // if hosting ever becomes reference-driven for third-party packages
+    // (as it already is for vprs's own router barrel), this expectation
+    // should flip.
+    await expect(
+      getSharedBuild(
+        "client-package-dangling-reference",
+        "client-package-dangling-reference",
+        {
+          setupProject: async (testDir: string) => {
+            await setupIndexHTML(testDir);
+            await mkdir(resolve(testDir, "src/page"), { recursive: true });
+
+            const pkg = resolve(testDir, "node_modules", "fake-ui");
+            await mkdir(pkg, { recursive: true });
+            await writeFile(
+              resolve(pkg, "package.json"),
+              JSON.stringify({
+                name: "fake-ui",
+                version: "1.0.0",
+                type: "module",
+                main: "index.js",
+                exports: { ".": "./index.js" },
+                peerDependencies: { react: "*" },
+              })
+            );
+            await writeFile(
+              resolve(pkg, "index.js"),
+              `"use client";
+import React from "react";
+
+export function FancyButton({ label }) {
+  const [count, setCount] = React.useState(0);
+  return React.createElement(
+    "button",
+    { onClick: () => setCount(count + 1) },
+    label,
+    " ",
+    count
+  );
+}
+`
+            );
+
+            await writeFile(
+              resolve(testDir, "src/page/page.tsx"),
+              `import React from "react";
+import { FancyButton } from "fake-ui";
+
+export function Page() {
+  return (
+    <div>
+      <h1>Dangling Reference Test</h1>
+      <FancyButton label="press" />
+    </div>
+  );
+}
+`
+            );
+
+            await writeFile(
+              resolve(testDir, "src/page/props.ts"),
+              `export const props = (url: string) => ({ url });`
+            );
+          },
+          pages: ["/"],
+          panicThreshold: "all_errors",
+          verbose: false,
+          clientPackages: ["fake-ui"],
+        }
+      )
+    ).rejects.toThrow(/fake-ui/);
+  }, 30000);
+});


### PR DESCRIPTION
## Why

README ("Third-party client-component packages") and `docs/configuration.md` ("Third-party `"use client"` packages") contradicted each other:

- README: client packages **can't** be imported directly into a server component; wrap them in a `"use client"` component.
- configuration.md: vprs picks up their per-file directives so they **can** be imported directly in server components, same as Next.js's App Router.

Neither was the whole contract, and the README's Chakra citation pointed at the v2 guide.

## The actual contract (now tested)

`test/examples/client-package-direct-import.test.ts` builds a fixture with a fake `node_modules` package whose compiled output carries a top-of-file `"use client"` and a client-only hook, imported directly by a server component. Under both test conditions:

- The server build converts the directive module into a client reference (no `react-server` execution, no `createContext`/`useState` throw). Direct import is honored server-side.
- The client build only hosts package modules reachable from the client graph through a first-party `"use client"` importer. With one present (the provider wrapper, in practice), the direct server import works end to end. Without one, the reference dangles at SSG render with `ERR_MODULE_NOT_FOUND` — the test pins this failing side too, so the docs can't silently drift again.

Providers separately need a `"use client"` wrapper regardless: props crossing the server→client boundary must be serializable and a provider's value typically isn't (Chakra's system object). Chakra's current App Router guide ships that wrapper as its CLI-generated `provider.tsx` snippet; the link now points there instead of the v2 guide.

## Changes

- README: section rewritten around the two rules (client-graph reachability, provider wrapper), Chakra link updated.
- `docs/configuration.md`: direct-import claim now carries the reachability condition.
- `plugin/config/resolveUserConfig.ts`: comment no longer promises unconditional chunk emission; points at the router-barrel special case.
- New example test pinning both sides of the contract.

## Follow-up candidates (not here)

- Reference-driven hosting for third-party packages, mirroring the special case `resolveAutoDiscover` already has for vprs's own router client barrel.
- A loud, actionable build error for a dangling third-party reference instead of the raw `ERR_MODULE_NOT_FOUND` from deep inside react-server-dom-esm.

Full gate: `npm test` green, 869 passed / 43 skipped under both conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)