### PR TITLE
test: pin the loud hoisted-barrel guard for package client modules

### DIFF
--- a/test/examples/edge-package-client-boundary.test.ts
+++ b/test/examples/edge-package-client-boundary.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { doBuild } from "../doBuild.js";
+
+const testDir = resolve(
+  __dirname,
+  "../fixtures/edge-package-client-boundary.test"
+);
+
+// A SERVER page importing a PACKAGE module that carries "use client"
+// (router/client's Link), under a hoisted install: the plugin resolves
+// outside the fixture's project root — the repo's own layout, and any
+// pnpm/monorepo consumer. preserveModules can't host the barrel's chunk
+// cluster there, so the build must fail loudly with the fix named
+// (first-party *.client.tsx wrapper, or install at the project root) rather
+// than dangle to a runtime ERR_MODULE_NOT_FOUND — or worse, statically bake
+// the barrel into dist/server-edge, where the vendored CJS flight client's
+// interop (`import { createRequire } from "node:module"`) fails a fetch
+// runtime's validator at deploy while every Node-based check stays green.
+// The root-install variant of that silent bake needs a pack-and-install
+// fixture and is tracked separately.
+async function setupFixture() {
+  await mkdir(join(testDir, "src/page"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/page/page.tsx"),
+    `import { Link } from "vite-plugin-react-server/router/client";\n` +
+      `export const Page = ({ name }: { name: string }) => (\n` +
+      `  <div id="root">Hello {name} <Link to="/">home</Link></div>\n` +
+      `);`
+  );
+  await writeFile(
+    join(testDir, "src/page/props.ts"),
+    `export const props = (_url: string) => ({ name: "boundary" });`
+  );
+  await writeFile(
+    join(testDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        jsx: "react-jsx",
+        strict: true,
+      },
+      include: ["src"],
+    })
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head><meta charset="utf-8" /></head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ patterns: ["/"] });`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {}
+}
+
+describe("server page importing the package client barrel (hoisted install)", () => {
+  beforeAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    await setupFixture();
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("fails the build loudly and names the fix", async () => {
+    await expect(
+      doBuild({
+        projectRoot: testDir,
+        moduleBase: "src",
+        Page: "src/page/page.tsx",
+        props: "src/page/props.ts",
+        transport: "webpack",
+        build: {
+          pages: ["/"],
+          outDir: "dist",
+          edge: true,
+        },
+      } as any)
+    ).rejects.toThrow(/router client barrel[\s\S]*\*\.client\.tsx/);
+  });
+});


### PR DESCRIPTION
Regression test for the class the official demo's Workers deploy hit: a server page importing `vite-plugin-react-server/router/client` directly.

Under a hoisted install (the repo's own test layout, and any pnpm/monorepo consumer) the build already fails loudly with the fix named — first-party `*.client.tsx` wrapper, or install at the project root — and this pins that contract so it can't regress into the dangerous alternative: statically baking the barrel into `dist/server-edge`, where the vendored CJS flight client's interop emits `import { createRequire } from "node:module"` and a fetch runtime's validator rejects the upload (Workers error 10021) while every Node-based check stays green.

The root-install variant is exactly that silent bake (the demo's case: main build hosts the reference correctly, the edge bake bundles it anyway). Reproducing it in-repo needs a pack-and-install fixture, since any fixture importing the repo's plugin is hoisted by construction — left tracked on the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)