### PR TITLE
chore(release): 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -10,7 +10,7 @@ import type {
   ResolvedUserOptions,
   AutoDiscoveredFiles,
 } from "../types.js";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
 // Vite 8 swaps Rollup→Rolldown; source bundle types from Vite's version-agnostic Rollup namespace.
 import type { Rollup } from "vite";
@@ -644,6 +644,9 @@ export const resolveUserConfig: ResolveUserConfigFn =
             ...config.build?.rollupOptions,
             // Use HTML + client entries for non-SSR client builds (static)
             // and pure client module entries for SSR client builds.
+            // Anchored to the root: Rollup (Vite 6/7) resolves relative
+            // entries against the process cwd, Rolldown (Vite 8) against
+            // root.
             input: Object.fromEntries(
               Object.entries(
                 ssr
@@ -651,7 +654,9 @@ export const resolveUserConfig: ResolveUserConfigFn =
                   : autoDiscoveredFiles.staticInputs
               ).map(([key, value]) => [
                 key,
-                value.slice(Number(value.startsWith("/"))),
+                isAbsolute(value)
+                  ? value
+                  : resolve(effectiveProjectRoot, value.replace(/^\/+/, "")),
               ])
             ),
             output: newOutput,
@@ -774,7 +779,19 @@ export const resolveUserConfig: ResolveUserConfigFn =
               : true,
           rollupOptions: {
             ...config.build?.rollupOptions,
-            input: autoDiscoveredFiles.serverInputs,
+            // Anchored to the root: Rollup (Vite 6/7) resolves relative
+            // entries against the process cwd, Rolldown (Vite 8) against
+            // root.
+            input: Object.fromEntries(
+              Object.entries(autoDiscoveredFiles.serverInputs).map(
+                ([key, value]) => [
+                  key,
+                  isAbsolute(value)
+                    ? value
+                    : resolve(effectiveProjectRoot, value.replace(/^\/+/, "")),
+                ]
+              )
+            ),
             preserveEntrySignatures:
               config.build?.rollupOptions?.preserveEntrySignatures ?? "strict",
             // Externalize core React deps for the server bundle

--- a/plugin/environments/resolveEnvironmentConfig.ts
+++ b/plugin/environments/resolveEnvironmentConfig.ts
@@ -2,7 +2,7 @@ import type { UserConfig, BuildEnvironmentOptions, Rollup } from "vite";
 import type { ResolvedUserOptions, AutoDiscoveredFiles } from "../types.js";
 // Vite 8 swaps Rollup→Rolldown; source bundle types from Vite's version-agnostic Rollup namespace.
 type OutputOptions = Rollup.OutputOptions;
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { createLogger } from "vite";
 import { getEnvValue, setEnvValue } from "../env/getEnvKey.js";
 import { effectiveModuleBaseURL } from "../config/effectiveModuleBaseURL.js";
@@ -154,11 +154,16 @@ export const resolveEnvironmentConfig: ResolveEnvironmentConfigFn =
         inputs = autoDiscoveredFiles.serverInputs;
       }
 
-      // Normalize inputs for this environment (following resolveUserConfig pattern)
+      // Normalize inputs for this environment (following resolveUserConfig
+      // pattern). Anchored to the root: Rollup (Vite 6/7) resolves relative
+      // entries against the process cwd, Rolldown (Vite 8) against root.
+      const inputRoot = resolve(config.root ?? userOptions.projectRoot);
       const normalizedInputs = Object.fromEntries(
         Object.entries(inputs).map(([key, value]) => [
           key,
-          value.slice(Number(value.startsWith("/"))),
+          isAbsolute(value)
+            ? value
+            : resolve(inputRoot, value.replace(/^\/+/, "")),
         ])
       );
 

--- a/test/examples/build-edge-router.test.ts
+++ b/test/examples/build-edge-router.test.ts
@@ -25,7 +25,8 @@ async function setupFixture() {
   // edge bundle must thread via ROUTE_PATTERNS.
   await writeFile(
     join(testDir, "src/routes/profile/$id/page.tsx"),
-    `export const Page = ({ label }: { label: string }) => <div id="root">edge {label}</div>;`
+    `import React from "react";
+export const Page = ({ label }: { label: string }) => <div id="root">edge {label}</div>;`
   );
   await writeFile(
     join(testDir, "src/routes/profile/$id/props.ts"),
@@ -37,7 +38,8 @@ async function setupFixture() {
   await mkdir(join(testDir, "src/routes/secret/$id"), { recursive: true });
   await writeFile(
     join(testDir, "src/routes/secret/$id/page.tsx"),
-    `export const Page = ({ who }: { who: string }) => <div id="root">{who}</div>;`
+    `import React from "react";
+export const Page = ({ who }: { who: string }) => <div id="root">{who}</div>;`
   );
   await writeFile(
     join(testDir, "src/routes/secret/$id/props.ts"),
@@ -62,7 +64,8 @@ export function Widget() {
   );
   await writeFile(
     join(testDir, "src/routes/widget/page.tsx"),
-    `import { Widget } from "../../Widget.client.js";
+    `import React from "react";
+import { Widget } from "../../Widget.client.js";
 export const Page = () => <Widget />;`
   );
   await writeFile(

--- a/test/examples/edge-document-complete.test.ts
+++ b/test/examples/edge-document-complete.test.ts
@@ -41,7 +41,8 @@ async function setupFixture() {
   // HTML on first paint, with no client fetch.
   await writeFile(
     join(testDir, "src/routes/page.tsx"),
-    `import styles from "./styles.module.css";\n` +
+    `import React from "react";\n` +
+      `import styles from "./styles.module.css";\n` +
       `export const Page = ({ region }: { region: string }) => (\n` +
       // Single expression → one text node, so SSR doesn't split it with a
       // comment marker (which would defeat a substring assertion).


### PR DESCRIPTION
Version bump for the 3.5.1 patch release. Stacked on #317 (Vite 6/7 entry resolution) — merge that first; this PR then reduces to the bump. Also carries the two docs commits on main since v3.5.0 (#315, #288 revert).

After merge, per [docs/releasing.md](./docs/releasing.md): tag `v3.5.1` on the merged main commit, then `npm publish` (2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)