### PR TITLE
ci: cache Chromium; a 20-minute install cap inside a 30-minute job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,10 @@ jobs:
   e2e:
     name: e2e (demo app, plain-Node prod server)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Must exceed the Install Chromium step's own cap, or the job timeout
+    # always wins and the step cap is decorative (checkout/build/install eat
+    # minutes before the step even starts).
+    timeout-minutes: 30
     steps:
       - name: Checkout the plugin
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,8 +140,24 @@ jobs:
           npm ci
           npm install ../vite-plugin-react-server-*.tgz
 
+      # The browser download has no timeout of its own and Playwright's CDN
+      # has real bad hours (a hang here ate 20+ minutes four times on
+      # 2026-08-19). The cache removes the download from the common path; the
+      # step timeout caps the damage when the CDN still gets a say.
+      - name: Resolve Playwright version (cache key)
+        id: playwright-version
+        working-directory: demo
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Chromium
         working-directory: demo
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
 
       - name: e2e — build, boot the prod server, drive the browser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,9 +141,12 @@ jobs:
           npm install ../vite-plugin-react-server-*.tgz
 
       # The browser download has no timeout of its own and Playwright's CDN
-      # has real bad hours (a hang here ate 20+ minutes four times on
-      # 2026-08-19). The cache removes the download from the common path; the
-      # step timeout caps the damage when the CDN still gets a say.
+      # has real bad hours (2026-08-19: installs crawled for 10–25 minutes,
+      # some finishing, some cancelled). The cache removes the download from
+      # the common path after one success per Playwright version; the step
+      # timeout is deliberately GENEROUS — tight enough to kill a true
+      # never-completes, loose enough that a slow-but-alive download still
+      # finishes and seeds the cache.
       - name: Resolve Playwright version (cache key)
         id: playwright-version
         working-directory: demo
@@ -157,7 +160,7 @@ jobs:
 
       - name: Install Chromium
         working-directory: demo
-        timeout-minutes: 5
+        timeout-minutes: 20
         run: npx playwright install --with-deps chromium
 
       - name: e2e — build, boot the prod server, drive the browser


### PR DESCRIPTION
The e2e job's `Install Chromium` step stalled repeatedly on 2026-08-19 — some installs crawled 10–25 minutes and eventually finished, others died at the job limit. A known Playwright CDN failure class ([playwright#41133](https://github.com/microsoft/playwright/issues/41133), [#28189](https://github.com/microsoft/playwright/issues/28189)); the CLI has no timeout or retry of its own.

- **Cache `~/.cache/ms-playwright`** keyed on runner OS + the demo's exact `@playwright/test` version. After one successful install per version the download leaves the common path (`--with-deps` still installs OS packages each run). The cache is already seeded in CI from this PR's own runs.
- **`timeout-minutes: 20` on the install step, `timeout-minutes: 30` on the job.** The step cap only means something if the job timeout can't fire first — checkout/build/`npm ci` eat minutes before the step starts, so with both at 20 the job always won. The step cap is deliberately generous: tight enough to kill a true never-completes, loose enough that a slow-but-alive download still finishes and seeds the cache on a bad CDN day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA