### PR TITLE
fix(env): browser env variant ships consumer-replaceable defines; renderer keeps process.env

### DIFF
--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -280,7 +280,12 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
 
         // Note: Path normalization should be handled in the file naming functions
         environments[envConfig.name] = {
-          keepProcessEnv: envConfig.name === "server" ? true : false,
+          // Every env except the browser one produces a Node-run bundle: the
+          // "ssr" env's output (dist/client) is the in-process renderer, and
+          // dropping process.env there rewrites env.node's runtime reads to {}
+          // — every env getter silently falls back (BASE_URL "/"), un-prefixing
+          // renderer-derived URLs under subpath deploys.
+          keepProcessEnv: envConfig.name !== "client",
           define: userConfig.define,
           consumer: consumer,
           optimizeDeps: {

--- a/plugin/utils/env.browser.ts
+++ b/plugin/utils/env.browser.ts
@@ -15,5 +15,11 @@ export const env = {
   DEV: import.meta.env.DEV,
   MODE: import.meta.env.MODE,
   PROD: import.meta.env.PROD,
-  SSR: import.meta.env.SSR,
+  // Hardcoded, not import.meta.env.SSR: Vite special-cases the SSR key and
+  // statically replaces it with the BUILDING environment's flag before any
+  // define (including the self-referential shield) can preserve it — vprs's
+  // own lib build would bake `true` into this browser-only module. This file
+  // only ever loads in a browser bundle, where SSR is false by definition;
+  // env.node is the `true` half of the pair.
+  SSR: false,
 } as ImportMetaEnv;

--- a/test/examples/use-client-utils-env.test.ts
+++ b/test/examples/use-client-utils-env.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { setupTestProject } from "../setup.js";
+import { getSharedBuild, type SharedBuildResult } from "./shared-build.js";
+
+// A "use client" component importing env helpers from
+// vite-plugin-react-server/utils must give the BROWSER bundle the browser env
+// variant with the consumer's define values baked in — and give the Node-run
+// renderer bundle (dist/client) live process.env reads. Two regressions are
+// pinned here:
+// - vprs's own lib build baking its build-time PROD/SSR into the shipped
+//   env.browser artifact (SSR:true in every consumer browser chunk);
+// - keepProcessEnv being dropped for the ssr environment, rewriting env.node's
+//   `process.env` capture to `{}` so every renderer-side env getter silently
+//   fell back (BASE_URL "/").
+
+const setupEnvProbeProject = async (testDir: string) => {
+  await setupTestProject(testDir);
+  await writeFile(
+    resolve(testDir, "src/components/EnvProbe.tsx"),
+    `"use client";
+import React from 'react'
+import { env, pageURL } from "vite-plugin-react-server/utils";
+export function EnvProbe() {
+  return <div data-base={env.BASE_URL} data-url={pageURL("/probe")}>{env.MODE}</div>;
+}
+`
+  );
+  await writeFile(
+    resolve(testDir, "src/page/page.tsx"),
+    `
+import React from 'react'
+import { EnvProbe } from '../components/EnvProbe.js'
+export function Page(props: any) {
+  return (<div><span>Page</span><EnvProbe /></div>)
+}
+`
+  );
+};
+
+describe("use-client /utils import: env variant per bundle role", () => {
+  let build: SharedBuildResult;
+  beforeAll(async () => {
+    build = await getSharedBuild("use-client-utils-env", "use-client-utils-env", {
+      setupProject: setupEnvProbeProject,
+      pages: ["/"],
+      build: { outDir: "dist-use-client-utils-env" },
+    });
+  });
+
+  // Bundle-event naming note: the BROWSER environment is named "client" and
+  // fires build.writeBundle.client, so clientChunks() is the browser output
+  // (dist/static on disk); the renderer environment is named "ssr" and fires
+  // build.writeBundle.static, so staticChunks() is the renderer bundle
+  // (dist/client on disk).
+  it("browser chunks carry baked env values, not process.env reads", () => {
+    const browserChunks = build.clientChunks();
+    const envChunks = browserChunks.filter(([, code]) =>
+      code.includes("PUBLIC_ORIGIN")
+    );
+    // The hosted EnvProbe chunk must exist and carry the env object at all —
+    // an empty match means the probe component fell out of the build.
+    expect(envChunks.length).toBeGreaterThan(0);
+    for (const [file, code] of envChunks) {
+      // env.node reaching the browser shows up as VITE_-prefixed process.env
+      // key reads surviving into the chunk.
+      expect(code, `${file} carries node env variant`).not.toContain(
+        "VITE_PUBLIC_ORIGIN"
+      );
+      expect(code, `${file} reads process.env`).not.toContain("process.env");
+    }
+  });
+
+  it("browser chunks bake SSR:false (vprs's own lib build must not leak in)", () => {
+    const offending = build
+      .clientChunks()
+      .filter(
+        ([, code]) => /SSR:\s*(true|!0)/.test(code) && code.includes("PUBLIC_ORIGIN")
+      );
+    expect(offending.map(([f]) => f)).toEqual([]);
+  });
+
+  it("the renderer bundle (dist/client) keeps live process.env reads", () => {
+    const envChunks = build
+      .staticChunks()
+      .filter(([file]) => /utils\/env\.js$/.test(file));
+    expect(envChunks.length).toBeGreaterThan(0);
+    for (const [file, code] of envChunks) {
+      // keepProcessEnv:false rewrites the capture to `{}` — the getters then
+      // silently fall back instead of reading the mirrored VITE_ values.
+      expect(code, `${file} lost its process.env capture`).toMatch(
+        /typeof process !== "undefined" \? process\.env/
+      );
+    }
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -236,9 +236,14 @@ export default defineConfig({
   // self-referential define (replace X with X) is a reliable, bundler-agnostic
   // shield that works under both esbuild and Vite 8's Oxc.
   // - import.meta.hot: consumers use useRscHmr in dev where hot IS defined.
-  // - import.meta.env.{BASE_URL,PUBLIC_ORIGIN,DEV,MODE}: read (dot access) by the
-  //   isomorphic env-URL helper (utils/envUrls) so absoluteURL/baseURL resolve
-  //   against the consumer's real BASE_URL / PUBLIC_ORIGIN, not "/".
+  // - import.meta.env.{BASE_URL,PUBLIC_ORIGIN,DEV,MODE,PROD}: read (dot
+  //   access) by the isomorphic env sources (utils/env.browser, utils/envUrls)
+  //   so every field resolves against the consumer's real environment. PROD
+  //   must be shielded like the rest: without it, vprs's own prod lib build
+  //   bakes PROD:true into the shipped env.browser artifact and a consumer's
+  //   dev build still reports PROD. SSR cannot be shielded this way — Vite
+  //   special-cases that key and replaces it before user define applies — so
+  //   env.browser hardcodes SSR:false instead.
   //   (utils/env.ts uses bracket access to stay out of this + Node-safe.)
   define: {
     "import.meta.hot": "import.meta.hot",
@@ -246,6 +251,7 @@ export default defineConfig({
     "import.meta.env.PUBLIC_ORIGIN": "import.meta.env.PUBLIC_ORIGIN",
     "import.meta.env.DEV": "import.meta.env.DEV",
     "import.meta.env.MODE": "import.meta.env.MODE",
+    "import.meta.env.PROD": "import.meta.env.PROD",
   },
   esbuild: {
     // Preserve import.meta expressions in utils files


### PR DESCRIPTION
## Why

A `"use client"` component importing `env`/`pageURL` from `vite-plugin-react-server/utils` got lying values depending on bundle role, silently:

1. **Browser bundles reported `SSR: true` (and a baked `PROD: true`).** The self-referential define shield in vprs's own `vite.config.ts` covered `BASE_URL`/`PUBLIC_ORIGIN`/`DEV`/`MODE` but not `PROD`/`SSR`, so vprs's own build (a prod SSR lib build) baked its build-time values into the shipped `dist/plugin/utils/env.browser.js` — visible in the artifact before this change. Consumers could never replace them.
2. **The in-process renderer bundle (`dist/client`) lost its `process.env` reads.** `createEnvironmentPlugin` set `keepProcessEnv: false` for the ssr environment, so Vite rewrote `env.node`'s capture to `{}` and every renderer-side env getter silently fell back (`BASE_URL` `"/"`) — un-prefixing renderer-derived URLs under subpath deploys.

## What

- `PROD` joins the self-referential define shield. `SSR` cannot be shielded (Vite special-cases the key and replaces it with the building environment's flag before user define applies), so `env.browser.ts` hardcodes `SSR: false` — the module only ever loads in browser bundles by its own contract; `env.node` is the `true` half of the pair.
- `keepProcessEnv` stays on for every non-browser environment (the ssr env's output is a Node-run bundle).

## Verification

- New regression test `test/examples/use-client-utils-env.test.ts` builds a real `use client` consumer of `/utils` and pins both roles: browser chunks carry baked values (`SSR:false`, no `process.env` reads), the renderer chunk keeps its live `process.env` capture. Red on the previous code (2/3 fail: the SSR bake and the renderer capture), green with the fix.
- Shipped artifact inspected before/after: `env.browser.js` now ships `PROD` unparsed and `SSR: false`.
- Full gate green on both condition legs: 1018 passed / 57 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)