### PR TITLE
fix(react-client): unify implicitSsr derivation across the two conditions

### DIFF
--- a/plugin/config/deriveImplicitSsr.ts
+++ b/plugin/config/deriveImplicitSsr.ts
@@ -1,0 +1,23 @@
+/**
+ * Derive whether the current `config()` pass is an SSR build from Vite's
+ * `build.ssr` (boolean flag or string SSR-entry path), falling back to a
+ * previously derived value, then to `configEnv.isSsrBuild`.
+ *
+ * A non-empty string `build.ssr` names an SSR entry — per Vite semantics that
+ * makes the build an SSR build regardless of the string's content. Both
+ * react-client plugin halves share this derivation so the two resolve
+ * conditions can't drift apart.
+ */
+export function deriveImplicitSsr({
+  buildSsr,
+  isSsrBuild,
+  previous,
+}: {
+  buildSsr: boolean | string | undefined;
+  isSsrBuild: boolean | undefined;
+  previous: boolean | undefined;
+}): boolean | undefined {
+  if (typeof buildSsr === "boolean") return buildSsr;
+  if (typeof buildSsr === "string") return buildSsr !== "";
+  return previous ?? isSsrBuild;
+}

--- a/plugin/react-client/plugin.client.ts
+++ b/plugin/react-client/plugin.client.ts
@@ -12,6 +12,7 @@ import type {
 import { resolveOptions } from "../config/resolveOptions.js";
 import { resolveUserConfig } from "../config/resolveUserConfig.js";
 import { resolveAutoDiscover } from "../config/autoDiscover/resolveAutoDiscover.js";
+import { deriveImplicitSsr } from "../config/deriveImplicitSsr.js";
 import { handleError } from "../error/handleError.js";
 import { assertNonReactServer } from "../config/getCondition.js";
 
@@ -62,14 +63,13 @@ export const reactClientPlugin: VitePluginFn = function _reactClientPlugin(
       
       
       
-      if(typeof config?.build?.ssr === "boolean" || typeof config?.build?.ssr === "string") {
-        implicitSsr = Boolean(config?.build?.ssr);
-        
-      } else if(implicitSsr === undefined) {
-        implicitSsr = configEnv.isSsrBuild;
-      }
-      
-      
+      implicitSsr = deriveImplicitSsr({
+        buildSsr: config?.build?.ssr,
+        isSsrBuild: configEnv.isSsrBuild,
+        previous: implicitSsr,
+      });
+
+
       const logger = config.customLogger || createLogger();
       const autoDiscoverResult = await resolveAutoDiscover({
         config,

--- a/plugin/react-client/plugin.server.ts
+++ b/plugin/react-client/plugin.server.ts
@@ -7,6 +7,7 @@ import type {
 import { resolveOptions } from "../config/resolveOptions.js";
 import { resolveUserConfig } from "../config/resolveUserConfig.js";
 import { resolveAutoDiscover } from "../config/autoDiscover/resolveAutoDiscover.js";
+import { deriveImplicitSsr } from "../config/deriveImplicitSsr.js";
 import { handleError } from "../error/handleError.js";
 import { assertReactServer } from "../config/getCondition.js";
 
@@ -56,12 +57,12 @@ export const reactClientPlugin: VitePluginFn = function _reactClientPlugin(
       if(configEnv.command !== "build") {
         return;
       }
-      if(typeof config?.build?.ssr === "boolean" || typeof config?.build?.ssr === "string") {
-        implicitSsr = config?.build?.ssr === "true" || config?.build?.ssr === true;
-      } else if(implicitSsr === undefined) {
-        implicitSsr = configEnv.isSsrBuild;
-      }
-    
+      implicitSsr = deriveImplicitSsr({
+        buildSsr: config?.build?.ssr,
+        isSsrBuild: configEnv.isSsrBuild,
+        previous: implicitSsr,
+      });
+
       const logger = config.customLogger || createLogger();
       const autoDiscoverResult = await resolveAutoDiscover({
         config,

--- a/test/unit/deriveImplicitSsr.test.ts
+++ b/test/unit/deriveImplicitSsr.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { deriveImplicitSsr } from "../../plugin/config/deriveImplicitSsr.js";
+
+describe("deriveImplicitSsr", () => {
+  it("boolean build.ssr wins verbatim", () => {
+    expect(
+      deriveImplicitSsr({ buildSsr: true, isSsrBuild: false, previous: false })
+    ).toBe(true);
+    expect(
+      deriveImplicitSsr({ buildSsr: false, isSsrBuild: true, previous: true })
+    ).toBe(false);
+  });
+
+  it("a string build.ssr is an SSR entry path: SSR regardless of content", () => {
+    expect(
+      deriveImplicitSsr({
+        buildSsr: "src/entry-server.ts",
+        isSsrBuild: false,
+        previous: undefined,
+      })
+    ).toBe(true);
+    // Even a string that reads like a false-y flag names an entry file.
+    expect(
+      deriveImplicitSsr({ buildSsr: "false", isSsrBuild: false, previous: undefined })
+    ).toBe(true);
+    expect(
+      deriveImplicitSsr({ buildSsr: "true", isSsrBuild: false, previous: undefined })
+    ).toBe(true);
+  });
+
+  it("an empty string is no entry: not SSR", () => {
+    expect(
+      deriveImplicitSsr({ buildSsr: "", isSsrBuild: true, previous: undefined })
+    ).toBe(false);
+  });
+
+  it("absent build.ssr keeps a previously derived value", () => {
+    expect(
+      deriveImplicitSsr({ buildSsr: undefined, isSsrBuild: false, previous: true })
+    ).toBe(true);
+    expect(
+      deriveImplicitSsr({ buildSsr: undefined, isSsrBuild: true, previous: false })
+    ).toBe(false);
+  });
+
+  it("absent build.ssr with no previous value falls back to configEnv.isSsrBuild", () => {
+    expect(
+      deriveImplicitSsr({ buildSsr: undefined, isSsrBuild: true, previous: undefined })
+    ).toBe(true);
+    expect(
+      deriveImplicitSsr({ buildSsr: undefined, isSsrBuild: undefined, previous: undefined })
+    ).toBe(undefined);
+  });
+});


### PR DESCRIPTION
## The drift

The two react-client plugin halves derived `implicitSsr` from `build.ssr` with different coercions:

- `plugin.server.ts` (react-server condition): `config.build.ssr === "true" || === true` — a string SSR entry path (`build.ssr: "src/entry-server.ts"`) resolved as **not SSR**
- `plugin.client.ts`: `Boolean(config.build.ssr)` — the same input resolved as **SSR**

The flag is consumed by `resolveUserConfig`, where it flips `resolve.external` (externalize React vs bundle everything) and `copyPublicDir`, so the react-server side was resolving string-entry SSR builds into static-style configs.

## The fix

Per Vite semantics, a non-empty string `build.ssr` names an SSR entry — the build is an SSR build regardless of the string's content. Both halves now share a single pure helper, `deriveImplicitSsr`, implementing that interpretation (empty string = no entry = not SSR, which both sides already agreed on; boolean passes through; absent falls back to the previously derived value, then `configEnv.isSsrBuild`).

Behavior changes **only** for the react-server condition with a string `build.ssr`: from misclassified-static to SSR. Everything else is byte-identical, now guaranteed by sharing the derivation.

## Verification

- New `test/unit/deriveImplicitSsr.test.ts` covers the boolean/string/empty/fallback matrix, including `"false"` and `"true"` as entry-path strings.
- Full `test-all` gate green: test:server 893, test:client 289, test:unit 651, typecheck 35.

Found while auditing the two halves for condition-split drift; the non-panic autoDiscover error paths also diverge (server throws, client skips configuring) — left untouched here, one behavior change per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)