### PR TITLE
fix(loader): route TS/JSX stripping through transformWithOxc on Vite 8

### DIFF
--- a/plugin/loader/createDefaultLoader.ts
+++ b/plugin/loader/createDefaultLoader.ts
@@ -2,8 +2,8 @@ import type { LoaderContext } from "../types.js";
 import type { RawSourceMap } from "source-map";
 import type { LoadFnOutput, LoadHookContext } from "node:module";
 import type { LoadHook } from "node:module";
-import { transformWithEsbuild } from "vite";
 import { readFile } from "node:fs/promises";
+import { transformTsSource } from "./transformTsSource.js";
 
 export type LoaderResult = {
   source: string;
@@ -20,15 +20,11 @@ export type Loader = {
 
 
 const defaultNextLoad: Parameters<LoadHook>[2] = async (url) => {
-  const result = await transformWithEsbuild(await readFile(url, "utf-8"), url, {
-    loader: "tsx",
-    format: "esm",
-    sourcemap: "external",
-  });
+  const result = await transformTsSource(await readFile(url, "utf-8"), url, "tsx");
   return {
     source: result["code"],
     format: "module",
-    map: result.map,
+    map: result.map as RawSourceMap,
   };
 };
 
@@ -59,15 +55,11 @@ export function createDefaultLoader(
   const defaultSourceNextLoad: Parameters<LoadHook>[2] =
     typeof defaultSource === "string"
       ? async (url = defaultId) => {
-          const result = await transformWithEsbuild(defaultSource, url, {
-            loader: "tsx",
-            format: "esm",
-            sourcemap: "external",
-          });
+          const result = await transformTsSource(defaultSource, url, "tsx");
           return {
             source: result["code"],
             format: "module",
-            map: result.map,
+            map: result.map as RawSourceMap,
           };
         }
       : defaultNextLoad;

--- a/plugin/loader/transformTsSource.ts
+++ b/plugin/loader/transformTsSource.ts
@@ -1,0 +1,36 @@
+// Strip TS/JSX from a source string with whichever transform the running
+// Vite provides. Vite 8 (rolldown) deprecates `transformWithEsbuild` in
+// favor of `transformWithOxc`; Vite 6/7 only have esbuild. Feature-detect at
+// call time — a static named import of the Oxc function would fail to link
+// under 6/7 and break the compat matrix. Options are normalized to the
+// intersection both transforms honor: language, ESM out, external sourcemap.
+import * as vite from "vite";
+import { transformWithEsbuild } from "vite";
+
+export type TransformedTsSource = { code: string; map: unknown };
+
+type OxcTransform = (
+  code: string,
+  filename: string,
+  options?: { lang: string; sourcemap: boolean; sourceType: "module" },
+) => Promise<TransformedTsSource>;
+
+const oxc = (vite as Record<string, unknown>)["transformWithOxc"] as
+  | OxcTransform
+  | undefined;
+
+export async function transformTsSource(
+  code: string,
+  filename: string,
+  lang: "ts" | "tsx",
+): Promise<TransformedTsSource> {
+  // sourceType pinned: a source without import/export statements would
+  // otherwise resolve "unambiguous" to script and the JSX runtime import
+  // comes out as require() — broken in the ESM contexts these callers serve.
+  if (oxc) return oxc(code, filename, { lang, sourcemap: true, sourceType: "module" });
+  return transformWithEsbuild(code, filename, {
+    loader: lang,
+    format: "esm",
+    sourcemap: "external",
+  });
+}

--- a/plugin/transformer/serverReferenceClientPlugin.ts
+++ b/plugin/transformer/serverReferenceClientPlugin.ts
@@ -1,6 +1,6 @@
 import type { ConfigEnv } from "vite";
-import { transformWithEsbuild } from "vite";
 import { readFile } from "node:fs/promises";
+import { transformTsSource } from "../loader/transformTsSource.js";
 import type { Program } from "acorn";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { createDefaultModuleID } from "../config/createModuleID.js";
@@ -97,9 +97,11 @@ export const serverReferenceClientPlugin: VitePluginFn = (userOptions) => {
       // Rollup parser (this.parse) is JS-only. esbuild preserves the top-level
       // "use server" directive and the export names, which is all we need.
       const isTsx = /\.[tj]sx$/.test(realPath);
-      const { code: js } = await transformWithEsbuild(src, realPath, {
-        loader: isTsx ? "tsx" : "ts",
-      });
+      const { code: js } = await transformTsSource(
+        src,
+        realPath,
+        isTsx ? "tsx" : "ts",
+      );
       const analysis = await analyzeModule(js, {
         loader: { parse: (s: string) => rslParse(s).ast as unknown as Program },
       });

--- a/plugin/transformer/serverReferenceClientPlugin.ts
+++ b/plugin/transformer/serverReferenceClientPlugin.ts
@@ -1,14 +1,9 @@
 import type { ConfigEnv } from "vite";
 import { readFile } from "node:fs/promises";
 import { transformTsSource } from "../loader/transformTsSource.js";
-import type { Program } from "acorn";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { createDefaultModuleID } from "../config/createModuleID.js";
 import { analyzeModule } from "react-server-loader/directives";
-// Version-independent acorn parse: the bundler's `this.parse` is Oxc on Vite 8
-// (different AST shape) but Rollup/acorn on 6/7. rsl's parser matches the
-// JS-only Rollup behavior we already relied on here.
-import { parse as rslParse } from "react-server-loader";
 import type { VitePluginFn } from "../types.js";
 
 // Virtual id prefix for the client-side server-reference proxy. The real
@@ -93,18 +88,17 @@ export const serverReferenceClientPlugin: VitePluginFn = (userOptions) => {
       const realPath = id.slice(PREFIX.length).split("?")[0];
       const src = await readFile(realPath, "utf8");
 
-      // Strip TS types before analysis — we read the raw .server source, and the
-      // Rollup parser (this.parse) is JS-only. esbuild preserves the top-level
-      // "use server" directive and the export names, which is all we need.
+      // Strip TS types before analysis — we read the raw .server source. The
+      // transform preserves the top-level "use server" directive and the
+      // export names, which is all analyzeModule needs; no parser is injected,
+      // so analysis runs on rsl's own version-stable parse.
       const isTsx = /\.[tj]sx$/.test(realPath);
       const { code: js } = await transformTsSource(
         src,
         realPath,
         isTsx ? "tsx" : "ts",
       );
-      const analysis = await analyzeModule(js, {
-        loader: { parse: (s: string) => rslParse(s).ast as unknown as Program },
-      });
+      const analysis = await analyzeModule(js);
       if (
         analysis.type !== "success" ||
         analysis.directiveInfo?.fileLevel?.type !== "server"


### PR DESCRIPTION
## Why

Vite 8 deprecates `transformWithEsbuild` and logs a warning on every call. Two vprs sites call it: `serverReferenceClientPlugin` (fires on every `.server.*` module a client imports — dashboard users see the warning constantly in dev) and `createDefaultLoader`.

## What

`transformTsSource(code, filename, lang)` — one shim, feature-detected at module load: `transformWithOxc` when the running Vite exports it, `transformWithEsbuild` otherwise. A static named import of the Oxc function would fail to link under Vite 6/7 and break the compat matrix, hence the namespace probe.

Trap caught while smoke-testing: Oxc classifies an import-less source as *script* under its default unambiguous `sourceType` and emits the JSX runtime helper as `require()` — broken in the ESM contexts both call sites serve (the Node ESM loader serves the result as `format: "module"`). `sourceType: "module"` is pinned in the shim.

## Verified

- Shim smoke on Vite 8.2: JSX in → `import { jsx as _jsx } …` ESM out, `"use server"` directive and export names preserved, sourcemap present.
- `test/dev/client-imports-server-action` + `test/dev/server-actions`: green, and the deprecation warning is gone from their output (grep: 0 occurrences).
- Full unit suite: 639 passed. `tsc` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)