### PR TITLE
fix: node-stream decode strips moduleBaseURL trailing slash — static HTML script src stays same-origin

### DIFF
--- a/plugin/stream/createFromNodeStream.client.ts
+++ b/plugin/stream/createFromNodeStream.client.ts
@@ -50,6 +50,14 @@ export const createFromNodeStream: CreateFromNodeStreamFn<"client"> =
       }
       moduleBaseURL = "/";
     }
+    // COMPOSITION CONTRACT with the stock esm transport (see
+    // createReactFetcher): the flight client builds browser-facing specifiers
+    // as `moduleBaseURL + id` and vprs ids carry a LEADING slash. A base
+    // ending in "/" composes "//…" — a protocol-relative URL, so the script
+    // hoistables this decode bakes into the HTML resolve the id's first path
+    // segment as a HOST instead of loading the same-origin chunk. Strip the
+    // trailing slash here, same as the browser side does before decoding.
+    moduleBaseURL = moduleBaseURL.replace(/\/+$/, "");
     if (!moduleRootPath) {
       moduleRootPath = "";
     } else if (!moduleRootPath.endsWith("/")) {

--- a/test/unit/createFromNodeStream-join-contract.test.ts
+++ b/test/unit/createFromNodeStream-join-contract.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * createFromNodeStream join contract: the SSR/static decode hands
+ * moduleBaseURL to react-server-dom-esm's client.node, which composes
+ * browser-facing script hoistables as `moduleBaseURL + id`. Ids are rooted,
+ * so a base ending in "/" bakes protocol-relative "//…" script src into the
+ * emitted HTML. Same contract createReactFetcher pins on the browser side.
+ *
+ * Isolated file so the vendor.client mock cannot leak into suites that need
+ * the real vendored modules.
+ */
+
+describe("createFromNodeStream join contract", () => {
+  const seen: string[] = [];
+
+  beforeEach(() => {
+    seen.length = 0;
+    vi.resetModules();
+    vi.doMock("../../plugin/vendor/vendor.client.js", () => ({
+      React: {
+        // Invoke function components eagerly so the decode call is observable.
+        createElement: (type: unknown) =>
+          typeof type === "function" ? (type as () => unknown)() : null,
+        use: (value: unknown) => value,
+      },
+      ReactDOMClient: {
+        createFromNodeStream: (
+          _stream: unknown,
+          _moduleRootPath: string,
+          moduleBaseURL: string
+        ) => {
+          seen.push(moduleBaseURL);
+          return Promise.resolve("ok");
+        },
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../plugin/vendor/vendor.client.js");
+    vi.resetModules();
+  });
+
+  const decode = async (moduleBaseURL: string | undefined) => {
+    const { createFromNodeStream } = await import(
+      "../../plugin/stream/createFromNodeStream.client.js"
+    );
+    createFromNodeStream({
+      rscStream: { readable: true } as never,
+      moduleRootPath: "/tmp/dist/client",
+      moduleBasePath: "/",
+      moduleBaseURL,
+    } as never);
+  };
+
+  it.each([
+    ["/", ""],
+    ["/app/", "/app"],
+    ["https://cdn.example.com/", "https://cdn.example.com"],
+  ])(
+    "strips the trailing slash before handing %s to the flight client",
+    async (base, expected) => {
+      await decode(base);
+      expect(seen).toEqual([expected]);
+    }
+  );
+
+  it("defaults a missing base to the rooted-id-safe empty string", async () => {
+    await decode(undefined);
+    expect(seen).toEqual([""]);
+  });
+
+  it("never composes a protocol-relative URL with a rooted id", async () => {
+    await decode("/");
+    const id = "/components/SimCanvas.client-15sninn.js";
+    expect(`${seen[0]}${id}`).toBe(id);
+    expect(`${seen[0]}${id}`.startsWith("//")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

A static build with the esm transport bakes a protocol-relative script hoistable into the emitted HTML:

```html
<script src="//components/Foo.client-abc123.js" type="module" async>
```

The browser resolves `//components/…` as host `components`, so the request fails with `ERR_NAME_NOT_RESOLVED` (and on hosts that 301-normalize `//`, the chunk would load under a second identity). Regression window: 3.7.0 is clean, 3.10.1 reproduces.

## Cause

`createFromNodeStream.client.ts` hands `moduleBaseURL` straight to react-server-dom-esm's `client.node`, which composes browser-facing specifiers as `moduleBaseURL + id`. Module ids are rooted per the module-id join contract, so the default `"/"` base composes `"//…"`. `createReactFetcher` already pins this contract on the browser side (strip the trailing slash before decoding); the node-stream side missed it.

## Fix

Apply the same trailing-slash strip before the decode. Covers the HTML worker (static builds and SSR) and the in-process pipeable-stream handler, which both decode through `createFromNodeStream`.

## Verification

- New `test/unit/createFromNodeStream-join-contract.test.ts` pins the strip (`"/"` → `""`, `"/app/"` → `"/app"`, absolute CDN origins, and the missing-base default).
- Full gate green: `npm test` (server + client halves, 1033 passed / 58 skipped each), `npx tsc --noEmit`.
- Reproduced end-to-end against a downstream static app (smm2-sim on 3.10.1): before, `dist/static/index.html` carries the `//`-prefixed script src and the browser logs `ERR_NAME_NOT_RESOLVED`; with this fix the src is single-slash and a headless probe shows zero page errors, zero hydration errors, and working interactivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QRRobAkXcVSJYhe7fojHT