### PR TITLE
fix: two Vite 8 consumer blockers — sibling rollupOptions alias clobber + deleted rolldown runtime helper

### DIFF
--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -28,6 +28,21 @@ import {
 } from "../clientPackages/index.js";
 import { createRollupLikeHash } from "./createRollupLikeHash.js";
 
+// rolldown-vite materializes a sibling plugin's build.rollupOptions
+// contribution (e.g. @vitejs/plugin-react's onwarn wrapper) as a real
+// rolldownOptions key, leaving rollupOptions a getter over it. Spreading
+// config.build into an environment build config copies that stale key
+// WITHOUT our inputs, and vite's `rolldownOptions ??= rollupOptions` compat
+// then lets it outrank the rollupOptions we write — every environment falls
+// back to the default index.html entry. Spread this after ...config.build to
+// drop the alias; the sibling's settings still arrive via the rollupOptions
+// getter spread. The key is absent from vite 6/7's BuildEnvironmentOptions
+// type, so it's spread from a type-erased object rather than written
+// literally — same runtime effect, typechecks on every supported vite major.
+const dropStaleRolldownAlias = {
+  rolldownOptions: undefined,
+} as Record<string, undefined>;
+
 const stashedUserConfig: Record<string, ResolvedUserConfig | null> = {};
 let originalConfig: UserConfig | null = null;
 // Once per process, not once per environment pass (resolveUserConfig runs for
@@ -632,16 +647,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
         // client build options
         build: {
           ...config.build,
-          // rolldown-vite materializes a sibling plugin's build.rollupOptions
-          // contribution (e.g. @vitejs/plugin-react's onwarn wrapper) as a
-          // real rolldownOptions key, leaving rollupOptions a getter over it.
-          // The spread above copies that stale key WITHOUT our inputs, and
-          // vite's `rolldownOptions ??= rollupOptions` compat then lets it
-          // outrank the rollupOptions we write below — every environment
-          // falls back to the default index.html entry. Drop the alias key;
-          // the sibling's settings still arrive via the rollupOptions getter
-          // spread below.
-          rolldownOptions: undefined,
+          ...dropStaleRolldownAlias,
           modulePreload: config.build?.modulePreload ?? false,
           emptyOutDir: config.build?.emptyOutDir ?? true,
           outDir:
@@ -767,10 +773,7 @@ export const resolveUserConfig: ResolveUserConfigFn =
         // server build options
         build: {
           ...config.build,
-          // Same stale-alias hazard as the client branch: drop any
-          // rolldownOptions the spread copied so the rollupOptions written
-          // below stays authoritative under rolldown-vite's `??=` compat.
-          rolldownOptions: undefined,
+          ...dropStaleRolldownAlias,
           modulePreload: config.build?.modulePreload ?? false,
           emptyOutDir: config.build?.emptyOutDir ?? true,
           outDir:

--- a/plugin/config/resolveUserConfig.ts
+++ b/plugin/config/resolveUserConfig.ts
@@ -632,6 +632,16 @@ export const resolveUserConfig: ResolveUserConfigFn =
         // client build options
         build: {
           ...config.build,
+          // rolldown-vite materializes a sibling plugin's build.rollupOptions
+          // contribution (e.g. @vitejs/plugin-react's onwarn wrapper) as a
+          // real rolldownOptions key, leaving rollupOptions a getter over it.
+          // The spread above copies that stale key WITHOUT our inputs, and
+          // vite's `rolldownOptions ??= rollupOptions` compat then lets it
+          // outrank the rollupOptions we write below — every environment
+          // falls back to the default index.html entry. Drop the alias key;
+          // the sibling's settings still arrive via the rollupOptions getter
+          // spread below.
+          rolldownOptions: undefined,
           modulePreload: config.build?.modulePreload ?? false,
           emptyOutDir: config.build?.emptyOutDir ?? true,
           outDir:
@@ -757,6 +767,10 @@ export const resolveUserConfig: ResolveUserConfigFn =
         // server build options
         build: {
           ...config.build,
+          // Same stale-alias hazard as the client branch: drop any
+          // rolldownOptions the spread copied so the rollupOptions written
+          // below stays authoritative under rolldown-vite's `??=` compat.
+          rolldownOptions: undefined,
           modulePreload: config.build?.modulePreload ?? false,
           emptyOutDir: config.build?.emptyOutDir ?? true,
           outDir:

--- a/plugin/react-static/plugin.server.ts
+++ b/plugin/react-static/plugin.server.ts
@@ -210,14 +210,44 @@ export const reactStaticPlugin: VitePluginFn = function _reactStaticPlugin(
             
             if (isVirtual && !isDynamicImportHelper) {
               keysToDelete.push(key);
-              if (userOptions.verbose) {
-                logger?.info(`[plugin.server] Filtered out virtual file: ${chunk.fileName || key} (moduleId: ${chunk.facadeModuleId || chunk.moduleIds?.[0]})`);
-              }
             }
           }
         }
-        // Delete after iteration to avoid modifying while iterating
-        for (const key of keysToDelete) {
+        // A virtual chunk another emitted chunk imports is load-bearing:
+        // rolldown emits its shared runtime helpers (__exportAll etc.) as
+        // _virtual/_rolldown/runtime.js and rewrites importers to that path,
+        // so deleting it leaves dangling imports that only surface at SSG /
+        // consumer import time (ERR_MODULE_NOT_FOUND). Keep every candidate
+        // a surviving chunk still references; iterate so helper→helper
+        // chains resolve.
+        const deletable = new Set(keysToDelete);
+        let changed = true;
+        while (changed) {
+          changed = false;
+          const referenced = new Set<string>();
+          for (const [key, chunk] of Object.entries(bundle)) {
+            if (deletable.has(key) || chunk.type !== "chunk") continue;
+            for (const dep of [...chunk.imports, ...chunk.dynamicImports]) {
+              referenced.add(dep);
+            }
+          }
+          for (const key of [...deletable]) {
+            const fileName = bundle[key]?.fileName ?? key;
+            if (referenced.has(fileName) || referenced.has(key)) {
+              deletable.delete(key);
+              changed = true;
+            }
+          }
+        }
+        for (const key of deletable) {
+          if (userOptions.verbose) {
+            const chunk = bundle[key];
+            const moduleId =
+              chunk?.type === "chunk"
+                ? chunk.facadeModuleId || chunk.moduleIds?.[0]
+                : undefined;
+            logger?.info(`[plugin.server] Filtered out virtual file: ${bundle[key]?.fileName || key} (moduleId: ${moduleId})`);
+          }
           delete bundle[key];
         }
       }

--- a/test/doBuild.ts
+++ b/test/doBuild.ts
@@ -1,4 +1,4 @@
-import { createBuilder } from "vite";
+import { createBuilder, type PluginOption } from "vite";
 import { vitePluginReactServer } from "vite-plugin-react-server";
 import type {
   PluginEvent,
@@ -11,9 +11,14 @@ import { inspect } from "node:util";
  * Builds the project with the test config and given options and returns the events
  * Handles changing to the test directory and restoring the original working directory
  * @param optionOverrides - Optional overrides for the options
+ * @param siblingPlugins - Plugins registered BEFORE vprs, the position consumer
+ *   configs give companions like @vitejs/plugin-react
  * @returns The events from the build
  */
-export async function doBuild(optionOverrides: Partial<StreamPluginOptions>) {
+export async function doBuild(
+  optionOverrides: Partial<StreamPluginOptions>,
+  siblingPlugins: PluginOption[] = []
+) {
   const events: PluginEvent[] = [];
   const metrics: any[] = [];
   
@@ -60,7 +65,7 @@ export async function doBuild(optionOverrides: Partial<StreamPluginOptions>) {
     // Use the Environment API with createBuilder to get full control
     // The environment configuration is now handled by the createEnvironmentPlugin
     const builder = await createBuilder({
-      plugins: vitePluginReactServer(options),
+      plugins: [...siblingPlugins, vitePluginReactServer(options)],
       mode: "test",
       root: options.projectRoot,
     });

--- a/test/examples/out-of-root-glob-runtime-helper.test.ts
+++ b/test/examples/out-of-root-glob-runtime-helper.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve } from "path";
+import { mkdir, writeFile, readFile, readdir } from "fs/promises";
+import { setupTestProject } from "../setup.js";
+import type {
+  PluginEvent,
+  FileWriteDoneEvent,
+} from "../../dist/plugin/types.js";
+import { doBuild } from "../doBuild.js";
+
+// A server module that pulls a module from OUTSIDE the project root via an
+// eager import.meta.glob (the "gitignored local config next to the project"
+// pattern). Under rolldown-vite's preserveModules output, the emitted server
+// chunks for this shape import Rolldown's shared runtime helper
+// (_virtual/_rolldown/runtime.js, e.g. __exportAll) — the build must emit
+// that helper into the server outDir it is imported from, or post-build SSG
+// dies at import time with ERR_MODULE_NOT_FOUND. The ssr environment emits
+// its copy of the same helper; the server environment's output naming must
+// pass it through as well.
+describe("out-of-root eager glob (rolldown runtime helper emission)", () => {
+  const testDir = resolve(
+    __dirname,
+    "../fixtures/out-of-root-glob-runtime-helper.test"
+  );
+  const outsideDir = resolve(
+    __dirname,
+    "../fixtures/out-of-root-glob-runtime-helper-outside"
+  );
+  let events: PluginEvent[];
+
+  beforeAll(async () => {
+    await setupTestProject(testDir);
+
+    // The out-of-root module — a sibling of the project root.
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(
+      resolve(outsideDir, "profile.ts"),
+      `export const profile = { name: "outside", flag: true as const };`
+    );
+
+    // Barrel that resolves the out-of-root module through an eager glob and
+    // re-exports the result (mirrors a local-config registry).
+    await mkdir(resolve(testDir, "src/profile"), { recursive: true });
+    await writeFile(
+      resolve(testDir, "src/profile/index.ts"),
+      `const found = import.meta.glob<{ profile: { name: string } }>(
+  "../../../out-of-root-glob-runtime-helper-outside/profile.ts",
+  { eager: true }
+);
+const first = Object.values(found)[0];
+export const profile = first ? first.profile : { name: "fallback" };
+export * from "./extra.js";
+`
+    );
+    await writeFile(
+      resolve(testDir, "src/profile/extra.ts"),
+      `export const extra = "extra";`
+    );
+
+    // Server props module consumes the barrel so the chain is in the server
+    // graph.
+    await writeFile(
+      resolve(testDir, "src/page/props.ts"),
+      `import { profile, extra } from "../profile/index.js";
+export const props = (url: string) => ({ url, who: profile.name, extra });
+`
+    );
+
+    ({ events } = await doBuild({ projectRoot: testDir }));
+  }, 120_000);
+
+  it("renders the page (no dangling runtime-helper import at SSG time)", () => {
+    const routeErrors = events.filter((e) => e.type === "route.error");
+    expect(routeErrors).toEqual([]);
+    const htmlEvent = events.find(
+      (e) => e.type === "file.write.done" && e.data.fileType === "html"
+    ) as FileWriteDoneEvent | undefined;
+    expect(htmlEvent, "expected an html file.write.done event").toBeDefined();
+  });
+
+  it("emits every runtime helper the server chunks import", async () => {
+    const serverDir = resolve(testDir, "dist/server");
+    const files: string[] = [];
+    const walk = async (dir: string) => {
+      for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const full = resolve(dir, entry.name);
+        if (entry.isDirectory()) await walk(full);
+        else if (entry.name.endsWith(".js")) files.push(full);
+      }
+    };
+    await walk(serverDir);
+    const dangling: string[] = [];
+    for (const file of files) {
+      const content = await readFile(file, "utf-8");
+      for (const match of content.matchAll(
+        /from\s+["']([^"']*_virtual[^"']*)["']/g
+      )) {
+        const target = resolve(file, "..", match[1]);
+        try {
+          await readFile(target, "utf-8");
+        } catch {
+          dangling.push(`${file} -> ${match[1]}`);
+        }
+      }
+    }
+    expect(dangling).toEqual([]);
+  });
+});

--- a/test/examples/sibling-rollup-options.test.ts
+++ b/test/examples/sibling-rollup-options.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve } from "path";
+import type { Plugin } from "vite";
+import { setupTestProject } from "../setup.js";
+import type {
+  PluginEvent,
+  FileWriteDoneEvent,
+} from "../../dist/plugin/types.js";
+import { doBuild } from "../doBuild.js";
+
+// A sibling plugin whose config hook contributes build.rollupOptions — the
+// shape @vitejs/plugin-react's vite:react-refresh plugin returns (its
+// silenceUseClientWarning onwarn wrapper). On rolldown-vite, Vite's compat
+// shim materializes such a contribution as a real build.rolldownOptions key
+// with rollupOptions left as a getter over it. Any vprs config assembly that
+// spreads config.build then carries that stale rolldownOptions (no input)
+// into the environment configs, where it outranks the rollupOptions.input
+// vprs writes — every environment falls back to the default index.html
+// entry and the ssr build rejects it ("rolldownOptions.input should not be
+// an html file when building for SSR").
+const siblingWithRollupOptions = (): Plugin => ({
+  name: "test:sibling-rollup-options",
+  // plugin-react's contributing plugin is enforce:"pre" and registered before
+  // vprs, so its config result is already merged (and compat-materialized)
+  // when vprs's config hooks read config.build.
+  enforce: "pre",
+  config: () => ({
+    build: {
+      rollupOptions: {
+        onwarn(warning, defaultHandler) {
+          defaultHandler(warning);
+        },
+      },
+    },
+  }),
+});
+
+describe("sibling plugin contributing build.rollupOptions", () => {
+  const testDir = resolve(__dirname, "../fixtures/sibling-rollup-options.test");
+  let events: PluginEvent[];
+
+  beforeAll(async () => {
+    await setupTestProject(testDir);
+    ({ events } = await doBuild({ projectRoot: testDir }, [
+      siblingWithRollupOptions(),
+    ]));
+  }, 120_000);
+
+  it("keeps vprs's per-environment inputs and renders the page", () => {
+    const htmlEvent = events.find(
+      (e) => e.type === "file.write.done" && e.data.fileType === "html"
+    ) as FileWriteDoneEvent | undefined;
+    expect(htmlEvent, "expected an html file.write.done event").toBeDefined();
+    expect(htmlEvent!.data.content).toContain("<div");
+  });
+
+  it("reports no route errors", () => {
+    const routeErrors = events.filter((e) => e.type === "route.error");
+    expect(routeErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Any consumer app combining vprs with @vitejs/plugin-react cannot build on Vite 8 today, and apps whose server graph pulls modules from outside the project root fail SSG even without plugin-react. Neither shape is covered by the suite (fixtures use neither plugin-react nor out-of-root globs), which is why test-all stayed green on 8.x. Both were found moving a real app (Vite 8.2.0 + @vitejs/plugin-react 6.0.5) off Vite 6.

**1. Sibling `build.rollupOptions` contributions clobber every environment's inputs (`fix(config)`)**

On rolldown-vite, a sibling plugin's config-hook `build.rollupOptions` return is materialized as a real `build.rolldownOptions` key with `rollupOptions` left as a compat getter. vprs's `...config.build` spreads carried that stale key (no input) into each environment config, where Vite's `rolldownOptions ??= rollupOptions` let it outrank the `rollupOptions.input` vprs writes — every environment fell back to the default `index.html` entry and the build died with `rolldownOptions.input should not be an html file when building for SSR`. plugin-react hits this via `vite:react-refresh`'s onwarn wrapper, but any enforce-pre sibling contributing `build.rollupOptions` does the same.

Fix: null the alias key at both build-assembly sites in `resolveUserConfig`. The sibling's settings still arrive through the getter spread; on Vite 6/7 the key never exists (no-op).

**2. Server-env `generateBundle` deletes Rolldown's shared runtime helper (`fix(build)`)**

The `_virtual` bundle sweep (junk-facade cleanup with a hardcoded `dynamic-import-helper` exemption) also matches `_virtual/_rolldown/runtime.js`, the chunk Rolldown emits for shared helpers like `__exportAll` — importers are already rewritten to that path, so the deletion only surfaces later as `ERR_MODULE_NOT_FOUND` at SSG or consumer import time. Triggered e.g. by a server module resolving an out-of-root module through an eager `import.meta.glob`.

Fix: keep any virtual chunk that surviving chunks still reference (iterated for helper chains); only truly unreferenced virtual chunks are dropped.

**Verification**

- Two failing-first regression specs: `sibling-rollup-options.test.ts` (stub sibling with plugin-react's exact enforce-pre shape; `doBuild` gains a `siblingPlugins` param) and `out-of-root-glob-runtime-helper.test.ts` (out-of-root eager glob + a scan asserting no emitted server chunk imports a `_virtual` path missing from disk).
- Full `test-all` green: 873/281/639/35 (both new specs run in both conditions).
- Real consumer: packed tarball into a Vite 8.2.0 + @vitejs/plugin-react 6.0.5 app — full `build --app` renders all 9 pages, `dist/server/_virtual/_rolldown/runtime.js` emitted, tsc clean. Same app builds unchanged on Vite 6.4.3 (registry 3.5.1) as before.

Pairs well with the compat-matrix CI in #319; a follow-up could add a plugin-react-equipped fixture to that matrix so sibling-plugin interactions stay covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)