### PR TITLE
fix: browser chunks load same-origin — baseURL, never publicOrigin

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,7 +21,7 @@ export const config = {
 | `moduleBase` | `string` | Root directory for project modules | `"src"` |
 | `moduleBasePath` | `string` | Second argument to `renderToPipeableStream` | `"/my-repo/"` |
 | `moduleBaseURL` | `string` | Requests from this base | `"/my-repo/"` |
-| `publicOrigin` | `string` | Origin for moduleBaseURL | `"https://username.github.io"` |
+| `publicOrigin` | `string` | Origin for building absolute urls (`absoluteURL`/`pageURL`, canonical hrefs in snapshots). Browser **module** loading is deliberately same-origin — the bootstrap entry and flight-loaded chunks must share one origin/module graph or hydration fails with two Reacts — so this never affects where chunks load from; to CDN-serve modules, pass an absolute `moduleBaseURL` explicitly. | `"https://username.github.io"` |
 | `Page` | `(url: string) => string` | Maps URLs to page component files | - |
 | `props` | `(url: string) => string` | Maps URLs to props files | - |
 | `routes` | `RoutesOption` | File-based router (v3+): scans a route tree and derives `Page`, `props`, `routePatterns` and the prerender worklist. Takes `{ dir?, staticPaths? }` or a `fileRouter()` result. See [Routing](./routing.md). | `{ dir: "routes" }` |

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
     "test:e2e": "playwright test",
     "test:e2e:server": "npx tsx test/e2e/server.ts",
     "test:dev-flight-hydration": "node scripts/verify-dev-flight-hydration.mjs",
-    "test-base-url": "export BASE_URL='/test-base-url/' && npm run build && npm run test:server",
+    "test-base-url": "export VITE_BASE_URL='/test-base-url/' && npm run build && npm run test:server",
     "test:transport-webpack": "./scripts/test-transport-webpack.sh",
     "test:coverage": "NODE_OPTIONS='--conditions react-server' vitest run --typecheck --coverage",
     "test:ui": "npm run setup:test-fixtures && vitest --ui",

--- a/plugin/utils/flightClient.browser.ts
+++ b/plugin/utils/flightClient.browser.ts
@@ -1,4 +1,4 @@
-import { absoluteURL } from "./envUrls.js";
+import { baseURL } from "./envUrls.js";
 // The one place browser code picks a flight client. WHICH client must follow
 // how the server encoded the payload: a webpack-transport bundle's document
 // injects `self.__vprsFlightTransport` (see createEdgeRenderHook) and its
@@ -25,13 +25,15 @@ export type BrowserFlightClient = {
 };
 
 // Chunk ids in the flight are root-relative identity keys ("/components/…").
-// The FETCH URL derives from the app's PUBLIC_ORIGIN + BASE_URL at load time
-// via the same composition the esm client's moduleBaseURL uses — full
-// transport parity, including CDN-origin deploys. Ids stay base-free, so a
-// snapshot baked once serves from any base/origin. External and
-// protocol-relative ids pass through; already-based ids are not re-prefixed
-// (createBaseURL guards both).
-export const resolveChunkUrl = (chunk: string): string => absoluteURL(chunk);
+// The FETCH URL derives from BASE_URL only — the SERVING origin loads the
+// chunk, never a baked PUBLIC_ORIGIN. Same-origin is the browser module
+// contract (see urls.test.ts): the bootstrap entry is injected same-origin,
+// and flight-loaded chunks must share its origin or the page ends up with
+// two module graphs and two Reacts (null-dispatcher hydration failure).
+// CDN-serving the module graph is the explicit absolute-moduleBaseURL
+// escape hatch, not a publicOrigin side effect. External and already-based
+// ids pass through (createBaseURL guards both).
+export const resolveChunkUrl = (chunk: string): string => baseURL(chunk);
 
 export const loadBrowserFlightClient = (): PromiseLike<BrowserFlightClient> =>
   (globalThis as { __vprsFlightTransport?: string }).__vprsFlightTransport ===

--- a/test/unit/env.test.ts
+++ b/test/unit/env.test.ts
@@ -9,6 +9,9 @@ describe('#env (condition-split env source)', () => {
 
     expect(envModule).toBeDefined();
     expect(envModule.env).toBeDefined();
-    expect(envModule.env.BASE_URL).toBe('/');
+    // env.node reads the mirrored VITE_BASE_URL live, so the assertion must
+    // follow the environment — a literal '/' made this test fail under the
+    // test-base-url rerun the moment that script actually set the base.
+    expect(envModule.env.BASE_URL).toBe(process.env.VITE_BASE_URL || '/');
   });
 }); 

--- a/test/unit/flightClientChunkBase.test.ts
+++ b/test/unit/flightClientChunkBase.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect, afterEach } from "vitest";
 import { resolveChunkUrl } from "../../plugin/utils/flightClient.browser.js";
 
 // The webpack flight's chunk ids are root-relative identity keys; the fetch
-// URL derives from PUBLIC_ORIGIN + BASE_URL at load time — the same
-// composition the esm client's moduleBaseURL uses. Under vitest the #env node
-// variant reads the mirrored VITE_ values live, so both knobs are settable
-// per test.
+// URL derives from BASE_URL only. The SERVING origin loads chunks — a baked
+// PUBLIC_ORIGIN must never leak in, or the bootstrap (injected same-origin)
+// and the flight-loaded chunks split into two module graphs and two Reacts
+// (the null-dispatcher class urls.test.ts pins for the esm path). Under
+// vitest the #env node variant reads the mirrored VITE_ values live.
 describe("resolveChunkUrl", () => {
   const savedBase = process.env.VITE_BASE_URL;
   const savedOrigin = process.env.VITE_PUBLIC_ORIGIN;
@@ -24,7 +25,7 @@ describe("resolveChunkUrl", () => {
     );
   });
 
-  it("leaves ids untouched at the root base with no origin", () => {
+  it("leaves ids untouched at the root base", () => {
     process.env.VITE_BASE_URL = "/";
     delete process.env.VITE_PUBLIC_ORIGIN;
     expect(resolveChunkUrl("/components/Link-abc.js")).toBe(
@@ -32,19 +33,11 @@ describe("resolveChunkUrl", () => {
     );
   });
 
-  it("applies publicOrigin after the base — the documented contract", () => {
+  it("IGNORES a baked publicOrigin — chunks load from the serving origin", () => {
     process.env.VITE_BASE_URL = "/app/";
     process.env.VITE_PUBLIC_ORIGIN = "https://cdn.example";
     expect(resolveChunkUrl("/components/Link-abc.js")).toBe(
-      "https://cdn.example/app/components/Link-abc.js"
-    );
-  });
-
-  it("applies publicOrigin at the root base", () => {
-    process.env.VITE_BASE_URL = "/";
-    process.env.VITE_PUBLIC_ORIGIN = "https://cdn.example";
-    expect(resolveChunkUrl("/components/Link-abc.js")).toBe(
-      "https://cdn.example/components/Link-abc.js"
+      "/app/components/Link-abc.js"
     );
   });
 
@@ -56,7 +49,7 @@ describe("resolveChunkUrl", () => {
     );
   });
 
-  it("passes through external urls", () => {
+  it("passes through external urls (the explicit CDN escape hatch)", () => {
     process.env.VITE_BASE_URL = "/my-repo/";
     process.env.VITE_PUBLIC_ORIGIN = "https://cdn.example";
     expect(resolveChunkUrl("https://other.example/x.js")).toBe(


### PR DESCRIPTION
## Why

Review correction on #371: browser **module** loading is deliberately same-origin in vprs — the bootstrap entry is injected same-origin (`plugin.server.ts` via `baseURL`), and flight-loaded chunks must share its origin or the page ends up with two module graphs and two React instances (the null-dispatcher hydration failure `urls.test.ts` exists to pin). #371 had the webpack loader compose `PUBLIC_ORIGIN`, which would split origins between bootstrap and chunks on any CDN-origin config. The esm parity claim goes the other way: esm's browser path uses the serving origin.

## What

- `resolveChunkUrl` composes `BASE_URL` only (`baseURL` from envUrls; external and already-based ids pass through via `createBaseURL`'s guards).
- The unit matrix's origin cases are replaced by the opposite **contract test**: a baked `publicOrigin` is provably ignored; the external-url passthrough documents the explicit absolute-`moduleBaseURL` CDN escape hatch.
- `publicOrigin`'s api-reference row now states the boundary (absolute-url building yes, module loading never).
- The older `test-base-url` script exported bare `BASE_URL` — ignored by the plugin, so it has always silently rerun the root base. Now `VITE_BASE_URL`. Its first real run surfaced two failures: `env.test`'s literal-`'/'` assertion (made base-aware in this PR) and the edge-action round-trip under a subpath base (real finding, tracked; the script is not wired into CI).

## Verification

- Unit: 795 passed incl. the publicOrigin-ignored contract.
- Webpack transport matrix: all four passes green (root + `/test-base-url/` × both legs).
- Full gate: client 313, server 1028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)