### PR TITLE
chore(release): 3.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Rolls up #333–#337 on top of 3.6.0:

- **feat**: unwired-layouts warning — route.tsx files on disk with no `layouts` resolver now warn once with the fix (#335).
- **fix**: edge-bake failures on `node:fs`/`node:path` imports name the no-filesystem constraint; the webpack SSG freeze checks both halves of the baked pair and fails fast with the cause instead of ERR_MODULE_NOT_FOUND (#336).
- **fix**: `htmlTimeout` is now an armed whole-render deadline in the server html stream (output-completion guard, disarmed on cleanup, firing-path unit tests) (#337).
- **chore**: dead handler-layer code removed; `CreateMessageHandlerFn` was reachable as public type surface via `./client`, hence minor rather than patch (#334).
- **docs**: transport de-headline trim extended to getting-started + react-type-compatibility (#333).

Gates: full `./scripts/test-both.sh` green on every constituent branch; publish-readiness rebuild + gate on this branch reported in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)