### PR TITLE
fix: name the real cause when an edge bake fails on filesystem imports

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -798,11 +798,18 @@ export async function ${actionExport}(request, opts = {}) {
     // fail an otherwise-good build. Warn loudly and skip the artifact; the
     // worker-based dist/server build stands on its own. Opt out with
     // `build.edge: false` if the bake is not wanted.
+    const message = error instanceof Error ? error.message : String(error);
+    // node:fs/promises and node:path are aliased to the throw-only nodeStub in
+    // the bake, so a USER module importing them surfaces as a missing export
+    // from the stub — name the real constraint instead of the stub internals.
+    const stubHint = message.includes("nodeStub")
+      ? " A module in the bake imports node:fs/promises or node:path; the " +
+        "baked bundle has no filesystem. Read files at build time instead " +
+        "(import.meta.glob, optionally with ?raw) or set build.edge:false."
+      : "";
     logger.warn(
       `${tag} skipped — edge bundle bake failed (the main build is unaffected; ` +
-        `set build.edge:false to silence): ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `set build.edge:false to silence): ${message}${stubHint}`
     );
   } finally {
     rmSync(entryPath, { force: true });

--- a/plugin/bundle/freezeStaticSnapshots.ts
+++ b/plugin/bundle/freezeStaticSnapshots.ts
@@ -51,24 +51,28 @@ export async function freezeStaticSnapshots(opts: {
   const rscName =
     userOptions.build.rscOutputPath ?? DEFAULT_CONFIG.BUILD.rscOutputPath;
 
-  // This pass renders THROUGH the baked pair, so a bake that failed upstream
-  // (warned and skipped, additive contract) must fail here naming that cause,
-  // not as the ERR_MODULE_NOT_FOUND a blind import would produce.
+  // This pass renders THROUGH the baked pair, so a bake that failed or was
+  // partially skipped upstream (warn-and-continue, additive contract) must
+  // fail here naming that cause, not as the ERR_MODULE_NOT_FOUND a blind
+  // import would produce. BOTH halves are required: buildConsumerBundle has
+  // warn-and-return skip paths that leave a producer without a consumer.
   const producerPath = join(edgeDir, DEFAULT_CONFIG.EDGE.entryFileName);
-  if (!existsSync(producerPath)) {
+  const consumerPath = join(edgeDir, "consumer.js");
+  const missing = [producerPath, consumerPath].filter((p) => !existsSync(p));
+  if (missing.length > 0) {
     throw new Error(
       `[transport:webpack] SSG renders through the baked edge pair, but ` +
-        `${producerPath} is missing — the edge bake failed or was disabled ` +
-        `(see the earlier [build.edge] warning for the cause). Fix the bake ` +
-        `failure, or set build.pages to [] to skip SSG.`
+        `${missing.join(" and ")} ${missing.length > 1 ? "are" : "is"} ` +
+        `missing — the edge bake failed or was partially skipped (see the ` +
+        `earlier [build.edge] warning for the cause; a skipped consumer bake ` +
+        `leaves per-request serving intact but the SSG freeze cannot run). ` +
+        `Fix the bake, or set build.pages to [] to skip SSG.`
     );
   }
 
   const { createEdgeRequestHandler } = await import("../edge/index.js");
   const bundle = await import(pathToFileURL(producerPath).href);
-  const consumer = await import(
-    pathToFileURL(join(edgeDir, "consumer.js")).href
-  );
+  const consumer = await import(pathToFileURL(consumerPath).href);
   // Collect render-time errors per route. The freeze only checks the response
   // STATUS, but the status commits on the first chunk — a component that
   // throws mid-stream (e.g. a router hook rendered in the HTML shell outside

--- a/plugin/bundle/freezeStaticSnapshots.ts
+++ b/plugin/bundle/freezeStaticSnapshots.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
@@ -50,10 +51,21 @@ export async function freezeStaticSnapshots(opts: {
   const rscName =
     userOptions.build.rscOutputPath ?? DEFAULT_CONFIG.BUILD.rscOutputPath;
 
+  // This pass renders THROUGH the baked pair, so a bake that failed upstream
+  // (warned and skipped, additive contract) must fail here naming that cause,
+  // not as the ERR_MODULE_NOT_FOUND a blind import would produce.
+  const producerPath = join(edgeDir, DEFAULT_CONFIG.EDGE.entryFileName);
+  if (!existsSync(producerPath)) {
+    throw new Error(
+      `[transport:webpack] SSG renders through the baked edge pair, but ` +
+        `${producerPath} is missing — the edge bake failed or was disabled ` +
+        `(see the earlier [build.edge] warning for the cause). Fix the bake ` +
+        `failure, or set build.pages to [] to skip SSG.`
+    );
+  }
+
   const { createEdgeRequestHandler } = await import("../edge/index.js");
-  const bundle = await import(
-    pathToFileURL(join(edgeDir, DEFAULT_CONFIG.EDGE.entryFileName)).href
-  );
+  const bundle = await import(pathToFileURL(producerPath).href);
   const consumer = await import(
     pathToFileURL(join(edgeDir, "consumer.js")).href
   );


### PR DESCRIPTION
DX fix for the confusing failure pair when a module in the edge bake imports `node:fs/promises` / `node:path` (e.g. a props loader using `readdir`):

- The bake aliases those specifiers to a throw-only stub, so the failure surfaced as `"readdir" is not exported by …/nodeStub.js` — stub internals, not the constraint. The bake-failure warning now adds the real cause when the stub is involved: the baked bundle has no filesystem; read files at build time (`import.meta.glob`, optionally `?raw`) or set `build.edge:false`.
- Under `transport: "webpack"` the SSG pass renders through the baked pair, so a failed bake cascaded into `ERR_MODULE_NOT_FOUND` on `dist/server-edge/render.js`. `freezeStaticSnapshots` now checks the producer exists first and fails with a message pointing at the earlier `[build.edge]` warning.

No behavior change on successful bakes. The stub stays throw-only on purpose: rounding out its fs surface would turn link-time failures into request-time throws in the deployed handler.

Gate: `tsc --noEmit` clean, full `./scripts/test-both.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)