### PR TITLE
chore(release): 3.9.0 — gate tests + version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",

--- a/test/examples/edge-join-hydration.test.ts
+++ b/test/examples/edge-join-hydration.test.ts
@@ -208,5 +208,42 @@ describe.skipIf(!createEdgeHandler || !browserAvailable)(
         await browser.close();
       }
     });
+
+    // The contract layer under the browser proof: the SERIALIZED reference-id
+    // shape. Under a rooted config every client reference in a payload must be
+    // a rooted single-slash path — the esm renderer serializes $$id minus the
+    // hosted-root prefix, and a trailing-slash prefix once consumed the id's
+    // leading slash HERE while every in-repo suite stayed green (the sibling
+    // gate caught it). Asserting the wire shape directly makes a future
+    // regression name the defective layer instead of surfacing as a distant
+    // hydration crash.
+    const expectRootedRefs = (payload: string, source: string) => {
+      const refs = [...payload.matchAll(/"(\/{0,2}[^"]*Counter\.client[^"]*)"/g)]
+        .map((m) => m[1])
+        .filter((s) => !s.includes("src/routes/")); // debug rows carry fs paths
+      expect(refs.length, `${source}: no Counter reference found`).toBeGreaterThan(0);
+      for (const ref of refs) {
+        expect(ref, `${source}: reference not rooted`).toMatch(/^\//);
+        expect(ref, `${source}: double-slash reference`).not.toMatch(/^\/\//);
+      }
+    };
+
+    it("serializes rooted single-slash reference ids (static payload + live response)", async () => {
+      // (a) The frozen/refetched payload on disk.
+      const staticPayload = readFileSync(
+        join(testDir, "dist/static/index.rsc"),
+        "utf8"
+      );
+      expectRootedRefs(staticPayload, "dist/static/index.rsc");
+
+      // (b) The per-request render through the baked pair — the serialization
+      // path action responses share, and the seam the static payload cannot
+      // cover.
+      const response = await fetch(`http://localhost:${PORT}/index.rsc`, {
+        headers: { accept: "text/x-component" },
+      });
+      expect(response.status).toBe(200);
+      expectRootedRefs(await response.text(), "live /index.rsc response");
+    });
   }
 );

--- a/test/examples/edge-stream-hydration.test.ts
+++ b/test/examples/edge-stream-hydration.test.ts
@@ -66,14 +66,14 @@ async function setupFixture() {
   );
   // The canonical supplied client entry — assembles initial-payload
   // consumption (blob OR streamed, via createReactFetcher) + hydration.
-  // moduleBaseURL is "" (not "/"): the browser transport string-concatenates
-  // base + id, and "/" + "/routes/x.js" makes a "//routes/x.js" URL — same
-  // bytes served, DIFFERENT module identity, so shared chunks (React!) load
-  // twice and hooks crash. Tracked as the base+id join normalization bead.
+  // moduleBaseURL "/" is the join-contract regression proof: ids are rooted
+  // and the fetcher strips the base's trailing slash, so "/" + "/routes/x.js"
+  // must compose ONE slash — a "//routes/x.js" URL is a second module
+  // identity, two React copies, and a hooks crash.
   await writeFile(
     join(testDir, "src/client.tsx"),
     `import { startClient } from "vite-plugin-react-server/router/client";\n` +
-      `startClient({ moduleBaseURL: "" });\n`
+      `startClient({ moduleBaseURL: "/" });\n`
   );
   await writeFile(
     join(testDir, "index.html"),


### PR DESCRIPTION
Completes main's sync with the published v3.9.0 artifact. Two commits cherry-picked from the release branch:

- The release-gate tests: the edge-stream-hydration fixture flips to `moduleBaseURL: "/"` (the stream-mode × join-contract composition proof), and the join e2e gains the reference-id shape contract — every serialized client reference in the static payload and the live per-request response must be a rooted single-slash path.
- The 3.9.0 version bump matching the published package.

With this merged, `origin/main`'s tree is byte-identical to the tree the `v3.9.0` tag and the npm artifact were built from (verified: empty `git diff` against the release branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHY8KAH6Taq7boWCzEB47M