### PR TITLE
feat: warn when route.tsx layouts exist but no layouts resolver is wired

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -23,6 +23,8 @@ import { resolveRoutesOption } from "../router/fileRouter.js";
 // Once-per-process guard for the loose-Page/props → `routes` nudge below
 // (resolveOptions runs per environment; the tip should print once).
 let routesNudgeShown = false;
+// Once-per-process guard for the unwired-layouts warning below.
+let layoutsWarningShown = false;
 import { resolveDirectiveMatcher } from "./resolveDirectiveMatcher.js";
 import { resolveAllowedDirectives } from "./resolveAllowedDirectives.js";
 import { resolveRegExp } from "./resolveRegExp.js";
@@ -32,8 +34,40 @@ import { createLogger, type Logger } from "vite";
 import { getCondition } from "./getCondition.js";
 import { getNodeEnv } from "./getNodeEnv.js";
 import { stashUserOptions, getStashedUserOptions, getEnvironmentId } from "./stashedOptionsState.js";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { createRollupLikeHash } from "./createRollupLikeHash.js";
+import { DEFAULT_LAYOUT } from "../router/scanRoutes.js";
+
+// Capped scan for a `route.tsx` layout file under the module tree, used only by
+// the unwired-layouts warning — a miss must stay cheap, so depth and entry
+// count are bounded and dot-dirs / node_modules are skipped.
+function findLayoutFile(
+  dir: string,
+  depth = 6,
+  budget = { entries: 400 }
+): string | null {
+  if (depth < 0 || budget.entries <= 0) return null;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    if (--budget.entries <= 0) return null;
+    if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    if (entry.isFile() && DEFAULT_LAYOUT.test(entry.name)) {
+      return join(dir, entry.name);
+    }
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+    const found = findLayoutFile(join(dir, entry.name), depth - 1, budget);
+    if (found) return found;
+  }
+  return null;
+}
 
 export type ResolveOptionsReturn =
   | {
@@ -247,6 +281,29 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
   // Nested layouts: the router table's per-url `route.tsx` chain resolver.
   // Threaded like Page/props so the renderer folds the nested tree.
   const effectiveLayouts = options.layouts ?? routerTable?.layouts;
+  // Silent footgun: `route.tsx` layouts on disk with no layouts resolver just
+  // render every page unwrapped, with nothing else signalling why. The
+  // `routes` option wires the resolver itself; the manual path (spreading a
+  // fileRouter table but omitting `.layouts`) is where this bites. Detection
+  // is on-disk so a hand-rolled config pointing Page at a routes tree is
+  // caught too.
+  if (
+    !effectiveLayouts &&
+    (effectivePage || effectiveProps) &&
+    !layoutsWarningShown
+  ) {
+    const layoutFile = findLayoutFile(resolve(projectRoot, moduleBase));
+    if (layoutFile) {
+      layoutsWarningShown = true;
+      console.warn(
+        `[vite-plugin-react-server] ${layoutFile} looks like a route.tsx ` +
+          "layout, but no `layouts` resolver is configured — pages will " +
+          "render without their layouts. Use `routes: { dir }` (wires " +
+          "layouts automatically) or pass `layouts` from your " +
+          "fileRouter(...) table."
+      );
+    }
+  }
 
   // Build options
   const preserveModulesRoot =

--- a/plugin/router/scanRoutes.ts
+++ b/plugin/router/scanRoutes.ts
@@ -61,7 +61,8 @@ export type ScanPatterns = {
 
 const DEFAULT_PAGE = /^page\.(t|j)sx?$/;
 const DEFAULT_PROPS = /^props\.(t|j)sx?$/;
-const DEFAULT_LAYOUT = /^route\.(t|j)sx?$/;
+/** Default `route.tsx` layout-file matcher; shared with the unwired-layouts warning. */
+export const DEFAULT_LAYOUT = /^route\.(t|j)sx?$/;
 // `index.tsx` is an alternate leaf-page name (TanStack-style; `page.tsx` wins
 // when both exist). Deliberately jsx/tsx-ONLY: `index.ts` is the conventional
 // barrel filename, and matching it would turn every re-export barrel inside the

--- a/test/unit/unwiredLayoutsWarning.test.ts
+++ b/test/unit/unwiredLayoutsWarning.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveOptions } from "../../plugin/config/resolveOptions.js";
+
+/**
+ * A routes tree containing `route.tsx` layouts, configured through the manual
+ * path (Page/props without a `layouts` resolver), renders every page unwrapped
+ * with no other signal. resolveOptions warns once when it finds a layout file
+ * on disk and no resolver wired.
+ *
+ * The warning is once-per-process and vitest isolates test files, so this file
+ * owns the whole budget — the quiet cases run FIRST (they'd be vacuous after
+ * the positive case consumes the guard).
+ */
+
+let root: string;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "vprs-layouts-warn-"));
+  mkdirSync(join(root, "src", "pages", "about"), { recursive: true });
+  writeFileSync(join(root, "src", "pages", "page.tsx"), "export const Page = () => null;\n");
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  rmSync(root, { recursive: true, force: true });
+});
+
+const layoutWarnings = () =>
+  warnSpy.mock.calls.filter(([msg]) =>
+    String(msg).includes("no `layouts` resolver is configured")
+  );
+
+const resolveWith = (extra: Record<string, unknown> = {}) =>
+  resolveOptions({
+    moduleBase: "src",
+    projectRoot: root,
+    Page: () => "src/pages/page.tsx",
+    forceResolve: true,
+    ...extra,
+  } as never);
+
+describe("config/resolveOptions — unwired route.tsx layouts warning", () => {
+  it("stays quiet when no route.tsx exists", () => {
+    expect(resolveWith().type).toBe("success");
+    expect(layoutWarnings().length).toBe(0);
+  });
+
+  it("stays quiet when a layouts resolver is configured", () => {
+    writeFileSync(join(root, "src", "pages", "route.tsx"), "export default null;\n");
+    expect(resolveWith({ layouts: () => [] }).type).toBe("success");
+    expect(layoutWarnings().length).toBe(0);
+  });
+
+  it("warns once when route.tsx files exist but no layouts resolver is passed", () => {
+    writeFileSync(join(root, "src", "pages", "about", "route.tsx"), "export default null;\n");
+    expect(resolveWith().type).toBe("success");
+    const warnings = layoutWarnings();
+    expect(warnings.length).toBe(1);
+    expect(String(warnings[0]?.[0])).toContain("route.tsx");
+
+    // Once per process: a second resolve stays quiet.
+    expect(resolveWith().type).toBe("success");
+    expect(layoutWarnings().length).toBe(1);
+  });
+});


### PR DESCRIPTION
The silent-footgun half of the forgotten-layouts DX issue: a config that spreads a fileRouter table's Page/props/routePatterns but omits `layouts` (or hand-points Page at a routes tree) renders every page unwrapped, and nothing says why. The `routes: { dir }` option already wires layouts automatically; this covers the manual path.

`resolveOptions` now runs a bounded scan (depth- and entry-capped, skips dot-dirs/node_modules) for `route.tsx` files when `Page`/`props` are configured without a `layouts` resolver, and warns once per process with the two fixes. `DEFAULT_LAYOUT` moves to an export on scanRoutes so the warning and the route scanner can never drift on what counts as a layout file.

Gate: `tsc --noEmit` clean; full `./scripts/test-both.sh` green; new unit suite covers quiet-without-layout-files, quiet-with-resolver, warn-once (ordered so the once-per-process guard can't make the negative cases vacuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)