### PR TITLE
fix: webpack chunk loader resolves ids against BASE_URL

### DIFF
--- a/plugin/utils/flightClient.browser.ts
+++ b/plugin/utils/flightClient.browser.ts
@@ -1,3 +1,4 @@
+import { env } from "#env";
 // The one place browser code picks a flight client. WHICH client must follow
 // how the server encoded the payload: a webpack-transport bundle's document
 // injects `self.__vprsFlightTransport` (see createEdgeRenderHook) and its
@@ -23,13 +24,27 @@ export type BrowserFlightClient = {
   encodeReply: (args: unknown[]) => Promise<string | FormData>;
 };
 
+// Chunk ids in the flight are root-relative identity keys ("/components/…").
+// The FETCH URL derives from the app's base at load time — transport parity
+// with the esm client, which resolves specifiers through moduleBaseURL. Ids
+// stay base-free, so a snapshot baked once serves from any base. Without
+// this, a subpath deploy (GitHub Pages, any mounted app) 404s every client
+// chunk against the domain root.
+export const withAppBase = (chunk: string): string => {
+  if (!chunk.startsWith("/") || chunk.startsWith("//")) return chunk;
+  const base = env.BASE_URL || "/";
+  if (base === "/" || chunk.startsWith(base)) return chunk;
+  return base.replace(/\/$/, "") + chunk;
+};
+
 export const loadBrowserFlightClient = (): PromiseLike<BrowserFlightClient> =>
   (globalThis as { __vprsFlightTransport?: string }).__vprsFlightTransport ===
   "webpack"
     ? (import("react-server-loader/webpack/runtime").then(
         ({ createWebpackClient }) =>
           createWebpackClient({
-            load: (chunk: string) => import(/* @vite-ignore */ chunk),
+            load: (chunk: string) =>
+              import(/* @vite-ignore */ withAppBase(chunk)),
           })
       ) as PromiseLike<BrowserFlightClient>)
     : (import(

--- a/scripts/test-transport-webpack.sh
+++ b/scripts/test-transport-webpack.sh
@@ -14,9 +14,18 @@ cd "$(dirname "$0")/.."
 
 export VPRS_TEST_TRANSPORT=webpack
 
-./scripts/test-both.sh \
-  test/dev/dev-transport-hint.test.ts \
-  test/dev/server-actions.test.ts \
-  test/dev/client-imports-server-action.test.ts \
-  test/dev/suspense-flight-roundtrip.test.ts \
+SUITES=(
+  test/dev/dev-transport-hint.test.ts
+  test/dev/server-actions.test.ts
+  test/dev/client-imports-server-action.test.ts
+  test/dev/suspense-flight-roundtrip.test.ts
   test/dev/hmr.test.ts
+)
+
+./scripts/test-both.sh "${SUITES[@]}"
+
+# Parity leg: the same suites under a subpath base. Transport must never be
+# a base-sensitivity dimension — the webpack chunk loader resolving ids
+# against BASE_URL (flightClient.browser withAppBase) is what this guards.
+export BASE_URL='/test-base-url/'
+./scripts/test-both.sh "${SUITES[@]}"

--- a/test/unit/flightClientChunkBase.test.ts
+++ b/test/unit/flightClientChunkBase.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { withAppBase } from "../../plugin/utils/flightClient.browser.js";
+
+// The webpack flight's chunk ids are root-relative identity keys; the fetch
+// URL must derive from the app's base at load time (transport parity with the
+// esm client's moduleBaseURL resolution). Under vitest the #env node variant
+// reads the mirrored VITE_BASE_URL live, so the base is settable per test.
+describe("withAppBase", () => {
+  const saved = process.env.VITE_BASE_URL;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.VITE_BASE_URL;
+    else process.env.VITE_BASE_URL = saved;
+  });
+
+  it("prefixes root-relative chunk ids under a subpath base", () => {
+    process.env.VITE_BASE_URL = "/my-repo/";
+    expect(withAppBase("/components/Link-abc.js")).toBe(
+      "/my-repo/components/Link-abc.js"
+    );
+  });
+
+  it("leaves ids untouched at the root base", () => {
+    process.env.VITE_BASE_URL = "/";
+    expect(withAppBase("/components/Link-abc.js")).toBe(
+      "/components/Link-abc.js"
+    );
+  });
+
+  it("never double-prefixes an already-based id", () => {
+    process.env.VITE_BASE_URL = "/my-repo/";
+    expect(withAppBase("/my-repo/components/Link-abc.js")).toBe(
+      "/my-repo/components/Link-abc.js"
+    );
+  });
+
+  it("passes through external and protocol-relative urls", () => {
+    process.env.VITE_BASE_URL = "/my-repo/";
+    expect(withAppBase("https://cdn.example/x.js")).toBe(
+      "https://cdn.example/x.js"
+    );
+    expect(withAppBase("//cdn.example/x.js")).toBe("//cdn.example/x.js");
+  });
+});


### PR DESCRIPTION
## Why

Under `transport: "webpack"` the flight's client-reference chunk ids are root-relative (`/components/…`), and the browser chunk loader `import()`ed them verbatim — resolved against the **domain root**. On any subpath deploy every client chunk 404s: HTML renders, hydration is dead. This is what broke the live GitHub Pages demo on its first webpack deploy; the esm transport was immune because its client resolves specifiers through `moduleBaseURL`.

## What

Transport parity by design: chunk ids stay base-free identity keys, and only the **fetch URL** derives from the app's base at load time (`withAppBase` in the browser flight client, reading the browser env's `BASE_URL`). A snapshot baked once serves from any base — nothing for the consumer to configure or think about.

## Verification

- Real-deploy acceptance: the demo app built with webpack at the Pages subpath (`BASE_URL=/vite-plugin-react-server-demo-official/`), served under that prefix, driven by a real browser — 3 client chunks loaded (zero 404s), zero page errors, and live client-side navigation through the Link island.
- Unit matrix: root base, subpath base, already-based, external, protocol-relative.
- The webpack transport matrix gains a full **subpath-base parity pass** (same curated suites, `BASE_URL=/test-base-url/`) — the coverage hole that let this ship. All four passes green (2 bases × 2 condition legs).
- Full gate green: client 313, server 1027.

With this released, the demo's Pages deploy can return to the webpack transport (reverting the per-deploy split that hotfixed the outage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)