### PR TITLE
fix: sealed action gate follows the use-server directive, not the filename

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -10,6 +10,10 @@ import { resolveModuleFromManifest } from "../helpers/resolveModuleFromManifest.
 import { UNKNOWN_ROUTE_MARKER } from "../stream/unknownRoute.js";
 import { buildWebpackClientManifest } from "./clientManifest.js";
 import { buildConsumerBundle } from "./buildConsumerBundle.js";
+import { hasDirectiveStatement } from "react-server-loader/directives";
+import { parse as rslParse } from "react-server-loader";
+import { transformTsSource } from "../loader/transformTsSource.js";
+import { readdirSync, statSync } from "node:fs";
 
 /** Resolve a package subpath's `react-server` export target to an absolute path. */
 function reactServerExportTarget(
@@ -504,17 +508,105 @@ export async function buildEdgeBundle(opts: {
   const rootNs = nsFor(rootComp.abs);
 
   // Enumerate server-action modules from the server manifest (the sealed-gate
-  // allowlist): keys matching the action pattern, baked so the gate resolves
-  // them without a disk import (and thus no `react-server` condition at runtime).
+  // allowlist), baked so the gate resolves them without a disk import (and
+  // thus no `react-server` condition at runtime).
+  //
+  // The DIRECTIVE is the source of truth for membership: a module is gated
+  // when its SOURCE carries a top-of-file `"use server"` — exactly the set the
+  // build REGISTERED as server references. Keying membership off the
+  // `.server.` FILENAME convention alone diverged the gate from the flight
+  // layer: a directive-marked module with any other name was registered,
+  // serialized into payloads, then rejected at the trust boundary at runtime
+  // ("Unknown server reference"). The filename pattern survives only as a
+  // fallback for manifest keys whose source is no longer readable; a name
+  // never gates what the directive didn't, and a directive-less module's
+  // exports carry no reference tag so gating one adds nothing.
   const actionKeyRe = new RegExp(DEFAULT_CONFIG.EDGE.actionKeyPattern);
+  // Mirrors the TRANSFORMER's own gate: strip TS/JSX with the running
+  // Vite's transform (raw TS does not parse under rsl's JS-only grammar),
+  // then scan for a REAL directive statement — module prologue or any
+  // function body, quoted strings and comments rejected. Answering from the
+  // same scanner the transform used is what keeps gate membership equal to
+  // what the build registered.
+  const isServerDirectiveSource = async (
+    srcAbs: string
+  ): Promise<boolean | null> => {
+    if (!existsSync(srcAbs)) return null; // unknowable — caller falls back
+    try {
+      const source = readFileSync(srcAbs, "utf8");
+      if (!source.includes("use server")) return false; // cheap pre-filter
+      const lang = /\.[cm]?tsx$|\.jsx$/.test(srcAbs) ? "tsx" : "ts";
+      const { code } = await transformTsSource(source, srcAbs, lang);
+      return hasDirectiveStatement(
+        rslParse(code).ast as never,
+        "use server"
+      );
+    } catch {
+      return null;
+    }
+  };
   const actionEntries: { key: string; file: string; ns: string }[] = [];
+  const gatedKeys = new Set<string>();
   for (const [key, entry] of Object.entries(
     manifest as Record<string, { file?: string } | undefined>
   )) {
-    if (!entry?.file || !actionKeyRe.test(key)) continue;
+    if (!entry?.file) continue;
     const abs = join(serverDir, entry.file);
     if (!existsSync(abs)) continue;
+    const byDirective = await isServerDirectiveSource(join(projectRoot, key));
+    const isAction = byDirective ?? actionKeyRe.test(key);
+    if (!isAction) continue;
     actionEntries.push({ key, file: entry.file, ns: nsFor(abs) });
+    gatedKeys.add(key);
+  }
+
+  // A `"use server"` module the server build never reached CANNOT be gated —
+  // nothing registered it, so its actions fail at runtime with an opaque
+  // "Unknown server reference". Say so at build time, naming each module and
+  // the fix (reach it from server code: a page, props, layout, or another
+  // action module). Bounded walk, same spirit as the unwired-layouts scan.
+  {
+    const moduleBaseDir = join(projectRoot, userOptions.moduleBase || "src");
+    const SKIP_DIRS = new Set(["node_modules", "dist", ".git", ".vite"]);
+    const SOURCE_RE = /\.[cm]?[jt]sx?$/;
+    const candidates: string[] = [];
+    const walk = (dir: string, depth: number): void => {
+      if (depth > 8 || candidates.length > 2000) return;
+      let names: string[];
+      try {
+        names = readdirSync(dir);
+      } catch {
+        return;
+      }
+      for (const name of names) {
+        if (name.startsWith(".") || SKIP_DIRS.has(name)) continue;
+        const abs = join(dir, name);
+        let st;
+        try {
+          st = statSync(abs);
+        } catch {
+          continue;
+        }
+        if (st.isDirectory()) walk(abs, depth + 1);
+        else if (SOURCE_RE.test(name)) candidates.push(abs);
+      }
+    };
+    walk(moduleBaseDir, 0);
+    const ungated: string[] = [];
+    for (const abs of candidates) {
+      const rel = relative(projectRoot, abs).split(sep).join("/");
+      if (gatedKeys.has(rel)) continue;
+      if ((await isServerDirectiveSource(abs)) === true) ungated.push(rel);
+    }
+    if (ungated.length > 0) {
+      logger.warn(
+        `${tag} ${ungated.length} "use server" module(s) are NOT in the sealed ` +
+          `action gate because the server build never reached them: ` +
+          `${ungated.join(", ")}. Import each from server code (a page, ` +
+          `props, layout, or another action module) — until then its actions ` +
+          `fail at runtime with 'Unknown server reference'.`
+      );
+    }
   }
   const actionDictLines = actionEntries.map(
     (a) => `  ${JSON.stringify(a.key)}: ${a.ns},`

--- a/test/examples/edge-action-roundtrip.test.ts
+++ b/test/examples/edge-action-roundtrip.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { resolve, join, extname } from "node:path";
+import { pathToFileURL } from "node:url";
+import { chromium } from "playwright";
+import { doBuild } from "../doBuild.js";
+import { fileRouter } from "../../plugin/router/fileRouter.js";
+
+/**
+ * The server-action round-trip, end to end in a real browser, under
+ * transport:"webpack" through the baked pair — the path a green release
+ * shipped broken because no test drove it.
+ *
+ * Two regressions pinned at once:
+ * - The sealed gate's allowlist follows the `"use server"` DIRECTIVE, not the
+ *   `.server.` filename convention: the action module here is named
+ *   `ping.ts` on purpose. Under the filename rule it was registered and
+ *   serialized but rejected at the trust boundary at runtime ("Unknown
+ *   server reference").
+ * - The browser leg (proxy → callServer → encodeReply → gate → response
+ *   decode) must run through the webpack flight client end to end.
+ */
+
+const browserAvailable = (() => {
+  try {
+    return existsSync(chromium.executablePath());
+  } catch {
+    return false;
+  }
+})();
+
+const testDir = resolve(__dirname, "../fixtures/edge-action-roundtrip.test");
+const PORT = 4189;
+
+const MIME: Record<string, string> = {
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".map": "application/json",
+};
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/routes"), { recursive: true });
+  // The action module: "use server" directive, deliberately NOT named
+  // *.server.* — membership must come from the directive.
+  await writeFile(
+    join(testDir, "src/ping.ts"),
+    `"use server";\n` +
+      `export async function ping(n: number): Promise<{ doubled: number }> {\n` +
+      `  return { doubled: n * 2 };\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/PingButton.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function PingButton({ ping }: { ping: (n: number) => Promise<{ doubled: number }> }) {\n` +
+      `  const [result, setResult] = React.useState<number | null>(null);\n` +
+      `  return (\n` +
+      `    <button id="ping" onClick={async () => setResult((await ping(21)).doubled)}>\n` +
+      `      {result === null ? "ping" : "doubled:" + result}\n` +
+      `    </button>\n` +
+      `  );\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import React from "react";\n` +
+      `import { ping } from "../ping.js";\n` +
+      `import { PingButton } from "./PingButton.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <div id="app">\n` +
+      `    <h1>{"action-roundtrip"}</h1>\n` +
+      `    <PingButton ping={ping} />\n` +
+      `  </div>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+function serve(
+  handler: (req: Request) => Promise<Response | null>,
+  staticRoots: string[]
+): Server {
+  return createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+    if (req.method === "GET") {
+      for (const root of staticRoots) {
+        const file = join(root, url.pathname);
+        if (extname(file) && existsSync(file) && file.startsWith(root)) {
+          res.writeHead(200, {
+            "content-type": MIME[extname(file)] ?? "application/octet-stream",
+          });
+          res.end(readFileSync(file));
+          return;
+        }
+      }
+    }
+    const body =
+      req.method === "POST"
+        ? await new Promise<Buffer>((r) => {
+            const chunks: Buffer[] = [];
+            req.on("data", (c) => chunks.push(c));
+            req.on("end", () => r(Buffer.concat(chunks)));
+          })
+        : undefined;
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(req.headers)) {
+      if (typeof v === "string" && !k.startsWith(":")) headers[k] = v;
+    }
+    const response = await handler(
+      new Request(url.href, { method: req.method, headers, body })
+    );
+    if (!response) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    res.writeHead(
+      response.status,
+      Object.fromEntries(response.headers.entries())
+    );
+    const stream = response.body;
+    if (!stream) return void res.end();
+    for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+      res.write(chunk);
+    }
+    res.end();
+  });
+}
+
+describe.skipIf(!browserAvailable)(
+  "webpack action round-trip through the baked gate",
+  () => {
+    let server: Server | undefined;
+
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+      const fr = fileRouter(join(testDir, "src/routes"), { root: testDir });
+      await doBuild({
+        projectRoot: testDir,
+        moduleBase: "src",
+        transport: "webpack",
+        Page: fr.Page,
+        props: fr.props,
+        routePatterns: fr.routePatterns,
+        build: {
+          pages: fr.build.pages,
+          outDir: "dist",
+          edge: true,
+        },
+      } as any);
+
+      // The DIRECTIVE-gated module must be in the baked allowlist even though
+      // its name matches no `.server.` pattern — assert the bake itself before
+      // the browser does.
+      const render = readFileSync(
+        join(testDir, "dist/server-edge/render.js"),
+        "utf8"
+      );
+      expect(render).toContain('"src/ping.ts"');
+
+      const bundle = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+      );
+      const consumer = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/consumer.js")).href
+      );
+      const { createEdgeRenderHook } = await import(
+        "vite-plugin-react-server/edge"
+      );
+      const renderHook = createEdgeRenderHook(bundle, {
+        renderFlightToHtml: consumer.renderFlightToHtml,
+      });
+      const { createRequestHandler } = await import(
+        "vite-plugin-react-server/request-handler"
+      );
+      const app = createRequestHandler({
+        staticDir: join(testDir, "dist/static"),
+        render: renderHook,
+        action: bundle.handleRouteAction,
+      });
+      server = serve(app as any, [
+        join(testDir, "dist/static"),
+        join(testDir, "dist/client"),
+      ]);
+      await new Promise<void>((r) => server!.listen(PORT, r));
+    }, 180000);
+
+    afterAll(async () => {
+      await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+      if (!process.env.KEEP_FIXTURE)
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("clicks through: encode, gate, execute, decode", async () => {
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        const pageErrors: string[] = [];
+        const consoleErrors: string[] = [];
+        page.on("pageerror", (e) => pageErrors.push(String(e)));
+        page.on("console", (m) => {
+          if (m.type() === "error") consoleErrors.push(m.text());
+        });
+        let actionStatus = 0;
+        page.on("response", (r) => {
+          if (r.request().method() === "POST") actionStatus = r.status();
+        });
+
+        await page.goto(`http://localhost:${PORT}/`, {
+          waitUntil: "networkidle",
+        });
+        const button = page.locator("#ping");
+        await button.waitFor({ timeout: 15000 });
+        await page.waitForFunction(
+          () => {
+            const b = document.querySelector("#ping") as HTMLButtonElement;
+            if (!b) return false;
+            b.click();
+            return b.textContent !== "ping";
+          },
+          undefined,
+          { timeout: 20000, polling: 400 }
+        );
+
+        expect(await button.textContent()).toBe("doubled:42");
+        expect(actionStatus).toBe(200);
+        expect(pageErrors).toEqual([]);
+        // The baked document's children arrays trip React's dev-only key
+        // warning — pre-existing, cosmetic, unrelated to the action path.
+        // Everything else (gate rejections, decode failures, hydration
+        // errors) must stay fatal here.
+        expect(
+          consoleErrors.filter((e) => !/unique "key" prop/.test(e))
+        ).toEqual([]);
+      } finally {
+        await browser.close();
+      }
+    });
+  }
+);


### PR DESCRIPTION
## Problem

The sealed action gate's allowlist was enumerated from server-manifest keys matching the `.server.` filename pattern, while the flight layer registers server references by the `"use server"` directive — two sources of truth. A directive-marked module with any other name was registered, serialized into payloads, then rejected at the trust boundary at runtime with `Unknown server reference`. Found live on vprs-starter's edge badge (`src/edgePing.ts`); reproduced with both import topologies. It is the same filename-vs-directive divergence rsl eliminated for client detection, surviving on the action side.

## Fix

- Gate membership follows the directive: each manifest module's source is stripped of TS/JSX with the running Vite's transform (`transformTsSource`, raw TS does not parse under rsl's JS-only grammar) and scanned with the same directive-statement scanner the transformer uses — module prologue or any function body, quoted strings and comments rejected. The filename pattern remains only as a fallback for unreadable sources; a name never gates what the directive didn't.
- A bounded source walk warns at build time, naming every `"use server"` module the server build never reached — the other silent variant (client-only-imported actions) of the same runtime failure, now diagnosed at build.

## Verification

- New `test/examples/edge-action-roundtrip.test.ts`: webpack transport, an action module deliberately NOT named `*.server.*`, passed as a prop, clicked in real chromium through encode → gate → execute → decode (response 200, correct result, no errors). The bake-level assertion alone is red on the old enumeration.
- Full suites green: unit 772 / server 1015 / client 303 / dev 43.
- bidoof sibling gate 3/3 via real tarball (its `.server.`-named actions keep gating via the directive).
- The originating repro: vprs-starter's `feat/edge-ping` branch with this fix installed as a tarball — the badge ping completes end to end, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHY8KAH6Taq7boWCzEB47M