### PR TITLE
fix: route callServer through the transport-aware flight client

### DIFF
--- a/plugin/transformer/createTransformerPlugin.ts
+++ b/plugin/transformer/createTransformerPlugin.ts
@@ -469,6 +469,12 @@ export const createTransformerPlugin = (
               ).map((e) => e.exportName);
               if (exportNames.length > 0) {
                 if (this.environment?.name === "client") {
+                  // The esm createServerReference is transport-safe here: its
+                  // callable only delegates to callServer(id, args), and every
+                  // flavor-sensitive step (encodeReply, response decode) lives
+                  // in createCallServer's transport chooser. Emitting the
+                  // webpack client instead would read module-loading globals
+                  // at eval time — an install-order footgun for no behavior.
                   const proxy = [
                     `import { createServerReference } from "react-server-dom-esm/client.browser";`,
                     `import { createCallServer } from "vite-plugin-react-server/utils";`,

--- a/plugin/transformer/serverReferenceClientPlugin.ts
+++ b/plugin/transformer/serverReferenceClientPlugin.ts
@@ -115,6 +115,9 @@ export const serverReferenceClientPlugin: VitePluginFn = (userOptions) => {
       const hostedId = moduleID ? moduleID(normalizedPath, src, false) : normalizedPath;
 
       if (this.environment?.name === "client") {
+        // esm createServerReference is transport-safe: the callable only
+        // delegates to callServer, where the transport chooser lives (see
+        // createTransformerPlugin's proxy emission for the full rationale).
         return [
           `import { createServerReference } from "react-server-dom-esm/client.browser";`,
           `import { createCallServer } from "vite-plugin-react-server/utils";`,

--- a/plugin/utils/createCallServer.ts
+++ b/plugin/utils/createCallServer.ts
@@ -2,12 +2,18 @@
 // import-safe under the `react-server` condition (importing it statically would
 // pull react-dom/client into the server graph). callServer only ever runs in the
 // browser, where the dynamic import resolves from the module cache.
+//
+// The client is CHOSEN per transport (loadBrowserFlightClient): under
+// transport:"webpack" the action response is webpack-flavored, and the esm
+// decoder mis-reads webpack reference rows — the export-name slot receives the
+// chunk array, so components resolve to undefined. Arg encoding (encodeReply)
+// follows the same flavor for symmetry with the server's decodeReply.
+
+import { loadBrowserFlightClient } from "./flightClient.browser.js";
 
 export const createCallServer = (moduleBaseURL: string) => {
   const callServer = async (id: string, args: unknown[]) => {
-    const { createFromFetch, encodeReply } = await import(
-      "react-server-dom-esm/client.browser"
-    );
+    const { createFromFetch, encodeReply } = await loadBrowserFlightClient();
     const response = await createFromFetch(
       fetch(moduleBaseURL, {
         method: "POST",
@@ -22,7 +28,7 @@ export const createCallServer = (moduleBaseURL: string) => {
 
     // Check if this is a server action response
     if (response && typeof response === "object" && "returnValue" in response) {
-      const serverResponse = response;
+      const serverResponse = response as { returnValue: unknown };
       return serverResponse.returnValue;
     }
 

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -1,5 +1,6 @@
 import type React from "react";
 import { createCallServer } from "./createCallServer.js";
+import { loadBrowserFlightClient } from "./flightClient.browser.js";
 import { env } from "#env";
 import { createPageURL } from "./urls.js";
 import { takeStreamedFlight } from "./streamedFlight.js";
@@ -136,18 +137,10 @@ export function createReactFetcher({
   };
 
   // Prefer the inlined initial-route payload (zero network round-trip) when
-  // present; otherwise fetch index.rsc. Either way the browser flight client is
-  // imported lazily so this module stays import-safe under the `react-server`
-  // condition (a static import of client.browser would drag react-dom/client
-  // into the server graph).
-  //
-  // WHICH flight client follows how the server encoded the payload. A
-  // webpack-transport bundle's document injects `self.__vprsFlightTransport`
-  // (see createEdgeRenderHook) and its payload carries baked-manifest ids —
-  // consumed through the webpack client over a chunk loader that `import()`s
-  // the served chunk URLs (the ids ARE the URLs; the map is closed, nothing is
-  // composed from payload input). Default: the esm client, unchanged.
-  type BrowserFlightClient = {
+  // present; otherwise fetch index.rsc. The client itself comes from the
+  // shared transport chooser (flightClient.browser.ts) — lazily, so this
+  // module stays import-safe under the `react-server` condition.
+  const flightClient = loadBrowserFlightClient as () => PromiseLike<{
     createFromReadableStream: (
       stream: ReadableStream<Uint8Array>,
       opts: typeof decodeOptions
@@ -156,19 +149,7 @@ export function createReactFetcher({
       response: Promise<Response>,
       opts: typeof decodeOptions
     ) => PromiseLike<React.ReactNode>;
-  };
-  const flightClient = (): PromiseLike<BrowserFlightClient> =>
-    (globalThis as { __vprsFlightTransport?: string }).__vprsFlightTransport ===
-    "webpack"
-      ? (import("react-server-loader/webpack/runtime").then(
-          ({ createWebpackClient }) =>
-            createWebpackClient({
-              load: (chunk: string) => import(/* @vite-ignore */ chunk),
-            })
-        ) as PromiseLike<BrowserFlightClient>)
-      : (import(
-          "react-server-dom-esm/client.browser"
-        ) as unknown as PromiseLike<BrowserFlightClient>);
+  }>;
 
   const fromInline = (bytes: Uint8Array): PromiseLike<React.ReactNode> =>
     flightClient().then(({ createFromReadableStream }) =>

--- a/plugin/utils/flightClient.browser.ts
+++ b/plugin/utils/flightClient.browser.ts
@@ -1,0 +1,37 @@
+// The one place browser code picks a flight client. WHICH client must follow
+// how the server encoded the payload: a webpack-transport bundle's document
+// injects `self.__vprsFlightTransport` (see createEdgeRenderHook) and its
+// payload carries baked-manifest ids — consumed through the webpack client
+// over a chunk loader that `import()`s the served chunk URLs (the ids ARE the
+// URLs; the map is closed, nothing is composed from payload input). Default:
+// the esm client.
+//
+// Always imported lazily, at call time: static imports would pull
+// react-dom/client into the react-server graph, and the webpack client
+// additionally reads module-loading globals at eval time — the
+// createWebpackClient factory owns that install-then-load ordering.
+
+export type BrowserFlightClient = {
+  createFromReadableStream: (
+    stream: ReadableStream<Uint8Array>,
+    opts: { callServer?: unknown; moduleBaseURL?: string }
+  ) => PromiseLike<unknown>;
+  createFromFetch: (
+    response: Promise<Response>,
+    opts: { callServer?: unknown; moduleBaseURL?: string }
+  ) => PromiseLike<unknown>;
+  encodeReply: (args: unknown[]) => Promise<string | FormData>;
+};
+
+export const loadBrowserFlightClient = (): PromiseLike<BrowserFlightClient> =>
+  (globalThis as { __vprsFlightTransport?: string }).__vprsFlightTransport ===
+  "webpack"
+    ? (import("react-server-loader/webpack/runtime").then(
+        ({ createWebpackClient }) =>
+          createWebpackClient({
+            load: (chunk: string) => import(/* @vite-ignore */ chunk),
+          })
+      ) as PromiseLike<BrowserFlightClient>)
+    : (import(
+        "react-server-dom-esm/client.browser"
+      ) as unknown as PromiseLike<BrowserFlightClient>);

--- a/test/unit/flightClientChooser.test.ts
+++ b/test/unit/flightClientChooser.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+
+/**
+ * The browser flight-client chooser must follow the transport hint: a
+ * webpack-transport document injects `self.__vprsFlightTransport = "webpack"`
+ * and every browser decode path (initial payload, refetch, and the server-fn
+ * proxy's callServer) must then use the webpack client — the esm decoder
+ * mis-reads webpack reference rows (the export-name slot receives the chunk
+ * array), silently resolving components to undefined. Without the hint the
+ * esm client is the default, unchanged.
+ */
+
+vi.mock("react-server-loader/webpack/runtime", () => ({
+  createWebpackClient: vi.fn(async () => ({
+    createFromReadableStream: vi.fn(),
+    createFromFetch: vi.fn(async () => ({ returnValue: "webpack" })),
+    encodeReply: vi.fn(async () => "webpack-body"),
+    flavor: "webpack",
+  })),
+}));
+
+vi.mock("react-server-dom-esm/client.browser", () => ({
+  createFromReadableStream: vi.fn(),
+  createFromFetch: vi.fn(async () => ({ returnValue: "esm" })),
+  encodeReply: vi.fn(async () => "esm-body"),
+  flavor: "esm",
+}));
+
+afterEach(() => {
+  delete (globalThis as { __vprsFlightTransport?: string })
+    .__vprsFlightTransport;
+  vi.unstubAllGlobals();
+});
+
+describe("loadBrowserFlightClient", () => {
+  it("defaults to the esm client", async () => {
+    const { loadBrowserFlightClient } = await import(
+      "../../plugin/utils/flightClient.browser.js"
+    );
+    const client = (await loadBrowserFlightClient()) as { flavor?: string };
+    expect(client.flavor).toBe("esm");
+  });
+
+  it("picks the webpack client when the document hints webpack transport", async () => {
+    (globalThis as { __vprsFlightTransport?: string }).__vprsFlightTransport =
+      "webpack";
+    const { loadBrowserFlightClient } = await import(
+      "../../plugin/utils/flightClient.browser.js"
+    );
+    const client = (await loadBrowserFlightClient()) as { flavor?: string };
+    expect(client.flavor).toBe("webpack");
+  });
+});
+
+describe("createCallServer transport dispatch", () => {
+  it("encodes and decodes through the webpack client under the hint", async () => {
+    (globalThis as { __vprsFlightTransport?: string }).__vprsFlightTransport =
+      "webpack";
+    const { createCallServer } = await import(
+      "../../plugin/utils/createCallServer.js"
+    );
+    const seen: RequestInit[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: unknown, init?: RequestInit) => {
+        seen.push(init ?? {});
+        return new Response("", { status: 200 });
+      })
+    );
+    const result = await createCallServer("/")("some/action#run", [1]);
+    expect(result).toBe("webpack");
+    expect(seen[0]?.body).toBe("webpack-body");
+  });
+
+  it("stays on the esm client without the hint", async () => {
+    const { createCallServer } = await import(
+      "../../plugin/utils/createCallServer.js"
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 200 }))
+    );
+    const result = await createCallServer("/")("some/action#run", [1]);
+    expect(result).toBe("esm");
+  });
+});


### PR DESCRIPTION
## Problem

The client-imported server-fn proxy path is esm-hardcoded regardless of transport: `createCallServer` imports the esm `createFromFetch`/`encodeReply` directly. Under `transport: "webpack"` an action response is a webpack-flavored payload decoded by the esm client.

Verified with a probe that feeds a real webpack-transport build's frozen payload to the esm browser client: the decoder accepts webpack `I["<id>",[chunks],"<name>"]` rows **without any error**, but mis-reads the metadata — the path slot only works because our webpack ids happen to be rooted URLs, and the export-name slot receives the chunks array. In a browser the module import resolves and the component lookup silently yields `undefined`. Every action response and refetched payload under webpack transport is affected.

## Fix

- The transport chooser `createReactFetcher` already used (esm default, rsl's `createWebpackClient` when the document hints `__vprsFlightTransport`) moves to a shared `plugin/utils/flightClient.browser.ts`.
- `createCallServer` now gets `createFromFetch` **and** `encodeReply` through it, so both directions of an action follow the payload flavor.
- `createReactFetcher` dedupes onto the shared helper (no behavior change).
- The emitted `createServerReference` proxies deliberately stay on the esm import: that callable only delegates to `callServer(id, args)` — every flavor-sensitive step lives behind the chooser — while emitting the webpack client would read module-loading globals at eval time (the install-order footgun `createWebpackClient` exists to prevent). Rationale is now commented at both emission sites.

## Verification

- New `test/unit/flightClientChooser.test.ts` pins the dispatch: esm by default, webpack under the hint, and `createCallServer` encoding/decoding through the hinted client.
- Full suites green: unit 738, server 980, client 290.
- The full browser round-trip e2e (webpack action through a served app) is planned separately alongside the webpack browser-action work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHY8KAH6Taq7boWCzEB47M