### PR TITLE
chore(release): 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.5.3",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for the release carrying #331, #326, #330, #328, #327.

Highlights: rsl 19.2.19 (JSX-capable directive analysis, React ^19.2.8 peer) with the experimental 7dfc7ccd alternate; `transformWithOxc` on Vite 8 with esbuild fallback for 6/7 (removes the dev deprecation warning); analysis call sites stop injecting parsers; build-side server-reference proxy coverage; `VPRS_TEST_TRANSPORT` webpack matrix.

**BREAKING** (#327): under the default condition, `helpers`' `handleServerAction` throws with setup guidance instead of silently resolving to the worker-delegating variant — now exported as `delegateServerActionToWorker`.

Full-gate evidence on the merged content: both-condition suite green (882 passed), publint + 109 entrypoints, bidoof e2e 10/10 against the linked build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)