### PR TITLE
refactor(transformer): drop the last this.parse; add build-side server-reference proxy test

### DIFF
--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -458,7 +458,9 @@ export const createTransformerPlugin = (
           //    also keeps server-only code out of the SSR bundle.
           if (!isServerEnvironment) {
             const serverAnalysis = await analyzeModule(code, {
-              loader: { parse: (src: string) => this.parse(src) as Program },
+              loader: {
+                parse: (src: string) => rslParse(src).ast as unknown as Program,
+              },
             });
             if (
               serverAnalysis.type === "success" &&

--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -457,11 +457,9 @@ export const createTransformerPlugin = (
           //    emit a render-safe stub that only throws if wrongly invoked. This
           //    also keeps server-only code out of the SSR bundle.
           if (!isServerEnvironment) {
-            const serverAnalysis = await analyzeModule(code, {
-              loader: {
-                parse: (src: string) => rslParse(src).ast as unknown as Program,
-              },
-            });
+            // No injected parser: analyzeModule defaults to rsl's own parse,
+            // the one version-stable grammar every analysis path shares.
+            const serverAnalysis = await analyzeModule(code);
             if (
               serverAnalysis.type === "success" &&
               serverAnalysis.directiveInfo?.fileLevel?.type === "server"

--- a/test/examples/server-reference-proxy-build.test.ts
+++ b/test/examples/server-reference-proxy-build.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { setupServerReferenceProxyProject } from "../setup.js";
+import { getSharedBuild, SharedBuildResult } from "./shared-build.js";
+
+/**
+ * Build-side guard for the client-imported "use server" module path.
+ *
+ * The dev path is covered by test/dev/client-imports-server-action.test.ts;
+ * this covers the BUILD (rolldown) transform context, where the analysis that
+ * gates proxy emission must not depend on the bundler's `this.parse` (Oxc on
+ * Vite 8, different AST shape than Rollup's acorn). A silently failing parse
+ * skips proxy emission and bundles server code into the browser build:
+ *
+ *  - the browser chunk must hold createServerReference proxies wired to the
+ *    hosted action id (`<moduleID>#<export>`), not the server function body,
+ *  - the SSR/static side must hold the render-safe stub, which only throws if
+ *    wrongly invoked during render,
+ *  - the server-only body must appear in NO client-reachable chunk.
+ */
+describe("Client-imported 'use server' module in static build", () => {
+  let buildResult: SharedBuildResult;
+
+  beforeAll(async () => {
+    buildResult = await getSharedBuild(
+      "server-reference-proxy-project",
+      "server-reference-proxy-build",
+      {
+        setupProject: setupServerReferenceProxyProject,
+        pages: ["/"],
+        panicThreshold: "all_errors",
+        verbose: false,
+      }
+    );
+  }, 30000);
+
+  it("builds without route errors", () => {
+    expect(buildResult).toBeDefined();
+    const routeErrors = buildResult.events.filter(
+      (e: any) => e.type === "route.error"
+    );
+    expect(routeErrors).toHaveLength(0);
+  });
+
+  it("emits createServerReference proxies with the hosted action id in the browser chunks", () => {
+    const clientContent = buildResult
+      .clientChunks()
+      .map(([, content]) => content)
+      .join("\n");
+    expect(clientContent).toContain("createServerReference");
+    expect(clientContent).toContain("#addItem");
+  });
+
+  it("keeps the server function body out of every client-reachable chunk", () => {
+    const allClientLike = [
+      ...buildResult.clientChunks(),
+      ...buildResult.staticChunks(),
+    ]
+      .map(([, content]) => content)
+      .join("\n");
+    expect(allClientLike).not.toContain("server-only-body-marker");
+  });
+
+  it("emits the render-safe stub on the SSR/static side", () => {
+    const staticContent = buildResult
+      .staticChunks()
+      .map(([, content]) => content)
+      .join("\n");
+    expect(staticContent).toContain("cannot run during SSR");
+    expect(staticContent).not.toContain("createServerReference");
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -605,6 +605,73 @@ export function Page(props: any) {
   );
 }
 
+// Client component importing a "use server" module: the build must replace the
+// module with createServerReference proxies in the browser environment and a
+// render-safe stub in SSR — never bundle the server body.
+export async function setupServerReferenceProxyProject(testDir: string) {
+  await setupIndexHTML(testDir);
+  await mkdir(resolve(testDir, "src/actions"), { recursive: true });
+  await mkdir(resolve(testDir, "src/components"), { recursive: true });
+  await mkdir(resolve(testDir, "src/page"), { recursive: true });
+
+  // Directive-only filename ON PURPOSE (no `.server.` suffix): the suffix
+  // route is handled by serverReferenceClientPlugin; only a directive-only
+  // name exercises the transformer's own analysis path. The string literal is
+  // the canary: it must never appear in a client or static chunk.
+  await writeFile(
+    resolve(testDir, "src/actions/todoActions.ts"),
+    `"use server";
+export async function addItem(title: string): Promise<{ ok: boolean; tag: string }> {
+  return { ok: !!title, tag: "server-only-body-marker" };
+}
+`
+  );
+
+  await writeFile(
+    resolve(testDir, "src/components/AddButton.tsx"),
+    `"use client";
+import React from "react";
+import { addItem } from "../actions/todoActions.js";
+
+export function AddButton() {
+  const [ok, setOk] = React.useState(false);
+  return (
+    <button
+      data-testid="add"
+      onClick={async () => {
+        const res = await addItem("hello");
+        setOk(res.ok);
+      }}
+    >
+      {ok ? "added" : "add"}
+    </button>
+  );
+}
+`
+  );
+
+  await writeFile(
+    resolve(testDir, "src/page/page.tsx"),
+    `import React from "react";
+import { AddButton } from "../components/AddButton.js";
+
+export function Page() {
+  return (
+    <div>
+      <h1>Server Reference Proxy Test</h1>
+      <AddButton />
+    </div>
+  );
+}
+`
+  );
+
+  await writeFile(
+    resolve(testDir, "src/page/props.ts"),
+    `export const props = (url: string) => ({ url });`
+  );
+}
+
 export async function setupTestProjectEnv(testDir: string) {
   await setupIndexHTML(testDir);
   await setupPageTSX2(testDir);


### PR DESCRIPTION
## Why

`createTransformerPlugin`'s client-imported-`'use server'` analysis was the last call site handing the bundler's `this.parse` to `analyzeModule`. Every other site was migrated to rsl's acorn parse so directive/export analysis never depends on the bundler's parser (Rollup acorn on Vite 6/7, Oxc on Vite 8). If that analysis ever fails, the `type === 'success'` guard silently skips proxy emission — which would bundle server code into the browser build with no error.

## What

- Swap the call site to `rslParse`, matching the other three sites in the file.
- Add `test/examples/server-reference-proxy-build.test.ts`: the build path had no coverage for proxy emission (only the dev path did, via `test/dev/client-imports-server-action.test.ts`). The fixture is a **directive-only** `'use server'` module (no `.server.` suffix, so `serverReferenceClientPlugin`'s suffix route can't mask the transformer path) imported by a `'use client'` component. Asserts: browser chunks get `createServerReference` proxies wired to the hosted `#addItem` id, the SSR/static side gets the render-safe stub, and the server-only body string appears in no client-reachable chunk.

## Measured

A/B against the pre-swap code on Vite 8.1: the old `this.parse` build path still analyzed correctly — rolldown's ESTree output is compatible for this analysis. So this is version-independence and consistency, not a live-bug fix; the new test pins the contract either way. New test green under both conditions (`test-both.sh`), dev-path suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)