### PR TITLE
fix: implement htmlTimeout as a whole-render deadline in createHtmlStream

### DIFF
--- a/plugin/react-static/rscToHtmlStream.server.ts
+++ b/plugin/react-static/rscToHtmlStream.server.ts
@@ -50,6 +50,7 @@ export const createRscToHtmlStream: RscToHtmlStreamFn = function _createRscToHtm
     build,
     onMetrics: options.onMetrics,
     onError: options.onError,
+    htmlTimeout: options.htmlTimeout,
   });
 
   // Handle abort signal

--- a/plugin/stream/createHtmlStream.server.ts
+++ b/plugin/stream/createHtmlStream.server.ts
@@ -323,6 +323,12 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
   // Let React manage the MessagePort lifecycle to prevent "Connection closed" errors
   const cleanup = () => {
     try {
+      // Every termination path (natural end, worker ERROR, abort, deadline)
+      // funnels through here — disarming the deadline here means an
+      // intentional abort can't be followed by a misleading timeout error.
+      // (`deadline` is declared below; message/abort callbacks only run
+      // after the synchronous body finished initializing it.)
+      if (deadline) clearTimeout(deadline);
       dataPort1.removeListener('message', dataMessageHandler);
       controlPort1.removeListener('message', controlMessageHandler);
       // Don't close ports - let React finish consuming and close naturally
@@ -341,7 +347,11 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
   const deadline =
     typeof htmlTimeout === "number" && htmlTimeout > 0
       ? setTimeout(() => {
-          if (isStreamEnded || htmlStream.destroyed) return;
+          // Completion is an OUTPUT property: the worker's null end-message
+          // calls htmlStream.end(). isStreamEnded would be the wrong guard —
+          // it marks the RSC INPUT fully delivered, which is exactly the
+          // state the canonical wedge is in when it hangs.
+          if (htmlStream.writableEnded || htmlStream.destroyed) return;
           htmlStream.destroy(
             new Error(
               `[createHtmlStream:${route}] HTML render did not complete within ${htmlTimeout}ms — ` +

--- a/plugin/stream/createHtmlStream.server.ts
+++ b/plugin/stream/createHtmlStream.server.ts
@@ -46,6 +46,7 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
     logger = createLogger(),
     onError,
     panicThreshold,
+    htmlTimeout,
   } = options;
 
   if (verbose) {
@@ -331,6 +332,31 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
   };
 
   // Note: Process-level cleanup is handled by worker shutdown protocol
+
+  // Whole-render deadline. A wedged worker render — canonically a client
+  // reference whose dynamic import never settles — sends neither output nor
+  // an ERROR message, so the stream would keep its consumer (the SSG
+  // fileWriter, a request handler) waiting forever. Destroying with a named
+  // error rides the same propagation path as worker-reported render errors.
+  const deadline =
+    typeof htmlTimeout === "number" && htmlTimeout > 0
+      ? setTimeout(() => {
+          if (isStreamEnded || htmlStream.destroyed) return;
+          htmlStream.destroy(
+            new Error(
+              `[createHtmlStream:${route}] HTML render did not complete within ${htmlTimeout}ms — ` +
+                `the html worker sent neither output nor an error. A client-reference ` +
+                `module that fails to load at render time can wedge the render this way; ` +
+                `check that the client build output is resolvable from the render.`
+            )
+          );
+          cleanup();
+        }, htmlTimeout)
+      : undefined;
+  deadline?.unref?.();
+  htmlStream.on("close", () => {
+    if (deadline) clearTimeout(deadline);
+  });
 
   return {
     pipe: (destination: any) => {

--- a/test/unit/htmlStreamDeadline.test.ts
+++ b/test/unit/htmlStreamDeadline.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import { createHtmlStream } from "../../plugin/stream/createHtmlStream.server.js";
+
+/**
+ * The htmlTimeout whole-render deadline, exercised in its FIRING path. The
+ * canonical wedge: the RSC input is fully delivered (isStreamEnded true) and
+ * the html worker then goes silent — neither output nor ERROR. The deadline
+ * must destroy the stream with its named error (guarding on OUTPUT completion,
+ * not the input-ended flag), and must NOT fire once the worker's null
+ * end-signal completed the render.
+ */
+
+const stubWorker = () => {
+  const ports: MessagePort[] = [];
+  return {
+    ports,
+    worker: {
+      postMessage: (_msg: unknown, transfer?: MessagePort[]) => {
+        if (transfer) ports.push(...transfer);
+      },
+    } as never,
+  };
+};
+
+describe("createHtmlStream htmlTimeout deadline", () => {
+  it("fires on the canonical wedge: input fully delivered, worker silent", async () => {
+    const { worker } = stubWorker();
+    const rsc = new PassThrough();
+    const html = createHtmlStream({
+      route: "/wedge",
+      rscStream: rsc,
+      htmlWorker: worker,
+      htmlTimeout: 150,
+    } as never);
+    const dest = new PassThrough();
+    const destError = new Promise<Error>((resolve) => dest.on("error", resolve));
+    html.pipe(dest);
+    rsc.end(); // input done — the state the wedge hangs in
+
+    const err = await Promise.race([
+      destError,
+      new Promise<never>((_res, reject) =>
+        setTimeout(() => reject(new Error("deadline never fired")), 2_000)
+      ),
+    ]);
+    expect(String(err)).toContain("did not complete within 150ms");
+  });
+
+  it("does not fire after the worker completes the render", async () => {
+    const stub = stubWorker();
+    const rsc = new PassThrough();
+    const html = createHtmlStream({
+      route: "/done",
+      rscStream: rsc,
+      htmlWorker: stub.worker,
+      htmlTimeout: 150,
+    } as never);
+    const dest = new PassThrough();
+    dest.resume();
+    let destErr: Error | undefined;
+    dest.on("error", (e) => (destErr = e));
+    html.pipe(dest);
+
+    // Simulate the worker: one HTML chunk, then the null end-signal on the
+    // data port (the transferred worker-side end captured from postMessage).
+    const dataPort2 = stub.ports[0]!;
+    dataPort2.postMessage(Buffer.from("<html>ok</html>"));
+    dataPort2.postMessage(null);
+    rsc.end();
+
+    await new Promise((r) => setTimeout(r, 400));
+    expect(destErr).toBeUndefined();
+  });
+});


### PR DESCRIPTION
`htmlTimeout` is a typed option resolved with a 15s default, and the client-side html stream applies it — but the server-side `createHtmlStream` never armed it, and `createRscToHtmlStream` dropped it on the floor. A wedged worker render (canonically: a client-reference module whose dynamic import never settles) sends neither output nor an ERROR message, so the stream neither ends nor errors and its consumer — the SSG fileWriter or a request handler — waits forever.

The deadline destroys the stream with a named error (`HTML render did not complete within Nms … check that the client build output is resolvable from the render`) that rides the existing render-error propagation path in the pipe wrapper, so a hang becomes a loud, attributable failure. Timer is unref'd and cleared on stream close; streams created without an `htmlTimeout` are unchanged.

Context: the historical harness hang this guards against (SSG build with client components stalling ~30s at "worker teardown") no longer reproduces — verified with a fresh fixture under both conditions, settling ~1.1s with correct prerendered output — so this is defense-in-depth for the remaining silent-wedge class, matching the degraded-document-guard philosophy of loud over hung.

Gate: `tsc --noEmit` clean, full `./scripts/test-both.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)