### PR TITLE
fix(helpers)!: handleServerAction means the sealed executor only

### DIFF
--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -159,10 +159,11 @@ needs configuring there. The rest of this section describes the on-disk
 helper for hosting mode 2.
 
 **`handleServerAction` seals automatically — you do not pass anything extra.**
-This is the `--conditions react-server` variant of the condition-split
-`vite-plugin-react-server/helpers` export; under the default condition the
-same import resolves to the worker-delegating variant, which requires a
-worker and takes none of these options — use the baked gate there instead. A
+It exists under `--conditions react-server` only: executing an action needs
+the react-server React build, so under the default condition the same import
+throws with setup guidance instead of executing anything. A process without
+the condition forwards the request to its RSC worker with
+`delegateServerActionToWorker` (same subpath), or uses the baked gate. A
 Web-standard `(Request) => Response` sibling, `handleServerActionRequest`, is
 what the baked gate itself wraps. In
 production it reads the build's server manifest from

--- a/plugin/helpers/handleServerAction.client.ts
+++ b/plugin/helpers/handleServerAction.client.ts
@@ -38,9 +38,30 @@ export function handleServerActionError(error: unknown, res: ServerResponse, log
 }
 
 /**
- * Client-side server action handler that delegates to worker
+ * `handleServerAction` means ONE thing across the package: the sealed HTTP
+ * handler that EXECUTES actions, which only exists under the react-server
+ * condition (execution needs the react-server React build). This is the
+ * default-condition binding of the name: it throws with setup guidance
+ * instead of silently resolving to different behavior with a different
+ * signature.
  */
-export async function handleServerAction(
+export async function handleServerAction(): Promise<never> {
+  throw new Error(
+    "handleServerAction executes server actions and requires the react-server " +
+      "condition — run the process that imports it with --conditions " +
+      "react-server (or route action requests to the process that has it). " +
+      "From a non-react-server process, forward the request to your RSC " +
+      "worker with delegateServerActionToWorker instead."
+  );
+}
+
+/**
+ * Forward a server-action request to a react-server worker thread and stream
+ * its RSC response back. Non-react-server counterpart to the sealed
+ * `handleServerAction`: this process cannot execute actions itself (wrong
+ * React condition), so it delegates to the worker that can.
+ */
+export async function delegateServerActionToWorker(
   req: IncomingMessage,
   res: ServerResponse,
   options: ServerActionHandlerOptions & { worker?: Worker }
@@ -128,7 +149,7 @@ export async function handleServerActionWithViteServer(
     worker?: Worker;
   }
 ): Promise<void> {
-  return handleServerAction(req, res, {
+  return delegateServerActionToWorker(req, res, {
     projectRoot: handlerOptions.projectRoot,
     verbose: handlerOptions.verbose,
     logger: server.config.customLogger || server.config.logger,

--- a/plugin/helpers/index.client.ts
+++ b/plugin/helpers/index.client.ts
@@ -1,11 +1,20 @@
 // Client-side aggregator for the public ./helpers subpath under the default
 // (react-client) condition. The condition-neutral surface lives in
 // index.shared.ts; this file adds the client-only resolveComponentsClient and
-// the client-side handleServerAction binding.
+// the client side of server-action handling.
 
 export * from "./index.shared.js";
 
 export { resolveComponents as resolveComponentsClient } from "./resolveComponents.client.js";
 
-// Server action handling
-export { handleServerAction } from "./handleServerAction.client.js";
+// Server-action handling. `handleServerAction` means ONE thing across the
+// package: the sealed HTTP handler that EXECUTES actions, which only exists
+// under the react-server condition (execution needs the react-server React
+// build). Under the default condition the name throws with setup guidance
+// instead of silently resolving to different behavior with a different
+// signature. A process on this side of the condition boundary forwards the
+// request instead — that is `delegateServerActionToWorker`.
+export {
+  handleServerAction,
+  delegateServerActionToWorker,
+} from "./handleServerAction.client.js";

--- a/test/unit/helpersActionSurface.test.ts
+++ b/test/unit/helpersActionSurface.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import {
+  handleServerAction as defaultConditionHandleServerAction,
+  delegateServerActionToWorker,
+} from "../../dist/plugin/helpers/handleServerAction.client.js";
+
+// `handleServerAction` means one thing package-wide: the sealed executor,
+// which exists only under react-server. The default-condition binding of the
+// name must fail loudly with guidance — never silently resolve to the
+// worker-delegating variant (different behavior, different signature).
+describe("./helpers server-action surface (default condition)", () => {
+  it("exports the worker delegator under its own name", () => {
+    expect(typeof delegateServerActionToWorker).toBe("function");
+  });
+
+  it("handleServerAction throws setup guidance instead of impersonating the executor", async () => {
+    const call = defaultConditionHandleServerAction();
+    await expect(call).rejects.toThrow(/react-server/);
+    await expect(call).rejects.toThrow(/delegateServerActionToWorker/);
+  });
+});


### PR DESCRIPTION
## Why

`vite-plugin-react-server/helpers` exported two **different** functions under the single name `handleServerAction`, selected by export condition: the sealed HTTP executor (react-server) and a worker-delegating variant with a different, worker-requiring signature (default). Any honest doc of the import had to say "depending on your React condition this is a different function" — flagged HIGH in the server-actions.md audit.

## What

- `handleServerAction` now means the sealed executor, full stop. Under the default condition the name still resolves but **throws with setup guidance** (executing an action needs the react-server React build), so the silent wrong-variant resolution becomes a loud, explained failure at the call site.
- The worker-delegating variant is exported as **`delegateServerActionToWorker`** from the same subpath (unchanged behavior; `handleServerActionWithViteServer` now calls it).
- `docs/server-actions.md` states the contract; `test/unit/helpersActionSurface.test.ts` pins both bindings (delegator exported, stub throws with guidance naming the alternative).

## Breaking

Default-condition consumers of `handleServerAction` must switch to `delegateServerActionToWorker`. No internal caller used the old conditional resolution (dev-server has its own module), and no sibling demo imports it under the default condition.

## Verified

- Unit suite under react-server: 641 passed (includes the new surface test).
- `test-both.sh` on `test/dev/server-actions.test.ts` + `test/dev/client-imports-server-action.test.ts`: green both conditions.
- (test/unit is excluded from the no-condition vitest config by design — the surface test targets the leaf module, which is condition-safe.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)