### PR TITLE
chore(release): 3.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 3.10.1

Patch release: subpath deploys under the webpack transport.

### Fixes
- **Webpack chunk loader resolves ids against `BASE_URL`** (#369, refined by #371/#372): subpath deploys no longer 404 every client chunk. Chunk ids stay base-free identity keys; the fetch URL derives at load time via `baseURL` — the **serving origin**, matching the esm browser path and the same-origin module contract (bootstrap and flight-loaded chunks must share one module graph; a baked `publicOrigin` is provably ignored, with CDN module serving remaining the explicit absolute-`moduleBaseURL` escape hatch). This is the fix for the Pages demo outage; once consumed, the demo's per-deploy transport split gets reverted.

### Coverage riding along
- The webpack transport matrix runs a genuine subpath-base parity pass (`VITE_BASE_URL=/test-base-url/`) and is a CI step (`npm run test:transport-webpack`) (#371).
- Chunk-resolution unit matrix incl. the publicOrigin-ignored contract test (#372).
- The older `test-base-url` script's bare `BASE_URL` export (silently ignored → always reran root) fixed to `VITE_BASE_URL` (#372); its first real run surfaced one open finding (edge-action round-trip under base, tracked; script not in CI).
- `publicOrigin` api-reference row states the module-loading boundary (#372).

### Verification
- Full gate green both legs: client 313, server 1028.
- Transport matrix: four passes green (root + `/test-base-url/` × both condition legs).
- The #369 fix was acceptance-tested in the real failure shape: the demo built with webpack at the Pages subpath, served under the prefix, real browser — zero chunk 404s, zero errors, live client navigation.

Merge + `npm publish` are the maintainer's steps (publish from main includes #369+#371+#372).
