### PR TITLE
chore(release): 3.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release carrying the two commits on main since v3.10.1:

- #374 — node-stream decode strips the trailing slash from `moduleBaseURL`, so static HTML script src stays same-origin (fixes the protocol-relative `//components/...` src that broke subpath static deploys)
- #373 — action-roundtrip test runs truthfully under a subpath base

🤖 Generated with [Claude Code](https://claude.com/claude-code)