### PR TITLE
feat(utils): browser reader for the streamed inline-flight protocol

### DIFF
--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -2,6 +2,7 @@ import type React from "react";
 import { createCallServer } from "./createCallServer.js";
 import { env } from "#env";
 import { createPageURL } from "./urls.js";
+import { takeStreamedFlight } from "./streamedFlight.js";
 import {
   INLINE_FLIGHT_ID,
   INLINE_FLIGHT_LENGTH_ATTR,
@@ -207,18 +208,41 @@ export function createReactFetcher({
     );
   };
 
+  const fromStreamed = (
+    stream: ReadableStream<Uint8Array>
+  ): PromiseLike<React.ReactNode> =>
+    flightClient().then(({ createFromReadableStream }) =>
+      createFromReadableStream(stream, decodeOptions)
+    );
+
+  // Streamed delivery (`inlineFlight: "stream"`) or the network, in that
+  // order — checked only when there is no blob payload, since a document
+  // carries at most one delivery shape.
+  const fromStreamedOrNetwork = (): PromiseLike<React.ReactNode> => {
+    const streamed = takeStreamedFlight();
+    if (streamed && "getReader" in streamed) return fromStreamed(streamed);
+    if (streamed) {
+      // Deferred: the parser hadn't reached any chunk script yet.
+      return Promise.resolve(streamed).then((stream) =>
+        stream ? fromStreamed(stream) : fromNetwork()
+      );
+    }
+    return fromNetwork();
+  };
+
   const inlineFlight = takeInlineFlight();
   let content: PromiseLike<React.ReactNode>;
   if (inlineFlight instanceof Uint8Array) {
     content = fromInline(inlineFlight);
   } else if (inlineFlight) {
     // Deferred to DOMContentLoaded: the payload was still being parsed. If it
-    // turns out to be empty after all, fall back to the network.
+    // turns out to be empty after all, fall back to the streamed shape or the
+    // network.
     content = Promise.resolve(inlineFlight).then((bytes) =>
-      bytes ? fromInline(bytes) : fromNetwork()
+      bytes ? fromInline(bytes) : fromStreamedOrNetwork()
     );
   } else {
-    content = fromNetwork();
+    content = fromStreamedOrNetwork();
   }
   if (!signal) {
     return content;

--- a/plugin/utils/streamedFlight.ts
+++ b/plugin/utils/streamedFlight.ts
@@ -1,0 +1,113 @@
+/**
+ * Browser-side reader for the STREAMED inline-flight protocol
+ * (`inlineFlight: "stream"`): the server interleaves the flight into the HTML
+ * as `<script>(self.__vprsFlightChunks||=[]).push("<base64>")</script>`
+ * chunks closed by a `push(null)` sentinel (see interleaveFlightIntoHtml).
+ * This module turns that global array back into a `ReadableStream<Uint8Array>`
+ * for the flight decoder: drain whatever already executed, then replace the
+ * array's `push` so chunks that arrive while the document is still parsing
+ * flow straight through.
+ *
+ * Mirrors takeInlineFlight's contract: claim-once, never throws from the take
+ * itself, `null` means "no streamed payload" and the caller falls back to
+ * fetching `index.rsc`. The one difference: a payload that went bad AFTER
+ * claiming (corrupt base64 mid-stream) errors the RETURNED stream — by then
+ * bytes may already be consumed, so a silent network restart is not possible;
+ * the decode failure surfaces to the caller's error path instead.
+ *
+ * The parser race (a cached client entry running before any chunk script has
+ * executed) is handled like the blob's short-read: if the global is absent
+ * while the document is still loading, wait for `DOMContentLoaded` — by then
+ * every inline script has run — and re-check. A document with no streamed
+ * payload resolves `null` and costs one event listener.
+ */
+import { INLINE_FLIGHT_STREAM_GLOBAL } from "./inlineFlightId.js";
+
+type FlightChunkArray = Array<string | null>;
+
+let streamedFlightConsumed = false;
+
+function base64ToBytes(encoded: string): Uint8Array {
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function currentChunkArray(): FlightChunkArray | null {
+  const value = (globalThis as Record<string, unknown>)[
+    INLINE_FLIGHT_STREAM_GLOBAL
+  ];
+  return Array.isArray(value) ? (value as FlightChunkArray) : null;
+}
+
+function adoptChunkArray(arr: FlightChunkArray): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      let settled = false;
+      const feed = (item: string | null) => {
+        if (settled) return; // anything after the sentinel (or an error) is noise
+        if (item === null) {
+          settled = true;
+          controller.close();
+          return;
+        }
+        try {
+          controller.enqueue(base64ToBytes(item));
+        } catch (error) {
+          settled = true;
+          controller.error(
+            error instanceof Error ? error : new Error(String(error))
+          );
+        }
+      };
+      for (const item of arr) feed(item);
+      // Late chunks: the interleaved scripts keep calling push on THIS array
+      // (the global stays set, so `(self.X ||= [])` resolves to it). Replace
+      // push so they stream through instead of piling up unread.
+      arr.push = (...items: Array<string | null>) => {
+        for (const item of items) feed(item);
+        return arr.length;
+      };
+    },
+  });
+}
+
+/**
+ * Take the streamed flight, if this document delivers one.
+ *
+ * Synchronous `ReadableStream` when chunk scripts have already executed; a
+ * promise when the document is still parsing and the answer isn't knowable
+ * yet; `null` when there is no streamed payload (fetch `index.rsc` as usual).
+ */
+export function takeStreamedFlight():
+  | ReadableStream<Uint8Array>
+  | PromiseLike<ReadableStream<Uint8Array> | null>
+  | null {
+  if (streamedFlightConsumed) return null;
+
+  const arr = currentChunkArray();
+  if (arr) {
+    streamedFlightConsumed = true;
+    return adoptChunkArray(arr);
+  }
+
+  // No chunk script has executed yet. If the parser is still running the
+  // payload may simply not have arrived — re-check once it has seen the
+  // whole document.
+  if (typeof document === "undefined" || document.readyState !== "loading") {
+    return null;
+  }
+  return new Promise<ReadableStream<Uint8Array> | null>((resolve) => {
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        const late = currentChunkArray();
+        if (!late || streamedFlightConsumed) return resolve(null);
+        streamedFlightConsumed = true;
+        resolve(adoptChunkArray(late));
+      },
+      { once: true }
+    );
+  });
+}

--- a/plugin/utils/streamedFlight.ts
+++ b/plugin/utils/streamedFlight.ts
@@ -15,6 +15,11 @@
  * bytes may already be consumed, so a silent network restart is not possible;
  * the decode failure surfaces to the caller's error path instead.
  *
+ * No backpressure toward the parser: chunks are enqueued as their scripts
+ * execute, so if flight delivery outruns the decoder the queued bytes sit in
+ * the stream controller (same non-propagation the server-side transform
+ * documents). Bounded in practice by the payload size, not by the reader.
+ *
  * The parser race (a cached client entry running before any chunk script has
  * executed) is handled like the blob's short-read: if the global is absent
  * while the document is still loading, wait for `DOMContentLoaded` — by then

--- a/test/unit/streamedFlight.test.ts
+++ b/test/unit/streamedFlight.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { INLINE_FLIGHT_STREAM_GLOBAL } from "../../plugin/utils/inlineFlightId.js";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const G = globalThis as Record<string, unknown>;
+
+// The reader claims once per module instance; reset the module registry so
+// each test's import re-evaluates with an unclaimed flag (module state by
+// design, mirroring takeInlineFlight).
+beforeEach(() => {
+  vi.resetModules();
+});
+
+async function freshTake() {
+  const mod = await import("../../plugin/utils/streamedFlight.js");
+  return mod.takeStreamedFlight;
+}
+
+function pushChunk(text: string | null) {
+  const arr = (G[INLINE_FLIGHT_STREAM_GLOBAL] ??= []) as Array<string | null>;
+  arr.push(text === null ? null : btoa(text));
+}
+
+async function collectText(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return out;
+    if (value) out += decoder.decode(value, { stream: true });
+  }
+}
+
+afterEach(() => {
+  delete G[INLINE_FLIGHT_STREAM_GLOBAL];
+});
+
+describe("takeStreamedFlight", () => {
+  it("returns null when no chunk script has executed (and no document to wait on)", async () => {
+    const take = await freshTake();
+    expect(take()).toBeNull();
+  });
+
+  it("drains the backlog and closes on the sentinel", async () => {
+    pushChunk("hello ");
+    pushChunk("world");
+    pushChunk(null);
+    const take = await freshTake();
+    const stream = take();
+    expect(stream).not.toBeNull();
+    expect(stream && "getReader" in stream).toBe(true);
+    await expect(
+      collectText(stream as ReadableStream<Uint8Array>)
+    ).resolves.toBe("hello world");
+  });
+
+  it("streams chunks that arrive AFTER the reader claimed the array", async () => {
+    pushChunk("early ");
+    const take = await freshTake();
+    const stream = take() as ReadableStream<Uint8Array>;
+    const collected = collectText(stream);
+    // Late scripts call push on the same global array.
+    pushChunk("late");
+    pushChunk(null);
+    await expect(collected).resolves.toBe("early late");
+  });
+
+  it("claims once: a second take returns null", async () => {
+    pushChunk("x");
+    pushChunk(null);
+    const take = await freshTake();
+    expect(take()).not.toBeNull();
+    expect(take()).toBeNull();
+  });
+
+  it("ignores pushes after the sentinel", async () => {
+    pushChunk("a");
+    pushChunk(null);
+    const take = await freshTake();
+    const stream = take() as ReadableStream<Uint8Array>;
+    pushChunk("ghost");
+    await expect(collectText(stream)).resolves.toBe("a");
+  });
+
+  it("errors the stream on corrupt base64 instead of throwing from take", async () => {
+    const arr = (G[INLINE_FLIGHT_STREAM_GLOBAL] ??= []) as Array<string | null>;
+    arr.push("%%not-base64%%");
+    const take = await freshTake();
+    const stream = take() as ReadableStream<Uint8Array>;
+    await expect(collectText(stream)).rejects.toThrow();
+  });
+
+  it("round-trips binary bytes exactly", async () => {
+    const bytes = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+    let binary = "";
+    for (const b of bytes) binary += String.fromCharCode(b);
+    const arr = (G[INLINE_FLIGHT_STREAM_GLOBAL] ??= []) as Array<string | null>;
+    arr.push(btoa(binary));
+    arr.push(null);
+    const take = await freshTake();
+    const stream = take() as ReadableStream<Uint8Array>;
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) chunks.push(value);
+    }
+    const merged = new Uint8Array(chunks.reduce((n, c) => n + c.byteLength, 0));
+    let offset = 0;
+    for (const c of chunks) {
+      merged.set(c, offset);
+      offset += c.byteLength;
+    }
+    expect([...merged]).toEqual([...bytes]);
+  });
+
+  it("a non-array global is treated as absent", async () => {
+    G[INLINE_FLIGHT_STREAM_GLOBAL] = "not an array";
+    const take = await freshTake();
+    expect(take()).toBeNull();
+  });
+
+  it("reader output matches what the interleave transform emits (contract round-trip)", async () => {
+    // Simulate the wire: what interleaveFlightIntoHtml's scripts would push
+    // is exactly base64-of-flight-bytes, in order, then null.
+    const flight = ['0:["$","div",null,{}]\n', "1:I[123]\n"];
+    for (const f of flight) {
+      const arr = (G[INLINE_FLIGHT_STREAM_GLOBAL] ??= []) as Array<
+        string | null
+      >;
+      let binary = "";
+      for (const b of encoder.encode(f)) binary += String.fromCharCode(b);
+      arr.push(btoa(binary));
+    }
+    pushChunk(null);
+    const take = await freshTake();
+    const stream = take() as ReadableStream<Uint8Array>;
+    await expect(collectText(stream)).resolves.toBe(flight.join(""));
+  });
+});


### PR DESCRIPTION
Slice 3a of the inlineFlight `"stream"` mode (follows the transform that shipped inside 3.8.0): the browser side that turns the interleaved push scripts back into a flight stream.

## What

- **`takeStreamedFlight()`** (`plugin/utils/streamedFlight.ts`): adopts the `__vprsFlightChunks` global — drains whatever chunk scripts already executed, then replaces the array's `push` so chunks still being parsed stream through live; the `null` sentinel closes the stream. Contract mirrors `takeInlineFlight`: claim-once, the take never throws, `null` means fall back to fetching `index.rsc`. One deliberate difference, documented: corrupt base64 *after* the claim errors the returned stream — bytes may already be consumed by the decoder, so a silent network restart isn't possible.
- **Parser race**: a cached client entry can run before any chunk script has executed. Absent global + `document.readyState === "loading"` → re-check at `DOMContentLoaded` (the same shape as the blob's short-read handling); documents with no streamed payload resolve `null` for the cost of one listener.
- **`createReactFetcher`** now tries the delivery shapes in order: blob element → streamed chunks → network.

## Verification

9 unit tests: backlog+sentinel, live pushes after claim, claim-once, pushes-after-sentinel ignored, corrupt-base64 error path, byte-exact binary round-trip, non-array global, absent global, and a contract round-trip against exactly what `interleaveFlightIntoHtml` emits. Full `test:unit` (695) and `test:client` (289) green.

## Still not user-reachable

`createEdgeHandler` wiring (use the transform on the `renderDocument` branch when the mode is `"stream"`) and the public `"stream"` option value are the remaining slice — nothing selects streamed delivery yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)