### PR TITLE
fix(router): index route beats empty-splat catch-all; suffix-aware fileRouter matching

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -229,6 +229,8 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
         moduleBase,
         projectRoot,
         patterns: { pagePattern, propsPattern },
+        rscOutputPath:
+          options.build?.rscOutputPath ?? DEFAULT_CONFIG.BUILD.rscOutputPath,
       })
     : undefined;
   // Soft nudge (not a break): the loose Page/props/routePatterns remain the

--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -16,6 +16,7 @@ import { cleanupWorker } from "../helpers/workerCleanup.js";
 import { mergeConfig, type ResolvedConfig } from "vite";
 import { resolvePageAndProps } from "../helpers/resolvePageAndProps.js";
 import { isNotFound, isRedirect } from "../router/loaderSignals.js";
+import { RSC_OUTPUT_PATH } from "../config/routeExportNames.js";
 
 export const configureReactServer: ConfigureReactServerFn =
   function _configureReactServer({
@@ -425,7 +426,11 @@ export const configureReactServer: ConfigureReactServerFn =
             verbose,
             logger,
             build: {
-              rscOutputPath: userHandlerOptions.build?.rscOutputPath || ".rsc",
+              // The REAL default ("index.rsc"), not ".rsc": stripping only
+              // ".rsc" leaves a phantom "index" segment on suffixed urls and
+              // param matching resolves the wrong route.
+              rscOutputPath:
+                userHandlerOptions.build?.rscOutputPath || RSC_OUTPUT_PATH,
             },
           });
 

--- a/plugin/router/fileRouter.ts
+++ b/plugin/router/fileRouter.ts
@@ -1,5 +1,10 @@
 import { join, relative, resolve, sep } from "node:path";
-import { fillPattern, matchRoutes } from "./matchRoute.js";
+import {
+  fillPattern,
+  matchRoutes,
+  normalizePathForMatch,
+} from "./matchRoute.js";
+import { RSC_OUTPUT_PATH } from "../config/routeExportNames.js";
 import {
   type RouteEntry,
   type RouteLayer,
@@ -61,6 +66,13 @@ export function fileRouter(
     root?: string;
     /** page/props/layout matchers; the plugin passes the resolved autoDiscover ones. */
     patterns?: ScanPatterns;
+    /**
+     * Transport suffix to strip before matching (`build.rscOutputPath`). The
+     * dev server resolves suffixed urls (`/a/b/index.rsc`) through the same
+     * router functions as folder urls; without stripping, the suffix reads as
+     * an extra path segment and a catch-all (or `$param`) swallows it.
+     */
+    rscOutputPath?: string;
   } = {},
 ): FileRouterConfig {
   // `root` decouples "where to scan" from "what path to emit": scan
@@ -91,9 +103,11 @@ export function fileRouter(
     : scanned;
   const patterns = routes.map((r) => r.pattern);
   const byPattern = new Map(routes.map((r) => [r.pattern, r] as const));
+  const rscOutputPath = opts.rscOutputPath ?? RSC_OUTPUT_PATH;
+  const forMatch = (url: string) => normalizePathForMatch(url, rscOutputPath);
 
   const matched = (url: string): RouteEntry => {
-    const m = matchRoutes(patterns, url);
+    const m = matchRoutes(patterns, forMatch(url));
     if (!m) throw new Error(`fileRouter: no route matches "${url}"`);
     return byPattern.get(m.pattern)!;
   };
@@ -128,7 +142,7 @@ export function fileRouter(
     build: { pages },
     routes,
     routePatterns: patterns,
-    getParams: (url) => matchRoutes(patterns, url)?.params ?? {},
+    getParams: (url) => matchRoutes(patterns, forMatch(url))?.params ?? {},
     layouts: (url) => matched(url).layouts,
   };
 }
@@ -172,6 +186,8 @@ export function resolveRoutesOption(
     projectRoot: string;
     /** Resolved autoDiscover page/props matchers so the scanner shares them. */
     patterns?: ScanPatterns;
+    /** Transport suffix stripped before matching (`build.rscOutputPath`). */
+    rscOutputPath?: string;
   },
 ): FileRouterConfig {
   // A pre-built router table has a `Page` resolver; a declarative config
@@ -181,5 +197,6 @@ export function resolveRoutesOption(
     patterns: opts.patterns,
     staticPaths: routes.staticPaths,
     root: opts.projectRoot,
+    rscOutputPath: opts.rscOutputPath,
   });
 }

--- a/plugin/router/matchRoute.ts
+++ b/plugin/router/matchRoute.ts
@@ -86,16 +86,22 @@ export function matchRoute<P extends string>(
   return p.length === u.length ? (params as RouteParams<P>) : null;
 }
 
-/** Per-segment specificity: literal beats param beats catch-all. */
+/** Per-segment specificity: literal beats param beats pattern-end beats catch-all. */
 function score(pattern: string): number[] {
-  return segs(pattern).map((s) => (s === "$" ? 0 : s.startsWith("$") ? 1 : 2));
+  return segs(pattern).map((s) => (s === "$" ? 0 : s.startsWith("$") ? 2 : 3));
 }
 
-/** Compare two specificity vectors left-to-right; more-specific sorts first. */
+/**
+ * Compare two specificity vectors left-to-right; more-specific sorts first.
+ * A missing segment — the pattern ENDS here — ranks 1: above a catch-all
+ * (`/a/` must beat `/a/$`, or an empty splat steals the index route from its
+ * sibling) but below params and literals (a longer concrete pattern still wins
+ * its shared prefix).
+ */
 function moreSpecific(a: number[], b: number[]): number {
   const n = Math.max(a.length, b.length);
   for (let i = 0; i < n; i++) {
-    const d = (b[i] ?? -1) - (a[i] ?? -1);
+    const d = (b[i] ?? 1) - (a[i] ?? 1);
     if (d) return d;
   }
   return 0;

--- a/test/router-fixtures/routes/files/page.tsx
+++ b/test/router-fixtures/routes/files/page.tsx
@@ -1,0 +1,1 @@
+export const Page = () => null;

--- a/test/unit/fileRouter.test.ts
+++ b/test/unit/fileRouter.test.ts
@@ -13,7 +13,7 @@ describe("fileRouter", () => {
 
   it("prerenders only the fully-static routes (no staticPaths)", () => {
     expect(new Set(r.build.pages as string[])).toEqual(
-      new Set(["/", "/profile/me"]),
+      new Set(["/", "/profile/me", "/files"]),
     );
   });
 
@@ -31,12 +31,14 @@ describe("fileRouter", () => {
       new Set([
         "/",
         "/profile/me",
+        "/files",
         "/profile/1",
         "/profile/2",
         "/blog/tech/rsc",
       ]),
     );
-    expect(pages.some((p) => p.startsWith("/files"))).toBe(false);
+    // The catch-all itself has no staticPaths entry → stays server-only.
+    expect(pages.filter((p) => p.startsWith("/files"))).toEqual(["/files"]);
   });
 
   it("resolves Page by matching the url (static beats param)", () => {
@@ -52,6 +54,36 @@ describe("fileRouter", () => {
 
   it("matches catch-all routes", () => {
     expect(r.Page("/files/a/b.png")).toMatch(/files\/\$\/page\.tsx$/);
+  });
+
+  it("prefers the index route over its catch-all sibling's empty splat", () => {
+    expect(r.Page("/files")).toMatch(/files\/page\.tsx$/);
+    expect(r.Page("/files/")).toMatch(/files\/page\.tsx$/);
+    expect(r.Page("/files/a")).toMatch(/files\/\$\/page\.tsx$/);
+  });
+
+  // The dev server resolves the browser's suffixed flight urls
+  // (`/profile/123/index.rsc`) through the same router functions as folder
+  // urls; the transport suffix must not read as a path segment.
+  it("strips the transport suffix before matching", () => {
+    expect(r.Page("/profile/123/index.rsc")).toMatch(
+      /profile\/\$id\/page\.tsx$/,
+    );
+    expect(r.getParams("/profile/123/index.rsc")).toEqual({ id: "123" });
+    expect(r.Page("/index.rsc")).toMatch(/routes\/page\.tsx$/);
+    expect(r.Page("/files/index.rsc")).toMatch(/files\/page\.tsx$/);
+    // .html strips too (prerendered-transport form).
+    expect(r.getParams("/profile/42.html")).toEqual({ id: "42" });
+  });
+
+  it("honors a custom rscOutputPath suffix", () => {
+    const custom = fileRouter(ROUTES, { rscOutputPath: "payload.rsc" });
+    expect(custom.Page("/profile/123/payload.rsc")).toMatch(
+      /profile\/\$id\/page\.tsx$/,
+    );
+    expect(custom.getParams("/profile/123/payload.rsc")).toEqual({
+      id: "123",
+    });
   });
 
   it("throws on an unmatched url", () => {

--- a/test/unit/matchRoute.test.ts
+++ b/test/unit/matchRoute.test.ts
@@ -79,6 +79,38 @@ describe("matchRoutes (specificity ordering)", () => {
     expect(matchRoutes(patterns, "/nope/x")).toBeNull();
   });
 
+  // The mission-control dashboard's route tree: an index route, a param
+  // sibling, and a docs catch-all under the same prefix. An empty splat must
+  // NOT steal the index route (the catch-all matches "/bot/" with _splat: ""),
+  // and the param sibling keeps its urls.
+  it("prefers the index route over a sibling catch-all's empty splat", () => {
+    const tree = ["/", "/$key/", "/$key/$id/", "/$key/$"] as const;
+    expect(matchRoutes(tree, "/bot")).toEqual({
+      pattern: "/$key/",
+      params: { key: "bot" },
+    });
+    expect(matchRoutes(tree, "/bot/xaq5")).toEqual({
+      pattern: "/$key/$id/",
+      params: { key: "bot", id: "xaq5" },
+    });
+    expect(matchRoutes(tree, "/bot/docs/readme")).toEqual({
+      pattern: "/$key/$",
+      params: { key: "bot", _splat: "docs/readme" },
+    });
+  });
+
+  it("prefers a literal index over its own catch-all's empty splat", () => {
+    const tree = ["/files/", "/files/$"] as const;
+    expect(matchRoutes(tree, "/files")).toEqual({
+      pattern: "/files/",
+      params: {},
+    });
+    expect(matchRoutes(tree, "/files/a")).toEqual({
+      pattern: "/files/$",
+      params: { _splat: "a" },
+    });
+  });
+
   // A malformed %-escape in an attacker-controlled url must not throw a URIError
   // (matched on the request thread, incl. the edge handler outside a try).
   it("does not throw on a malformed percent-encoded segment", () => {

--- a/test/unit/scanRoutes.test.ts
+++ b/test/unit/scanRoutes.test.ts
@@ -19,6 +19,7 @@ describe("scanRoutes", () => {
         "/profile/$id",
         "/profile/me",
         "/blog/$category/$slug",
+        "/files",
         "/files/$",
       ]),
     );


### PR DESCRIPTION
Fixes the route-resolution failure that broke all board navigation in the mission-control dashboard after its file-router refactor introduced a docs catch-all (`$key/$`) beside `$key/` and `$key/$id/` — every project url rendered the catch-all's page with a null doc, and every suffixed flight url resolved the wrong page entirely.

## The three defects

1. **Empty splat outranked the index route.** `moreSpecific` treated a missing tail segment as `-1`, below catch-all's `0`, so `/$key/$` (matching `/bot/` with `_splat: ""`) sorted above `/$key/`. Pattern-end now ranks between catch-all and param: `/a/` beats `/a/$`, longer concrete patterns still win their shared prefix, deep paths still reach the catch-all. The documented catch-all-vs-`$name`-sibling ordering (`patternProbeUrl`) is unchanged.

2. **fileRouter matched raw urls.** The dev server resolves the browser's suffixed flight urls (`/bot/xaq5/index.rsc`) through the same `Page`/`props`/`getParams` functions as folder urls; unstripped, the suffix reads as an extra path segment and a catch-all (or `$param`) swallows it — while props resolution normalized elsewhere, producing a split-brain render (right props, wrong page component). The router functions now strip the transport suffix via `normalizePathForMatch`, with `build.rscOutputPath` threaded through `resolveRoutesOption` (default `index.rsc`).

3. **Wrong suffix fallback in the react-server dev handler.** `".rsc"` where the real default is `"index.rsc"` — stripping only `.rsc` leaves a phantom `index` segment.

## Verification

- New tests: index-vs-empty-splat ordering (param and literal flavors), suffix stripping through `Page`/`getParams` (default + custom `rscOutputPath`), plus the fixture gains an index sibling next to its catch-all. All prior ordering/probe tests unchanged and green.
- Full suites: test:server 893, test:client 289, test:unit 651, typecheck clean.
- End-to-end against the real consumer: patched build overlaid into the dashboard's `node_modules`, dev server restarted — `/bot/` renders its bead list again, clicking a bead navigates and renders the detail view, zero page errors. Before the fix: every route rendered the overview fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)