### PR TITLE
fix: server environment dies in vite:css-post on pure-css entries with asset references (Vite 8)

### DIFF
--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -43,6 +43,43 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
     name: "vite:plugin-react-server/environments",
     enforce: "pre",
 
+    generateBundle: {
+      // "pre" so this runs BEFORE vite:css-post's generateBundle, and it
+      // lives HERE (not in the react-static plugins) because the orchestrator
+      // registers this plugin under both react conditions — the server
+      // environment builds either way. On rolldown-vite the server env never
+      // carries emitted css assets, but a bare css entry
+      // (autoDiscover.cssEntry) whose stylesheet references assets above
+      // build.assetsInlineLimit gets a pure-css placeholder chunk with a
+      // populated viteMetadata.importedAssets — css-post's bookkeeping then
+      // writes that metadata onto bundle[getFileName(referenceId)], which
+      // does not exist here, and the whole build dies on
+      // `undefined.viteMetadata`. Emptying importedAssets steers css-post
+      // onto its safe path (css-post itself removes the entry's own file
+      // from importedCss, leaving it empty): skip the transfer, delete the
+      // placeholder — the same server output Vite 6/Rollup produced. Those
+      // assets are never emitted into the server outDir, so nothing true is
+      // lost. importedCss must stay: vite:manifest serializes it as the
+      // entry's css list, which is how css files get delivered to documents.
+      order: "pre",
+      handler(_options, bundle) {
+        if (this.environment.name !== "server") return;
+        for (const chunk of Object.values(bundle)) {
+          if (
+            chunk.type === "chunk" &&
+            chunk.isEntry &&
+            chunk.facadeModuleId &&
+            /\.(css|less|sass|scss|styl|stylus|pcss|postcss)(\?.*)?$/.test(
+              chunk.facadeModuleId
+            ) &&
+            chunk.viteMetadata
+          ) {
+            chunk.viteMetadata.importedAssets.clear();
+          }
+        }
+      },
+    },
+
     async config(config: UserConfig, configEnv) {
       // Resolve plugin options
       const resolvedOptionsResult = resolveOptions(options);

--- a/test/examples/pure-css-entry.test.ts
+++ b/test/examples/pure-css-entry.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve } from "path";
+import { mkdir, writeFile, readdir } from "fs/promises";
+import type {
+  PluginEvent,
+  FileWriteDoneEvent,
+} from "../../dist/plugin/types.js";
+import { doBuild } from "../doBuild.js";
+
+// A bare .css file under moduleBase is auto-discovered as a build entry in
+// every environment (autoDiscover.cssEntry "**/*.css"). In the server
+// environment on rolldown-vite this becomes a "pure CSS entry": rolldown
+// produces a JS placeholder chunk and vite:css-post emits the stylesheet as
+// an asset via referenceId, then in generateBundle transfers metadata from
+// the placeholder onto bundle[getFileName(ref)] WITHOUT a null guard. If the
+// server environment never adds that asset to its bundle, the whole build
+// dies with `TypeError: Cannot read properties of undefined (reading
+// 'viteMetadata')` — even though nothing downstream needs the asset.
+describe("pure css entry (server environment)", () => {
+  const testDir = resolve(__dirname, "../fixtures/pure-css-entry.test");
+  let events: PluginEvent[];
+
+  beforeAll(async () => {
+    // Hand-rolled minimal scaffold (NOT setupTestProject): the shared
+    // scaffold ships .module.css pages, and the css-modules pipeline lazily
+    // require()s postcss — under full-suite worker load that intermittently
+    // dies with Node's "Cannot require() ES Module ... in a cycle". This
+    // repro needs plain css only, so it avoids the css-modules path
+    // entirely.
+    await mkdir(resolve(testDir, "src/page"), { recursive: true });
+    await writeFile(
+      resolve(testDir, "index.html"),
+      `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /><title>Pure CSS Entry</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client.tsx"></script>
+  </body>
+</html>
+`
+    );
+
+    // Bare css files under moduleBase are auto-discovered ENTRIES, and both
+    // are ALSO statically imported by modules in the graph — the client entry
+    // and a server-rendered component. Entry + imported is the shape whose
+    // server-env placeholder chunk takes vite:css-post's pure-css path; an
+    // unimported css entry never does.
+    // The url() references are load-bearing for the repro: they populate the
+    // placeholder's viteMetadata.importedAssets, which is what forces
+    // vite:css-post's metadata transfer onto the (absent) real css asset. A
+    // pure-css entry WITHOUT asset refs takes the safe path and never
+    // crashed.
+    // Must exceed build.assetsInlineLimit (4096) — smaller refs are inlined
+    // as data URLs and never reach importedAssets.
+    await mkdir(resolve(testDir, "src/fonts"), { recursive: true });
+    await writeFile(
+      resolve(testDir, "src/fonts/body.woff2"),
+      Buffer.alloc(8192, 0x77)
+    );
+    await writeFile(
+      resolve(testDir, "src/globalStyles.css"),
+      `@font-face { font-family: Body; src: url("./fonts/body.woff2"); }
+body { margin: 0; background: #fafafa; font-family: Body; }`
+    );
+    await writeFile(
+      resolve(testDir, "src/client.tsx"),
+      `import "./globalStyles.css"
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+const root = createRoot(document.getElementById('root')!)
+root.render(<div>Client App</div>)
+`
+    );
+    await mkdir(resolve(testDir, "src/components"), { recursive: true });
+    await writeFile(
+      resolve(testDir, "src/components/flag-icons.css"),
+      `.flag { width: 16px; height: 12px; }`
+    );
+    await writeFile(
+      resolve(testDir, "src/components/Flag.tsx"),
+      `import React from "react";
+import "./flag-icons.css";
+
+export function Flag({ code }: { code: string }) {
+  return <span className={"flag flag-" + code} />;
+}
+`
+    );
+    await writeFile(
+      resolve(testDir, "src/page/page.tsx"),
+      `import React from "react";
+import { Flag } from "../components/Flag.js";
+
+export function Page(props: any) {
+  return (
+    <div>
+      <h1>Pure CSS Entry Test</h1>
+      <Flag code="nl" />
+    </div>
+  );
+}
+`
+    );
+    await writeFile(
+      resolve(testDir, "src/page/props.ts"),
+      `export const props = (url: string) => ({ url });`
+    );
+
+    // css.inlineThreshold makes vprs inline small stylesheets into the
+    // document instead of shipping them as assets — the server env then has
+    // no css asset for vite:css-post's pure-css-entry bookkeeping to find.
+    ({ events } = await doBuild({
+      projectRoot: testDir,
+      css: { inlineThreshold: 4096 },
+    }));
+  }, 120_000);
+
+  it("builds and renders the page", () => {
+    const routeErrors = events.filter((e) => e.type === "route.error");
+    expect(routeErrors).toEqual([]);
+    const htmlEvent = events.find(
+      (e) => e.type === "file.write.done" && e.data.fileType === "html"
+    ) as FileWriteDoneEvent | undefined;
+    expect(htmlEvent, "expected an html file.write.done event").toBeDefined();
+  });
+
+  it("leaves no pure-css placeholder chunks in the server dist", async () => {
+    const serverDir = resolve(testDir, "dist/server");
+    const names: string[] = [];
+    const walk = async (dir: string) => {
+      for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const full = resolve(dir, entry.name);
+        if (entry.isDirectory()) await walk(full);
+        else names.push(entry.name);
+      }
+    };
+    await walk(serverDir);
+    expect(names.filter((n) => /^(globalStyles|flag-icons)/.test(n))).toEqual(
+      []
+    );
+  });
+});


### PR DESCRIPTION
On rolldown-vite, a bare css file auto-discovered as a build entry (`autoDiscover.cssEntry`) whose stylesheet references assets above `build.assetsInlineLimit` kills the whole `vite build --app`: the server environment's pure-css placeholder chunk carries `viteMetadata.importedAssets`, and vite:css-post's generateBundle transfers that metadata onto `bundle[getFileName(referenceId)]` — an asset the server environment never emits — crashing with `TypeError: Cannot read properties of undefined (reading 'viteMetadata')`. The trigger needs all three of: a css entry, a static import of it somewhere in the graph, and a `url()` reference above the inline limit (smaller refs become data URLs and never populate `importedAssets`). Theme-heavy consumers with font/icon stylesheets are the natural victims; Vite 6/7 (Rollup) is unaffected.

**Fix**: a `generateBundle` hook at `order: "pre"` in `createEnvironmentPlugin` — registered under both react conditions, since the server environment builds either way — empties `importedAssets` on css-facade entry chunks in the server environment. css-post then takes its safe path (it removes the entry's own file from `importedCss` itself): skip the transfer, delete the placeholder, producing exactly the server output Vite 6/Rollup produced. `importedCss` is deliberately left intact — vite:manifest serializes it as each entry's css list, which is how stylesheets reach documents (clearing it passes the crash spec but silently strips every `<link>`; the full suite caught that).

**Verification**
- Failing-first spec `pure-css-entry.test.ts` with all three trigger conditions, green under both react conditions; asserts the render and that no placeholder junk lands in the server dist. It hand-rolls a plain-css scaffold — the shared scaffold's css-modules pages intermittently hit Node's require(ESM)-in-a-cycle on postcss under full-suite load, which is unrelated to this fix.
- Full `test-all` green on Vite 8.1.0, 6.4.3, and 7.3.6.
- Real consumer: packed tarball into a theme-heavy app on Vite 8.2.0 + plugin-react 6 — previously crashed on exactly this bug, now renders all 300 pages, vitest green; same app unchanged on Vite 6.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)