### PR TITLE
fix: dev delivers css as link — inline style hoistables never hot-update

### DIFF
--- a/plugin/dev-server/configureReactServer.server.ts
+++ b/plugin/dev-server/configureReactServer.server.ts
@@ -360,10 +360,17 @@ export const configureReactServer: ConfigureReactServerFn =
         const serverEnv = server.environments['server'];
         const moduleGraphForCss = serverEnv?.moduleGraph ?? server.moduleGraph;
         
+        // Dev delivers css as <link> regardless of the inline threshold —
+        // same reasoning as the runner css bridge: an inline <style> is a
+        // React hoistable whose content never updates on the HMR refetch, so
+        // css edits would never visually apply. Links cache-bust in place.
         const cssFilesResult = await collectViteModuleGraphCss({
           moduleGraph: moduleGraphForCss,
           parentUrl: pagePath,
-          handlerOptions: handlerOptions,
+          handlerOptions: {
+            ...handlerOptions,
+            css: { ...handlerOptions.css, inlineCss: false },
+          },
         });
 
         if (verbose) {

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -933,8 +933,20 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
               projectRoot,
               (msg.options.layouts ?? []).map((l) => l.component),
             ])) || [];
+            // Dev delivers css as <link> regardless of the inline threshold.
+            // Inline <style> rides the flight as a React hoistable, and React
+            // dedupes style hoistables by identity WITHOUT updating the
+            // content of one already inserted — a css edit's HMR refetch
+            // silently drops the new styles forever. A <link> is
+            // URL-addressable, so useRscHmr's cache-bust path updates it in
+            // place. Prod/static keep the configured inline behavior: the
+            // snapshot is written once, nothing hot-updates it.
+            const devLinkCssUserOptions = {
+              ...cssFileUserOptions,
+              css: { ...cssFileUserOptions.css, inlineCss: false },
+            };
             for (const { id, code } of collected) {
-              addCssFileContent(id, code, cssFileUserOptions);
+              addCssFileContent(id, code, devLinkCssUserOptions);
             }
             if (verbose) {
               logger?.info(

--- a/test/dev/inline-css-dev-link.test.ts
+++ b/test/dev/inline-css-dev-link.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type ViteDevServer } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { testUserOptions } from "../test-config";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { handleRSCStream, type RSCStreamResponse } from "../rsc-stream.js";
+
+/**
+ * Dev must deliver css as <link>, even when the configured inline threshold
+ * would inline it in a build. Inline <style> rides the flight as a React
+ * hoistable, and React dedupes style hoistables by identity without updating
+ * the content of one already inserted — so the HMR refetch after a css edit
+ * silently drops the new styles. A <link> is URL-addressable and useRscHmr's
+ * cache-bust path updates it in place. Build output is unaffected: snapshots
+ * are written once and keep the configured inline behavior.
+ */
+
+let server: ViteDevServer;
+let port = 3141;
+let response: RSCStreamResponse;
+const testDir = resolve(__dirname, "../fixtures/inline-css-dev-link.test");
+
+async function setupTestFiles() {
+  await mkdir(join(testDir, "src/page"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/page/styles.module.css"),
+    `.tiny { color: rgb(1, 2, 3); }\n`
+  );
+  await writeFile(
+    join(testDir, "src/page/page.tsx"),
+    `import React from "react";
+import styles from "./styles.module.css";
+
+export const Page = ({ title }: { title: string }) => (
+  <div className={styles.tiny}>{title}</div>
+);`
+  );
+  await writeFile(
+    join(testDir, "src/page/props.ts"),
+    `export const props = (url: string) => ({ title: "Inline CSS Dev", url });`
+  );
+}
+
+describe("dev css delivery under an inline-eligible threshold", () => {
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await mkdir(testDir, { recursive: true });
+    await setupTestFiles();
+
+    const parentNodeModules = resolve(__dirname, "../../node_modules");
+    try {
+      await symlink(parentNodeModules, join(testDir, "node_modules"), "dir");
+    } catch {}
+
+    server = await createServer({
+      mode: "test",
+      root: testDir,
+      plugins: [
+        vitePluginReactServer({
+          ...testUserOptions,
+          projectRoot: testDir,
+          moduleBase: "src",
+          Page: "src/page/page.tsx",
+          props: "src/page/props.ts",
+          // The stylesheet above is a few bytes: any build would INLINE it
+          // under this config. Dev must still link it.
+          css: { inlineCss: true, inlineThreshold: 10_000 },
+        }),
+      ],
+      server: { port },
+      cacheDir: join(process.cwd(), "node_modules", `.vite-test-${port}`),
+    });
+    await server.listen();
+    port = server.config?.server?.port ?? port;
+    response = await handleRSCStream(`http://localhost:${port}/index.rsc`);
+  });
+
+  afterAll(async () => {
+    await server?.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("serves the flight successfully", () => {
+    expect(response.ok).toBe(true);
+  });
+
+  it("delivers the page css as a stylesheet link, not an inline style", () => {
+    // The link entry carries rel/href pointing at the vite-served stylesheet.
+    expect(response.result).toMatch(
+      /"rel":"stylesheet"[^}]*"href":"[^"]*styles\.module\.css/
+    );
+    // And no style element carrying the sheet's content as children — that is
+    // the hoistable shape React refuses to update on refetch.
+    expect(response.result).not.toContain("rgb(1, 2, 3)");
+  });
+});


### PR DESCRIPTION
## Why

In dev, editing a css file that the configured `inlineThreshold` delivers **inline** never updates the visible styles — reload shows them, live HMR never does. The chain, each step verified: the server side is correct (worker invalidation works; a fresh flight after the edit carries the new rule), linked css works (`useRscHmr` cache-busts `<link>` tags by DOM mutation), but an inline `<style>` rides the flight as a React **hoistable**, and React dedupes style hoistables by identity without ever updating the content of one already inserted — so the css-edit refetch silently drops the new styles, forever.

It was invisible to CI because every css-HMR suite ran `inlineCss: false` (linked-only); inline delivery had zero dev-HMR coverage.

## What

Dev delivers css as `<link>` regardless of the inline threshold, in **both** dev topologies: the runner css bridge (client-condition dev) and the main-thread `collectViteModuleGraphCss` call (react-server-condition dev). Links are URL-addressable, so the existing cache-bust path updates them in place. **Build output is unchanged** — snapshots are written once and keep the configured inline behavior; `inlineCss`/`inlineThreshold`/patterns still govern prod exactly as documented.

## Verification

- New regression test (`test/dev/inline-css-dev-link.test.ts`) pins the dev flight shape — an inline-eligible stylesheet must arrive as a `rel=stylesheet` link, not style children. Red on the previous code on both condition legs (each leg caught one of the two topologies); green with the fix.
- Full gate green both legs: client 313, server 1023.
- The release HMR spec's pinned expected-fail css test flips to unexpected-pass once the demo consumes a release with this fix — that annotation comes off then, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)