### PR TITLE
fix(config): module-id join contract — stop '//' double-React crashes (bd-fnmz)

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -534,7 +534,7 @@ export async function buildEdgeBundle(opts: {
   // esm takes the module base path (open import), webpack takes the baked
   // client manifest (closed map). Both are top-level consts in the entry.
   const flightArg =
-    transport === "webpack" ? clientManifestExport : "MODULE_BASE_PATH";
+    transport === "webpack" ? clientManifestExport : "FLIGHT_HOSTED_ROOT";
 
   const entryPath = join(serverDir, `.vprs-${entryFileName}`);
   const entrySource = `import * as React from "react";
@@ -553,6 +553,12 @@ const LAYOUT_EXPORT = ${JSON.stringify(layoutExport)};
 const MODULE_BASE = ${JSON.stringify(moduleBase)};
 const MODULE_BASE_PATH = ${JSON.stringify(moduleBasePath)};
 const MODULE_BASE_URL = ${JSON.stringify(moduleBaseURL)};
+// The esm renderer serializes references as $$id minus this prefix; ids are
+// canonically rooted and the browser join strips the base's trailing slash,
+// so the prefix must never consume the id's leading slash (same rule as
+// resolveFlightRenderer). Baked separately from MODULE_BASE_PATH, which the
+// document/decode side still receives verbatim.
+const FLIGHT_HOSTED_ROOT = ${JSON.stringify(moduleBasePath.replace(/\/+$/, ""))};
 const ROUTE_PATTERNS = ${JSON.stringify(userOptions.routePatterns ?? [])};
 // Built stylesheets, baked from the static manifest, so the document producer
 // renders styled HTML on the edge with no per-app CSS wiring. Consumers can

--- a/plugin/config/createModuleID.ts
+++ b/plugin/config/createModuleID.ts
@@ -8,6 +8,7 @@ import type { ConfigEnv } from "vite";
 import { sep, resolve, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
 import { createRollupLikeHash } from "./createRollupLikeHash.js";
+import { wrapModuleID } from "./moduleIdContract.js";
 
 export type ModuleIDKey =
   | "modulePattern"
@@ -55,11 +56,10 @@ export const createDefaultModuleID = (
   const virtualPattern = autoDiscover?.virtualPattern ?? DEFAULT_CONFIG.AUTO_DISCOVER.virtualPattern;
   
   // A module is a client component (and therefore must get a hosted,
-  // `moduleBasePath`-prefixed moduleID) when the unified `detectClientModule`
-  // helper says so — filename `.client.[cm]?[jt]sx?$` OR a top-of-file
-  // `"use client"` directive. The `isClientByDirective` override fast-paths
-  // the build's transformer answer (computed with Rollup's JSX-aware
-  // `this.parse`), so we don't re-parse here.
+  // `moduleBasePath`-prefixed moduleID) when `detectClientModule` says so —
+  // directive-ONLY by rsl design (the filename is deliberately not a signal).
+  // The `isClientByDirective` override fast-paths the build's transformer
+  // answer (computed with a JSX-aware parse), so we don't re-parse here.
   //
   // This is what lets directive-only client modules (no `.client.` suffix,
   // e.g. node_modules libs that ship `"use client"`) be hosted in the static
@@ -156,7 +156,10 @@ export const createDefaultModuleID = (
   const serverDist = isBuild ? join(build?.outDir || "dist", build?.server || "server") : "";
   const buildDirs = isBuild ? [serverDist, ssrClientDist, staticClientDist] : [];
 
-  return (
+  // wrapModuleID roots hosted client-reference ids so the browser join
+  // `moduleBaseURL + id` stays coherent under every moduleBasePath shape
+  // (including the historical bare-id `""` configs). See moduleIdContract.ts.
+  return wrapModuleID((
     id: string,
     sourceContent?: string,
     isClientByDirective?: boolean
@@ -269,12 +272,8 @@ export const createDefaultModuleID = (
     // the client-reference id a phantom .js the dev module graph never has —
     // the import resolves to "<name>.client.js.tsx", which 404s on the second
     // HMR fetch and kills Fast Refresh after the first edit (bd-572). Keep the
-    // real .tsx id in dev.
-    const isClientComponent = isClientComponentId(
-      id,
-      sourceContent,
-      isClientByDirective
-    );
+    // real .tsx id in dev. Client-ness for hashing is re-derived inside `hash`
+    // (and again by the outer wrapModuleID for the join contract).
     if (isBuild) {
       id = replaceExtension(id, {
         build: { extensionMap: build.extensionMap },
@@ -291,19 +290,15 @@ export const createDefaultModuleID = (
       id = hash(id, false, sourceContent, isClientByDirective);
     }
     
-    // For client components, ensure no leading slash to allow proper relative resolution
-    // (isClientComponent already defined in Step 6)
-    if (isClientComponent && moduleBasePath === '') {
-      return id; // No leading slash for client components
-    }
-    
-    // Don't add leading slash for relative paths - this causes module resolution issues
+    // Bare `moduleBasePath: ""` historically returned unprefixed ids; the
+    // outer wrapModuleID roots client ids so the browser join stays coherent.
+    // Non-client ids stay verbatim (they never travel through that join).
     if (moduleBasePath === '') {
-      return id; // Return as-is without leading slash
+      return id;
     }
-    
+
     // id already has moduleBasePath from Step 5 — return as-is
     return id;
-  };
+  });
 };
 

--- a/plugin/config/moduleIdContract.ts
+++ b/plugin/config/moduleIdContract.ts
@@ -1,0 +1,49 @@
+import { detectClientModule } from "react-server-loader/directives";
+
+/**
+ * The join contract with the stock esm transport: the browser composes
+ * client-reference specifiers as `moduleBaseURL + id` (plain concat, upstream
+ * React code). The pair is only coherent when exactly one side carries the
+ * joining slash. vprs canonicalizes BOTH sides: hosted client-reference ids
+ * are ROOTED (single leading slash, this module) and the base handed to the
+ * flight client never ends in "/" (createReactFetcher). Coherent by
+ * construction, independent of moduleBasePath config or custom moduleID fns.
+ */
+
+export type ModuleIDFn = (
+  id: string,
+  sourceContent?: string,
+  isClientByDirective?: boolean
+) => string;
+
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+/**
+ * Root a client-reference id: exactly one leading slash. Absolute URLs
+ * (scheme-prefixed) pass through — they are not composed with moduleBaseURL.
+ */
+export const canonicalModuleId = (id: string): string => {
+  if (!id || SCHEME_RE.test(id)) return id;
+  return "/" + id.replace(/^\/+/, "");
+};
+
+/**
+ * Wrap a moduleID fn so hosted client-reference ids come out rooted. Only
+ * client modules are canonicalized — server files, node_modules and virtual
+ * ids keep the fn's verbatim answer (they never travel through the browser
+ * join). Client detection mirrors createDefaultModuleID's isClientComponentId:
+ * the transformer's directive answer when threaded, else `detectClientModule`
+ * on the INPUT source — directive-only by design, the filename is not a
+ * signal. A call without source or directive answer therefore canonicalizes
+ * nothing, same as the inner fn hashes nothing for it.
+ */
+export const wrapModuleID = (fn: ModuleIDFn): ModuleIDFn => {
+  const wrapped: ModuleIDFn = (id, sourceContent, isClientByDirective) => {
+    const result = fn(id, sourceContent, isClientByDirective);
+    const isClient =
+      isClientByDirective === true ||
+      detectClientModule({ source: sourceContent, moduleId: id });
+    return isClient ? canonicalModuleId(result) : result;
+  };
+  return wrapped;
+};

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -37,6 +37,7 @@ import { stashUserOptions, getStashedUserOptions, getEnvironmentId } from "./sta
 import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { createRollupLikeHash } from "./createRollupLikeHash.js";
 import { DEFAULT_LAYOUT } from "../router/scanRoutes.js";
+import { wrapModuleID } from "./moduleIdContract.js";
 
 // Capped scan for a `route.tsx` layout file under the module tree, used only by
 // the unwired-layouts warning — a miss must stay cheap, so depth and entry
@@ -960,7 +961,13 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
         isClientComponentByCode,
         isClientComponentByName,
         parse: options?.loader?.parse ?? DEFAULT_LOADER_CONFIG.parse,
-        moduleID: options?.loader?.moduleID ?? options?.moduleID,
+        // Canonicalize client-reference ids at the resolved boundary so every
+        // moduleID source (user fn OR later createDefaultModuleID) feeds the
+        // same rooted join contract. See moduleIdContract.ts.
+        moduleID: (() => {
+          const fn = options?.loader?.moduleID ?? options?.moduleID;
+          return typeof fn === "function" ? wrapModuleID(fn) : fn;
+        })(),
       } as Required<LoaderConfig>)
     : undefined;
 
@@ -1021,7 +1028,10 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
       Root: options.Root ?? DEFAULT_CONFIG.ROOT,
       components: options.components,
       normalizer: normalizer,
-      moduleID: options.moduleID, // if not provided, will be created when config hook is called
+      moduleID:
+        typeof options.moduleID === "function"
+          ? wrapModuleID(options.moduleID)
+          : options.moduleID, // if not provided, will be created when config hook is called
       pageExportName:
         options.pageExportName ?? (DEFAULT_CONFIG.PAGE_EXPORT_NAME as PageName),
       propsExportName:

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -13,6 +13,7 @@ import { resolveUserConfig } from "../config/resolveUserConfig.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { handleError } from "../error/handleError.js";
 import { createDefaultModuleID } from "../config/createModuleID.js";
+import { wrapModuleID } from "../config/moduleIdContract.js";
 import { createLogger, version as viteVersion } from "vite";
 import { join } from "node:path";
 import { DEFAULT_LOADER_CONFIG } from "../config/defaults.js";
@@ -107,6 +108,10 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
           configEnv,
           userOptions.loader?.mode
         );
+      } else {
+        // User-supplied moduleID still goes through the join contract so
+        // hosted client ids come out rooted regardless of what the fn returns.
+        userOptions.moduleID = wrapModuleID(userOptions.moduleID);
       }
       // Always override the moduleID function to ensure it has the forTransformer logic
       if (!userOptions.loader) {

--- a/plugin/stream/flightRenderer.server.ts
+++ b/plugin/stream/flightRenderer.server.ts
@@ -41,13 +41,18 @@ export function resolveFlightRenderer(options: {
     };
   }
   const renderToPipeableStream = ReactDOMServer.renderToPipeableStream;
+  // The esm renderer serializes each client reference as $$id minus this
+  // prefix (resolveClientReferenceMetadata slices it off, and startsWith
+  // guards the hosted root). Registration ids are canonically ROOTED, and the
+  // browser composes a trailing-slash-stripped moduleBaseURL with the
+  // serialized id — so the prefix must never consume the id's leading slash.
+  // Hand the renderer the prefix without its trailing slash ("/" → "",
+  // "/app/" → "/app"): every payload id then keeps its root, matching the
+  // join contract on the other end of the wire.
+  const hostedRoot = (options.moduleBasePath || "").replace(/\/+$/, "");
   return {
     render: (element, streamOptions) =>
-      renderToPipeableStream(
-        element as any,
-        options.moduleBasePath || "",
-        streamOptions as any
-      ),
+      renderToPipeableStream(element as any, hostedRoot, streamOptions as any),
     getLoadedMode: getVendoredRendererMode,
   };
 }

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -726,6 +726,16 @@ export interface StreamPluginOptions<
   transport?: "esm" | "webpack";
   moduleBase: string; // defaults to 'src'
   moduleBasePath?: string; // defaults to ''
+  /**
+   * Where the built client bundle is served, for resolving client-reference
+   * modules in the browser. Composition contract: the stock esm transport
+   * builds specifiers as `moduleBaseURL + id` and vprs ids carry a LEADING
+   * slash, so the base is handed to the flight client WITHOUT a trailing
+   * slash (createReactFetcher strips it) — any shape ("/", "/app/", a full
+   * origin) composes to single-slash URLs. Double-slash URLs would load
+   * shared chunks under two identities and crash hooks.
+   * @default "/"
+   */
   moduleBaseURL?: string; // defaults to '/'
   moduleRootPath?: string; // defaults to client's dist folder
   publicOrigin?: string; // defaults to window.location.origin in client & http://localhost:port in development

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -130,9 +130,22 @@ export function createReactFetcher({
     env.DEV
   )(url, indexRSC);
 
+  // COMPOSITION CONTRACT with the stock esm transport: the flight client
+  // builds client-reference specifiers as `moduleBaseURL + id` (a plain
+  // concat, upstream React code), and vprs's moduleID system emits ids with a
+  // LEADING slash (moduleIdContract / createDefaultModuleID). A base ending
+  // in "/" therefore composes "//…" — the same file under a DIFFERENT URL, so
+  // the browser instantiates shared chunks (React included) twice and hooks
+  // crash with a null dispatcher. Production hosts that 301-normalize "//"
+  // mask this; plain servers surface it. This is the one place vprs hands the
+  // base to the transport: strip the trailing slash so every config shape
+  // ("/", "/app/", absolute origins) composes to a single slash. The same
+  // base feeds action-response decodes through callServer, which keeps those
+  // references coherent too.
+  const flightBaseURL = parsedURL.moduleBaseURL.replace(/\/+$/, "");
   const decodeOptions = {
-    callServer: createCallServer(parsedURL.moduleBaseURL),
-    moduleBaseURL: parsedURL.moduleBaseURL,
+    callServer: createCallServer(flightBaseURL),
+    moduleBaseURL: flightBaseURL,
   };
 
   // Prefer the inlined initial-route payload (zero network round-trip) when

--- a/test/examples/edge-join-hydration.test.ts
+++ b/test/examples/edge-join-hydration.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { resolve, join, extname } from "node:path";
+import { pathToFileURL } from "node:url";
+import * as streamApi from "vite-plugin-react-server/stream";
+import { chromium } from "playwright";
+import { doBuild } from "../doBuild.js";
+import { fileRouter } from "../../plugin/router/fileRouter.js";
+
+/**
+ * Regression for the moduleBaseURL + id join contract (bd-fnmz).
+ *
+ * The stock esm transport concatenates `moduleBaseURL + id`. With rooted ids
+ * and a trailing-slash base that produced "//…" URLs — same bytes, different
+ * module identity, two React copies, hooks crash. createReactFetcher strips
+ * the base's trailing slash; createDefaultModuleID roots client ids. This
+ * fixture uses moduleBaseURL "/" on purpose: it must hydrate.
+ *
+ * Blob-mode inline flight (available on main); the stream-mode twin lives on
+ * the inlineFlight "stream" PR and flips the same way once that lands.
+ */
+const createEdgeHandler = (streamApi as { createEdgeHandler?: unknown })
+  .createEdgeHandler;
+
+const browserAvailable = (() => {
+  try {
+    return existsSync(chromium.executablePath());
+  } catch {
+    return false;
+  }
+})();
+
+const testDir = resolve(__dirname, "../fixtures/edge-join-hydration.test");
+const PORT = 4188;
+
+const MIME: Record<string, string> = {
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".map": "application/json",
+};
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/routes"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function Counter() {\n` +
+      `  const [n, setN] = React.useState(0);\n` +
+      `  return (\n` +
+      `    <button id="counter" onClick={() => setN((v) => v + 1)}>\n` +
+      `      {"count:" + n}\n` +
+      `    </button>\n` +
+      `  );\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import React from "react";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <div id="app">\n` +
+      `    <h1>{"join-hydration"}</h1>\n` +
+      `    <Counter />\n` +
+      `  </div>\n` +
+      `);\n`
+  );
+  // moduleBaseURL "/" is the REGRESSION CASE: without the join contract the
+  // transport composed "//routes/…" and hooks crashed on a null dispatcher.
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+/**
+ * Minimal Node bridge: edge fetch handler first, static files second.
+ * Deliberately does NOT collapse "//" in the pathname — production hosts that
+ * 301-normalize mask the bug; this fixture must surface a broken join.
+ */
+function serve(
+  edgeHandler: (req: Request) => Promise<Response>,
+  staticRoots: string[]
+): Server {
+  return createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+    for (const root of staticRoots) {
+      const file = join(root, url.pathname);
+      if (extname(file) && existsSync(file) && file.startsWith(root)) {
+        res.writeHead(200, {
+          "content-type": MIME[extname(file)] ?? "application/octet-stream",
+        });
+        res.end(readFileSync(file));
+        return;
+      }
+    }
+    const response = await edgeHandler(
+      new Request(url.href, { headers: { accept: "text/html" } })
+    );
+    res.writeHead(
+      response.status,
+      Object.fromEntries(response.headers.entries())
+    );
+    const body = response.body;
+    if (!body) return void res.end();
+    for await (const chunk of body as AsyncIterable<Uint8Array>) {
+      res.write(chunk);
+    }
+    res.end();
+  });
+}
+
+describe.skipIf(!createEdgeHandler || !browserAvailable)(
+  "edge join contract — moduleBaseURL '/' hydrates (bd-fnmz)",
+  () => {
+    let server: Server | undefined;
+
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+      const fr = fileRouter(join(testDir, "src/routes"), { root: testDir });
+      await doBuild({
+        projectRoot: testDir,
+        moduleBase: "src",
+        Page: fr.Page,
+        props: fr.props,
+        routePatterns: fr.routePatterns,
+        build: {
+          pages: fr.build.pages,
+          outDir: "dist",
+          edge: true,
+          inlineFlight: true,
+        },
+      } as any);
+
+      const bundle = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+      );
+      const { createEdgeRequestHandler } = await import(
+        "vite-plugin-react-server/edge"
+      );
+      const handler = createEdgeRequestHandler(bundle);
+      server = serve(handler, [
+        join(testDir, "dist/static"),
+        join(testDir, "dist/client"),
+      ]);
+      await new Promise<void>((r) => server!.listen(PORT, r));
+    }, 180000);
+
+    afterAll(async () => {
+      await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+      if (!process.env.KEEP_FIXTURE)
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("hydrates under moduleBaseURL '/': interactive, error-free", async () => {
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        const pageErrors: string[] = [];
+        const consoleErrors: string[] = [];
+        page.on("pageerror", (e) => pageErrors.push(String(e)));
+        page.on("console", (m) => {
+          if (m.type() === "error") consoleErrors.push(m.text());
+        });
+
+        await page.goto(`http://localhost:${PORT}/`, {
+          waitUntil: "networkidle",
+        });
+
+        const counter = page.locator("#counter");
+        await counter.waitFor({ timeout: 15000 });
+        await page.waitForFunction(
+          () => {
+            const b = document.querySelector("#counter") as HTMLButtonElement;
+            if (!b) return false;
+            b.click();
+            return b.textContent !== "count:0";
+          },
+          undefined,
+          { timeout: 20000, polling: 400 }
+        );
+        expect(await counter.textContent()).toMatch(/^count:[1-9]/);
+
+        expect(pageErrors).toEqual([]);
+        expect(
+          consoleErrors.filter((e) => /#4(18|23|25)|hydrat|useState/i.test(e))
+        ).toEqual([]);
+      } finally {
+        await browser.close();
+      }
+    });
+  }
+);

--- a/test/unit/createModuleID.test.ts
+++ b/test/unit/createModuleID.test.ts
@@ -148,4 +148,34 @@ describe("createDefaultModuleID — dev-mode build ref/emit parity", () => {
       );
     });
   });
+
+  describe("join contract — bare moduleBasePath still roots client ids", () => {
+    const bareOptions = {
+      ...options,
+      moduleBasePath: "",
+    } satisfies Parameters<typeof createDefaultModuleID>[0];
+
+    it("build: bare moduleBasePath emits rooted client refs (bidoof migration)", () => {
+      const id = createDefaultModuleID(bareOptions, buildProd, "production")(
+        CLIENT_ID,
+        CLIENT_SOURCE
+      );
+      expect(id).toMatch(/^\/components\/Widget\.client-[A-Za-z0-9]+\.js$/);
+    });
+
+    it("dev: bare moduleBasePath roots client refs without hashing", () => {
+      const id = createDefaultModuleID(bareOptions, serveDev, "development")(
+        CLIENT_ID,
+        CLIENT_SOURCE
+      );
+      expect(id).toMatch(/^\/src\/components\/Widget\.client/);
+    });
+
+    it("non-client ids stay bare under moduleBasePath ''", () => {
+      const id = createDefaultModuleID(bareOptions, serveDev, "development")(
+        "src/routes/page.tsx"
+      );
+      expect(id.startsWith("/")).toBe(false);
+    });
+  });
 });

--- a/test/unit/createReactFetcher-join-contract.test.ts
+++ b/test/unit/createReactFetcher-join-contract.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * createReactFetcher join contract (bd-fnmz): the base handed to the flight
+ * client must not end in "/" once ids are rooted, or `base + id` composes
+ * "//…" and the browser loads shared chunks under two identities.
+ *
+ * Isolated file so the client.browser mock cannot leak into the AbortSignal /
+ * inline-flight suites in createReactFetcher.test.ts.
+ */
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function flightResponse(body = '0:"ok"\n'): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/x-component" },
+  });
+}
+
+describe("createReactFetcher join contract (bd-fnmz)", () => {
+  const seen: Array<{ moduleBaseURL?: string }> = [];
+
+  beforeEach(() => {
+    seen.length = 0;
+    vi.resetModules();
+    vi.doMock("react-server-dom-esm/client.browser", () => ({
+      createFromFetch: (
+        _response: Promise<Response>,
+        opts: { moduleBaseURL?: string }
+      ) => {
+        seen.push(opts);
+        return Promise.resolve("ok");
+      },
+      createFromReadableStream: (
+        _stream: ReadableStream,
+        opts: { moduleBaseURL?: string }
+      ) => {
+        seen.push(opts);
+        return Promise.resolve("ok");
+      },
+    }));
+    vi.stubGlobal("window", { location: { pathname: "/" } });
+    vi.stubGlobal("document", {
+      readyState: "complete",
+      getElementById: () => null,
+      addEventListener: () => {},
+    });
+    globalThis.fetch = vi.fn(async () => flightResponse()) as any;
+  });
+
+  afterEach(() => {
+    vi.doUnmock("react-server-dom-esm/client.browser");
+    vi.unstubAllGlobals();
+    globalThis.fetch = ORIGINAL_FETCH;
+    vi.resetModules();
+  });
+
+  it("strips trailing slashes from moduleBaseURL before handing it to the flight client", async () => {
+    const { createReactFetcher } = await import(
+      "../../plugin/utils/createReactFetcher.js"
+    );
+    const content = createReactFetcher({
+      url: "/",
+      moduleBaseURL: "/",
+      publicOrigin: "http://localhost:4173/",
+    });
+    await Promise.resolve(content);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(seen.length).toBeGreaterThan(0);
+    for (const opts of seen) {
+      expect(opts.moduleBaseURL).toBeDefined();
+      expect(opts.moduleBaseURL).not.toMatch(/\/$/);
+    }
+  });
+});

--- a/test/unit/moduleIdContract.test.ts
+++ b/test/unit/moduleIdContract.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  canonicalModuleId,
+  wrapModuleID,
+} from "../../plugin/config/moduleIdContract.js";
+
+/**
+ * The join contract: the browser composes `moduleBaseURL + id` by plain
+ * concat (upstream React code), so exactly one side may carry the joining
+ * slash. Ids are canonicalized ROOTED; the base side (createReactFetcher)
+ * strips its trailing slash. Two id conventions existed in the wild — bare
+ * ids under moduleBasePath "" and rooted ids under "/" — which is why no
+ * base-side-only normalization could serve both.
+ */
+
+describe("canonicalModuleId", () => {
+  it("roots a bare id", () => {
+    expect(canonicalModuleId("components/Link.client-abc.js")).toBe(
+      "/components/Link.client-abc.js"
+    );
+  });
+
+  it("keeps an already-rooted id unchanged", () => {
+    expect(canonicalModuleId("/routes/Counter.client-x.js")).toBe(
+      "/routes/Counter.client-x.js"
+    );
+  });
+
+  it("collapses duplicate leading slashes to one", () => {
+    expect(canonicalModuleId("//routes/Counter.client-x.js")).toBe(
+      "/routes/Counter.client-x.js"
+    );
+  });
+
+  it("passes absolute URLs through (never composed with moduleBaseURL)", () => {
+    expect(canonicalModuleId("https://cdn.example.com/x.js")).toBe(
+      "https://cdn.example.com/x.js"
+    );
+    expect(canonicalModuleId("data:text/javascript,export{}")).toBe(
+      "data:text/javascript,export{}"
+    );
+  });
+
+  it("passes empty input through", () => {
+    expect(canonicalModuleId("")).toBe("");
+  });
+});
+
+describe("wrapModuleID", () => {
+  const identity = (id: string) => id;
+
+  it("does NOT root on filename alone — client-ness is directive-only", () => {
+    const fn = wrapModuleID(identity);
+    expect(fn("components/Link.client.tsx")).toBe("components/Link.client.tsx");
+  });
+
+  it("roots client ids detected by the transformer's directive answer", () => {
+    const fn = wrapModuleID(identity);
+    expect(fn("view/View.tsx", undefined, true)).toBe("/view/View.tsx");
+  });
+
+  it("roots client ids detected by a use client directive in source", () => {
+    const fn = wrapModuleID(identity);
+    expect(fn("lib/widget.tsx", '"use client";\nexport const W = 1;')).toBe(
+      "/lib/widget.tsx"
+    );
+  });
+
+  it("canonicalizes the fn's OUTPUT (hashed built id), detecting on the input", () => {
+    const hashing = (id: string) =>
+      id.replace(/\.client\.tsx$/, ".client-abc123.js");
+    const fn = wrapModuleID(hashing);
+    expect(fn("components/Link.client.tsx", undefined, true)).toBe(
+      "/components/Link.client-abc123.js"
+    );
+  });
+
+  it("leaves non-client ids verbatim (server files, node_modules, virtual)", () => {
+    const fn = wrapModuleID(identity);
+    expect(fn("routes/page.tsx")).toBe("routes/page.tsx");
+    expect(fn("node_modules/react/index.js")).toBe(
+      "node_modules/react/index.js"
+    );
+    expect(fn("_virtual/some-module.js")).toBe("_virtual/some-module.js");
+  });
+
+  it("is idempotent over an already-canonical fn", () => {
+    const fn = wrapModuleID(wrapModuleID(identity));
+    expect(fn("components/Link.client.tsx", undefined, true)).toBe(
+      "/components/Link.client.tsx"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The stock esm transport concatenates `moduleBaseURL + id`. With rooted ids and a trailing-slash base that composed `//…` URLs — same bytes, different module identity, two React copies, hooks crash on a null dispatcher. Hosts that 301-normalize `//` masked it; bare Node / edge surfaces it.
- **Option (iv)**: one join contract on both sides — hosted client-reference ids are always rooted (`canonicalModuleId` / `wrapModuleID`), and `createReactFetcher` strips the base's trailing slash before handing it to the flight client. Coherent by construction for every `moduleBasePath` shape (including historical bare-id `""` configs).
- No vendored React patch. Custom `moduleID` fns are wrapped too.
- **Serialization seams** (the follow-up commits on this head): the esm flight server serializes each reference as `$$id.slice(moduleBasePath.length)`, so a trailing-slash prefix consumed the rooted id's leading slash at serialization. Normalized at both producers — `resolveFlightRenderer` (worker/SSG renders) and the baked edge entry's `FLIGHT_HOSTED_ROOT` (per-request renders and action responses).

## Test plan

- [x] Unit: `moduleIdContract`, `createModuleID` bare-path migration, `createReactFetcher` strip
- [x] Browser regression: `test/examples/edge-join-hydration.test.ts` — `moduleBaseURL: '/'` hydrates under blob-mode edge
- [x] Edge blast radius: `build-edge-bundle`, `build-edge-router`, `inline-flight-build`, `edge-document-complete`
- [x] Full suites on this head's tree: unit 749 / server 991 / client 291
- [x] Sibling: `validate-sibling.sh ../bidoof-template` via real packed tarball — prod e2e 3/3 (was 0/3 before the serialization-seam commits; bidoof is on `moduleBasePath: "/"`)
- [ ] After #347 merges: flip stream e2e fixture to `moduleBaseURL: '/'` as the twin proof — a 3.9.0 tag blocker, deliberately open here

Closes the known-limit called out on #347.

Made with [Cursor](https://cursor.com)