### PR TITLE
chore(release): 3.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Releases everything merged since 3.7.0 (#339/#340, #341, #342, #344). Version bump only — the commit message carries the release summary.

**Headline:** the router fixes from #344 — index routes beat empty-splat catch-alls, and suffixed flight urls resolve the same route as their folder form. This is what gets the mission-control dashboard off its patched `node_modules` overlay.

**Minor (not patch)** because #342 widened public option surface: `build.inlineFlight` now accepts `"blob"` (same convention as 3.7.0's bump for public type surface).

Not included: #343 (streamed-interleave transform) is still in review — it's unreachable by users, so nothing user-facing waits on it; it rides the next release.

After merge: tag + `npm publish` as usual (`prepublishOnly` runs verify:tag + build + verify:package). Then the dashboard bump follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)