### PR TITLE
feat(router): navigation pending state — useNavigation + Link data-pending

### DIFF
--- a/plugin/router/client.ts
+++ b/plugin/router/client.ts
@@ -21,10 +21,13 @@ export type {
 export {
   RouterProvider,
   useLocation,
+  useNavigation,
+  useOptionalNavigation,
   useOptionalRouter,
   useParams,
   useRouter,
 } from "./router-react.js";
+export type { NavigationState } from "./router-react.js";
 export { Link } from "./link.js";
 export type { LinkPrefetch, LinkProps } from "./link.js";
 export { createErrorBoundary } from "./errorBoundary.js";

--- a/plugin/router/createRouter.ts
+++ b/plugin/router/createRouter.ts
@@ -4,7 +4,12 @@ import type { ToPath } from "./register.js";
 // Headless client router: history + a flight cache + a subscribe store. The
 // React bindings (<Router>, useLocation, useParams) are a thin layer over this
 // via useSyncExternalStore, so the navigation logic stays testable without React.
-export type RouterState = { url: string };
+//
+// `url` moves on navigate/popstate; `shownUrl` trails it, advanced by the view
+// (startClient's RouteView calls markShown) once the target's content has
+// actually been committed. The gap between the two IS the navigation-pending
+// window — the old view stays on screen while the next route's flight loads.
+export type RouterState = { url: string; shownUrl: string };
 
 export type CreateRouterOptions<T> = {
   /** Fetch the RSC flight for a url (e.g. createReactFetcher({ url })). */
@@ -21,6 +26,9 @@ export type Router<T> = {
   getState: () => RouterState;
   subscribe: (cb: () => void) => () => void;
   navigate: (to: ToPath, opts?: { replace?: boolean }) => void;
+  /** The view calls this after committing a url's content, closing the
+   *  pending window that `useNavigation()` reports. */
+  markShown: (url: string) => void;
   prefetch: (to: ToPath) => void;
   /** The (cached) flight for a url; reuses a warmed/in-flight fetch. */
   flight: (url: string) => Promise<T>;
@@ -34,17 +42,22 @@ const currentUrl = () =>
 export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
   const cache = opts.cache ?? createFlightCache<T>();
   const listeners = new Set<() => void>();
-  let state: RouterState = { url: currentUrl() };
+  const initialUrl = currentUrl();
+  let state: RouterState = { url: initialUrl, shownUrl: initialUrl };
 
   const ttlFor = (url: string) =>
     opts.isDynamic?.(url) ? (opts.dynamicTtlMs ?? 2000) : undefined;
   const flight = (url: string) =>
     cache.get(url, { fetcher: opts.fetchFlight, ttlMs: ttlFor(url) });
 
+  const notify = () => {
+    for (const l of listeners) l();
+  };
+
   const setUrl = (url: string) => {
     if (url === state.url) return;
-    state = { url };
-    for (const l of listeners) l();
+    state = { ...state, url };
+    notify();
   };
 
   const onPop = () => setUrl(currentUrl());
@@ -70,6 +83,11 @@ export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
         else history.pushState({ url: to }, "", to);
       }
       setUrl(to);
+    },
+    markShown: (url) => {
+      if (url === state.shownUrl) return;
+      state = { ...state, shownUrl: url };
+      notify();
     },
     prefetch: (to) => {
       cache.prefetch(to, { fetcher: opts.fetchFlight, ttlMs: ttlFor(to) });

--- a/plugin/router/link.tsx
+++ b/plugin/router/link.tsx
@@ -6,7 +6,7 @@ import type {
   MouseEvent as ReactMouseEvent,
 } from "react";
 import type { ToPath } from "./register.js";
-import { useOptionalRouter } from "./router-react.js";
+import { useOptionalNavigation, useOptionalRouter } from "./router-react.js";
 
 // Client-side <Link> over the nav primitive: intercepts plain internal clicks
 // to navigate without a reload, and warms the target's flight on hover/focus so
@@ -25,6 +25,8 @@ export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
 };
 
 const INTENT_MS = 60;
+
+const stripSlash = (p: string) => p.replace(/\/+$/, "") || "/";
 
 const isModified = (e: ReactMouseEvent) =>
   e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
@@ -48,7 +50,15 @@ export function Link({
   // Optional: Link also renders during static prerender (no provider yet) and
   // as a plain <a> outside a router — it just doesn't intercept there.
   const router = useOptionalRouter();
+  const navigation = useOptionalNavigation();
   const timer = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // While a navigation to THIS link's target is in flight (the old view is
+  // still on screen), the anchor announces it — style via a[data-pending],
+  // e.g. dim the outgoing page with body:has(a[data-pending]).
+  const pending =
+    navigation?.pending === true &&
+    stripSlash(navigation.to ?? "") === stripSlash(to);
 
   const canIntercept =
     router !== null && !isExternal(to) && (!target || target === "_self");
@@ -67,6 +77,8 @@ export function Link({
     <a
       href={to}
       target={target}
+      data-pending={pending || undefined}
+      aria-busy={pending || undefined}
       onClick={(e) => {
         onClick?.(e);
         if (e.defaultPrevented || !canIntercept || isModified(e)) return;

--- a/plugin/router/router-react.tsx
+++ b/plugin/router/router-react.tsx
@@ -16,7 +16,16 @@ type RouterContextValue = {
   router: Router<unknown>;
   location: string;
   params: Record<string, string>;
+  navigation: NavigationState;
 };
+
+/**
+ * The navigation-pending window: the router swaps resolve-then-set, so between
+ * a navigation and its content committing, the OLD view is still on screen.
+ * While that window is open `pending` is true and `to` names the target;
+ * otherwise `to` is null.
+ */
+export type NavigationState = { pending: boolean; to: string | null };
 
 const RouterContext = React.createContext<RouterContextValue | null>(null);
 
@@ -35,13 +44,15 @@ export function RouterProvider<T>({
     router.getState,
     router.getState,
   );
+  const pending = state.url !== state.shownUrl;
   const value = React.useMemo<RouterContextValue>(
     () => ({
       router: router as Router<unknown>,
       location: state.url,
       params: matchRoutes(patterns, state.url)?.params ?? {},
+      navigation: { pending, to: pending ? state.url : null },
     }),
-    [router, state.url, patterns],
+    [router, state.url, pending, patterns],
   );
   return (
     <RouterContext.Provider value={value}>{children}</RouterContext.Provider>
@@ -71,4 +82,12 @@ export function useOptionalRouter(): Router<unknown> | null {
 export const useLocation = () => useRouterContext().location;
 export function useParams<P extends string = string>(): RouteParams<P> {
   return useRouterContext().params as RouteParams<P>;
+}
+export const useNavigation = (): NavigationState =>
+  useRouterContext().navigation;
+
+/** Non-throwing useNavigation, for components (Link) that also render outside
+ *  a provider. */
+export function useOptionalNavigation(): NavigationState | null {
+  return React.useContext(RouterContext)?.navigation ?? null;
 }

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -56,17 +56,35 @@ function RouteView({
     if (rootEl) applyRouteHead(rootEl);
   });
 
+  // After every commit, tell the router which url's content is actually on
+  // screen. The gap between this and the navigated url is the pending window
+  // `useNavigation()` / Link's data-pending report; the swap below closes it.
+  React.useEffect(() => {
+    router.markShown(shown.current);
+  });
+
   React.useEffect(() => {
     if (location === shown.current) return;
     let cancelled = false;
     const target = location;
-    Promise.resolve(router.flight(target)).then((next) => {
-      // Ignore a stale resolve (a newer navigation won the race).
-      if (!cancelled && router.getState().url === target) {
-        shown.current = target;
-        setNode(next);
-      }
-    });
+    Promise.resolve(router.flight(target)).then(
+      (next) => {
+        // Ignore a stale resolve (a newer navigation won the race).
+        if (!cancelled && router.getState().url === target) {
+          shown.current = target;
+          setNode(next);
+        }
+      },
+      () => {
+        // The flight failed — network error, or a host that has no such route
+        // answered HTML (a static-only deploy). Fall back to a full document
+        // load so the server's real response shows instead of the old view
+        // staying pending forever.
+        if (!cancelled && router.getState().url === target) {
+          window.location.assign(target);
+        }
+      },
+    );
     return () => {
       cancelled = true;
     };

--- a/test/router/link.test.tsx
+++ b/test/router/link.test.tsx
@@ -106,4 +106,35 @@ describe("Link", () => {
     });
     expect(ev.defaultPrevented).toBe(false);
   });
+
+  it("announces data-pending/aria-busy only on the link whose target is loading", async () => {
+    const { router, ui } = withRouter(
+      <>
+        <Link to="/slow/">slow</Link>
+        <Link to="/other">other</Link>
+      </>,
+    );
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(ui);
+    });
+    const [slow, other] = Array.from(container.querySelectorAll("a"));
+
+    await act(async () => {
+      // navigate without markShown: the pending window is open
+      router.navigate("/slow");
+    });
+    // trailing-slash difference between `to` and the navigated url still matches
+    expect(slow?.getAttribute("data-pending")).toBe("true");
+    expect(slow?.getAttribute("aria-busy")).toBe("true");
+    expect(other?.hasAttribute("data-pending")).toBe(false);
+
+    await act(async () => {
+      router.markShown("/slow");
+    });
+    expect(slow?.hasAttribute("data-pending")).toBe(false);
+    expect(slow?.hasAttribute("aria-busy")).toBe(false);
+  });
 });

--- a/test/router/router-react.test.tsx
+++ b/test/router/router-react.test.tsx
@@ -52,4 +52,43 @@ describe("RouterProvider + hooks", () => {
       root.unmount();
     });
   });
+
+  it("useNavigation reports the pending window between navigate and markShown", async () => {
+    const { useNavigation } = await import("../../plugin/router/router-react.js");
+    function NavProbe() {
+      const nav = useNavigation();
+      return (
+        <span>
+          {String(nav.pending)}|{nav.to ?? "none"}
+        </span>
+      );
+    }
+    const router = createRouter({ fetchFlight: async (u: string) => u });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <RouterProvider router={router}>
+          <NavProbe />
+        </RouterProvider>,
+      );
+    });
+    expect(container.textContent).toBe("false|none");
+
+    await act(async () => {
+      router.navigate("/next");
+    });
+    expect(container.textContent).toBe("true|/next");
+
+    await act(async () => {
+      router.markShown("/next");
+    });
+    expect(container.textContent).toBe("false|none");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });

--- a/test/unit/createRouter.test.ts
+++ b/test/unit/createRouter.test.ts
@@ -88,4 +88,33 @@ describe("createRouter", () => {
     await r.flight("/static"); // still reused (no ttl)
     expect(fetchFlight).toHaveBeenCalledTimes(3);
   });
+
+  it("tracks the pending window: navigate opens it, markShown closes it", () => {
+    const r = createRouter({ fetchFlight: async (u) => u });
+    expect(r.getState().shownUrl).toBe(r.getState().url);
+
+    let notified = 0;
+    r.subscribe(() => notified++);
+
+    r.navigate("/next");
+    expect(r.getState()).toEqual({ url: "/next", shownUrl: "/" });
+    expect(notified).toBe(1);
+
+    r.markShown("/next");
+    expect(r.getState()).toEqual({ url: "/next", shownUrl: "/next" });
+    expect(notified).toBe(2);
+
+    // Marking the already-shown url again is a no-op (no extra notify).
+    r.markShown("/next");
+    expect(notified).toBe(2);
+  });
+
+  it("keeps the pending window open across a superseding navigation", () => {
+    const r = createRouter({ fetchFlight: async (u) => u });
+    r.navigate("/a");
+    r.navigate("/b");
+    expect(r.getState()).toEqual({ url: "/b", shownUrl: "/" });
+    r.markShown("/b");
+    expect(r.getState().shownUrl).toBe("/b");
+  });
 });


### PR DESCRIPTION
## What

The client router keeps the old view mounted while the next route's flight loads (resolve-then-set, no flash) — but nothing reported that window, so consumers wanting transition feedback had to hand-roll location-vs-baseline tricks in their own components (the Pokédex demo grew exactly that wrapper).

- `RouterState` gains `shownUrl`, trailing `url`; `startClient`'s RouteView advances it via the new `router.markShown()` after each content commit
- `useNavigation()` / `useOptionalNavigation()` expose `{pending, to}` for that gap
- `Link` announces when a navigation to **its** target is in flight: `data-pending` + `aria-busy` — style the transition with plain CSS (`a[data-pending]`, `body:has(a[data-pending])`), NavLink-style, no screen-level loading element
- A rejected flight fetch (network failure, or a static-only host answering HTML for a route it doesn't have) now falls back to `window.location.assign` so the server's real response shows instead of the old view staying pending forever

## Testing

- 3 new tests: headless pending-window transitions (`createRouter`), `useNavigation` lifecycle through a provider, `Link` announcing only on the matching anchor and clearing on `markShown`
- Full gate green: 1017 passed | 57 skipped across both condition suites; `tsc --noEmit` clean

The demo repo's hand-rolled wrapper (vite-plugin-react-server-demo-official) can collapse onto this once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)