### PR TITLE
chore(release): 3.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release carrying #322 — the server environment's vite:css-post crash on pure-css entries with asset references (Vite 8), the last blocker for css-heavy consumers moving to Vite 8.

Release verification: full `test-all` green on Vite 8.1.0 / 6.4.3 / 7.3.6; tarball into a theme-heavy 300-page consumer on Vite 8.2.0 + plugin-react 6 (previously crashed, now fully green incl. vitest), unchanged on Vite 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)