### PR TITLE
feat: runner flag with the validated runner/condition invariant (4.0)

### DIFF
--- a/plugin/config/runner.ts
+++ b/plugin/config/runner.ts
@@ -1,0 +1,64 @@
+// Note: do not import Node-only modules here. Like getCondition.ts, this file
+// is consumed in both server and client plugin contexts.
+
+import { getCondition, REACT_CONDITION } from "./getCondition.js";
+
+/**
+ * The execution paradigms a consumer can declare. See
+ * docs/internals/runner-spec.md: the runner replaces the process condition as
+ * API dispatch, never as react-server resolution.
+ */
+export const RUNNER_NAMES = ["main", "isolated", "edge"] as const;
+export type RunnerName = (typeof RUNNER_NAMES)[number];
+
+const RUNNER_PITCH: Record<RunnerName, string> = {
+  main: "react-server on the main thread; best stack traces, React usable in vite.config.ts; requires NODE_OPTIONS='--conditions react-server'",
+  isolated:
+    "worker_threads rsc-worker owns react-server resolution; no process flag",
+  edge: "single isolate, React baked per environment at build time; Web streams, no process flag",
+};
+
+const runnerList = (): string =>
+  RUNNER_NAMES.map((name) => `  - "${name}": ${RUNNER_PITCH[name]}`).join("\n");
+
+/**
+ * The runner/condition invariant, validated at config-resolve time (the flag
+ * names an intent; the process either matches it or the build says so loudly):
+ *
+ * - `main` requires the process condition present — the flag cannot
+ *   retroactively add `--conditions react-server` to imports that already
+ *   resolved (vite.config.ts and its graph load before any plugin code runs).
+ * - `isolated` / `edge` require the condition absent — a global
+ *   `--conditions react-server` poisons every module the orchestrator loads
+ *   outside its per-environment `resolve.conditions`.
+ *
+ * Returns the validated runner, or undefined when none was declared (the
+ * legacy condition-inferred dispatch; a declared runner becomes required in
+ * the next major).
+ */
+export function validateRunner(runner: unknown): RunnerName | undefined {
+  if (runner === undefined || runner === null) return undefined;
+  if (!RUNNER_NAMES.includes(runner as RunnerName)) {
+    throw new Error(
+      `[vite-plugin-react-server] Unknown runner ${JSON.stringify(runner)}. Pick one:\n${runnerList()}`
+    );
+  }
+  const name = runner as RunnerName;
+  const conditionPresent = getCondition() === REACT_CONDITION.server;
+  if (name === "main" && !conditionPresent) {
+    throw new Error(
+      "[vite-plugin-react-server] runner 'main' needs NODE_OPTIONS='--conditions react-server' (react-in-config resolves at process start)."
+    );
+  }
+  if (name !== "main" && conditionPresent) {
+    throw new Error(
+      `[vite-plugin-react-server] runner '${name}' owns react-server resolution itself; remove the process flag.`
+    );
+  }
+  if (name === "edge") {
+    throw new Error(
+      "[vite-plugin-react-server] runner 'edge' is not implemented yet — use runner 'isolated' (or 'main') with build.edge to emit the baked pair meanwhile."
+    );
+  }
+  return name;
+}

--- a/plugin/index.shared.ts
+++ b/plugin/index.shared.ts
@@ -10,6 +10,7 @@
 import type { VitePluginMainFn } from "./types.js";
 import { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.js";
 import type { UserOptions, Strategy } from "./orchestrator/types.js";
+import { validateRunner } from "./config/runner.js";
 
 export function makeVitePluginReactServer(
   importContext: Strategy["importContext"],
@@ -18,6 +19,11 @@ export function makeVitePluginReactServer(
     if (options == null) {
       throw new Error("options is required");
     }
+
+    // Runner/condition invariant: a declared runner either matches the
+    // process condition or errors here, at config-resolve time.
+    validateRunner((options as UserOptions).runner);
+
     const userStrategy = (options as UserOptions).strategy || {};
     const finalStrategy: Strategy = {
       mode: "auto",

--- a/plugin/orchestrator/createPluginOrchestrator.client.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.client.ts
@@ -1,18 +1,28 @@
 import type { Plugin } from "vite";
 import { vitePluginReactDevServer } from "../dev-server/plugin.client.js";
 import { reactStaticPlugin } from "../react-static/plugin.client.js";
-import { createPluginOrchestratorImpl } from "./createPluginOrchestrator.impl.js";
+import {
+  createPluginOrchestratorImpl,
+  type OrchestratorStrategy,
+} from "./createPluginOrchestrator.impl.js";
 import type { ReactCondition } from "../config/getCondition.js";
 
-// Client-first orchestrator — pulls the .client dev-server / react-static plugins
-// and runs the transformer with a "client" default environment. The shared body
-// lives in createPluginOrchestrator.impl.ts.
+// The `isolated` runner record: the worker_threads rsc-worker owns
+// react-server resolution, so the main thread stays client-first — this face
+// pulls the .client dev-server / react-static plugins and runs the
+// transformer with a "client" default environment. It lives in the .client
+// tree because its imports only initialize without the process condition —
+// the runner/condition invariant (plugin/config/runner.ts) guarantees a
+// declared `isolated` runner and this tree coincide. The shared body lives in
+// createPluginOrchestrator.impl.ts.
+const isolatedRunner: OrchestratorStrategy = {
+  defaultEnvironment: "client",
+  devServerPlugin: vitePluginReactDevServer,
+  staticPlugin: reactStaticPlugin,
+};
+
 export const createPluginOrchestrator = (userOptions: any): Plugin[] =>
-  createPluginOrchestratorImpl(userOptions, {
-    defaultEnvironment: "client",
-    devServerPlugin: vitePluginReactDevServer,
-    staticPlugin: reactStaticPlugin,
-  });
+  createPluginOrchestratorImpl(userOptions, isolatedRunner);
 
 
 export interface Strategy {

--- a/plugin/orchestrator/createPluginOrchestrator.server.ts
+++ b/plugin/orchestrator/createPluginOrchestrator.server.ts
@@ -1,18 +1,27 @@
 import type { Plugin } from "vite";
 import { vitePluginReactDevServer } from "../dev-server/plugin.server.js";
 import { reactStaticPlugin } from "../react-static/plugin.server.js";
-import { createPluginOrchestratorImpl } from "./createPluginOrchestrator.impl.js";
+import {
+  createPluginOrchestratorImpl,
+  type OrchestratorStrategy,
+} from "./createPluginOrchestrator.impl.js";
 import type { ReactCondition } from "../config/getCondition.js";
 
-// Server-first orchestrator — pulls the .server dev-server / react-static plugins
-// and runs the transformer with a "server" default environment. The shared body
-// lives in createPluginOrchestrator.impl.ts.
+// The `main` runner record: react-server executes on the main thread, so this
+// face pulls the .server dev-server / react-static plugins and runs the
+// transformer with a "server" default environment. It lives in the .server
+// tree because its imports only initialize under the process condition — the
+// runner/condition invariant (plugin/config/runner.ts) guarantees a declared
+// `main` runner and this tree coincide. The shared body lives in
+// createPluginOrchestrator.impl.ts.
+const mainRunner: OrchestratorStrategy = {
+  defaultEnvironment: "server",
+  devServerPlugin: vitePluginReactDevServer,
+  staticPlugin: reactStaticPlugin,
+};
+
 export const createPluginOrchestrator = (userOptions: any): Plugin[] =>
-  createPluginOrchestratorImpl(userOptions, {
-    defaultEnvironment: "server",
-    devServerPlugin: vitePluginReactDevServer,
-    staticPlugin: reactStaticPlugin,
-  });
+  createPluginOrchestratorImpl(userOptions, mainRunner);
 
 
 export interface Strategy {

--- a/plugin/plugin.client.ts
+++ b/plugin/plugin.client.ts
@@ -2,6 +2,7 @@ import type { VitePluginMainFn } from "./types.js";
 import { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.client.js";
 import type { UserOptions, Strategy } from "./orchestrator/types.js";
 import { assertNonReactServer } from "./config/getCondition.js";
+import { validateRunner } from "./config/runner.js";
 
 assertNonReactServer();
 
@@ -23,7 +24,11 @@ export const vitePluginReactServer: VitePluginMainFn =
     if (options == null) {
       throw new Error("options is required");
     }
-    
+
+    // Runner/condition invariant: a declared runner either matches the
+    // process condition or errors here, at config-resolve time.
+    validateRunner((options as UserOptions).runner);
+
     // Use the intelligent orchestrator for plugin composition with client context
     const userStrategy = (options as UserOptions).strategy || {};
     const finalStrategy: Strategy = {

--- a/plugin/plugin.server.ts
+++ b/plugin/plugin.server.ts
@@ -2,6 +2,7 @@ import type { VitePluginMainFn } from "./types.js";
 import type { UserOptions, Strategy } from "./orchestrator/types.js";
 
 import { assertReactServer } from "./config/getCondition.js";
+import { validateRunner } from "./config/runner.js";
 import { createPluginOrchestrator } from "./orchestrator/createPluginOrchestrator.server.js";
 
 assertReactServer();
@@ -25,6 +26,9 @@ export const vitePluginReactServer: VitePluginMainFn =
       throw new Error("options is required");
     }
 
+    // Runner/condition invariant: a declared runner either matches the
+    // process condition or errors here, at config-resolve time.
+    validateRunner((options as UserOptions).runner);
 
     // Use the intelligent orchestrator for plugin composition with server context
     const userStrategy = (options as UserOptions).strategy || {};

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -29,6 +29,7 @@ import type {
 } from "./helpers/serializeUserOptions.js";
 import type { AllowedDirectives, Program } from "react-server-loader/directives";
 import type { RoutesOption } from "./router/fileRouter.js";
+import type { RunnerName } from "./config/runner.js";
 import type { RouteLayer } from "./router/scanRoutes.js";
 import type { ResolvedLayoutLayer } from "./helpers/resolveLayoutChain.js";
 
@@ -723,6 +724,18 @@ export type PluginEventType = PluginEvent["type"];
 export interface StreamPluginOptions<
   Interface extends ViteReactServerComponentsPlugin = DefaultInterface
 > {
+  /**
+   * The execution paradigm, declared instead of inferred from the process
+   * condition (see docs/internals/runner-spec.md). "main" runs react-server
+   * on the main thread and requires NODE_OPTIONS='--conditions react-server';
+   * "isolated" resolves react-server inside the rsc-worker with no process
+   * flag; "edge" bakes React per environment at build time. Validated against
+   * the process condition at config-resolve time — a mismatch is a
+   * config-time error, not a runtime mystery. Currently optional (omitting it
+   * keeps the condition-inferred dispatch); becomes required in the next
+   * major.
+   */
+  runner?: RunnerName;
   projectRoot?: string; // defaults to process.cwd()
   /**
    * The deploy's RSC flight flavor. Default "esm". With "webpack" every

--- a/test/examples/runner-invariant.test.ts
+++ b/test/examples/runner-invariant.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The runner/condition invariant (docs/internals/runner-spec.md): a declared
+ * runner either matches the process condition or errors at config-resolve
+ * time. This suite runs under BOTH conditions (test-both), so each side
+ * asserts the half of the invariant its ambient condition can observe.
+ */
+import { describe, it, expect } from "vitest";
+import { validateRunner, RUNNER_NAMES } from "../../plugin/config/runner.js";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+const conditionPresent = getCondition() === REACT_CONDITION.server;
+
+describe("validateRunner", () => {
+  it("returns undefined when no runner is declared (legacy inference)", () => {
+    expect(validateRunner(undefined)).toBeUndefined();
+    expect(validateRunner(null)).toBeUndefined();
+  });
+
+  it("rejects unknown runners, listing all three options", () => {
+    for (const bad of ["worker", "MAIN", 3, {}]) {
+      try {
+        validateRunner(bad);
+        expect.unreachable("should have thrown");
+      } catch (e) {
+        const msg = String(e);
+        for (const name of RUNNER_NAMES) {
+          expect(msg).toContain(`"${name}"`);
+        }
+      }
+    }
+  });
+
+  if (conditionPresent) {
+    it("accepts 'main' under the process condition", () => {
+      expect(validateRunner("main")).toBe("main");
+    });
+
+    it("rejects 'isolated' and 'edge' under the process condition", () => {
+      expect(() => validateRunner("isolated")).toThrow(
+        /owns react-server resolution itself; remove the process flag/
+      );
+      expect(() => validateRunner("edge")).toThrow(
+        /owns react-server resolution itself; remove the process flag/
+      );
+    });
+  } else {
+    it("rejects 'main' without the process condition", () => {
+      expect(() => validateRunner("main")).toThrow(
+        /needs NODE_OPTIONS='--conditions react-server'/
+      );
+    });
+
+    it("accepts 'isolated' without the process condition", () => {
+      expect(validateRunner("isolated")).toBe("isolated");
+    });
+
+    it("rejects 'edge' as not implemented yet", () => {
+      expect(() => validateRunner("edge")).toThrow(/not implemented yet/);
+    });
+  }
+});

--- a/test/examples/runner-invariant.test.ts
+++ b/test/examples/runner-invariant.test.ts
@@ -5,11 +5,13 @@
  * asserts the half of the invariant its ambient condition can observe.
  */
 import { describe, it, expect } from "vitest";
+import { vitePluginReactServer } from "vite-plugin-react-server";
 import { validateRunner, RUNNER_NAMES } from "../../plugin/config/runner.js";
 import {
   getCondition,
   REACT_CONDITION,
 } from "../../plugin/config/getCondition.js";
+import { testUserOptions } from "../test-config.js";
 
 const conditionPresent = getCondition() === REACT_CONDITION.server;
 
@@ -59,6 +61,47 @@ describe("validateRunner", () => {
 
     it("rejects 'edge' as not implemented yet", () => {
       expect(() => validateRunner("edge")).toThrow(/not implemented yet/);
+    });
+  }
+});
+
+// The `.` package entry (resolved through the exports map into dist/) is what
+// normal consumers call — it must enforce the invariant itself, not only the
+// explicit /client and /server subpaths.
+describe("root package entry enforces the invariant", () => {
+  const withRunner = (runner: unknown) => () =>
+    vitePluginReactServer({
+      ...testUserOptions,
+      runner,
+    } as Parameters<typeof vitePluginReactServer>[0]);
+
+  it("rejects unknown runners", () => {
+    expect(withRunner("bogus")).toThrow(/Unknown runner/);
+  });
+
+  it("still accepts an undeclared runner (legacy inference)", () => {
+    expect(vitePluginReactServer(testUserOptions)).toBeInstanceOf(Array);
+  });
+
+  if (conditionPresent) {
+    it("accepts 'main' under the process condition", () => {
+      expect(withRunner("main")()).toBeInstanceOf(Array);
+    });
+
+    it("rejects 'isolated' under the process condition", () => {
+      expect(withRunner("isolated")).toThrow(
+        /owns react-server resolution itself; remove the process flag/
+      );
+    });
+  } else {
+    it("rejects 'main' without the process condition", () => {
+      expect(withRunner("main")).toThrow(
+        /needs NODE_OPTIONS='--conditions react-server'/
+      );
+    });
+
+    it("accepts 'isolated' without the process condition", () => {
+      expect(withRunner("isolated")()).toBeInstanceOf(Array);
     });
   }
 });


### PR DESCRIPTION
## Why

The execution paradigm is inferred today: which orchestrator face runs is the reverse image of the consumer's `--conditions` launch flag, restated per script across consumers. The accepted runner spec (docs/internals/runner-spec.md, merged in #329) makes the paradigm a declared choice. This is the first implementation slice.

## What

- `runner: "main" | "isolated" | "edge"` on the public options. **Optional in this slice** — omitting it keeps the condition-inferred dispatch. The flip to required (with the three-option error) rides the follow-up that migrates the test matrix, because the suite deliberately runs the same configs under both conditions and each config becomes valid in exactly one paradigm once declared.
- `validateRunner()` enforces the runner/condition invariant at config-resolve time in both plugin entries, with the spec's error semantics: `main` without the process condition errors; `isolated`/`edge` with it error; unknown values list the three options with one-line pitches. `edge` passes the invariant and then errors not-implemented — the edge paradigm (own dev shape, per-env `resolve.conditions`, baked-pair serving) lands as its own slice.
- The two condition-selected orchestrator faces are now named runner records (`mainRunner` / `isolatedRunner`) over the shared impl. They stay internal: exporting them asymmetrically would trip the export-parity guard and grow exactly the condition-split surface this epic retires; they get a public home in the de-split slice.

## Design note

With the invariant enforced, the condition-picked module trees provably coincide with the declared runner (a validated `main` implies the react-server tree loaded, a validated `isolated` implies the client tree). That is what makes this stageable: dispatch correctness is guaranteed now, and the exports-map de-split can follow separately without a correctness gap.

## Verification

- New both-conditions invariant test (`test/examples/runner-invariant.test.ts` — placed there, not `test/unit`, because the unit suite is excluded from client-condition runs and both halves of the invariant need their ambient condition to execute): 5 client-mode + 4 server-mode assertions.
- Full gate green: client 320 passed / 16 skipped, server 1045 passed / 62 skipped, typecheck included, exit 0.

**Breaking direction, non-breaking slice**: with `runner` omitted nothing changes; this targets the 4.0 train and is staged as a draft like #383. Retarget to an integration branch if the train gets one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)