### PR TITLE
fix(dev): css hotUpdate returns only hot-swappable modules — no reload dead ends

### DIFF
--- a/plugin/dev-server/devPluginShared.ts
+++ b/plugin/dev-server/devPluginShared.ts
@@ -81,3 +81,32 @@ export function devFlightTransportTags(
     },
   ];
 }
+
+/**
+ * Split a css file's client-graph modules into the ones Vite's native css
+ * HMR can actually hot-swap: nodes with a JS importer other than the file
+ * itself (a "use client" component importing the stylesheet). A
+ * server-collected stylesheet served as <link> also gets client-graph nodes
+ * from the browser's fetch (the url node and its ?direct twin) with no such
+ * importer — letting those ride into propagation dead-ends Vite into a full
+ * page reload, wiping the client state the refetch + link cache-bust path
+ * exists to preserve. Returning ONLY the swappable modules from `hotUpdate`
+ * keeps both worlds: genuinely client-imported css hot-swaps in place, the
+ * link-delivered copy cache-busts via the kind:"css" event, and nothing
+ * dead-ends.
+ */
+// deno-lint-ignore no-explicit-any — callers hand Vite's EnvironmentModuleNode
+// (or the legacy ModuleNode) through an untyped hook ctx; the filter only
+// touches `importers` and must return the SAME nodes for Vite to propagate.
+export const clientOwnedCssModules = <M,>(
+  modules: M[] | undefined,
+  cssFile: string
+): M[] =>
+  (modules ?? []).filter((m) =>
+    [...(((m as { importers?: Set<unknown> }).importers ?? []) as Set<{ file?: string | null; id?: string | null }>)].some(
+      (imp) => {
+        const impFile = (imp?.file ?? imp?.id ?? "").split("?")[0];
+        return !!impFile && impFile !== cssFile;
+      }
+    )
+  );

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -2,7 +2,7 @@ import type { VitePluginFn } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.client.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
-import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags } from "./devPluginShared.js";
+import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags, clientOwnedCssModules } from "./devPluginShared.js";
 import { getDevShellHeadProvider } from "./devShellHeadProvider.js";
 import { mergeDevShellHead } from "./devShellHead.js";
 import type { ConfigEnv } from "vite";
@@ -123,17 +123,17 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       // hashes) until a server restart. This is the dev:ssr counterpart to
       // the #96 fix in plugin.server.ts: that fix only takes effect on the
       // dev:rsc main thread; dev:ssr loads plugin.client.ts instead.
-      const isClientGraphCss =
-        isCssFile &&
-        (ctx.modules ?? []).some(
-          (m: { importers?: Set<unknown> }) => (m.importers?.size ?? 0) > 0,
-        );
-      if (isClientGraphCss) {
-        // Vite owns the visible update, but the RSC worker still holds the
-        // css-module JS proxy — drop it so the next server render agrees
-        // with the new stylesheet's class-name hashes.
+      const clientOwnedCss = isCssFile
+        ? clientOwnedCssModules(ctx.modules, file)
+        : [];
+      if (isCssFile && clientOwnedCss.length > 0) {
+        // Vite owns the visible update for the client-imported modules, but
+        // the RSC worker still holds the css-module JS proxy — drop it so
+        // the next server render agrees with the new class-name hashes.
+        // Return ONLY the swappable modules: the link-fetch artifact nodes
+        // riding along would dead-end propagation into a full reload.
         hmrHandler?.sendHmrUpdate(file);
-        return; // let Vite's native client CSS HMR apply the update
+        return clientOwnedCss as never[];
       }
 
       const isServerFile = isSourceFile && !isClientFile;

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -84,7 +84,20 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       // environment ('unknown') — handle both, or the RSC worker never hears
       // about the edit. Multiple calls for the same change are deduped by
       // `isProcessingHmr` below.
-      if (envName !== 'client' && envName !== 'unknown') return;
+      if (envName !== 'client' && envName !== 'unknown') {
+        // Not a plain pass-through for css: the server/ssr environments hold
+        // their own node for a server-imported stylesheet (page.tsx imports
+        // it for class-name hashes), and Vite's native propagation for that
+        // node dead-ends into a full reload — the dev:rsc orchestrator
+        // suppresses this in plugin.server.ts, and dev:ssr must match. The
+        // client-environment call owns the real update (worker invalidation
+        // + the kind:'css' cache-bust event).
+        const rel = file.replace(userOptions.projectRoot || server.config.root, '').replace(/^\/+/, '');
+        if (rel.startsWith((userOptions.moduleBase || 'src') + '/') && CSS_EXT.test(file)) {
+          return [];
+        }
+        return;
+      }
       
       // Prevent recursive HMR updates
       if (isProcessingHmr) {
@@ -133,6 +146,18 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
         // Return ONLY the swappable modules: the link-fetch artifact nodes
         // riding along would dead-end propagation into a full reload.
         hmrHandler?.sendHmrUpdate(file);
+        // Dual-graph: the SAME stylesheet may also be server-rendered as a
+        // <link> (the <Css cssFiles={...}/> pattern), whose href doesn't
+        // change on edit — without the cache-bust event that copy stays
+        // stale. Cascade order can mask it (an edited declaration wins via
+        // Vite's fresher <style>), but a DELETED rule survives in the stale
+        // link. Send the tagged event so useRscHmr cache-busts matching
+        // links, exactly as the non-client-owned css branch below does.
+        server.ws.send({
+          type: "custom",
+          event: "vite-plugin-react-server:server-component-update",
+          data: { file: normalizedFile, path: file, kind: "css" },
+        });
         return clientOwnedCss as never[];
       }
 

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -3,7 +3,7 @@ import { configureReactServer } from "./configureReactServer.server.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
 import type { Plugin, ViteDevServer } from "vite";
-import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags } from "./devPluginShared.js";
+import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags, clientOwnedCssModules } from "./devPluginShared.js";
 import { getDevShellHeadProvider } from "./devShellHeadProvider.js";
 import { mergeDevShellHead } from "./devShellHead.js";
 
@@ -87,14 +87,13 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
         // Suppressing genuinely client-owned css here (the `return []` below)
         // is what previously left client-graph CSS edits stuck until a manual
         // refresh: the RSC <link> cache-bust never matches a Vite <style>.
-        if (
-          isCssFile &&
-          (ctx.modules ?? []).some(
-            (m: { importers?: Set<unknown> }) => (m.importers?.size ?? 0) > 0,
-          )
-        ) {
-          return; // let Vite's native client CSS HMR apply the update
-        }
+        // Css: hand Vite ONLY the modules its native css HMR can hot-swap
+        // (client-JS-imported nodes); the link-fetch artifacts would
+        // dead-end propagation into a full reload. The kind:"css" event
+        // below cache-busts the <link> copy either way.
+        const clientOwnedCss = isCssFile
+          ? clientOwnedCssModules(ctx.modules, file)
+          : [];
 
         // CSS files that aren't imported via the client module graph (vprs's
         // <Css cssFiles={...}/> pattern collects them server-side) aren't
@@ -114,7 +113,8 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
           data: { file: normalizedFile, path: file, kind },
         });
 
-        return []; // Don't trigger client-side page reload
+        // Css keeps its hot-swappable modules; everything else suppresses.
+        return (isCssFile ? clientOwnedCss : []) as never[]; // no full-reload dead ends
       }
       
       // Server/SSR environments: suppress page reload for all source files

--- a/test/dev/css-hmr-dual-graph.test.ts
+++ b/test/dev/css-hmr-dual-graph.test.ts
@@ -5,6 +5,7 @@ import { testUserOptions } from "../test-config";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { resolve, join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { clientOwnedCssModules } from "../../plugin/dev-server/devPluginShared.js";
 
 /**
  * Dual-graph CSS: the SAME stylesheet imported by a "use client" component
@@ -99,15 +100,17 @@ describe("dual-graph css edit", () => {
     // carries import.meta.hot.accept — Vite then marks the node
     // self-accepting and hot-swaps it in place. Plain fetches can't run that
     // client-side registration, so mirror the browser-driven state — but
-    // ONLY on the client-IMPORTED node (the one with a JS importer). The
-    // link-fetch artifact nodes stay exactly as a browser leaves them:
-    // non-accepting, which is what the plugin's importer predicate must
-    // filter out of the returned module list.
-    for (const m of (server as any).environments.client.moduleGraph.getModulesByFile(
-      join(testDir, "src/page/card.module.css"),
-    ) ?? []) {
-      const node = m as { isSelfAccepting?: boolean; importers?: Set<unknown> };
-      if ((node.importers?.size ?? 0) > 0) node.isSelfAccepting = true;
+    // ONLY on nodes the production predicate itself classifies as
+    // client-owned (a JS importer that is not the stylesheet's own file):
+    // the exact filter the plugin applies, so the guard cannot be
+    // accidentally satisfied by a looser marking. Artifact nodes stay as a
+    // browser leaves them: non-accepting.
+    const cssAbs = join(testDir, "src/page/card.module.css");
+    const cssNodes = [
+      ...((server as any).environments.client.moduleGraph.getModulesByFile(cssAbs) ?? []),
+    ];
+    for (const m of clientOwnedCssModules(cssNodes, cssAbs)) {
+      (m as { isSelfAccepting?: boolean }).isSelfAccepting = true;
     }
 
     const events: Array<{ type: string; event?: string; data?: { kind?: string } }> = [];

--- a/test/dev/css-hmr-dual-graph.test.ts
+++ b/test/dev/css-hmr-dual-graph.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type ViteDevServer } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import { testUserOptions } from "../test-config";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+/**
+ * Dual-graph CSS: the SAME stylesheet imported by a "use client" component
+ * (client module graph — Vite hot-swaps its injected <style>) AND by the
+ * server page (collected into a server-rendered <link>). On edit, Vite's
+ * swap alone leaves the <link> copy stale — cascade order can mask an edited
+ * declaration, but a DELETED rule survives in the cached link. The plugin
+ * must therefore still emit the kind:"css" cache-bust event alongside
+ * handing Vite the hot-swappable modules, and must not fall back to a full
+ * reload. Both dev orchestrators are covered by test:both — the client
+ * (dev:ssr) leg exercises plugin.client.ts, the react-server leg
+ * plugin.server.ts.
+ */
+
+let server: ViteDevServer;
+const port = 3119;
+const testDir = resolve(__dirname, "../fixtures/css-hmr-dual-graph.test");
+
+const CSS = `.card { color: rgb(1, 2, 3); }\n.gone { margin: 7px; }\n`;
+
+async function setupTestFiles() {
+  await mkdir(join(testDir, "src/page"), { recursive: true });
+  await writeFile(join(testDir, "src/page/card.module.css"), CSS);
+  await writeFile(
+    join(testDir, "src/page/Card.client.tsx"),
+    `"use client";
+import React from "react";
+import styles from "./card.module.css";
+export const Card = () => <div className={styles["card"]}>card</div>;`
+  );
+  await writeFile(
+    join(testDir, "src/page/page.tsx"),
+    `import React from "react";
+import styles from "./card.module.css";
+import { Card } from "./Card.client.js";
+export const Page = () => (
+  <div className={styles["card"]}>
+    server copy
+    <Card />
+  </div>
+);`
+  );
+  await writeFile(
+    join(testDir, "src/page/props.ts"),
+    `export const props = () => ({});`
+  );
+}
+
+describe("dual-graph css edit", () => {
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await setupTestFiles();
+    server = await createServer({
+      root: testDir,
+      configFile: false,
+      server: { port, strictPort: true },
+      plugins: [
+        vitePluginReactServer({
+          ...testUserOptions,
+          projectRoot: testDir,
+          moduleBase: "src",
+        }),
+      ],
+      logLevel: "warn",
+    });
+    await server.listen();
+  }, 30000);
+
+  afterAll(async () => {
+    await server?.close();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("cache-busts the server-rendered link and never full-reloads", async () => {
+    // Populate the server graph (RSC render) …
+    const rsc = await fetch(`http://localhost:${port}/`, {
+      headers: { Accept: "text/x-component" },
+    });
+    expect(rsc.ok).toBe(true);
+    await rsc.text();
+    // … and the CLIENT graph: transform the client component and its css
+    // import the way a browser would, so the stylesheet gains a client-side
+    // JS importer (the dual-graph condition).
+    await (await fetch(`http://localhost:${port}/src/page/Card.client.tsx`)).text();
+    // The css-as-JS module (what the browser's import graph requests — goes
+    // through import analysis, which marks it self-accepting) AND the raw
+    // form (what a server-rendered <link href> fetch creates).
+    await (await fetch(`http://localhost:${port}/src/page/card.module.css?import`)).text();
+    await (await fetch(`http://localhost:${port}/src/page/card.module.css`)).text();
+    await sleep(200);
+    // A real browser executes the css-as-JS module, whose dev transform
+    // carries import.meta.hot.accept — Vite then marks the node
+    // self-accepting and hot-swaps it in place. Plain fetches can't run that
+    // client-side registration, so mirror the browser-driven state on the
+    // graph node; without it the propagation dead-ends and this test would
+    // assert a reload that real usage doesn't have.
+    for (const m of (server as any).environments.client.moduleGraph.getModulesByFile(
+      join(testDir, "src/page/card.module.css"),
+    ) ?? []) {
+      (m as { isSelfAccepting?: boolean }).isSelfAccepting = true;
+    }
+
+    const events: Array<{ type: string; event?: string; data?: { kind?: string } }> = [];
+    const originalSend = server.ws.send.bind(server.ws);
+    server.ws.send = function (payload: unknown) {
+      if (payload && typeof payload === "object") {
+        events.push(payload as (typeof events)[number]);
+      }
+      return originalSend(payload as never);
+    } as typeof server.ws.send;
+
+    // Delete a rule — the case cascade order cannot mask.
+    const abs = join(testDir, "src/page/card.module.css");
+    await writeFile(abs, `.card { color: rgb(9, 9, 9); }\n`);
+    server.watcher.emit("change", abs);
+
+    // Wait for the hotUpdate chain to run.
+    const deadline = Date.now() + 8000;
+    while (Date.now() < deadline) {
+      if (
+        events.some(
+          (e) =>
+            e.type === "custom" &&
+            e.event === "vite-plugin-react-server:server-component-update" &&
+            e.data?.kind === "css",
+        )
+      )
+        break;
+      await sleep(100);
+    }
+
+    const cssEvents = events.filter(
+      (e) =>
+        e.type === "custom" &&
+        e.event === "vite-plugin-react-server:server-component-update" &&
+        e.data?.kind === "css",
+    );
+    // The cache-bust event is what refreshes the server-rendered <link>.
+    expect(cssEvents.length).toBeGreaterThan(0);
+    // And the dual-graph shape must not dead-end into a reload.
+    expect(events.some((e) => e.type === "full-reload")).toBe(false);
+  }, 20000);
+});

--- a/test/dev/css-hmr-dual-graph.test.ts
+++ b/test/dev/css-hmr-dual-graph.test.ts
@@ -98,13 +98,16 @@ describe("dual-graph css edit", () => {
     // A real browser executes the css-as-JS module, whose dev transform
     // carries import.meta.hot.accept — Vite then marks the node
     // self-accepting and hot-swaps it in place. Plain fetches can't run that
-    // client-side registration, so mirror the browser-driven state on the
-    // graph node; without it the propagation dead-ends and this test would
-    // assert a reload that real usage doesn't have.
+    // client-side registration, so mirror the browser-driven state — but
+    // ONLY on the client-IMPORTED node (the one with a JS importer). The
+    // link-fetch artifact nodes stay exactly as a browser leaves them:
+    // non-accepting, which is what the plugin's importer predicate must
+    // filter out of the returned module list.
     for (const m of (server as any).environments.client.moduleGraph.getModulesByFile(
       join(testDir, "src/page/card.module.css"),
     ) ?? []) {
-      (m as { isSelfAccepting?: boolean }).isSelfAccepting = true;
+      const node = m as { isSelfAccepting?: boolean; importers?: Set<unknown> };
+      if ((node.importers?.size ?? 0) > 0) node.isSelfAccepting = true;
     }
 
     const events: Array<{ type: string; event?: string; data?: { kind?: string } }> = [];
@@ -144,6 +147,10 @@ describe("dual-graph css edit", () => {
     );
     // The cache-bust event is what refreshes the server-rendered <link>.
     expect(cssEvents.length).toBeGreaterThan(0);
+    // Vite's native hot-swap must ALSO go out — proof the hook returned the
+    // client-owned module (an empty return would log "no modules matched"
+    // and send nothing) rather than merely avoiding a reload.
+    expect(events.some((e) => e.type === "update")).toBe(true);
     // And the dual-graph shape must not dead-end into a reload.
     expect(events.some((e) => e.type === "full-reload")).toBe(false);
   }, 20000);


### PR DESCRIPTION
Second half of the dev inline-css HMR fix started in #368. With css delivered as a link in dev, a stylesheet can be dual-graph: a client component imports it AND the server page links it, so the client module graph holds one genuinely hot-swappable module plus link-fetch artifact nodes (?direct/url). Handing Vite the full list dead-ends propagation on an artifact node, which flips needFullReload and reloads the page before the cache-bust event can matter.

Both dev plugins' css branch now returns only the modules with a JS importer other than the stylesheet itself: Vite hot-swaps the client-imported module natively, the linked copy cache-busts through the kind:css websocket event, and pure server css keeps suppressing native handling.

Verified in a browser acceptance against the Pokédex demo: editing an inline-threshold css module applies live — no reload, input state preserved. The release HMR spec's pinned test.fail css case flips green once this ships and the demo is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)