### PR TITLE
chore(release): 3.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.9.1",
+      "version": "3.10.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 3.10.0

Minor release: the router's navigation-pending API is new public surface.

### Features
- **Router navigation pending state** (#359): `useNavigation()` → `{ pending, to }`, `Link` carries `data-pending`/`aria-busy` while its target's flight loads, and an unfetchable flight falls back to a full document load instead of hanging.

### Fixes
- **Env variants per bundle role** (#362): browser bundles no longer inherit `PROD: true` / `SSR: true` baked from vprs's own lib build (PROD joins the self-define shield, SSR is hardcoded false in the browser-only variant); the in-process renderer bundle keeps live `process.env` reads (`keepProcessEnv` for every non-browser environment).

- **Inline-css dev HMR** (#368): css edits now apply live in dev even when the inline threshold would inline the sheet — dev always delivers css as `<link>` (React never updates the content of an inserted style hoistable, so inline styles could refetch forever without visually changing). Build output keeps the configured inline behavior.

### Tests
- Webpack transport matrix grown to 5 curated suites (#361).
- Edge bundles (esm bake and both halves of the webpack pair) are guarded against statically-evaluated node builtin imports (#364).

### Docs
- `inlineFlight` mode contract (blob vs stream per target), vendored-ESM serverless note, and six stale-claim fixes from a full docs audit (#363).
- Router navigation-pending surface (#365).

### Release verification (releasing.md)
- 1a full gate on merged main: client 311 passed, server 1021 passed.
- 1b fresh build clean.
- 1c file-linked downstream builds: bidoof-template main (build + dev smoke 200/200) and mmc (300 pages rendered + dev smoke 200/200), both restored after.
- Tarball into a clean stable-React fixture (react 19.2.8, real npm install): build green, rendered output verified.
- 1d (`test/e2e/hmr.spec.ts`) is currently un-runnable: the spec targets the demo's removed `/todos` surface (stale since the Pokédex redesign, tracked for rewrite). Equivalent coverage ran green in-repo: `test/dev/hmr.test.ts` + CSS HMR on both condition legs and under the webpack transport matrix.

Merge + `npm publish` are the maintainer's steps (2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
