### PR TITLE
chore(release): 3.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.10.2",
+      "version": "3.11.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.10.2",
+  "version": "3.11.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Minor release carrying the reviewed batch merged from #329–#378:

- **feat** #377 — `stripHtmlSuffix` router knob (.html as transport vs content), threaded through every param-derivation path including the worker, with docs
- **fix** #376 — dev css HMR: hotUpdate returns only hot-swappable modules (no reload dead ends), dev:ssr dual-graph stylesheets cache-bust their linked copy, server-env propagation suppressed
- **test** #378 — hoisted-barrel guard for package client modules in the edge bake
- **docs** #329/#360 — accepted runner and host specs (internals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)