### PR TITLE
test: VPRS_TEST_TRANSPORT knob + curated webpack dev matrix

### DIFF
--- a/scripts/test-transport-webpack.sh
+++ b/scripts/test-transport-webpack.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Webpack-transport matrix: rerun curated transport-agnostic suites with
+# transport:"webpack" (via the VPRS_TEST_TRANSPORT knob in test-config.ts),
+# the way test-both.sh reruns both React conditions.
+#
+# Deliberately NOT a blanket rerun: suites whose assertions encode esm
+# artifacts by design (bare module-path reference rows, esm SSG pass events,
+# maybeInlineFlight, snapshots without a bake) fail under webpack by design
+# and stay esm-only, as do fixtures with build.edge:false (webpack requires
+# the baked pair and refuses to configure without it). Grow this list one
+# verified-green suite at a time.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export VPRS_TEST_TRANSPORT=webpack
+
+./scripts/test-both.sh \
+  test/dev/dev-transport-hint.test.ts \
+  test/dev/server-actions.test.ts \
+  test/dev/client-imports-server-action.test.ts

--- a/test/dev/dev-transport-hint.test.ts
+++ b/test/dev/dev-transport-hint.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type ViteDevServer } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { testUserOptions, TEST_TRANSPORT } from "../test-config";
+import { setupIndexHTML } from "../setup.js";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { resolve, join } from "node:path";
+
+/**
+ * The dev document's flight-transport hint is the observable that proves the
+ * VPRS_TEST_TRANSPORT matrix knob actually reaches the dev server — action
+ * round-trips look identical in both flavors when the payload carries no
+ * client references, so a green suite alone can't distinguish "webpack dev
+ * works" from "transport option silently ignored".
+ *
+ * transport:"webpack" → transformIndexHtml prepends the classic inline
+ * `self.__vprsFlightTransport="webpack"` script (the client entry picks its
+ * flight client off it). Default esm → no tag, byte-for-byte the plain
+ * document. This suite runs in BOTH matrix legs and asserts the flavor it
+ * was launched under.
+ */
+
+let server: ViteDevServer;
+const port = 3137;
+const testDir = resolve(__dirname, "../fixtures/dev-transport-hint.test");
+
+describe(`dev document transport hint (${TEST_TRANSPORT})`, () => {
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await setupIndexHTML(testDir);
+    await mkdir(join(testDir, "src/page"), { recursive: true });
+    await writeFile(
+      join(testDir, "src/page/page.tsx"),
+      `import React from "react";
+export const Page = () => <div>Transport Hint Test</div>;`
+    );
+    await writeFile(
+      join(testDir, "src/page/props.ts"),
+      `export const props = () => ({});`
+    );
+
+    try {
+      await symlink(
+        resolve(__dirname, "../../node_modules"),
+        join(testDir, "node_modules"),
+        "dir"
+      );
+    } catch {}
+
+    server = await createServer({
+      mode: "test",
+      root: testDir,
+      plugins: [
+        vitePluginReactServer({
+          ...testUserOptions,
+          projectRoot: testDir,
+          moduleBase: "src",
+          Page: () => `src/page/page.tsx`,
+          props: () => `src/page/props.ts`,
+        }),
+      ],
+      server: { port },
+    });
+    await server.listen();
+  }, 60_000);
+
+  afterAll(async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      server?.close(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, 15_000);
+        timer.unref?.();
+      }),
+    ]);
+    clearTimeout(timer);
+    await rm(testDir, { recursive: true, force: true });
+  }, 30_000);
+
+  it(
+    TEST_TRANSPORT === "webpack"
+      ? "carries the webpack flight hint in <head>"
+      : "stays hint-free on the default esm transport",
+    async () => {
+      const res = await fetch(`http://localhost:${port}/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      if (TEST_TRANSPORT === "webpack") {
+        expect(html).toContain('self.__vprsFlightTransport="webpack"');
+      } else {
+        expect(html).not.toContain("__vprsFlightTransport");
+      }
+    }
+  );
+});

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -1,7 +1,17 @@
 import type {  StreamPluginOptions } from "vite-plugin-react-server/types";
 import { metricWatcher } from "vite-plugin-react-server/metrics";
 
+// Transport matrix knob — the transport twin of test-both.sh's condition
+// rerun. VPRS_TEST_TRANSPORT=webpack reruns transport-AGNOSTIC suites with
+// the webpack flight flavor (scripts/test-transport-webpack.sh holds the
+// curated list). Suites whose assertions encode esm artifacts by design
+// (bare module-path reference rows, esm SSG pass events, snapshots without a
+// bake) branch or skip on TEST_TRANSPORT rather than run wrong-flavored.
+export const TEST_TRANSPORT: "esm" | "webpack" =
+  process.env.VPRS_TEST_TRANSPORT === "webpack" ? "webpack" : "esm";
+
 export const testUserOptions = {
+  ...(TEST_TRANSPORT === "webpack" ? { transport: "webpack" as const } : {}),
   moduleBase: "src",
   Page: "src/page/page.tsx",
   props: "src/page/props.ts",


### PR DESCRIPTION
## What

- `VPRS_TEST_TRANSPORT=webpack` knob in `test/test-config.ts`: `testUserOptions` carries `transport: "webpack"`, so any suite spreading it reruns under the webpack flight flavor. Exported `TEST_TRANSPORT` lets transport-sensitive suites branch or skip.
- `scripts/test-transport-webpack.sh`: the curated rerun (transport twin of `test-both.sh`'s condition matrix). Not a blanket rerun on purpose — suites asserting esm artifacts by design (bare module-path reference rows, esm SSG pass events, no-bake snapshots, `build.edge:false` fixtures) stay esm-only. The list grows one verified-green suite at a time.
- `test/dev/dev-transport-hint.test.ts`: asserts the observable that distinguishes "webpack dev works" from "transport silently ignored" — the `self.__vprsFlightTransport="webpack"` head hint present under the knob, absent under esm. Runs in both matrix legs. (Motivation: the action suites pass under both flavors because their payloads carry no client references; green alone proved nothing until this.)

## Coverage gained

Server actions and the client-imported-server-function path under webpack DEV — empirically green in demo probes but previously untested in-tree.

## Verified

Webpack leg: 8/8 under both React conditions. Esm leg (knob unset): green, hint absent. `tsc --noEmit` clean.