### PR TITLE
test+refactor(worker): pin the component cache, then extract loadCachedComponent

### DIFF
--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -222,6 +222,87 @@ async function loadDefaultHtml({
 }
 
 /**
+ * Load a single component (Root/Html) through the worker cache: serve the
+ * cached identity unless the module was HMR-invalidated, otherwise clear the
+ * stale entry, resolve fresh, and re-cache. A resolve failure must never
+ * degrade silently to a fragment — it routes through handleError (dedup +
+ * panicThreshold) and throws so the outer worker catch propagates it to the
+ * main thread.
+ */
+async function loadCachedComponent({
+  componentPath,
+  exportName,
+  kind,
+  loader,
+  verbose,
+  logger,
+  panicThreshold,
+  marks,
+}: {
+  componentPath: string;
+  exportName: string;
+  kind: "Root" | "Html";
+  loader: any;
+  verbose?: boolean;
+  logger?: any;
+  panicThreshold?: PanicThreshold;
+  marks?: { moduleRunAt?: number };
+}) {
+  const id = `${componentPath}#${exportName}`;
+  const invalidated = isModuleInvalidated(componentPath);
+
+  if (hasCachedComponent(id) && !invalidated) {
+    if (verbose) {
+      logger?.info(
+        `[rsc-worker] Using cached ${kind} component from: ${componentPath}`
+      );
+    }
+    return getCachedComponent(id);
+  }
+
+  if (invalidated && hasCachedComponent(id)) {
+    clearCachedComponent(id);
+    if (verbose) {
+      logger?.info(
+        `[rsc-worker] Cleared invalidated ${kind} component cache: ${componentPath}`
+      );
+    }
+  }
+
+  if (marks) marks.moduleRunAt ??= Date.now();
+  const result = await resolveComponent({
+    componentPath,
+    exportName,
+    loader,
+  });
+
+  if (result.type === "success") {
+    cacheComponent(id, result.component);
+    if (verbose) {
+      logger?.info(
+        `[rsc-worker] Loaded and cached ${kind} component from: ${componentPath}`
+      );
+    }
+    return result.component;
+  }
+
+  const componentError =
+    result.error ??
+    new Error(
+      `[rsc-worker] Failed to load ${kind} component from ${componentPath}`
+    );
+  const panicError = handleError({
+    error: componentError,
+    logger,
+    panicThreshold,
+    critical: true,
+    context: `rsc-worker: load ${kind} from ${componentPath}`,
+    log: true,
+  });
+  throw panicError ?? componentError;
+}
+
+/**
  * Helper function to load components with caching
  */
 export async function loadComponentsWithCache(options: {
@@ -535,64 +616,16 @@ export async function loadComponentsWithCache(options: {
 
   // Load Root component
   if (rootPath) {
-    const rootId = `${rootPath}#${rootExportName}`;
-    // CRITICAL: Check if module is invalidated before using cache
-    // This ensures file changes are picked up immediately
-    const isRootInvalidated = isModuleInvalidated(rootPath);
-    if (hasCachedComponent(rootId) && !isRootInvalidated) {
-      RootComponent = getCachedComponent(rootId);
-      if (verbose) {
-        logger?.info(
-          `[rsc-worker] Using cached Root component from: ${rootPath}`
-        );
-      }
-    } else {
-      // Clear cache if invalidated
-      if (isRootInvalidated && hasCachedComponent(rootId)) {
-        clearCachedComponent(rootId);
-        if (verbose) {
-          logger?.info(
-            `[rsc-worker] Cleared invalidated Root component cache: ${rootPath}`
-          );
-        }
-      }
-      if (marks) marks.moduleRunAt ??= Date.now();
-      const rootResult = await resolveComponent({
-        componentPath: rootPath,
-        exportName: rootExportName,
-        loader,
-      });
-
-      if (rootResult.type === "success") {
-        RootComponent = rootResult.component;
-        cacheComponent(rootId, RootComponent);
-        if (verbose) {
-          logger?.info(
-            `[rsc-worker] Loaded and cached Root component from: ${rootPath}`
-          );
-          logger?.info(
-            `[rsc-worker] Root component type: ${typeof RootComponent}, isSymbol: ${typeof RootComponent === 'symbol'}, keys: ${RootComponent ? Object.keys(RootComponent) : 'null'}`
-          );
-        }
-      } else {
-        // Root module failed to resolve. Previously fell back to React.Fragment
-        // under !verbose — same silent-failure pattern as the Page path. Route
-        // through handleError for dedup + panic handling, then re-throw so
-        // the outer worker catch propagates to the main thread's customLogger.
-        const rootError = rootResult.error ?? new Error(
-          `[rsc-worker] Failed to load Root component from ${rootPath}`,
-        );
-        const panicError = handleError({
-          error: rootError,
-          logger,
-          panicThreshold,
-          critical: true,
-          context: `rsc-worker: load Root from ${rootPath}`,
-          log: true,
-        });
-        throw panicError ?? rootError;
-      }
-    }
+    RootComponent = await loadCachedComponent({
+      componentPath: rootPath,
+      exportName: rootExportName,
+      kind: "Root",
+      loader,
+      verbose,
+      logger,
+      panicThreshold,
+      marks,
+    });
   } else {
     // No rootPath provided - use built-in default Root component. Imported
     // lazily here (matching the Html path below) so the static import graph
@@ -615,68 +648,16 @@ export async function loadComponentsWithCache(options: {
       logger?.info(`[rsc-worker] Using headless Html component (empty string)`);
     }
   } else if (htmlPath) {
-    if (verbose) {
-      logger?.info(`[rsc-worker] Attempting to load custom Html component from: ${htmlPath}`);
-    }
-    const htmlId = `${htmlPath}#${htmlExportName}`;
-    // CRITICAL: Check if module is invalidated before using cache
-    const isHtmlInvalidated = isModuleInvalidated(htmlPath);
-    if (hasCachedComponent(htmlId) && !isHtmlInvalidated) {
-      HtmlComponent = getCachedComponent(htmlId);
-      if (verbose) {
-        logger?.info(
-          `[rsc-worker] Using cached Html component from: ${htmlPath}`
-        );
-      }
-    } else {
-      // Clear cache if invalidated
-      if (isHtmlInvalidated && hasCachedComponent(htmlId)) {
-        clearCachedComponent(htmlId);
-        if (verbose) {
-          logger?.info(
-            `[rsc-worker] Cleared invalidated Html component cache: ${htmlPath}`
-          );
-        }
-      }
-      if (verbose) {
-        logger?.info(`[rsc-worker] Component not cached, calling resolveComponent with path: ${htmlPath}, exportName: ${htmlExportName}`);
-      }
-      if (marks) marks.moduleRunAt ??= Date.now();
-      const htmlResult = await resolveComponent({
-        componentPath: htmlPath,
-        exportName: htmlExportName,
-        loader,
-      });
-
-      if (htmlResult.type === "success") {
-        HtmlComponent = htmlResult.component;
-        cacheComponent(htmlId, HtmlComponent);
-        if (verbose) {
-          logger?.info(
-            `[rsc-worker] Loaded and cached Html component from: ${htmlPath}`
-          );
-        }
-      } else {
-        // The document wrapper failed to load. Falling back to React.Fragment
-        // here renders every route as an <html>-less fragment — a silent
-        // degrade that hides the real load error (the fileWriter's
-        // degraded-document guard then reports the symptom, not the cause).
-        // Mirror the Root path: route through handleError for dedup + panic
-        // handling, then re-throw so the outer worker catch propagates it.
-        const htmlError = htmlResult.error ?? new Error(
-          `[rsc-worker] Failed to load Html component from ${htmlPath}`,
-        );
-        const panicError = handleError({
-          error: htmlError,
-          logger,
-          panicThreshold,
-          critical: true,
-          context: `rsc-worker: load Html from ${htmlPath}`,
-          log: true,
-        });
-        throw panicError ?? htmlError;
-      }
-    }
+    HtmlComponent = await loadCachedComponent({
+      componentPath: htmlPath,
+      exportName: htmlExportName,
+      kind: "Html",
+      loader,
+      verbose,
+      logger,
+      panicThreshold,
+      marks,
+    });
   } else {
     // No html configured (undefined) — use the built-in document wrapper.
     if (verbose) {

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -224,7 +224,7 @@ async function loadDefaultHtml({
 /**
  * Helper function to load components with caching
  */
-async function loadComponentsWithCache(options: {
+export async function loadComponentsWithCache(options: {
   pagePath?: string;
   propsPath?: string;
   rootPath?: string;

--- a/test/unit/worker-component-cache.test.ts
+++ b/test/unit/worker-component-cache.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The worker modules read workerData at module scope (state.server.ts throws
+// without it), so the mock must be in place before the first import.
+vi.mock("node:worker_threads", () => ({
+  workerData: {
+    userOptions: {
+      projectRoot: "/test-project",
+      moduleBasePath: "",
+      verbose: false,
+    },
+    resolvedConfig: { logLevel: "silent" },
+  },
+  parentPort: null,
+}));
+
+import { loadComponentsWithCache } from "../../plugin/worker/rsc/messageHandler.server.js";
+import {
+  hmrState,
+  clearAllCachedComponents,
+  hasCachedComponent,
+} from "../../plugin/worker/rsc/state.server.js";
+import { Html as DefaultHtml } from "../../plugin/components/html.js";
+import { React } from "../../plugin/vendor/vendor.server.js";
+
+const PAGE = "src/page.tsx";
+const ROOT = "src/root.tsx";
+const HTML = "src/html.tsx";
+const URL = "/test/";
+
+type ModuleMap = Record<string, Record<string, unknown>>;
+
+// Fresh component identities per generation so cache hits are provable:
+// a hit returns generation 1's function even when the loader would serve
+// generation 2's.
+function makeGeneration(propsValue: Record<string, unknown>) {
+  const Page = () => null;
+  const Root = () => null;
+  const Html = () => null;
+  const props = vi.fn(() => propsValue);
+  const modules: ModuleMap = {
+    [PAGE]: { Page, props },
+    [ROOT]: { Root },
+    [HTML]: { Html },
+  };
+  return { Page, Root, Html, props, modules };
+}
+
+function makeLoader(modules: ModuleMap) {
+  return vi.fn(async (id: string) => {
+    const path = id.split("#")[0];
+    const mod = modules[path];
+    if (!mod) throw new Error(`unexpected module request: ${id}`);
+    return mod;
+  });
+}
+
+function loaderPaths(loader: ReturnType<typeof makeLoader>) {
+  return loader.mock.calls.map(([id]) => id.split("#")[0]);
+}
+
+async function load(
+  modules: ModuleMap,
+  overrides: Partial<Parameters<typeof loadComponentsWithCache>[0]> = {}
+) {
+  const loader = makeLoader(modules);
+  const result = await loadComponentsWithCache({
+    pagePath: PAGE,
+    rootPath: ROOT,
+    htmlPath: HTML,
+    url: URL,
+    loader,
+    ...overrides,
+  });
+  return { loader, result };
+}
+
+function invalidate(path: string) {
+  hmrState.set(path, { timestamp: 1, invalidated: true, routes: [] });
+}
+
+beforeEach(() => {
+  clearAllCachedComponents();
+  hmrState.clear();
+});
+
+describe("worker component cache (loadComponentsWithCache)", () => {
+  it("cold load resolves Page/Root/Html through the loader and caches them", async () => {
+    const gen = makeGeneration({ title: "one" });
+    const { loader, result } = await load(gen.modules);
+
+    expect(result.PageComponent).toBe(gen.Page);
+    expect(result.RootComponent).toBe(gen.Root);
+    expect(result.HtmlComponent).toBe(gen.Html);
+    expect(result.pageProps).toEqual({ title: "one" });
+
+    const paths = loaderPaths(loader);
+    expect(paths).toContain(PAGE);
+    expect(paths).toContain(ROOT);
+    expect(paths).toContain(HTML);
+
+    expect(hasCachedComponent(`${PAGE}#Page`)).toBe(true);
+    expect(hasCachedComponent(`${ROOT}#Root`)).toBe(true);
+    expect(hasCachedComponent(`${HTML}#Html`)).toBe(true);
+  });
+
+  it("warm load serves Page/Root/Html from cache", async () => {
+    const gen1 = makeGeneration({ title: "one" });
+    await load(gen1.modules);
+
+    const gen2 = makeGeneration({ title: "two" });
+    const { loader, result } = await load(gen2.modules);
+
+    // Cached identities win even though the loader would now serve gen2.
+    expect(result.PageComponent).toBe(gen1.Page);
+    expect(result.RootComponent).toBe(gen1.Root);
+    expect(result.HtmlComponent).toBe(gen1.Html);
+
+    // Root and Html are full cache hits: the loader is never consulted.
+    const paths = loaderPaths(loader);
+    expect(paths).not.toContain(ROOT);
+    expect(paths).not.toContain(HTML);
+  });
+
+  it("re-resolves props on every request even when Page is cached (bd-5xu)", async () => {
+    const gen1 = makeGeneration({ title: "one" });
+    await load(gen1.modules);
+
+    const gen2 = makeGeneration({ title: "two" });
+    const { loader, result } = await load(gen2.modules);
+
+    // Props come fresh from the current loader, not from any cache …
+    expect(result.pageProps).toEqual({ title: "two" });
+    expect(gen2.props).toHaveBeenCalledTimes(1);
+    // gen1's props ran only for its own (cold) request.
+    expect(gen1.props).toHaveBeenCalledTimes(1);
+    // … which means the page module itself is re-loaded on the warm path
+    // (only the PageComponent identity is served from cache).
+    expect(loaderPaths(loader)).toContain(PAGE);
+  });
+
+  it("skips the props load when the main thread pre-resolved them", async () => {
+    const gen1 = makeGeneration({ title: "one" });
+    await load(gen1.modules);
+
+    const gen2 = makeGeneration({ title: "two" });
+    const { loader, result } = await load(gen2.modules, {
+      resolvedPageProps: { title: "pre-resolved" },
+    });
+
+    expect(result.PageComponent).toBe(gen1.Page);
+    expect(result.pageProps).toEqual({ title: "pre-resolved" });
+    expect(loaderPaths(loader)).not.toContain(PAGE);
+    expect(gen2.props).not.toHaveBeenCalled();
+  });
+
+  it("invalidation reloads the Page and leaves Root/Html cached", async () => {
+    const gen1 = makeGeneration({ title: "one" });
+    await load(gen1.modules);
+
+    invalidate(PAGE);
+    const gen2 = makeGeneration({ title: "two" });
+    const { result } = await load(gen2.modules);
+
+    expect(result.PageComponent).toBe(gen2.Page);
+    expect(result.RootComponent).toBe(gen1.Root);
+    expect(result.HtmlComponent).toBe(gen1.Html);
+
+    // Invalidation is sticky: until HMR_CLEANUP clears the hmrState entry,
+    // every load reloads the module again.
+    const gen3 = makeGeneration({ title: "three" });
+    const { result: third } = await load(gen3.modules);
+    expect(third.PageComponent).toBe(gen3.Page);
+
+    // Once cleared, the latest reload is served from cache again, and an
+    // unrelated invalidation doesn't evict it.
+    hmrState.delete(PAGE);
+    invalidate(ROOT);
+    const gen4 = makeGeneration({ title: "four" });
+    const { result: fourth } = await load(gen4.modules);
+    expect(fourth.PageComponent).toBe(gen3.Page);
+  });
+
+  it("invalidation reloads the Root and leaves Page/Html cached", async () => {
+    const gen1 = makeGeneration({ title: "one" });
+    await load(gen1.modules);
+
+    invalidate(ROOT);
+    const gen2 = makeGeneration({ title: "two" });
+    const { result } = await load(gen2.modules);
+
+    expect(result.RootComponent).toBe(gen2.Root);
+    expect(result.PageComponent).toBe(gen1.Page);
+    expect(result.HtmlComponent).toBe(gen1.Html);
+  });
+
+  it("invalidation reloads the Html and leaves Page/Root cached", async () => {
+    const gen1 = makeGeneration({ title: "one" });
+    await load(gen1.modules);
+
+    invalidate(HTML);
+    const gen2 = makeGeneration({ title: "two" });
+    const { result } = await load(gen2.modules);
+
+    expect(result.HtmlComponent).toBe(gen2.Html);
+    expect(result.PageComponent).toBe(gen1.Page);
+    expect(result.RootComponent).toBe(gen1.Root);
+  });
+
+  it("htmlPath '' means explicitly headless: React.Fragment, no load, no cache", async () => {
+    const gen = makeGeneration({ title: "one" });
+    const { loader, result } = await load(gen.modules, { htmlPath: "" });
+
+    expect(result.HtmlComponent).toBe(React.Fragment);
+    expect(loaderPaths(loader)).not.toContain(HTML);
+    expect(hasCachedComponent(`${HTML}#Html`)).toBe(false);
+  });
+
+  it("htmlPath undefined falls back to the built-in Html document", async () => {
+    const gen = makeGeneration({ title: "one" });
+    const { result } = await load(gen.modules, { htmlPath: undefined });
+
+    expect(result.HtmlComponent).toBe(DefaultHtml);
+  });
+
+  it("rootPath undefined falls back to the built-in Root component", async () => {
+    const gen = makeGeneration({ title: "one" });
+    const { result } = await load(gen.modules, { rootPath: undefined });
+
+    const { Root: BuiltinRoot } = await import("../../plugin/components/root.js");
+    expect(result.RootComponent).toBe(BuiltinRoot);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,13 +11,16 @@ export default defineConfig({
       : ["node", "import"],
     // `react-server-dom-esm` is not a direct dependency — it ships vendored
     // inside `react-server-loader`, and at runtime the plugin resolves it from
-    // there. Tests that import it in-process (e.g. createReactFetcher) otherwise
-    // depend on it being hoisted to top-level node_modules, which is not
-    // guaranteed. Point the one browser subpath they use at the vendored copy,
-    // the same place the plugin resolves it. (Only this condition-free subpath is
-    // aliased; aliasing the whole package would bypass its conditional exports.)
+    // there. Tests that import it in-process (e.g. createReactFetcher, or the
+    // worker's messageHandler) otherwise depend on it being hoisted to
+    // top-level node_modules, which is not guaranteed. Point the subpaths they
+    // use at the vendored copy, the same place the plugin resolves it. (Only
+    // these subpaths are aliased, each pinned to the file its react-server
+    // resolution would pick; aliasing the whole package would bypass its
+    // conditional exports.)
     alias: {
       "react-server-dom-esm/client.browser": join(transportPkgDir, "client.browser.js"),
+      "react-server-dom-esm/server": join(transportPkgDir, "server.node.js"),
     },
   },
   ssr: {


### PR DESCRIPTION
Now carries the full stack (#340 was merged into this branch): the pinning test first, then the extraction it gates.

## What

1. **`test/unit/worker-component-cache.test.ts`** (new): first direct unit coverage of the RSC worker's component cache. Mocks `node:worker_threads` and drives `loadComponentsWithCache` with an injected spy loader against the real `state.server` cache. Pins: per-kind cache hit/miss for Page/Root/Html, the props-always-fresh contract (props re-resolve every request even on a cached Page — the page module reloads but the cached component identity wins), the `resolvedPageProps` skip path, invalidation being per-kind and sticky until HMR cleanup, and the `""`/undefined fallback contracts.
2. **`loadCachedComponent` extraction**: the Root and Html branches repeated the same compute-id → check-invalidated → cache-or-resolve → handleError block; now one helper (−120/+101). The Page branch deliberately stays inline — it's entangled with props resolution and loader-signal passthrough, so it's a different shape, not duplication. Error messages, `handleError` contexts, and `moduleRunAt` stamping unchanged; two verbose-only debug lines dropped.
3. **CI fix**: `react-server-dom-esm/server` aliased to the vendored copy in vitest.config (the package ships inside `react-server-loader`; only a stray hoisted copy made it resolve locally).

## Verification

Pinning test 10/10 (also passes with the local stray package hidden, i.e. CI conditions); full `test:unit` and `test:server` green before and after the extraction; CI green on the merged stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)