### PR TITLE
feat: flash-free dev shell — serve the document component's head in dev

### DIFF
--- a/plugin/dev-server/configureRequestHandler.client.ts
+++ b/plugin/dev-server/configureRequestHandler.client.ts
@@ -15,6 +15,7 @@ import { isReactServerCondition } from "../config/getCondition.js";
 import { setupGlobalErrorHandler, cleanupGlobalErrorHandler } from "../error/setupGlobalErrorHandler.js";
 import { pipeToResponse } from "../helpers/pipeToResponse.js";
 import { isNotFound, isRedirect } from "../router/loaderSignals.js";
+import { createDevShellHeadProvider } from "./devShellHeadProvider.js";
 
 /**
  * Configures the worker request handler.
@@ -434,4 +435,101 @@ export const configureRequestHandler: ConfigureWorkerRequestHandlerFn =
     // attach handler to the server
     server.middlewares.use(handler);
     // port check, should be handled by strictPort
+
+    // Dev-shell head-merge: one full-document (Fragment-page) flight render
+    // through the SAME worker the route renders use; the head is read from
+    // the flight rows (devShellHeadFlight), so no client React and no html
+    // worker run in dev. The provider owns caching + the warn-once fallback;
+    // the transformIndexHtml hooks consume it via the server registry.
+    createDevShellHeadProvider(
+      server,
+      async () => {
+        const shellHandlerOptions = { ...handlerOptions, url: "/" };
+        const serialized = serializedOptions(
+          shellHandlerOptions,
+          autoDiscoveredFiles
+        );
+        if (!currentWorker) {
+          currentWorker = await restartWorker({
+            server,
+            autoDiscoveredFiles,
+            userOptions: serialized,
+            configEnv: configEnv,
+            hmrChannel,
+          });
+        }
+        if (!currentWorker) {
+          throw new Error("worker unavailable for the dev-shell render");
+        }
+        const routeFiles = await getRouteFiles(
+          "/",
+          autoDiscoveredFiles,
+          shellHandlerOptions,
+          logger
+        );
+        // htmlPath must never be "" here — "" means headless. Undefined falls
+        // back to the built-in document wrapper, same as the static build.
+        const htmlPath =
+          routeFiles.type === "error" ? undefined : routeFiles.html || undefined;
+        const stream = handleRscStream({
+          options: {
+            ...serialized,
+            worker: currentWorker,
+            // isHeadless keys off the id containing "headless" — this id must
+            // not, so the render keeps the real Html wrapper.
+            id: "__vprs-dev-shell__",
+            type: "INIT",
+            logger,
+            route: "/",
+            url: "/",
+            shell: true,
+            pagePath: "",
+            propsPath: undefined,
+            layouts: [],
+            serializedRequest: {
+              url: "http://localhost/",
+              method: "GET",
+              headers: {},
+            },
+            resolvedPageProps: undefined,
+            // The app Root is skipped: the shell wants the Html component's
+            // head only, and a Root may reach for request/props context that
+            // a Fragment-page render does not have.
+            rootPath: undefined,
+            htmlPath,
+            HtmlComponent: undefined,
+            RootComponent: undefined,
+            projectRoot: serialized.projectRoot || server.config.root,
+            build: {
+              ...(serialized.build || {}),
+              pages: [],
+            },
+            manifest: {},
+            cssFiles: new Map(),
+            globalCss: new Map(),
+            serverPipeableStreamOptions: serialized.serverPipeableStreamOptions,
+            clientPipeableStreamOptions: serialized.clientPipeableStreamOptions,
+          } as any,
+          handlers: {
+            onMetrics: () => {},
+            onHmrAccept: () => {},
+            onHmrUpdate: () => {},
+            onError: () => {},
+            onShellError: () => {},
+          },
+          ...shellHandlerOptions,
+        } as any);
+        const reader = stream.getReader();
+        const decoder = new TextDecoder();
+        let payload = "";
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          payload += decoder.decode(value, { stream: true });
+        }
+        payload += decoder.decode();
+        return payload;
+      },
+      logger
+    );
   };

--- a/plugin/dev-server/devShellHead.ts
+++ b/plugin/dev-server/devShellHead.ts
@@ -1,0 +1,80 @@
+import type { HtmlTagDescriptor } from "vite";
+
+/**
+ * Stage-1 head-merge for the flash-free dev shell: the document/Html
+ * component is the source of truth for <head>, and the dev index.html is only
+ * the body scaffold. These helpers turn a RENDERED document (the same
+ * pipeline output the static build freezes) into transformIndexHtml tags, and
+ * reconcile the user's index.html against them.
+ *
+ * Input contract: React-rendered markup — well-formed, no conditional
+ * comments, attributes quoted. This is not a general HTML parser and must
+ * only ever be fed the document render's output.
+ *
+ * Scope is a whitelist: title, meta, link, inline style. Scripts are
+ * deliberately excluded — the dev shell has Vite's own entry and HMR client,
+ * and a document bootstrap script would double-load the app.
+ */
+
+const HEAD_RE = /<head[^>]*>([\s\S]*?)<\/head>/i;
+const TAG_RE =
+  /<(title|meta|link|style)\b([^>]*?)\/?>(?:([\s\S]*?)<\/\1>)?/gi;
+const ATTR_RE = /([a-zA-Z-][a-zA-Z0-9-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g;
+
+function parseAttrs(raw: string): Record<string, string | boolean> {
+  const attrs: Record<string, string | boolean> = {};
+  for (const m of raw.matchAll(ATTR_RE)) {
+    const [, name, dq, sq] = m;
+    if (!name) continue;
+    attrs[name] = dq ?? sq ?? true;
+  }
+  return attrs;
+}
+
+/**
+ * Extract the whitelisted head elements of a rendered document as
+ * transformIndexHtml tag descriptors (injectTo: "head").
+ */
+export function extractDocumentHeadTags(
+  documentHtml: string
+): HtmlTagDescriptor[] {
+  const head = HEAD_RE.exec(documentHtml)?.[1];
+  if (!head) return [];
+  const tags: HtmlTagDescriptor[] = [];
+  for (const m of head.matchAll(TAG_RE)) {
+    const [, tag, rawAttrs, children] = m;
+    const lower = tag.toLowerCase();
+    // Void elements (meta/link) never have children; title/style keep theirs.
+    const descriptor: HtmlTagDescriptor = {
+      tag: lower,
+      attrs: parseAttrs(rawAttrs ?? ""),
+      injectTo: "head",
+    };
+    if ((lower === "title" || lower === "style") && children != null) {
+      descriptor.children = children;
+    }
+    tags.push(descriptor);
+  }
+  return tags;
+}
+
+/**
+ * Reconcile the user's index.html with the document-provided head.
+ *
+ * transformIndexHtml tags can only ADD, so collisions are resolved by
+ * rewriting the served html: when the document supplies a <title>, the user
+ * index.html's title is dropped (the document is the source of truth — a
+ * kept copy is exactly the silent-divergence footgun this feature removes).
+ * Everything else is additive; React's own hoisting dedupes identical
+ * meta/link at hydration.
+ */
+export function mergeDevShellHead(
+  indexHtml: string,
+  documentTags: HtmlTagDescriptor[]
+): { html: string; tags: HtmlTagDescriptor[] } {
+  const hasTitle = documentTags.some((t) => t.tag === "title");
+  const html = hasTitle
+    ? indexHtml.replace(/<title\b[^>]*>[\s\S]*?<\/title>\s*/i, "")
+    : indexHtml;
+  return { html, tags: documentTags };
+}

--- a/plugin/dev-server/devShellHeadFlight.ts
+++ b/plugin/dev-server/devShellHeadFlight.ts
@@ -1,0 +1,125 @@
+import type { HtmlTagDescriptor } from "vite";
+
+/**
+ * Head extraction straight from a FLIGHT payload — the dev-shell render needs
+ * only the document's <head>, and in flight the Html component's head is
+ * plain element rows. Reading them here means the shell render is served by
+ * the existing dev rsc worker alone: no client React, no html worker in dev.
+ *
+ * Same whitelist and rationale as devShellHead.ts (title/meta/link/style;
+ * scripts excluded). React prop names are mapped to their HTML attribute
+ * form, since descriptors are serialized into the served index.html.
+ *
+ * The walker is deliberately conservative: it only descends plain JSON
+ * (arrays, objects, element tuples). Reference placeholders ("$L1", "$@2" …)
+ * are opaque without a full flight client, so a head that hides behind one is
+ * treated as absent — the caller falls back to serving index.html unchanged.
+ */
+
+type FlightElement = [string, string, unknown, Record<string, unknown>];
+
+const HEAD_TAGS = new Set(["title", "meta", "link", "style"]);
+
+const ATTR_NAME: Record<string, string> = {
+  className: "class",
+  charSet: "charset",
+  httpEquiv: "http-equiv",
+  htmlFor: "for",
+};
+
+function isElement(node: unknown): node is FlightElement {
+  return (
+    Array.isArray(node) &&
+    node.length === 4 &&
+    node[0] === "$" &&
+    typeof node[1] === "string" &&
+    node[3] !== null &&
+    typeof node[3] === "object"
+  );
+}
+
+function toDescriptor(el: FlightElement): HtmlTagDescriptor {
+  const [, tag, , props] = el;
+  const attrs: Record<string, string | boolean> = {};
+  let children: string | undefined;
+  for (const [key, value] of Object.entries(props)) {
+    if (key === "children") {
+      if (typeof value === "string") children = value;
+      else if (Array.isArray(value) && value.every((v) => typeof v === "string"))
+        children = value.join("");
+      continue;
+    }
+    if (value == null || typeof value === "object") continue;
+    if (typeof value === "boolean") {
+      if (value) attrs[ATTR_NAME[key] ?? key] = true;
+      continue;
+    }
+    attrs[ATTR_NAME[key] ?? key] = String(value);
+  }
+  const descriptor: HtmlTagDescriptor = {
+    tag: tag.toLowerCase(),
+    attrs,
+    injectTo: "head",
+  };
+  if (children !== undefined) descriptor.children = children;
+  return descriptor;
+}
+
+function findHead(node: unknown, depth = 0): FlightElement | null {
+  if (depth > 40 || node == null || typeof node !== "object") return null;
+  if (isElement(node)) {
+    if (node[1].toLowerCase() === "head") return node;
+    return findHead(node[3]["children"], depth + 1);
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findHead(child, depth + 1);
+      if (found) return found;
+    }
+    return null;
+  }
+  for (const value of Object.values(node)) {
+    const found = findHead(value, depth + 1);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * Parse a raw flight payload (the wire text: `N:JSON` rows) and return the
+ * document head's whitelisted elements as transformIndexHtml descriptors.
+ * Returns [] when no plain-JSON head is found — never throws on payload
+ * shape; a malformed row is skipped like any other non-element.
+ */
+export function extractHeadTagsFromFlight(
+  payload: string
+): HtmlTagDescriptor[] {
+  for (const line of payload.split("\n")) {
+    const sep = line.indexOf(":");
+    if (sep < 1) continue;
+    let row: unknown;
+    try {
+      row = JSON.parse(line.slice(sep + 1));
+    } catch {
+      continue; // model rows only; binary/partial rows are not our head
+    }
+    const head = findHead(row);
+    if (!head) continue;
+    const children = head[3]["children"];
+    const list = Array.isArray(children) ? children : [children];
+    const tags: HtmlTagDescriptor[] = [];
+    const collect = (nodes: unknown[]): void => {
+      for (const child of nodes) {
+        if (!isElement(child)) {
+          // Fragments/arrays nest one level down; anything else is skipped.
+          if (Array.isArray(child)) collect(child);
+          continue;
+        }
+        if (HEAD_TAGS.has(child[1].toLowerCase())) tags.push(toDescriptor(child));
+      }
+    };
+    collect(list);
+    return tags;
+  }
+  return [];
+}

--- a/plugin/dev-server/devShellHeadFlight.ts
+++ b/plugin/dev-server/devShellHeadFlight.ts
@@ -16,7 +16,9 @@ import type { HtmlTagDescriptor } from "vite";
  * treated as absent — the caller falls back to serving index.html unchanged.
  */
 
-type FlightElement = [string, string, unknown, Record<string, unknown>];
+/** ["$", type, key, props, ...devFields] — dev payloads append owner/stack/
+ *  validated entries, so an element tuple is AT LEAST 4 long, not exactly. */
+type FlightElement = [string, string, unknown, Record<string, unknown>, ...unknown[]];
 
 const HEAD_TAGS = new Set(["title", "meta", "link", "style"]);
 
@@ -30,7 +32,7 @@ const ATTR_NAME: Record<string, string> = {
 function isElement(node: unknown): node is FlightElement {
   return (
     Array.isArray(node) &&
-    node.length === 4 &&
+    node.length >= 4 &&
     node[0] === "$" &&
     typeof node[1] === "string" &&
     node[3] !== null &&

--- a/plugin/dev-server/devShellHeadProvider.ts
+++ b/plugin/dev-server/devShellHeadProvider.ts
@@ -1,0 +1,84 @@
+import type { HtmlTagDescriptor, Logger, ViteDevServer } from "vite";
+import { extractHeadTagsFromFlight } from "./devShellHeadFlight.js";
+
+/**
+ * Lazy, cached provider of the document's head for the dev shell. The
+ * request-handler side owns the actual render (it holds the worker
+ * lifecycle); this module owns caching, the warn-once fallback, and the
+ * server→provider registry the transformIndexHtml hooks read from.
+ *
+ * Contract with the hooks: getTags NEVER rejects and never blocks beyond the
+ * render timeout — on any failure it resolves [] and the dev shell is served
+ * unchanged, exactly as before the feature. The first HTML request pays the
+ * render; subsequent ones hit the cache until invalidate() (the Html-module
+ * hotUpdate signal) clears it, and the NEXT request re-renders lazily.
+ */
+
+export type DevShellHeadProvider = {
+  getTags: () => Promise<HtmlTagDescriptor[]>;
+  invalidate: () => void;
+};
+
+const providers = new WeakMap<ViteDevServer, DevShellHeadProvider>();
+
+const RENDER_TIMEOUT_MS = 5_000;
+
+export function createDevShellHeadProvider(
+  server: ViteDevServer,
+  renderShellFlight: () => Promise<string>,
+  logger: Logger
+): DevShellHeadProvider {
+  let cache: HtmlTagDescriptor[] | null = null;
+  let inflight: Promise<HtmlTagDescriptor[]> | null = null;
+  let warned = false;
+
+  const provider: DevShellHeadProvider = {
+    async getTags() {
+      if (cache) return cache;
+      if (!inflight) {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        inflight = Promise.race([
+          renderShellFlight(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error(`shell render timed out after ${RENDER_TIMEOUT_MS}ms`)),
+              RENDER_TIMEOUT_MS
+            );
+            timer.unref?.();
+          }),
+        ])
+          .then((payload) => {
+            const tags = extractHeadTagsFromFlight(payload);
+            cache = tags;
+            return tags;
+          })
+          .catch((error) => {
+            if (!warned) {
+              warned = true;
+              logger.warn(
+                `[vite-plugin-react-server] dev-shell head render failed; serving index.html unchanged: ` +
+                  String(error instanceof Error ? error.message : error)
+              );
+            }
+            return [] as HtmlTagDescriptor[];
+          })
+          .finally(() => {
+            clearTimeout(timer);
+            inflight = null;
+          });
+      }
+      return inflight;
+    },
+    invalidate() {
+      cache = null;
+    },
+  };
+
+  providers.set(server, provider);
+  return provider;
+}
+
+export const getDevShellHeadProvider = (
+  server: ViteDevServer | undefined
+): DevShellHeadProvider | undefined =>
+  server ? providers.get(server) : undefined;

--- a/plugin/dev-server/devShellHeadProvider.ts
+++ b/plugin/dev-server/devShellHeadProvider.ts
@@ -19,7 +19,11 @@ export type DevShellHeadProvider = {
   invalidate: () => void;
 };
 
-const providers = new WeakMap<ViteDevServer, DevShellHeadProvider>();
+// Keyed by the server's ResolvedConfig, NOT the server object: Vite hands
+// plugins proxied dev-server instances in several paths (restart wrappers,
+// environment contexts), and a proxy fails WeakMap identity while property
+// reads like `.config` pass through to the same underlying object.
+const providers = new WeakMap<object, DevShellHeadProvider>();
 
 const RENDER_TIMEOUT_MS = 5_000;
 
@@ -49,6 +53,14 @@ export function createDevShellHeadProvider(
         ])
           .then((payload) => {
             const tags = extractHeadTagsFromFlight(payload);
+            // An empty extraction is a failed render (error payload, head
+            // behind a reference row, worker raced) — do NOT cache it, so
+            // the next html request retries instead of pinning a bare shell.
+            if (tags.length === 0) {
+              throw new Error(
+                `no head elements found in the shell flight (${payload.length} bytes)`
+              );
+            }
             cache = tags;
             return tags;
           })
@@ -74,11 +86,11 @@ export function createDevShellHeadProvider(
     },
   };
 
-  providers.set(server, provider);
+  providers.set(server.config, provider);
   return provider;
 }
 
 export const getDevShellHeadProvider = (
   server: ViteDevServer | undefined
 ): DevShellHeadProvider | undefined =>
-  server ? providers.get(server) : undefined;
+  server?.config ? providers.get(server.config) : undefined;

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -3,6 +3,8 @@ import { configureReactServer } from "./configureReactServer.client.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
 import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags } from "./devPluginShared.js";
+import { getDevShellHeadProvider } from "./devShellHeadProvider.js";
+import { mergeDevShellHead } from "./devShellHead.js";
 import type { ConfigEnv } from "vite";
 
 
@@ -41,11 +43,19 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       configEnv = viteConfigEnv;
 
     },
-    // transport:"webpack": stamp the dev document with the flight-transport
-    // hint so the browser picks the webpack flight client (dev/prod parity
-    // with the baked pair's documents). No-op on esm.
-    transformIndexHtml() {
-      return devFlightTransportTags(userOptions);
+    // Two dev-document concerns ride this hook:
+    // - transport:"webpack": stamp the flight-transport hint (no-op on esm).
+    // - dev-shell head-merge: inject the document component's head so the dev
+    //   shell matches prod (lazy render + cache via the provider; on any
+    //   failure the provider resolves [] and the html is served unchanged).
+    async transformIndexHtml(html: string, ctx: { server?: import("vite").ViteDevServer }) {
+      const transportTags = devFlightTransportTags(userOptions) ?? [];
+      const provider = getDevShellHeadProvider(ctx?.server);
+      if (!provider) {
+        return transportTags.length ? transportTags : undefined;
+      }
+      const merged = mergeDevShellHead(html, await provider.getTags());
+      return { html: merged.html, tags: [...transportTags, ...merged.tags] };
     },
     configureServer(server) {      
       // Log that plugin is being configured
@@ -131,6 +141,12 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
 
       if (shouldInvalidateWorker && hmrHandler) {
         isProcessingHmr = true;
+
+        // The document head may have changed with any server-tree edit (the
+        // Html component is a server file); drop the dev-shell cache and let
+        // the NEXT html request re-render it lazily. Superset of "the Html
+        // module invalidated", chosen over module-graph tracking for stage 1.
+        getDevShellHeadProvider(server)?.invalidate();
 
         try {
           if (userOptions.verbose) {

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -4,6 +4,8 @@ import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
 import type { Plugin, ViteDevServer } from "vite";
 import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags } from "./devPluginShared.js";
+import { getDevShellHeadProvider } from "./devShellHeadProvider.js";
+import { mergeDevShellHead } from "./devShellHead.js";
 
 /**
  * Dev server plugin for server environment.
@@ -32,8 +34,17 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
     // with the baked pair's documents). No-op on esm. Lives on this plugin
     // (not the server-environment one) because the html transform runs
     // outside the server environment filter.
-    transformIndexHtml() {
-      return devFlightTransportTags(userOptions);
+    async transformIndexHtml(html: string, ctx: { server?: ViteDevServer }) {
+      const transportTags = devFlightTransportTags(userOptions) ?? [];
+      // Dev-shell head-merge, when a provider is registered (the worker-based
+      // dev flow configures one; without it this is transport tags only —
+      // byte-for-byte the previous document).
+      const provider = getDevShellHeadProvider(ctx?.server);
+      if (!provider) {
+        return transportTags.length ? transportTags : undefined;
+      }
+      const merged = mergeDevShellHead(html, await provider.getTags());
+      return { html: merged.html, tags: [...transportTags, ...merged.tags] };
     },
     // Server-level handleHotUpdate — sends custom WS event to client
     // Vite 6 Environment API: hotUpdate runs per-environment.

--- a/plugin/stream/handleRscStream.client.ts
+++ b/plugin/stream/handleRscStream.client.ts
@@ -61,6 +61,9 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
     // therefore only ends the stream as a delayed fallback for a worker that
     // died before posting `null`.
     let dataEndedReceived = false;
+    // Timestamp of the last data-port chunk; the RSC_END fallback treats
+    // recent flow as proof of a live worker and re-arms instead of ending.
+    let lastChunkAt = 0;
     const endDataStream = () => {
       dataEndedReceived = true;
       rscStream.end();
@@ -99,13 +102,26 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
           controlEndedReceived = true;
           // Do not end the data stream here — see the dataEndedReceived note
           // above. Fall back to ending only if the data port's `null` never
-          // arrives (worker died between chunks and its onEnd).
+          // arrives (worker died between chunks and its onEnd). The fallback
+          // must not fire while data is still ARRIVING: a flooded data queue
+          // (dev debug rows are many small chunks) lets this one control
+          // message jump ahead across ports, and a fixed short timer then
+          // truncates the payload right before its final model rows. Live
+          // chunk flow proves the worker is alive, so re-arm until the data
+          // queue goes quiet.
           if (!dataEndedReceived) {
-            setTimeout(() => {
-              if (!dataEndedReceived) {
+            const FALLBACK_QUIET_MS = 500;
+            const armEndFallback = () => {
+              setTimeout(() => {
+                if (dataEndedReceived) return;
+                if (Date.now() - lastChunkAt < FALLBACK_QUIET_MS) {
+                  armEndFallback();
+                  return;
+                }
                 endDataStream();
-              }
-            }, 100).unref?.();
+              }, FALLBACK_QUIET_MS).unref?.();
+            };
+            armEndFallback();
           }
           break;
         case "ERROR": {
@@ -171,6 +187,7 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
         }
         rscStream.destroy(new Error(data.error));
       } else if (Buffer.isBuffer(data) || data instanceof Uint8Array) {
+        lastChunkAt = Date.now();
         // RSC chunk data - pass through without mutation
         if (options.verbose) {
           options.logger?.info(

--- a/plugin/stream/handleRscStream.client.ts
+++ b/plugin/stream/handleRscStream.client.ts
@@ -61,9 +61,6 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
     // therefore only ends the stream as a delayed fallback for a worker that
     // died before posting `null`.
     let dataEndedReceived = false;
-    // Timestamp of the last data-port chunk; the RSC_END fallback treats
-    // recent flow as proof of a live worker and re-arms instead of ending.
-    let lastChunkAt = 0;
     const endDataStream = () => {
       dataEndedReceived = true;
       rscStream.end();
@@ -102,26 +99,13 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
           controlEndedReceived = true;
           // Do not end the data stream here — see the dataEndedReceived note
           // above. Fall back to ending only if the data port's `null` never
-          // arrives (worker died between chunks and its onEnd). The fallback
-          // must not fire while data is still ARRIVING: a flooded data queue
-          // (dev debug rows are many small chunks) lets this one control
-          // message jump ahead across ports, and a fixed short timer then
-          // truncates the payload right before its final model rows. Live
-          // chunk flow proves the worker is alive, so re-arm until the data
-          // queue goes quiet.
+          // arrives (worker died between chunks and its onEnd).
           if (!dataEndedReceived) {
-            const FALLBACK_QUIET_MS = 500;
-            const armEndFallback = () => {
-              setTimeout(() => {
-                if (dataEndedReceived) return;
-                if (Date.now() - lastChunkAt < FALLBACK_QUIET_MS) {
-                  armEndFallback();
-                  return;
-                }
+            setTimeout(() => {
+              if (!dataEndedReceived) {
                 endDataStream();
-              }, FALLBACK_QUIET_MS).unref?.();
-            };
-            armEndFallback();
+              }
+            }, 100).unref?.();
           }
           break;
         case "ERROR": {
@@ -187,7 +171,6 @@ export const handleRscStream: HandleRscStreamFn<"client"> =
         }
         rscStream.destroy(new Error(data.error));
       } else if (Buffer.isBuffer(data) || data instanceof Uint8Array) {
-        lastChunkAt = Date.now();
         // RSC chunk data - pass through without mutation
         if (options.verbose) {
           options.logger?.info(

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -325,6 +325,8 @@ export async function loadComponentsWithCache(options: {
   layoutExportName?: string;
   rscOutputPath?: string;  // Transport suffix, for stripping when matching params
   request?: Request;  // Rebuilt from serializedRequest; threaded into loader ctx
+  /** Document-only render: Fragment page, no page/props/loader work. */
+  shell?: boolean;
   /**
    * Written, not read, by this function: `moduleRunAt` is stamped (wall-clock,
    * once) right before the FIRST actual load call — the moment module code
@@ -381,7 +383,13 @@ export async function loadComponentsWithCache(options: {
       `[loadComponentsWithCache] pagePath=${pagePath}, propsPath=${propsPath}, url=${url}`
     );
   }
-  if (pagePath) {
+  if (options.shell) {
+    // Shell render: the document wrapper with NO page — the dev-shell
+    // head-merge asks for the Html component's <head> and nothing route-
+    // specific. Skipping the page load entirely means no page module, no
+    // props, no loaders run.
+    PageComponent = React.Fragment;
+  } else if (pagePath) {
     if (verbose) {
       logger?.info(
         `[loadComponentsWithCache] Loading page and props for pagePath=${pagePath}`
@@ -832,6 +840,7 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
 
         const { PageComponent, pageProps, RootComponent, HtmlComponent, layoutChain } =
           await loadComponentsWithCache({
+            shell: msg.options.shell === true,
             pagePath: msg.options.pagePath,
             propsPath: msg.options.propsPath,
             rootPath: msg.options.rootPath,

--- a/plugin/worker/rsc/types.ts
+++ b/plugin/worker/rsc/types.ts
@@ -154,6 +154,9 @@ export type RscRenderOpt = WorkerMessage & {
     HtmlComponent?: any;
     // Pre-resolved props from main thread (for server actions support in dev:ssr)
     resolvedPageProps?: Record<string, unknown>;
+    // Document-only render (dev-shell head-merge): Fragment page, no
+    // page/props/loader work; the Html wrapper stays real.
+    shell?: boolean;
   };
 };
 

--- a/test/dev/dev-shell-head-merge.test.ts
+++ b/test/dev/dev-shell-head-merge.test.ts
@@ -5,6 +5,7 @@ import { testUserOptions } from "../test-config";
 import { setupIndexHTML } from "../setup.js";
 import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
 import { resolve, join } from "node:path";
+import { getCondition } from "../../plugin/config/getCondition.js";
 
 /**
  * The dev shell serves the DOCUMENT component's head: the served index.html
@@ -18,6 +19,11 @@ import { resolve, join } from "node:path";
  * shell), so the assertions poll until the merge appears.
  */
 
+// Stage 1 registers the provider in the worker-based dev flow only; dev:rsc
+// (react-server condition on the main thread) serves the plain shell, so this
+// e2e runs on the client leg.
+const clientLeg = getCondition() !== "react-server" ? describe : describe.skip;
+
 let server: ViteDevServer;
 const port = 3139;
 const testDir = resolve(__dirname, "../fixtures/dev-shell-head-merge.test");
@@ -28,7 +34,7 @@ async function fetchShell(): Promise<string> {
   return res.text();
 }
 
-describe("dev shell head-merge", () => {
+clientLeg("dev shell head-merge", () => {
   beforeAll(async () => {
     await rm(testDir, { recursive: true, force: true });
     await setupIndexHTML(testDir);
@@ -84,7 +90,6 @@ export const Html: HtmlComponentType = ({
           ...testUserOptions,
           projectRoot: testDir,
           moduleBase: "src",
-          verbose: true,
           Page: () => `src/page/page.tsx`,
           props: () => `src/page/props.ts`,
           Html: "src/Html.tsx",

--- a/test/dev/dev-shell-head-merge.test.ts
+++ b/test/dev/dev-shell-head-merge.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type ViteDevServer } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { testUserOptions } from "../test-config";
+import { setupIndexHTML } from "../setup.js";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { resolve, join } from "node:path";
+
+/**
+ * The dev shell serves the DOCUMENT component's head: the served index.html
+ * must carry the Html component's title/meta/style (rendered through the dev
+ * worker's shell render and injected via transformIndexHtml), and the
+ * hand-written index.html title must be gone — one source of truth, no
+ * silent divergence between the dev shell and the production document.
+ *
+ * The first request can legitimately be served unmerged (the provider races
+ * a cold worker boot against its render timeout and falls back to the plain
+ * shell), so the assertions poll until the merge appears.
+ */
+
+let server: ViteDevServer;
+const port = 3139;
+const testDir = resolve(__dirname, "../fixtures/dev-shell-head-merge.test");
+
+async function fetchShell(): Promise<string> {
+  const res = await fetch(`http://localhost:${port}/`);
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+describe("dev shell head-merge", () => {
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await setupIndexHTML(testDir);
+    await mkdir(join(testDir, "src/page"), { recursive: true });
+    await writeFile(
+      join(testDir, "src/page/page.tsx"),
+      `import React from "react";
+export const Page = () => <div>Head Merge Test</div>;`
+    );
+    await writeFile(
+      join(testDir, "src/page/props.ts"),
+      `export const props = () => ({});`
+    );
+    await writeFile(
+      join(testDir, "src/Html.tsx"),
+      `import React from "react";
+import { Root as DefaultRoot } from "vite-plugin-react-server/components";
+import type { HtmlComponentType } from "vite-plugin-react-server/types";
+
+export const Html: HtmlComponentType = ({
+  Root = DefaultRoot,
+  cssFiles,
+  pageProps,
+  Page,
+  as = "div",
+}) => {
+  return React.createElement("html", { lang: "en" },
+    React.createElement("head", {},
+      React.createElement("title", {}, "Document Title From Html"),
+      React.createElement("meta", { name: "description", content: "from-the-document" }),
+      React.createElement("style", {}, ":root{--shell:1}")
+    ),
+    React.createElement("body", {},
+      React.createElement(Root as React.ElementType, { as, id: "root", cssFiles, pageProps, Page })
+    )
+  );
+};`
+    );
+
+    try {
+      await symlink(
+        resolve(__dirname, "../../node_modules"),
+        join(testDir, "node_modules"),
+        "dir"
+      );
+    } catch {}
+
+    server = await createServer({
+      mode: "test",
+      root: testDir,
+      plugins: [
+        vitePluginReactServer({
+          ...testUserOptions,
+          projectRoot: testDir,
+          moduleBase: "src",
+          verbose: true,
+          Page: () => `src/page/page.tsx`,
+          props: () => `src/page/props.ts`,
+          Html: "src/Html.tsx",
+        }),
+      ],
+      server: { port },
+    });
+    await server.listen();
+  }, 60_000);
+
+  afterAll(async () => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      server?.close(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, 15_000);
+        timer.unref?.();
+      }),
+    ]);
+    clearTimeout(timer);
+    await rm(testDir, { recursive: true, force: true });
+  }, 30_000);
+
+  it("serves the document component's head in the dev shell", async () => {
+    // Poll: the first response may race the cold worker boot and fall back
+    // to the unmerged shell by design.
+    let html = "";
+    const deadline = Date.now() + 30_000;
+    for (;;) {
+      html = await fetchShell();
+      if (html.includes("Document Title From Html") || Date.now() > deadline) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+
+    // The document's head made it into the served shell…
+    expect(html).toContain("<title>Document Title From Html</title>");
+    expect(html).toContain('content="from-the-document"');
+    expect(html).toContain(":root{--shell:1}");
+    // …the hand-written title is gone (one source of truth)…
+    expect(html).not.toContain("Test App");
+    // …and the shell is still Vite's: entry script and mount node intact.
+    expect(html).toContain('src="/src/client.tsx"');
+    expect(html).toContain('<div id="root"></div>');
+  }, 45_000);
+});

--- a/test/unit/devShellHead.test.ts
+++ b/test/unit/devShellHead.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractDocumentHeadTags,
+  mergeDevShellHead,
+} from "../../plugin/dev-server/devShellHead.js";
+
+const DOC = `<!DOCTYPE html><html lang="en"><head>
+<link rel="stylesheet" href="/assets/main.css" data-precedence="high"/>
+<meta charSet="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>My App — Home</title>
+<style>:root{--x:1}</style>
+<script type="module" src="/entry.js"></script>
+</head><body><div id="root"></div></body></html>`;
+
+describe("extractDocumentHeadTags", () => {
+  const tags = extractDocumentHeadTags(DOC);
+
+  it("extracts the whitelisted head elements in document order", () => {
+    expect(tags.map((t) => t.tag)).toEqual([
+      "link",
+      "meta",
+      "meta",
+      "title",
+      "style",
+    ]);
+  });
+
+  it("keeps attributes, including valueless ones", () => {
+    const link = tags[0];
+    expect(link.attrs).toMatchObject({
+      rel: "stylesheet",
+      href: "/assets/main.css",
+    });
+    const viewport = tags[2];
+    expect(viewport.attrs).toMatchObject({
+      name: "viewport",
+      content: "width=device-width, initial-scale=1",
+    });
+  });
+
+  it("keeps title and style children", () => {
+    expect(tags.find((t) => t.tag === "title")?.children).toBe(
+      "My App — Home"
+    );
+    expect(tags.find((t) => t.tag === "style")?.children).toBe(
+      ":root{--x:1}"
+    );
+  });
+
+  it("excludes scripts — the dev shell has its own entry", () => {
+    expect(tags.some((t) => t.tag === "script")).toBe(false);
+  });
+
+  it("returns empty for a document without a head", () => {
+    expect(extractDocumentHeadTags("<html><body/></html>")).toEqual([]);
+  });
+});
+
+describe("mergeDevShellHead", () => {
+  const INDEX = `<!DOCTYPE html><html><head>
+  <meta charset="UTF-8" />
+  <title>hand-written dev title</title>
+  <link rel="icon" href="/favicon.ico" />
+</head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>`;
+
+  it("drops the index.html title when the document provides one", () => {
+    const { html } = mergeDevShellHead(INDEX, extractDocumentHeadTags(DOC));
+    expect(html).not.toContain("hand-written dev title");
+    expect(html).toContain('rel="icon"'); // everything else untouched
+  });
+
+  it("keeps the index.html title when the document has none", () => {
+    const { html } = mergeDevShellHead(
+      INDEX,
+      extractDocumentHeadTags("<html><head><meta name=\"a\" content=\"b\"/></head></html>")
+    );
+    expect(html).toContain("hand-written dev title");
+  });
+
+  it("passes the document tags through for injection", () => {
+    const tags = extractDocumentHeadTags(DOC);
+    expect(mergeDevShellHead(INDEX, tags).tags).toBe(tags);
+  });
+});

--- a/test/unit/devShellHeadFlight.test.ts
+++ b/test/unit/devShellHeadFlight.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { extractHeadTagsFromFlight } from "../../plugin/dev-server/devShellHeadFlight.js";
+
+/**
+ * Wire-shaped flight rows (N:JSON model rows) for a full-document render:
+ * html > (head, body). Mirrors the esm flight model format — element tuples
+ * ["$", tag, key, props] with nested children.
+ */
+const PAYLOAD = [
+  `0:["$","html",null,{"lang":"en","children":[["$","head",null,{"children":[["$","meta",null,{"charSet":"utf-8"}],["$","meta",null,{"name":"viewport","content":"width=device-width, initial-scale=1"}],["$","title",null,{"children":"My App — Home"}],["$","link",null,{"rel":"stylesheet","href":"/assets/main.css","precedence":"high"}],["$","style",null,{"children":":root{--x:1}"}],["$","script",null,{"type":"module","src":"/entry.js"}]]}],["$","body",null,{"children":["$","div",null,{"id":"root"}]}]]}]`,
+  `1:{"name":"Page","env":"Server"}`,
+].join("\n");
+
+describe("extractHeadTagsFromFlight", () => {
+  const tags = extractHeadTagsFromFlight(PAYLOAD);
+
+  it("extracts whitelisted head elements in order", () => {
+    expect(tags.map((t) => t.tag)).toEqual([
+      "meta",
+      "meta",
+      "title",
+      "link",
+      "style",
+    ]);
+  });
+
+  it("maps React prop names to HTML attribute names", () => {
+    expect(tags[0].attrs).toEqual({ charset: "utf-8" });
+  });
+
+  it("keeps title and style children, and stringifies attr values", () => {
+    expect(tags.find((t) => t.tag === "title")?.children).toBe(
+      "My App — Home"
+    );
+    expect(tags.find((t) => t.tag === "style")?.children).toBe(":root{--x:1}");
+    expect(tags.find((t) => t.tag === "link")?.attrs).toMatchObject({
+      rel: "stylesheet",
+      href: "/assets/main.css",
+      precedence: "high",
+    });
+  });
+
+  it("excludes scripts", () => {
+    expect(tags.some((t) => t.tag === "script")).toBe(false);
+  });
+
+  it("returns [] when the head hides behind a reference placeholder", () => {
+    const lazy = `0:["$","html",null,{"children":"$L1"}]`;
+    expect(extractHeadTagsFromFlight(lazy)).toEqual([]);
+  });
+
+  it("returns [] for payloads without a document head", () => {
+    const headless = `0:["$","div",null,{"children":"page only"}]`;
+    expect(extractHeadTagsFromFlight(headless)).toEqual([]);
+    expect(extractHeadTagsFromFlight("")).toEqual([]);
+  });
+
+  it("skips non-JSON rows without throwing", () => {
+    const noisy = "2:T5,hello\n" + PAYLOAD;
+    expect(extractHeadTagsFromFlight(noisy).length).toBe(5);
+  });
+});

--- a/test/unit/devShellHeadFlight.test.ts
+++ b/test/unit/devShellHeadFlight.test.ts
@@ -55,6 +55,13 @@ describe("extractHeadTagsFromFlight", () => {
     expect(extractHeadTagsFromFlight("")).toEqual([]);
   });
 
+  it("accepts dev-mode element tuples (owner/stack fields appended)", () => {
+    const dev = `0:["$","html",null,{"children":[["$","head",null,{"children":[["$","title",null,{"children":"Dev Title"},"$1","$8",1]]},"$1","$7",1],["$","body",null,{"children":"$c"},"$1","$b",1]]},"$1","$6",1]`;
+    const tags = extractHeadTagsFromFlight(dev);
+    expect(tags.map((t) => t.tag)).toEqual(["title"]);
+    expect(tags[0].children).toBe("Dev Title");
+  });
+
   it("skips non-JSON rows without throwing", () => {
     const noisy = "2:T5,hello\n" + PAYLOAD;
     expect(extractHeadTagsFromFlight(noisy).length).toBe(5);


### PR DESCRIPTION
The static build regenerates `<head>` from the document/Html component and drops everything authored in the source `index.html` — correct by design, but it leaves the DEV shell hand-maintained and silently divergent: title/meta/styles put in `index.html` vanish in the build, and the document's head never reaches dev.

Stage 1 of closing that gap: the dev shell now serves the document component's head.

## How

- **One shell render through the existing dev worker**: a new `shell: true` render flag makes the worker render the real document wrapper around a Fragment page — no page module, no props, no loaders. The head is read straight from the flight rows (`devShellHeadFlight.ts`), so no client React and no html worker run in dev. Dev flight element tuples carry appended owner/stack fields, so the extractor accepts `length >= 4`.
- **Injection via `transformIndexHtml`**: a per-server provider (keyed on `server.config` — Vite hands plugins proxied server instances, and a proxy fails WeakMap identity while property reads pass through) caches the extracted head; both dev plugins merge it into the served `index.html`, dropping the hand-written `<title>` when the document provides one. `index.html` stays the body scaffold.
- **Lazy + fail-open**: the first HTML request pays one render (5s timeout); any failure serves `index.html` unchanged with a single warning — dev startup can never block on this. An empty extraction counts as failure and is never cached, so the next HTML request retries. Any server-tree edit drops the cache; the next HTML request re-renders lazily.
- **Scope**: the worker-based dev flow. dev:rsc registers no provider and stays byte-for-byte unchanged. No changes outside the dev-server/worker layer — the stream lifecycle is untouched (an earlier RSC_END fallback change was reverted out of this PR; that question is tracked separately).

## Verification

- Real-server e2e (`test/dev/dev-shell-head-merge.test.ts`): boots `vite dev` with a custom Html fixture and asserts the served shell carries the document's title/meta/style, the hand-written title is gone, and Vite's entry script + mount node are intact.
- 15 unit tests pin the extractors and merge rules, including the dev tuple shape.
- Full suites green: unit 750, dev 43, server 992, client 291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHY8KAH6Taq7boWCzEB47M