### PR TITLE
chore(release): 3.9.1 — version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Syncs main with the published v3.9.1 artifact: the version-bump commit from the release branch. With this merged, main's tree is identical to what the v3.9.1 tag and the npm package were built from (verified: empty diff against the release branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHY8KAH6Taq7boWCzEB47M