### PR TITLE
chore: react-server-loader 19.2.19 (+ experimental 7dfc7ccd-20260803)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.18 || 0.0.0-experimental-172742b4-20260716.1",
+        "react-server-loader": "^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -2292,7 +2292,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6409,24 +6408,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -6437,12 +6436,13 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.18",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.18.tgz",
-      "integrity": "sha512-grrUSq8rVeI4eBnY1Uv9pu+IgCwQiLGJkCHVyhZ6rihwfpPa7KNl8mosaJDQZGqddYWmBH9D2IRifddKxuzpFQ==",
+      "version": "19.2.19",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.19.tgz",
+      "integrity": "sha512-zwRsbVhd/xm5BO6lAVl/d0pVhq+0vlPPjIAV+RyVzMYeZ7qVErQRaR1eLY9T2R3pg+rZ0ahPPsdvibAfl506uQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
         "picocolors": "^1.1.1",
         "source-map": "^0.7.6"
       },
@@ -6450,8 +6450,8 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -441,7 +441,7 @@
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
-    "react-server-loader": "^19.2.18 || 0.0.0-experimental-172742b4-20260716.1",
+    "react-server-loader": "^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }


### PR DESCRIPTION
Bumps the compound range `^19.2.18 || 0.0.0-experimental-172742b4-20260716.1` → `^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803`.

Stable 19.2.19 ships rsl #31 (JSX-capable `parse()` — directive analysis stops degrading to the raw text regex on untranspiled JSX) and floors the React peer at ^19.2.8. The experimental alternate advances to the 2026-08-03 nightly, which carries the `pending_weak` Flight thenable protocol and FlightReply decode performance work.

Gate: build clean, unit suite 639 passed against the installed 19.2.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)