### PR TITLE
chore(release): 3.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release carrying #320 — the two Vite 8 consumer blockers (sibling `build.rollupOptions` contributions clobbering per-environment inputs; the server-env `_virtual` sweep deleting Rolldown's shared runtime helper).

Release verification on the merged main:
- Full `test-all` green on Vite 6.4.3, 7.3.6, and 8.1.0.
- Tarball into bidoof-template: 3/3 Playwright e2e against the plain-Node prod server, node_modules restored.
- Tarball into mmc: 300-page build green, restored.
- HMR spec 10/10.
- Tarball into a Vite 8.2.0 + @vitejs/plugin-react 6.0.5 consumer: full `build --app`, 9 pages SSG, helper chunk emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)