### PR TITLE
fix(config): build inputs anchor to the root, not the process cwd

### DIFF
--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -10,7 +10,7 @@ import type {
   ResolvedUserOptions,
   AutoDiscoveredFiles,
 } from "../types.js";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
 // Vite 8 swaps Rollup→Rolldown; source bundle types from Vite's version-agnostic Rollup namespace.
 import type { Rollup } from "vite";
@@ -644,6 +644,9 @@ export const resolveUserConfig: ResolveUserConfigFn =
             ...config.build?.rollupOptions,
             // Use HTML + client entries for non-SSR client builds (static)
             // and pure client module entries for SSR client builds.
+            // Anchored to the root: Rollup (Vite 6/7) resolves relative
+            // entries against the process cwd, Rolldown (Vite 8) against
+            // root.
             input: Object.fromEntries(
               Object.entries(
                 ssr
@@ -651,7 +654,9 @@ export const resolveUserConfig: ResolveUserConfigFn =
                   : autoDiscoveredFiles.staticInputs
               ).map(([key, value]) => [
                 key,
-                value.slice(Number(value.startsWith("/"))),
+                isAbsolute(value)
+                  ? value
+                  : resolve(effectiveProjectRoot, value.replace(/^\/+/, "")),
               ])
             ),
             output: newOutput,
@@ -774,7 +779,19 @@ export const resolveUserConfig: ResolveUserConfigFn =
               : true,
           rollupOptions: {
             ...config.build?.rollupOptions,
-            input: autoDiscoveredFiles.serverInputs,
+            // Anchored to the root: Rollup (Vite 6/7) resolves relative
+            // entries against the process cwd, Rolldown (Vite 8) against
+            // root.
+            input: Object.fromEntries(
+              Object.entries(autoDiscoveredFiles.serverInputs).map(
+                ([key, value]) => [
+                  key,
+                  isAbsolute(value)
+                    ? value
+                    : resolve(effectiveProjectRoot, value.replace(/^\/+/, "")),
+                ]
+              )
+            ),
             preserveEntrySignatures:
               config.build?.rollupOptions?.preserveEntrySignatures ?? "strict",
             // Externalize core React deps for the server bundle

--- a/plugin/environments/resolveEnvironmentConfig.ts
+++ b/plugin/environments/resolveEnvironmentConfig.ts
@@ -2,7 +2,7 @@ import type { UserConfig, BuildEnvironmentOptions, Rollup } from "vite";
 import type { ResolvedUserOptions, AutoDiscoveredFiles } from "../types.js";
 // Vite 8 swaps Rollup→Rolldown; source bundle types from Vite's version-agnostic Rollup namespace.
 type OutputOptions = Rollup.OutputOptions;
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { createLogger } from "vite";
 import { getEnvValue, setEnvValue } from "../env/getEnvKey.js";
 import { effectiveModuleBaseURL } from "../config/effectiveModuleBaseURL.js";
@@ -154,11 +154,16 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
         inputs = autoDiscoveredFiles.serverInputs;
       }
 
-      // Normalize inputs for this environment (following resolveUserConfig pattern)
+      // Normalize inputs for this environment (following resolveUserConfig
+      // pattern). Anchored to the root: Rollup (Vite 6/7) resolves relative
+      // entries against the process cwd, Rolldown (Vite 8) against root.
+      const inputRoot = resolve(config.root ?? userOptions.projectRoot);
       const normalizedInputs = Object.fromEntries(
         Object.entries(inputs).map(([key, value]) => [
           key,
-          value.slice(Number(value.startsWith("/"))),
+          isAbsolute(value)
+            ? value
+            : resolve(inputRoot, value.replace(/^\/+/, "")),
         ])
       );
 

--- a/test/examples/build-edge-router.test.ts
+++ b/test/examples/build-edge-router.test.ts
@@ -25,7 +25,8 @@ async function setupFixture() {
   // edge bundle must thread via ROUTE_PATTERNS.
   await writeFile(
     join(testDir, "src/routes/profile/$id/page.tsx"),
-    `export const Page = ({ label }: { label: string }) => <div id="root">edge {label}</div>;`
+    `import React from "react";
+export const Page = ({ label }: { label: string }) => <div id="root">edge {label}</div>;`
   );
   await writeFile(
     join(testDir, "src/routes/profile/$id/props.ts"),
@@ -37,7 +38,8 @@ async function setupFixture() {
   await mkdir(join(testDir, "src/routes/secret/$id"), { recursive: true });
   await writeFile(
     join(testDir, "src/routes/secret/$id/page.tsx"),
-    `export const Page = ({ who }: { who: string }) => <div id="root">{who}</div>;`
+    `import React from "react";
+export const Page = ({ who }: { who: string }) => <div id="root">{who}</div>;`
   );
   await writeFile(
     join(testDir, "src/routes/secret/$id/props.ts"),
@@ -62,7 +64,8 @@ export function Widget() {
   );
   await writeFile(
     join(testDir, "src/routes/widget/page.tsx"),
-    `import { Widget } from "../../Widget.client.js";
+    `import React from "react";
+import { Widget } from "../../Widget.client.js";
 export const Page = () => <Widget />;`
   );
   await writeFile(

--- a/test/examples/edge-document-complete.test.ts
+++ b/test/examples/edge-document-complete.test.ts
@@ -41,7 +41,8 @@ async function setupFixture() {
   // HTML on first paint, with no client fetch.
   await writeFile(
     join(testDir, "src/routes/page.tsx"),
-    `import styles from "./styles.module.css";\n` +
+    `import React from "react";\n` +
+      `import styles from "./styles.module.css";\n` +
       `export const Page = ({ region }: { region: string }) => (\n` +
       // Single expression → one text node, so SSR doesn't split it with a
       // comment marker (which would defeat a substring assertion).


### PR DESCRIPTION
## Why

The published peer range claims `^6.3.5 || ^7 || ^8`, but the test gate only ever runs against Vite 8, and two example suites (`config-base-build`, `transport-webpack-build`) fail on Vite 6/7 with Rollup's `Could not resolve entry module "index.html"`.

## What

**Entry resolution.** The plugin hands the bundler root-relative input paths (`index.html`, `src/...`). Rolldown (Vite 8) resolves those against `config.root`; Rollup (Vite 6/7) resolves them against the process cwd, so any build whose root is not the cwd fails. Inputs are now made absolute against the effective project root at each assembly site: the static/client and server branches in `resolveUserConfig`, and the Environment API path in `resolveEnvironmentConfig`. Already-absolute inputs pass through untouched.

**Edge fixtures.** `build-edge-router` and `edge-document-complete` write fixture pages without an explicit `React` import. The repo tsconfig uses the classic JSX transform (`"jsx": "react"`), which esbuild (Vite 6/7) honors — the emitted `React.createElement` then throws `React is not defined` at render. Oxc tolerated the missing import, which is why this only surfaced off Vite 8. The fixtures now import React like every other fixture in the suite.

## Verification

`npm run test-all` (the full gate) passes against all three claimed majors, swapped in via `npm install --no-save`:

| vite | result |
|------|--------|
| 6.4.3 | green |
| 7.3.6 | green |
| 8.1.0 | green (unchanged from main) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)