### PR TITLE
fix: isolated-runner SSG deadlocked on suspended renders — last lost-drain copy removed; Suspense hydration proven on both topologies

### DIFF
--- a/plugin/stream/createRenderToPipeableStreamHandler.client.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.client.ts
@@ -184,38 +184,15 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       }
     });
 
-    // Create a custom writable stream that pipes to our PassThrough
-    // This ensures the stream is consumed to completion naturally
-    const customWritable = {
-      write(chunk: any, _encoding?: any, callback?: any) {
-        // Pipe the chunk to our PassThrough stream
-        htmlStream.write(chunk);
-        if (callback) callback();
-      },
-      end(chunk?: any, _encoding?: any, callback?: any) {
-        if (chunk) {
-          htmlStream.write(chunk);
-        }
-        // End the PassThrough stream
-        htmlStream.end();
-        if (callback) callback();
-      },
-      destroy(error?: Error) {
-        // Destroy the PassThrough stream with the error
-        try {
-          htmlStream.destroy(error);
-        } catch (destroyError) {
-          // Stream may already be destroyed, ignore
-        }
-      },
-      on() {}, // No-op for event listeners
-      once() {}, // No-op for event listeners
-      emit() { return false; }, // No-op for event emitters
-    };
-
-    // Pipe the React stream directly to our custom writable
-    // This ensures the stream is consumed to completion naturally
-    pipe(customWritable as any);
+    // Pipe React into the REAL PassThrough — never a faked writable. React's
+    // pipe() honors the write() return value and waits for 'drain' on
+    // backpressure, so a no-op event emitter deadlocks every render whose
+    // content arrives in a second flush (a Suspense boundary that actually
+    // suspended, e.g. on a client-reference module import): the first flush
+    // exhausts the fake capacity, the drain that would resume the flush can
+    // never fire, and the SSG hangs with no error. Same lost-drain class the
+    // html worker's handleHtmlRender fix removed — this was its last copy.
+    pipe(htmlStream);
 
     if (verbose) {
       logger?.info(

--- a/test/examples/static-suspense-hydration.test.ts
+++ b/test/examples/static-suspense-hydration.test.ts
@@ -25,6 +25,15 @@ const browserAvailable = (() => {
     return false;
   }
 })();
+// Fail CLOSED where a browser is guaranteed (the CI browser-regressions job
+// sets this): a missing Chromium must fail the job, never skip it green.
+// Local runs without a browser still skip. Same discipline as
+// VPRS_REQUIRE_MINIFLARE in the workerd smoke.
+if (!browserAvailable && process.env["VPRS_REQUIRE_BROWSER"]) {
+  throw new Error(
+    "VPRS_REQUIRE_BROWSER is set but Playwright Chromium is not installed"
+  );
+}
 
 
 const testDir = resolve(__dirname, "../fixtures/static-suspense-hydration.test");

--- a/test/examples/static-suspense-hydration.test.ts
+++ b/test/examples/static-suspense-hydration.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink, readFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { resolve, join, extname } from "node:path";
+import { chromium } from "playwright";
+import { doBuild } from "../doBuild.js";
+import { fileRouter } from "../../plugin/router/fileRouter.js";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// A DELAYED Suspense boundary, prerendered, served from a DUMB file server,
+// hydrated in a real browser — the failure this pins is a completed static
+// HTML file that still carries an unfinished Suspense representation, which
+// React discards during hydration (error #419 / the boundary snapping back to
+// its fallback). The html-backpressure regression proves delayed content
+// reaches the OUTPUT; this proves the output HYDRATES. The server here is
+// deliberately stupid: files in, bytes out, no render path, no negotiation —
+// exactly what a static deploy (CDN, GitHub Pages) provides.
+const browserAvailable = (() => {
+  try {
+    return existsSync(chromium.executablePath());
+  } catch {
+    return false;
+  }
+})();
+
+// The isolated-runner leg is gated OFF: the client-condition SSG pipeline
+// hangs on ANY Suspense boundary in a prerendered page (even a synchronous
+// child — removing only the wrapper builds in ~500ms). Writing this proof is
+// what surfaced the hang. Ungate when the worker pipeline handles multi-flush
+// renders; until then the hydration contract is proven on the main-runner
+// build, whose output is byte-equivalent by the build-parity invariant.
+const mainConditionLeg = getCondition() === REACT_CONDITION.server;
+
+const testDir = resolve(__dirname, "../fixtures/static-suspense-hydration.test");
+const PORT = 4193;
+
+const MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".map": "application/json",
+  ".rsc": "text/x-component; charset=utf-8",
+};
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/routes"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function Counter() {\n` +
+      `  const [n, setN] = React.useState(0);\n` +
+      `  return (\n` +
+      `    <button id="counter" onClick={() => setN((v) => v + 1)}>\n` +
+      `      {"count:" + n}\n` +
+      `    </button>\n` +
+      `  );\n` +
+      `}\n`
+  );
+  // The interactive client component lives INSIDE the suspended subtree, so
+  // hydration success is provable exactly where the discarded-boundary
+  // failure would bite. The resolved tree is bulky enough to force the
+  // prerender into a fallback flush + a content flush.
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Suspense } from "react";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `async function Delayed() {\n` +
+      `  await new Promise((r) => setTimeout(r, 30));\n` +
+      `  return (\n` +
+      `    <section data-resolved="yes">\n` +
+      `      <Counter />\n` +
+      `      {Array.from({ length: 300 }, (_, i) => (\n` +
+      `        <p key={i}>resolved-row-{i}-padding-to-split-the-flush</p>\n` +
+      `      ))}\n` +
+      `    </section>\n` +
+      `  );\n` +
+      `}\n` +
+      `export const Page = () => (\n` +
+      `  <main id="app">\n` +
+      `    <h1>{"static-suspense"}</h1>\n` +
+      `    <Suspense fallback={<div id="fallback">{"loading"}</div>}>\n` +
+      `      <Delayed />\n` +
+      `    </Suspense>\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+/**
+ * The dumb file server: dist/static then dist/client, extension-less paths
+ * get index.html, unknown paths get 404. No handler, no Accept negotiation.
+ */
+function serveStatic(roots: string[]): Server {
+  return createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+    let pathname = decodeURIComponent(url.pathname).replace(/\/{2,}/g, "/");
+    if (pathname.endsWith("/")) pathname += "index.html";
+    else if (!extname(pathname)) pathname += "/index.html";
+    for (const root of roots) {
+      const file = join(root, pathname);
+      if (existsSync(file) && file.startsWith(root)) {
+        res.writeHead(200, {
+          "content-type": MIME[extname(file)] ?? "application/octet-stream",
+        });
+        res.end(readFileSync(file));
+        return;
+      }
+    }
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+}
+
+describe.skipIf(!browserAvailable || !mainConditionLeg)(
+  "static Suspense — prerendered boundary hydrates from a dumb file server",
+  () => {
+    let server: Server | undefined;
+    let html = "";
+
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+      const fr = fileRouter(join(testDir, "src/routes"), { root: testDir });
+      await doBuild({
+        projectRoot: testDir,
+        moduleBase: "src",
+        Page: fr.Page,
+        props: fr.props,
+        routePatterns: fr.routePatterns,
+        build: { pages: fr.build.pages, outDir: "dist" },
+      } as never);
+
+      html = await readFile(join(testDir, "dist/static/index.html"), "utf8");
+      server = serveStatic([
+        join(testDir, "dist/static"),
+        join(testDir, "dist/client"),
+      ]);
+      await new Promise<void>((r) => server!.listen(PORT, r));
+    }, 180000);
+
+    afterAll(async () => {
+      await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+      if (!process.env["KEEP_FIXTURE"])
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("the prerendered document carries the RESOLVED content, not the fallback", () => {
+      expect(html).toContain('data-resolved="yes"');
+      expect(html).toContain("padding-to-split-the-flush");
+    });
+
+    it("hydrates without #419: the boundary stays resolved and answers a click", async () => {
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        const pageErrors: string[] = [];
+        const consoleErrors: string[] = [];
+        page.on("pageerror", (e) => pageErrors.push(String(e)));
+        page.on("console", (m) => {
+          if (m.type() === "error") consoleErrors.push(m.text());
+        });
+
+        await page.goto(`http://localhost:${PORT}/`, {
+          waitUntil: "networkidle",
+        });
+
+        // Hydration proof INSIDE the boundary: poll clicks until one lands
+        // (the first observed increment is the hydration-complete signal).
+        const counter = page.locator("#counter");
+        await counter.waitFor({ timeout: 15000 });
+        await page.waitForFunction(
+          () => {
+            const b = document.querySelector("#counter") as HTMLButtonElement;
+            if (!b) return false;
+            b.click();
+            return b.textContent !== "count:0";
+          },
+          undefined,
+          { timeout: 20000, polling: 400 }
+        );
+        expect(await counter.textContent()).toMatch(/^count:[1-9]/);
+
+        // The boundary must never have snapped back to its fallback — that
+        // is #419's visible half (React discarding the unfinished server
+        // representation and client-rendering the fallback first).
+        expect(await page.locator('[data-resolved="yes"]').count()).toBe(1);
+        expect(await page.locator("#fallback").count()).toBe(0);
+
+        // The invisible half: no hydration errors of any flavor.
+        expect(pageErrors).toEqual([]);
+        expect(
+          consoleErrors.filter((e) => /#4(18|19|23|25)|hydrat/i.test(e))
+        ).toEqual([]);
+      } finally {
+        await browser.close();
+      }
+    });
+  }
+);

--- a/test/examples/static-suspense-hydration.test.ts
+++ b/test/examples/static-suspense-hydration.test.ts
@@ -4,8 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { resolve, join, extname } from "node:path";
 import { chromium } from "playwright";
-import { doBuild } from "../doBuild.js";
-import { fileRouter } from "../../plugin/router/fileRouter.js";
+import { spawnSync } from "node:child_process";
 import {
   getCondition,
   REACT_CONDITION,
@@ -27,13 +26,6 @@ const browserAvailable = (() => {
   }
 })();
 
-// The isolated-runner leg is gated OFF: the client-condition SSG pipeline
-// hangs on ANY Suspense boundary in a prerendered page (even a synchronous
-// child — removing only the wrapper builds in ~500ms). Writing this proof is
-// what surfaced the hang. Ungate when the worker pipeline handles multi-flush
-// renders; until then the hydration contract is proven on the main-runner
-// build, whose output is byte-equivalent by the build-parity invariant.
-const mainConditionLeg = getCondition() === REACT_CONDITION.server;
 
 const testDir = resolve(__dirname, "../fixtures/static-suspense-hydration.test");
 const PORT = 4193;
@@ -137,7 +129,7 @@ function serveStatic(roots: string[]): Server {
   });
 }
 
-describe.skipIf(!browserAvailable || !mainConditionLeg)(
+describe.skipIf(!browserAvailable)(
   "static Suspense — prerendered boundary hydrates from a dumb file server",
   () => {
     let server: Server | undefined;
@@ -146,15 +138,54 @@ describe.skipIf(!browserAvailable || !mainConditionLeg)(
     beforeAll(async () => {
       await rm(testDir, { recursive: true, force: true });
       await setupFixture();
-      const fr = fileRouter(join(testDir, "src/routes"), { root: testDir });
-      await doBuild({
-        projectRoot: testDir,
-        moduleBase: "src",
-        Page: fr.Page,
-        props: fr.props,
-        routePatterns: fr.routePatterns,
-        build: { pages: fr.build.pages, outDir: "dist" },
-      } as never);
+
+      // Build in a SPAWNED process with NODE_ENV=production, like the
+      // html-backpressure regression: a deploy's build is a production build,
+      // and vitest's ambient NODE_ENV=test would silently swap the vendored
+      // transport to its dev variant — a different pipeline than any deploy
+      // runs (and one with its own, separately tracked, suspended-flight
+      // stall in the isolated topology). The runner follows this leg's
+      // ambient condition, so test-both still covers both topologies.
+      const mainLeg = getCondition() === REACT_CONDITION.server;
+      await writeFile(
+        join(testDir, "build.mjs"),
+        `import { createBuilder } from "vite";\n` +
+          `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+          `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+          `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+          `const builder = await createBuilder({\n` +
+          `  configFile: false,\n` +
+          `  root: process.cwd(),\n` +
+          `  mode: "production",\n` +
+          `  esbuild: { jsx: "automatic" },\n` +
+          `  plugins: vitePluginReactServer({\n` +
+          `    runner: ${JSON.stringify(mainLeg ? "main" : "isolated")},\n` +
+          `    moduleBase: "src",\n` +
+          `    Page: fr.Page,\n` +
+          `    props: fr.props,\n` +
+          `    routePatterns: fr.routePatterns,\n` +
+          `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
+          `    moduleBasePath: "",\n` +
+          `    moduleBaseURL: "/",\n` +
+          `    projectRoot: process.cwd(),\n` +
+          `  }),\n` +
+          `});\n` +
+          `await builder.buildApp();\n` +
+          `console.log("SUSPENSE_BUILD_OK");\n` +
+          `process.exit(0);\n`
+      );
+      const env = { ...process.env, NODE_ENV: "production" };
+      env["NODE_OPTIONS"] = mainLeg ? "--conditions react-server" : "";
+      const proc = spawnSync("node", ["build.mjs"], {
+        cwd: testDir,
+        encoding: "utf8",
+        timeout: 120000,
+        env,
+      });
+      expect(
+        proc.stdout,
+        `build failed (status ${proc.status}):\n${proc.stderr}`
+      ).toContain("SUSPENSE_BUILD_OK");
 
       html = await readFile(join(testDir, "dist/static/index.html"), "utf8");
       server = serveStatic([


### PR DESCRIPTION
Two things, one branch — the proof and the bug it caught.

**The fix.** The client-condition SSG's RSC-to-HTML handler piped React into a hand-faked writable whose `on`/`once`/`emit` were no-ops and whose `write()` return was meaningless. React's `pipe()` honors the write return and waits for `'drain'` on falsy — which a no-op emitter can never fire — so any render whose HTML arrives in a **second flush** deadlocked the build silently. A Suspense boundary only produces a second flush when it actually suspends: a client-reference child (async module import) inside a boundary with enough surrounding payload was the reliable trigger. This was the **last copy** of the exact lost-drain class the html-worker backpressure fix removed — that fix was only ever proven under the forced-main path, and this handler is the isolated topology's equivalent. Every isolated-runner build of a prerendered Suspense page hung; no known app shipped one, which is why it survived. Fix: pipe into the real `PassThrough` (9 lines replace 32).

**The proof** (what surfaced the hang): a delayed async Suspense boundary, prerendered, served from a deliberately dumb file server, hydrated and clicked in real Chromium — resolved content in the document, boundary never snaps back to its fallback, the client component **inside** the boundary answers a click, zero page/hydration errors. Runs **ungated on both topologies**, building in a spawned `NODE_ENV=production` process (the html-backpressure discipline — a deploy's build is a production build, and vitest's ambient `NODE_ENV=test` swaps the vendored transport to its dev variant, a pipeline no deploy runs).

**Known residue, tracked separately:** under dev-variant transport builds (`NODE_ENV != production`) a suspended flight stream from the rsc-worker still never completes — the HTML gets written with an unresolved `<!--$?--><template id="B:0">` marker (the live #419 artifact) while the `.rsc` write hangs. Suspects: the worker's finish/close-event completion workaround plus dev flight debug rows. Production deploys are unaffected.

Verdict from the proof: main-runner `renderToPipeableStream` prerender output hydrates cleanly — **no reason to switch SSG to `react-dom/static`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA