### PR TITLE
feat(build): inlineFlight resolves to a mode value (false | 'blob')

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -849,7 +849,9 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
       (effectiveBuildPages && (Array.isArray(effectiveBuildPages) || typeof effectiveBuildPages === 'function')) ? true : DEFAULT_CONFIG.BUILD.useHtmlWorker,
     renderMode: options.build?.renderMode ?? "parallel",
     batchSize: options.build?.batchSize ?? 8,
-    inlineFlight: options.build?.inlineFlight ?? false,
+    // Mode value: false = no inlining, "blob" = buffered single-script inline
+    // (`true` is the boolean alias for "blob").
+    inlineFlight: options.build?.inlineFlight ? ("blob" as const) : false,
     edge: (() => {
       // `build.edge`: boolean | EdgeBuildConfig, default ON. `false` disables;
       // `true`/omitted enables with defaults; an object enables + overrides.

--- a/plugin/react-static/maybeInlineFlight.ts
+++ b/plugin/react-static/maybeInlineFlight.ts
@@ -22,7 +22,7 @@ import { inlineFlightPayload } from "./inlineFlightPayload.js";
 
 export interface MaybeInlineFlightOptions {
   build: {
-    inlineFlight?: boolean;
+    inlineFlight?: boolean | "blob";
     outDir?: string;
     static?: string;
     htmlOutputPath?: string;

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -496,7 +496,11 @@ export type ResolvedUserOptions = {
   loader?:
     | (Required<Omit<LoaderConfig, "logger">> & { logger?: Logger })
     | undefined;
-  build: Omit<Required<BuildConfig>, "edge"> & { edge: ResolvedEdgeConfig };
+  // inlineFlight resolves the boolean alias away: `true` normalizes to "blob".
+  build: Omit<Required<BuildConfig>, "edge" | "inlineFlight"> & {
+    edge: ResolvedEdgeConfig;
+    inlineFlight: false | "blob";
+  };
   dev: Required<DevConfig>;
   css: RootOptions<boolean>;
   components?: StreamPluginOptions["components"]; // Direct component overrides (optional)
@@ -1290,15 +1294,21 @@ export type BuildConfig = {
    */
   batchSize?: number;
   /**
-   * Inline each prerendered route's flight payload into its own `index.html`
-   * (a non-executable `<script id="vprs-flight">`), so the browser has the
-   * initial RSC payload at load and hydrates in place with no `index.rsc`
-   * round-trip or flash. The plugin runs this itself at the post-SSG point in
-   * BOTH build modes (client-first and server-first), so the outcome is
-   * identical regardless of `--conditions react-server`. Idempotent.
+   * How each prerendered route's flight payload is delivered with its HTML:
+   * - `false`: not inlined — the client fetches `index.rsc` separately.
+   * - `"blob"`: inline the whole payload into the route's `index.html` as one
+   *   non-executable `<script id="vprs-flight">`, so the browser has the
+   *   initial RSC payload at load and hydrates in place with no `index.rsc`
+   *   round-trip or flash. Best for static/CDN targets: the file is buffered
+   *   by construction, and the client reads a single script.
+   * - `true`: boolean alias for `"blob"`.
+   *
+   * The plugin runs the inlining itself at the post-SSG point in BOTH build
+   * modes (client-first and server-first), so the outcome is identical
+   * regardless of `--conditions react-server`. Idempotent.
    * @default false
    */
-  inlineFlight?: boolean;
+  inlineFlight?: boolean | "blob";
   /**
    * Single-isolate edge build. Emits an additional baked rsc bundle to
    * `build.edge.outDir` (default `server-edge`): the server graph with React

--- a/test/unit/inlineFlightMode.test.ts
+++ b/test/unit/inlineFlightMode.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { resolveOptions } from "../../plugin/config/resolveOptions.js";
+
+// forceResolve bypasses the per-env stash so each case resolves fresh.
+function resolveInlineFlight(inlineFlight: boolean | "blob" | undefined) {
+  const result = resolveOptions(
+    inlineFlight === undefined ? {} : { build: { inlineFlight } },
+    true
+  );
+  expect(result.type).toBe("success");
+  if (result.type !== "success") throw new Error("unreachable");
+  return result.userOptions.build.inlineFlight;
+}
+
+describe("build.inlineFlight resolves to a mode", () => {
+  it("defaults to false", () => {
+    expect(resolveInlineFlight(undefined)).toBe(false);
+  });
+
+  it("false stays false", () => {
+    expect(resolveInlineFlight(false)).toBe(false);
+  });
+
+  it("true is the boolean alias for 'blob'", () => {
+    expect(resolveInlineFlight(true)).toBe("blob");
+  });
+
+  it("'blob' passes through", () => {
+    expect(resolveInlineFlight("blob")).toBe("blob");
+  });
+});


### PR DESCRIPTION
First slice of the inlineFlight boolean → mode evolution: the option becomes a stream-shape choice rather than an on/off flag, without adding a new knob.

## What

- Public type: `inlineFlight?: boolean | "blob"` — `"blob"` names today's behavior (one buffered, non-executable `<script id="vprs-flight">` per prerendered route); `true` remains as its boolean alias; `false`/omitted means no inlining (client fetches `index.rsc`). Doc comment restates the contract per mode.
- Resolution: `resolveOptions` normalizes to a strict `false | "blob"` (resolved type overridden accordingly), so downstream code switches off the mode value instead of a boolean.
- `maybeInlineFlight` accepts the widened type; its truthiness gate is unchanged by construction (`"blob"` is truthy).

No behavior changes on current inputs: `true`/`false`/omitted resolve to the same effective behavior as before. New unit test pins the normalization matrix.

## Why this shape

The upcoming `"stream"` mode (interleave the flight into the SSR stream on the dynamic path, deleting the buffered splice + `<!--head-->`/`<!--body-->` marker machinery from the request handler) then lands as a new mode value with its implementation, rather than a rewire of boolean call sites. Build-time, per-target choice: `"blob"` for static/CDN + simplest client, `"stream"` for dynamic/edge + low TTFB.

## Verification

- New `test/unit/inlineFlightMode.test.ts`: default/false/true/'blob' resolution (4/4)
- Full gate: test:server 891 passed + 1 known-flaky `css-hmr` ECONNRESET that passes 3/3 in isolation (dev-path test; this change doesn't touch dev), test:client 289, test:unit 650, typecheck 35 — the typecheck also proves no site relied on the resolved value being strictly boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)