### PR TITLE
test: every config in the matrix declares its runner (4.0 groundwork)

### DIFF
--- a/docs-site/vite.config.ts
+++ b/docs-site/vite.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
   optimizeDeps: { include: ["react-server-dom-esm/client.browser"] },
   plugins: [
     ...vitePluginReactServer({
+      runner: "main",
       moduleBase: "src",
       Page: "src/page/page.tsx",
       Html: "src/page/html.tsx",

--- a/examples/hello-world/package-lock.json
+++ b/examples/hello-world/package-lock.json
@@ -8,8 +8,9 @@
       "name": "vite-plugin-react-server-hello-world",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-server-loader": "^19.2.20",
         "vite-plugin-react-server": "file:../.."
       },
       "devDependencies": {
@@ -20,12 +21,11 @@
       }
     },
     "../..": {
-      "version": "2.11.1",
+      "version": "3.11.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.12 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -36,6 +36,7 @@
         "@types/react-dom": "^19.0.3",
         "@vitest/coverage-v8": "^3.0.4",
         "acorn-loose": "^8.3.0",
+        "es-module-lexer": "^1.7.0",
         "eslint": "^9.28.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0",
@@ -45,8 +46,9 @@
         "marked": "^18.0.5",
         "playwright": "^1.58.1",
         "publint": "^0.3.21",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-server-loader": "^19.2.20",
         "shiki": "^4.2.0",
         "source-map": "^0.7.4",
         "supports-color": "^10.0.0",
@@ -62,8 +64,9 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
-        "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
+        "react": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-dom": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.20 || 0.0.0-experimental-eb8feb71-20260814",
         "vite": "^6.3.5 || ^7 || ^8"
       },
       "peerDependenciesMeta": {
@@ -71,6 +74,9 @@
           "optional": false
         },
         "react-dom": {
+          "optional": false
+        },
+        "react-server-loader": {
           "optional": false
         },
         "vite": {
@@ -436,6 +442,27 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -770,7 +797,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -816,24 +842,43 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-server-loader": {
+      "version": "19.2.20",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.20.tgz",
+      "integrity": "sha512-Av3ZhAgdmdG9hGRAYpQn0vH9U7buq8MLP90o+PQtSLuwbZrwKBloMntVThdaxn+wuCoF1nzWmHK3Z+zSk0yigQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "picocolors": "^1.1.1",
+        "source-map": "^0.7.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       }
     },
     "node_modules/rolldown": {
@@ -875,6 +920,15 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -9,8 +9,9 @@
     "edge": "node edge-server.mjs"
   },
   "dependencies": {
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-server-loader": "^19.2.20",
     "vite-plugin-react-server": "file:../.."
   },
   "devDependencies": {

--- a/examples/hello-world/vite.config.ts
+++ b/examples/hello-world/vite.config.ts
@@ -3,6 +3,7 @@ import { StreamPluginOptions, vitePluginReactServer } from "vite-plugin-react-se
 
 export default defineConfig({
   plugins: [vitePluginReactServer({
+    runner: "isolated",
     moduleBase: "src",
     // File-based routing: scan `moduleBase` itself — src/page.tsx (+ sibling
     // props.ts) becomes "/", and the prerender worklist derives from the tree.

--- a/examples/react-router/package-lock.json
+++ b/examples/react-router/package-lock.json
@@ -8,9 +8,10 @@
       "name": "vite-plugin-react-server-react-router",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-router": "^7.9.0",
+        "react-server-loader": "^19.2.20",
         "vite-plugin-react-server": "file:../.."
       },
       "devDependencies": {
@@ -21,12 +22,11 @@
       }
     },
     "../..": {
-      "version": "3.8.0",
+      "version": "3.11.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.19 || 0.0.0-experimental-7dfc7ccd-20260803",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -37,6 +37,7 @@
         "@types/react-dom": "^19.0.3",
         "@vitest/coverage-v8": "^3.0.4",
         "acorn-loose": "^8.3.0",
+        "es-module-lexer": "^1.7.0",
         "eslint": "^9.28.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0",
@@ -46,8 +47,9 @@
         "marked": "^18.0.5",
         "playwright": "^1.58.1",
         "publint": "^0.3.21",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-server-loader": "^19.2.20",
         "shiki": "^4.2.0",
         "source-map": "^0.7.4",
         "supports-color": "^10.0.0",
@@ -63,8 +65,9 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
-        "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
+        "react": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-dom": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.20 || 0.0.0-experimental-eb8feb71-20260814",
         "vite": "^6.3.5 || ^7 || ^8"
       },
       "peerDependenciesMeta": {
@@ -72,6 +75,9 @@
           "optional": false
         },
         "react-dom": {
+          "optional": false
+        },
+        "react-server-loader": {
           "optional": false
         },
         "vite": {
@@ -352,6 +358,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/cookie": {
@@ -701,7 +728,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -789,6 +815,25 @@
         }
       }
     },
+    "node_modules/react-server-loader": {
+      "version": "19.2.20",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.20.tgz",
+      "integrity": "sha512-Av3ZhAgdmdG9hGRAYpQn0vH9U7buq8MLP90o+PQtSLuwbZrwKBloMntVThdaxn+wuCoF1nzWmHK3Z+zSk0yigQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "picocolors": "^1.1.1",
+        "source-map": "^0.7.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
@@ -833,6 +878,15 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -9,8 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-server-loader": "^19.2.20",
     "react-router": "^7.9.0",
     "vite-plugin-react-server": "file:../.."
   },

--- a/examples/react-router/vite.config.ts
+++ b/examples/react-router/vite.config.ts
@@ -9,6 +9,7 @@ import { StreamPluginOptions, vitePluginReactServer } from "vite-plugin-react-se
 export default defineConfig({
   plugins: [
     vitePluginReactServer({
+      runner: "isolated",
       moduleBase: "src",
       Page: () => "src/page.tsx",
       props: () => "src/props.ts",

--- a/examples/router/package-lock.json
+++ b/examples/router/package-lock.json
@@ -8,8 +8,9 @@
       "name": "vite-plugin-react-server-router",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-server-loader": "^19.2.20",
         "vite-plugin-react-server": "file:../.."
       },
       "devDependencies": {
@@ -20,12 +21,11 @@
       }
     },
     "../..": {
-      "version": "2.11.1",
+      "version": "3.11.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.12 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -36,6 +36,7 @@
         "@types/react-dom": "^19.0.3",
         "@vitest/coverage-v8": "^3.0.4",
         "acorn-loose": "^8.3.0",
+        "es-module-lexer": "^1.7.0",
         "eslint": "^9.28.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0",
@@ -45,8 +46,9 @@
         "marked": "^18.0.5",
         "playwright": "^1.58.1",
         "publint": "^0.3.21",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-server-loader": "^19.2.20",
         "shiki": "^4.2.0",
         "source-map": "^0.7.4",
         "supports-color": "^10.0.0",
@@ -62,8 +64,9 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
-        "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
+        "react": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-dom": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.20 || 0.0.0-experimental-eb8feb71-20260814",
         "vite": "^6.3.5 || ^7 || ^8"
       },
       "peerDependenciesMeta": {
@@ -71,6 +74,9 @@
           "optional": false
         },
         "react-dom": {
+          "optional": false
+        },
+        "react-server-loader": {
           "optional": false
         },
         "vite": {
@@ -436,6 +442,27 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -770,7 +797,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -816,24 +842,43 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-server-loader": {
+      "version": "19.2.20",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.20.tgz",
+      "integrity": "sha512-Av3ZhAgdmdG9hGRAYpQn0vH9U7buq8MLP90o+PQtSLuwbZrwKBloMntVThdaxn+wuCoF1nzWmHK3Z+zSk0yigQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "picocolors": "^1.1.1",
+        "source-map": "^0.7.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       }
     },
     "node_modules/rolldown": {
@@ -875,6 +920,15 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/examples/router/package.json
+++ b/examples/router/package.json
@@ -9,8 +9,9 @@
     "edge": "node edge-server.mjs"
   },
   "dependencies": {
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-server-loader": "^19.2.20",
     "vite-plugin-react-server": "file:../.."
   },
   "devDependencies": {

--- a/examples/router/vite.config.ts
+++ b/examples/router/vite.config.ts
@@ -9,6 +9,7 @@ import { StreamPluginOptions, vitePluginReactServer } from "vite-plugin-react-se
 export default defineConfig({
   plugins: [
     vitePluginReactServer({
+      runner: "isolated",
       moduleBase: "src",
       routes: {
         dir: "routes",

--- a/test/examples/dev-prod-error-visibility.test.ts
+++ b/test/examples/dev-prod-error-visibility.test.ts
@@ -79,6 +79,7 @@ async function setupFixture(dir: string) {
       `  esbuild: { jsx: "automatic" },\n` +
       `  optimizeDeps: { include: ["react-server-dom-esm/client.browser"] },\n` +
       `  plugins: vitePluginReactServer({\n` +
+      `    runner: "main",\n` +
       `    moduleBase: "src",\n` +
       `    Page: "src/page/page.tsx",\n` +
       `    props: "src/page/props.ts",\n` +

--- a/test/examples/html-backpressure-build.test.ts
+++ b/test/examples/html-backpressure-build.test.ts
@@ -112,6 +112,7 @@ async function setupFixture(dir: string) {
       `  mode: "production",\n` +
       `  esbuild: { jsx: "automatic" },\n` +
       `  plugins: vitePluginReactServer({\n` +
+      `    runner: "main",\n` +
       `    moduleBase: "src",\n` +
       `    Page: "src/page/page.tsx",\n` +
       `    props: "src/page/page.tsx",\n` +

--- a/test/examples/node-env-flip-build.test.ts
+++ b/test/examples/node-env-flip-build.test.ts
@@ -73,6 +73,7 @@ async function setupFixture(dir: string) {
       `  mode: "production",\n` +
       `  esbuild: { jsx: "automatic" },\n` +
       `  plugins: vitePluginReactServer({\n` +
+      `    runner: "main",\n` +
       `    moduleBase: "src",\n` +
       `    Page: "src/page/page.tsx",\n` +
       `    props: "src/page/props.ts",\n` +

--- a/test/examples/runner-invariant.test.ts
+++ b/test/examples/runner-invariant.test.ts
@@ -80,7 +80,10 @@ describe("root package entry enforces the invariant", () => {
   });
 
   it("still accepts an undeclared runner (legacy inference)", () => {
-    expect(vitePluginReactServer(testUserOptions)).toBeInstanceOf(Array);
+    // testUserOptions declares runnerForCondition() — strip it so this case
+    // actually exercises the undeclared path.
+    const { runner: _runner, ...withoutRunner } = testUserOptions;
+    expect(vitePluginReactServer(withoutRunner)).toBeInstanceOf(Array);
   });
 
   if (conditionPresent) {

--- a/test/test-config.ts
+++ b/test/test-config.ts
@@ -1,5 +1,13 @@
 import type {  StreamPluginOptions } from "vite-plugin-react-server/types";
+import { getCondition } from "vite-plugin-react-server";
 import { metricWatcher } from "vite-plugin-react-server/metrics";
+
+// The suite deliberately runs BOTH paradigms over the same configs
+// (test-both.sh reruns every suite under each condition), so the declared
+// runner must track the ambient condition or the runner/condition invariant
+// errors the whole matrix. Real consumer configs declare a literal runner.
+export const runnerForCondition = (): "main" | "isolated" =>
+  getCondition() === "react-server" ? "main" : "isolated";
 
 // Transport matrix knob — the transport twin of test-both.sh's condition
 // rerun. VPRS_TEST_TRANSPORT=webpack reruns transport-AGNOSTIC suites with
@@ -12,6 +20,7 @@ export const TEST_TRANSPORT: "esm" | "webpack" =
 
 export const testUserOptions = {
   ...(TEST_TRANSPORT === "webpack" ? { transport: "webpack" as const } : {}),
+  runner: runnerForCondition(),
   moduleBase: "src",
   Page: "src/page/page.tsx",
   props: "src/page/props.ts",

--- a/test/types/fileRouter.test.ts
+++ b/test/types/fileRouter.test.ts
@@ -32,6 +32,7 @@ describe("fileRouter → plugin options", () => {
     // like the example config — a regression on `routePatterns` (undeclared) or
     // `props` (too narrow) fails here.
     const options = {
+      runner: "main" as const,
       moduleBase: "src",
       Page: router.Page,
       props: router.props,
@@ -45,6 +46,7 @@ describe("fileRouter → plugin options", () => {
 describe("routes field", () => {
   it("accepts an empty config (scan moduleBase itself)", () => {
     const options = {
+      runner: "main" as const,
       moduleBase: "app",
       routes: {},
     } satisfies StreamPluginOptions;
@@ -53,6 +55,7 @@ describe("routes field", () => {
 
   it("accepts the declarative { dir } form", () => {
     const options = {
+      runner: "main" as const,
       moduleBase: "src",
       routes: {
         dir: "page",
@@ -70,6 +73,7 @@ describe("routes field", () => {
       build: { pages: [] as string[] },
     };
     const options = {
+      runner: "main" as const,
       moduleBase: "src",
       routes: table,
     } satisfies StreamPluginOptions;

--- a/test/types/interface-usage-demo.test.ts
+++ b/test/types/interface-usage-demo.test.ts
@@ -63,6 +63,7 @@ describe("Interface-Aware Type Usage Demo", () => {
 
   it("should use interface-aware types correctly", () => {
     const options: StreamPluginOptions<CustomInterface> = {
+      runner: "main",
       moduleBase: "src",
       pageExportName: "PageComponent",
       propsExportName: "pageProps",


### PR DESCRIPTION
Groundwork for the runner-abstraction epic (spec: docs/internals/runner-spec.md), non-breaking on its own: every config that constructs the plugin now declares a runner, while a missing runner stays legal.

- `testUserOptions` declares `runnerForCondition()` — the suite deliberately runs both paradigms over the same configs under test-both, so the declared runner tracks the ambient condition.
- The three spawned-build suites that force the react-server condition declare `runner: "main"` in their generated configs.
- The five `test/types` fixtures declare `runner: "main"`, matching the react-server condition `test:typecheck` runs under.
- In-repo consumers declare literal runners matching their scripts: docs-site `"main"`, the three examples `"isolated"`. The examples also catch up with the peer contract (react `^19.2.8`, explicit `react-server-loader`).

Follow-ups land separately: the required-runner flip (missing runner becomes the three-option error) and the `.` exports-map de-split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)