### PR TITLE
chore: react-server-loader 19.2.20 (+ experimental eb8feb71-20260814)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803",
+        "react-server-loader": "^19.2.20 || 0.0.0-experimental-eb8feb71-20260814",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -6437,9 +6437,9 @@
       "license": "MIT"
     },
     "node_modules/react-server-loader": {
-      "version": "19.2.19",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.19.tgz",
-      "integrity": "sha512-zwRsbVhd/xm5BO6lAVl/d0pVhq+0vlPPjIAV+RyVzMYeZ7qVErQRaR1eLY9T2R3pg+rZ0ahPPsdvibAfl506uQ==",
+      "version": "19.2.20",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.20.tgz",
+      "integrity": "sha512-Av3ZhAgdmdG9hGRAYpQn0vH9U7buq8MLP90o+PQtSLuwbZrwKBloMntVThdaxn+wuCoF1nzWmHK3Z+zSk0yigQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -443,7 +443,7 @@
   "dependencies": {
     "acorn": "^8.16.0",
     "picocolors": "^1.1.1",
-    "react-server-loader": "^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803",
+    "react-server-loader": "^19.2.20 || 0.0.0-experimental-eb8feb71-20260814",
     "tsx": "^4.21.0",
     "vitefu": "^1.1.3"
   }


### PR DESCRIPTION
Moves the compound rsl pin from `^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803` to `^19.2.20 || 0.0.0-experimental-eb8feb71-20260814`.

- Stable 19.2.20 ships rsl's reference-manifest emitter (`react-server-loader/manifest`, static-import registration artifact) and a gate fix: a sealed open-mode gate no longer falls back to `devResolve` for unknown ids.
- The experimental alternate moves to the eb8feb71-20260814 nightly, matching React's current `experimental` npm builds so fresh installs of `react@experimental` peer-match again.

Full local gate (`npm test`, server + client legs) passes against the published packages: 1041 passed, 58 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)