### PR TITLE
test: edge bundle guard — no statically-evaluated node builtin imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react-dom": "^19.0.3",
         "@vitest/coverage-v8": "^3.0.4",
         "acorn-loose": "^8.3.0",
+        "es-module-lexer": "^1.7.0",
         "eslint": "^9.28.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -416,6 +416,7 @@
     "@types/react-dom": "^19.0.3",
     "@vitest/coverage-v8": "^3.0.4",
     "acorn-loose": "^8.3.0",
+    "es-module-lexer": "^1.7.0",
     "eslint": "^9.28.0",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.2.0",

--- a/test/examples/build-edge-bundle.test.ts
+++ b/test/examples/build-edge-bundle.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdir, rm, writeFile, symlink, readFile, readdir } from "node:fs/promises";
+import { mkdir, rm, writeFile, symlink, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { builtinModules } from "node:module";
-import { init as lexerInit, parse as lexerParse } from "es-module-lexer";
+import { collectStaticBuiltinImports } from "./edge-bundle-guard.js";
 import * as streamApi from "vite-plugin-react-server/stream";
 import * as edgeApi from "vite-plugin-react-server/edge";
 import { doBuild } from "../doBuild.js";
@@ -108,30 +107,9 @@ describe.skipIf(!renderFlightToHtml)(
     });
 
     it("bakes no statically-evaluated node builtin imports (edge-runtime safe)", async () => {
-      // The single-isolate bundle must EVALUATE on a runtime with no node:*
-      // at all. Static imports of node builtins crash module evaluation there;
-      // dynamic import("node:...") is the sanctioned lazy-fallback shape (the
-      // disk-manifest fallback) and only evaluates if that path actually runs.
-      // es-module-lexer classifies the two exactly — no regex over strings.
-      await lexerInit;
-      const edgeDir = join(testDir, "dist/server-edge");
-      const files = (await readdir(edgeDir, { recursive: true })).filter((f) =>
-        f.endsWith(".js")
-      );
-      expect(files.length).toBeGreaterThan(0);
-      const isBuiltin = (spec: string) =>
-        spec.startsWith("node:") || builtinModules.includes(spec);
-      const offenders: string[] = [];
-      for (const f of files) {
-        const code = await readFile(join(edgeDir, f), "utf8");
-        const [imports] = lexerParse(code, f);
-        for (const imp of imports) {
-          if (!imp.n || !isBuiltin(imp.n)) continue;
-          if (imp.d > -1) continue; // dynamic import(): lazy, boot-safe
-          offenders.push(`${f}: ${imp.n}`);
-        }
-      }
-      expect(offenders).toEqual([]);
+      expect(
+        await collectStaticBuiltinImports(join(testDir, "dist/server-edge"))
+      ).toEqual([]);
     });
 
     it("keeps the default worker-based server build (additive)", () => {

--- a/test/examples/build-edge-bundle.test.ts
+++ b/test/examples/build-edge-bundle.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdir, rm, writeFile, symlink, readFile } from "node:fs/promises";
+import { mkdir, rm, writeFile, symlink, readFile, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { builtinModules } from "node:module";
+import { init as lexerInit, parse as lexerParse } from "es-module-lexer";
 import * as streamApi from "vite-plugin-react-server/stream";
 import * as edgeApi from "vite-plugin-react-server/edge";
 import { doBuild } from "../doBuild.js";
@@ -103,6 +105,33 @@ describe.skipIf(!renderFlightToHtml)(
 
     it("emits a baked rsc bundle to dist/server-edge", () => {
       expect(existsSync(join(testDir, "dist/server-edge/render.js"))).toBe(true);
+    });
+
+    it("bakes no statically-evaluated node builtin imports (edge-runtime safe)", async () => {
+      // The single-isolate bundle must EVALUATE on a runtime with no node:*
+      // at all. Static imports of node builtins crash module evaluation there;
+      // dynamic import("node:...") is the sanctioned lazy-fallback shape (the
+      // disk-manifest fallback) and only evaluates if that path actually runs.
+      // es-module-lexer classifies the two exactly — no regex over strings.
+      await lexerInit;
+      const edgeDir = join(testDir, "dist/server-edge");
+      const files = (await readdir(edgeDir, { recursive: true })).filter((f) =>
+        f.endsWith(".js")
+      );
+      expect(files.length).toBeGreaterThan(0);
+      const isBuiltin = (spec: string) =>
+        spec.startsWith("node:") || builtinModules.includes(spec);
+      const offenders: string[] = [];
+      for (const f of files) {
+        const code = await readFile(join(edgeDir, f), "utf8");
+        const [imports] = lexerParse(code, f);
+        for (const imp of imports) {
+          if (!imp.n || !isBuiltin(imp.n)) continue;
+          if (imp.d > -1) continue; // dynamic import(): lazy, boot-safe
+          offenders.push(`${f}: ${imp.n}`);
+        }
+      }
+      expect(offenders).toEqual([]);
     });
 
     it("keeps the default worker-based server build (additive)", () => {

--- a/test/examples/edge-bundle-guard.ts
+++ b/test/examples/edge-bundle-guard.ts
@@ -1,0 +1,38 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { builtinModules } from "node:module";
+import { init as lexerInit, parse as lexerParse } from "es-module-lexer";
+
+/**
+ * Walk every emitted `.js` in an edge output dir and collect the imports that
+ * would EVALUATE a node builtin at module load — the class of regression that
+ * crashes the single-isolate bundle on a runtime with no `node:*` while every
+ * Node-based test stays green. Dynamic `import("node:...")` is the sanctioned
+ * lazy-fallback shape and is not collected: it only evaluates if its path
+ * actually runs. es-module-lexer's static/dynamic records classify the two
+ * exactly, so `node:` inside error-message strings cannot false-positive.
+ */
+export async function collectStaticBuiltinImports(
+  edgeDir: string
+): Promise<string[]> {
+  await lexerInit;
+  const files = (await readdir(edgeDir, { recursive: true })).filter((f) =>
+    f.endsWith(".js")
+  );
+  if (files.length === 0) {
+    throw new Error(`edge-bundle-guard: no .js bundles found in ${edgeDir}`);
+  }
+  const isBuiltin = (spec: string) =>
+    spec.startsWith("node:") || builtinModules.includes(spec);
+  const offenders: string[] = [];
+  for (const f of files) {
+    const code = await readFile(join(edgeDir, f), "utf8");
+    const [imports] = lexerParse(code, f);
+    for (const imp of imports) {
+      if (!imp.n || !isBuiltin(imp.n)) continue;
+      if (imp.d > -1) continue; // dynamic import(): lazy, boot-safe
+      offenders.push(`${f}: ${imp.n}`);
+    }
+  }
+  return offenders;
+}

--- a/test/examples/transport-webpack-build.test.ts
+++ b/test/examples/transport-webpack-build.test.ts
@@ -6,6 +6,7 @@ import { ensureFixture, hashSetupFn } from "./fixture-cache.js";
 import { testUserOptions } from "../test-config.js";
 import { readFile as readFileFs, readFile, rm } from "node:fs/promises";
 import { resolve } from "node:path";
+import { collectStaticBuiltinImports } from "./edge-bundle-guard.js";
 
 /**
  * transport: "webpack" — the static snapshots must carry the webpack flight
@@ -90,6 +91,14 @@ describe("transport: webpack — snapshots frozen through the baked pair", () =>
       "utf-8"
     );
     expect(consumer.length).toBeGreaterThan(0);
+  });
+
+  it("bakes no statically-evaluated node builtin imports in either half", async () => {
+    // Producer AND consumer: the pair exists so the whole request path can
+    // compose on a runtime with no node:* at all (see buildConsumerBundle).
+    expect(
+      await collectStaticBuiltinImports(resolve(testDir, OUT_DIR, "server-edge"))
+    ).toEqual([]);
   });
 
   it("freezes webpack-flavored snapshots for every route", async () => {


### PR DESCRIPTION
## Why

The single-isolate edge bundle (`dist/server-edge`) is meant to evaluate on runtimes with no `node:*` at all. Nothing in CI guarded that: a statically-imported node builtin sneaking into the bake would crash module evaluation on such a runtime while every Node-based test stays green.

## What

A guard test in the existing `build.edge single-isolate bake` suite: it walks every emitted `.js` in `dist/server-edge` and asserts no **statically-evaluated** node builtin import exists (`node:`-prefixed or bare builtin names). Dynamic `import("node:...")` is allowed — that is the sanctioned lazy-fallback shape (e.g. the disk-manifest fallback), which only evaluates if its path actually runs.

Classification uses `es-module-lexer` (static vs dynamic import records), so `node:` appearing inside error-message strings cannot false-positive. The lexer was already in the tree as a transitive dependency; it's now pinned as an explicit devDependency.

## Verification

Suite green (18/18) on the current esm bake — the guard lands as a tripwire, red only on regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)