### PR TITLE
fix: the data-port backpressure protocol resumes and keeps the paused write

### DIFF
--- a/plugin/stream/MessagePortReadable.ts
+++ b/plugin/stream/MessagePortReadable.ts
@@ -56,15 +56,13 @@ export class MessagePortReadable extends Readable {
       // Push data to the stream
       const canContinue = this.push(bufferChunk);
       
-      // If the stream is backpressured, send a drain signal to the worker
-      if (!canContinue && !this.closed) {
+      // Buffer full: pause the worker's writable (wire naming is historical —
+      // DRAIN means "pause"). Control traffic rides the CONTROL port only;
+      // posting objects onto the data port would interleave them with the
+      // flight bytes.
+      if (!canContinue && !this.closed && this.toWorker) {
         try {
-          if (this.toWorker) {
-            this.toWorker.postMessage({ type: 'DRAIN' });
-          } else {
-            // Fallback to data port if no control port
-            this.fromWorker.postMessage({ type: 'DRAIN' });
-          }
+          this.toWorker.postMessage({ type: 'DRAIN' });
         } catch (error) {
           // Port may be closed - ignore drain signal
         }
@@ -93,13 +91,16 @@ export class MessagePortReadable extends Readable {
   }
 
   _read() {
-    // The stream is ready to receive more data
-    // Send a drain signal to the worker to resume writing
-    if (!this.closed && !this.ended) {
+    // The stream is ready for more data: un-pause the worker's writable.
+    // This must be RESUME on the CONTROL port — the writable only listens
+    // there, and DRAIN is the pause signal. The old code sent DRAIN on the
+    // DATA port: never received, so a paused producer stayed paused forever
+    // (the isolated-runner suspended-flight stall under dev-variant builds).
+    if (!this.closed && !this.ended && this.toWorker) {
       try {
-        this.fromWorker.postMessage({ type: 'DRAIN' });
+        this.toWorker.postMessage({ type: 'RESUME' });
       } catch (error) {
-        // Port may be closed - ignore drain signal
+        // Port may be closed - ignore resume signal
       }
     }
   }

--- a/plugin/stream/MessagePortWritable.ts
+++ b/plugin/stream/MessagePortWritable.ts
@@ -13,6 +13,18 @@ export class MessagePortWritable extends Writable {
   private isBackpressured: boolean = false;
   private closeHandler: (() => void) | null = null;
   private messageHandler: ((message: any) => void) | null = null;
+  /**
+   * The one in-flight write parked while the consumer holds us paused. The
+   * Writable contract guarantees a single pending _write at a time, so one
+   * slot suffices. A paused write MUST be parked — chunk AND callback — and
+   * flushed on RESUME: dropping the chunk corrupts the stream, and never
+   * calling the callback wedges the Writable (React's flight pipe then waits
+   * forever on a drain that cannot come). Both happened here once.
+   */
+  private pendingWrite: {
+    chunk: unknown;
+    callback: (error?: Error | null) => void;
+  } | null = null;
 
   constructor(fromWorker: MessagePort, toWorker?: MessagePort) {
     super({
@@ -31,16 +43,31 @@ export class MessagePortWritable extends Writable {
     };
     this.fromWorker.on('close', this.closeHandler);
 
-    // Listen for backpressure signals on the control port
+    // Listen for backpressure signals on the control port. Wire naming is
+    // historical: DRAIN = "pause, my buffer is full", RESUME = "go again".
     if (this.toWorker) {
       this.messageHandler = (message: any) => {
         if (message.type === 'DRAIN') {
           this.isBackpressured = true;
         } else if (message.type === 'RESUME') {
           this.isBackpressured = false;
+          this.flushPendingWrite();
         }
       };
       this.toWorker.on('message', this.messageHandler);
+    }
+  }
+
+  /** Release the parked write after the consumer un-pauses us. */
+  private flushPendingWrite() {
+    const pending = this.pendingWrite;
+    if (!pending) return;
+    this.pendingWrite = null;
+    try {
+      this.fromWorker.postMessage(pending.chunk);
+      pending.callback();
+    } catch (error) {
+      pending.callback(error as Error);
     }
   }
 
@@ -57,13 +84,14 @@ export class MessagePortWritable extends Writable {
 
   _write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
     try {
-      // Check if we're backpressured - if so, don't send data
+      // Paused by the consumer: PARK the write until RESUME. Returning
+      // without completing the callback is correct Writable backpressure —
+      // but only if the chunk and callback are kept and flushed later.
       if (this.isBackpressured) {
-        // Signal backpressure to React by not calling callback immediately
-        // React will wait and retry when the stream is ready
+        this.pendingWrite = { chunk, callback };
         return;
       }
-      
+
       // Check if the chunk contains an error - if so, don't send it through the data stream
       // Errors should be handled through the control port, not the data stream
       if (chunk && typeof chunk === 'object' && chunk.type === 'error') {
@@ -97,6 +125,11 @@ export class MessagePortWritable extends Writable {
   }
 
   _destroy(error: Error | null, callback: (error?: Error | null) => void) {
+    // A write parked at destroy time must not dangle — fail it so the
+    // producer's pipeline settles instead of waiting forever.
+    const pending = this.pendingWrite;
+    this.pendingWrite = null;
+    pending?.callback(error ?? new Error("MessagePortWritable destroyed"));
     this.removeListeners();
     callback(error);
   }

--- a/test/examples/isolated-suspense-dev-build.test.ts
+++ b/test/examples/isolated-suspense-dev-build.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdir, writeFile, rm, readFile, symlink } from "node:fs/promises";
+import { resolve, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Regression: the ISOLATED-runner static build of a suspended render under
+ * DEV-VARIANT transport builds (NODE_ENV != production — the pipeline a
+ * `vite build` in development mode or a test-ambient build runs).
+ *
+ * The stall lived in the data-port backpressure protocol: the dev flight
+ * payload is large enough to fill the consumer's 16KB buffer, the consumer
+ * sent DRAIN (pause), and then (a) the worker-side writable dropped the
+ * paused chunk and never completed its write callback, and (b) the
+ * consumer's "resume" was a DRAIN sent on the DATA port, which nothing
+ * listens to. The build hung forever, and the HTML that had already flushed
+ * froze an UNRESOLVED Suspense boundary — the #419 artifact, on disk.
+ *
+ * The trigger needs a boundary that actually suspends (a client-reference
+ * child — async module import) plus enough payload to engage backpressure;
+ * the prod-variant equivalent is covered by the browser-level
+ * static-suspense-hydration proof.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = resolve(__dirname, "../fixtures/isolated-suspense-dev-build");
+
+async function setupFixture(dir: string) {
+  await rm(dir, { recursive: true, force: true });
+  await mkdir(resolve(dir, "src/routes"), { recursive: true });
+
+  await writeFile(
+    resolve(dir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    resolve(dir, "src/client.tsx"),
+    `import { startClient } from "vite-plugin-react-server/router/client";\nstartClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    resolve(dir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function Counter() {\n` +
+      `  const [n, setN] = React.useState(0);\n` +
+      `  return <button onClick={() => setN((v) => v + 1)}>{"count:" + n}</button>;\n` +
+      `}\n`
+  );
+  await writeFile(
+    resolve(dir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Suspense } from "react";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `async function Delayed() {\n` +
+      `  await new Promise((r) => setTimeout(r, 30));\n` +
+      `  return (\n` +
+      `    <section data-resolved="yes">\n` +
+      `      <Counter />\n` +
+      `      {Array.from({ length: 300 }, (_, i) => (\n` +
+      `        <p key={i}>resolved-row-{i}-padding-to-engage-backpressure</p>\n` +
+      `      ))}\n` +
+      `    </section>\n` +
+      `  );\n` +
+      `}\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1>{"isolated-dev-suspense"}</h1>\n` +
+      `    <Suspense fallback={<div>{"loading"}</div>}>\n` +
+      `      <Delayed />\n` +
+      `    </Suspense>\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    resolve(dir, "build.mjs"),
+    `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: "isolated",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: "src/routes/page.tsx",\n` +
+      `    build: { pages: ["/"], outDir: "dist" },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("ISOLATED_DEV_SUSPENSE_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(dir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+describe("isolated-runner dev-variant build of a suspended render", () => {
+  let status: number | null;
+  let stdout: string;
+  let stderr: string;
+
+  beforeAll(async () => {
+    await setupFixture(FIXTURE_ROOT);
+
+    // The point of the test: NODE_ENV=test picks the DEV variants of the
+    // vendored transport and React at require time. The runner is isolated
+    // (no process flag) in BOTH suite legs — that is the pipeline that hung.
+    const env = { ...process.env, NODE_ENV: "test" };
+    env["NODE_OPTIONS"] = "";
+    const proc = spawnSync("node", ["build.mjs"], {
+      cwd: FIXTURE_ROOT,
+      encoding: "utf8",
+      timeout: 120000,
+      env,
+    });
+    status = proc.status;
+    stdout = proc.stdout ?? "";
+    stderr = proc.stderr ?? "";
+  }, 180000);
+
+  afterAll(async () => {
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(FIXTURE_ROOT, { recursive: true, force: true });
+  });
+
+  it("the build completes (no lost-write stall in the port protocol)", () => {
+    expect(status, `build failed or hung:\n${stderr}`).toBe(0);
+    expect(stdout).toContain("ISOLATED_DEV_SUSPENSE_BUILD_OK");
+  });
+
+  it("the prerendered HTML carries the RESOLVED boundary, not a frozen fallback", async () => {
+    const html = await readFile(
+      resolve(FIXTURE_ROOT, "dist/static/index.html"),
+      "utf8"
+    );
+    expect(html).toContain('data-resolved="yes"');
+    expect(html).toContain("padding-to-engage-backpressure");
+  });
+
+  it("the flight artifact is complete (the .rsc write used to hang forever)", async () => {
+    const rsc = await readFile(
+      resolve(FIXTURE_ROOT, "dist/static/index.rsc"),
+      "utf8"
+    );
+    expect(rsc).toContain("data-resolved");
+    expect(rsc).toContain("padding-to-engage-backpressure");
+  });
+});

--- a/test/unit/messagePortBackpressure.test.ts
+++ b/test/unit/messagePortBackpressure.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The data-port backpressure protocol, pinned end to end: DRAIN (pause) rides
+ * the control port when the consumer's buffer fills, RESUME rides it back
+ * when the consumer wants more, and a write parked during the pause is
+ * FLUSHED — chunk and callback both. Two historical failure modes, both
+ * silent: the paused _write dropped its chunk and never completed its
+ * callback (wedging the producer forever), and the readable's "resume" was a
+ * DRAIN sent on the data port, which nothing listens to. Together they
+ * stalled every isolated-runner build whose flight stream outgrew the 16KB
+ * buffer (the dev-variant suspended-render hang).
+ */
+import { describe, it, expect } from "vitest";
+import { MessageChannel } from "node:worker_threads";
+import { Writable, Readable, pipeline } from "node:stream";
+import { createHash } from "node:crypto";
+import { MessagePortWritable } from "../../dist/plugin/stream/MessagePortWritable.js";
+import { MessagePortReadable } from "../../dist/plugin/stream/MessagePortReadable.js";
+
+describe("MessagePort backpressure protocol", () => {
+  it("delivers every byte through a slow consumer that engages DRAIN/RESUME", async () => {
+    const dataChannel = new MessageChannel();
+    const controlChannel = new MessageChannel();
+
+    // Producer half (the worker's side of the ports).
+    const writable = new MessagePortWritable(
+      dataChannel.port2,
+      controlChannel.port2
+    );
+    // Consumer half (the main thread's side).
+    const readable = new MessagePortReadable(
+      dataChannel.port1,
+      controlChannel.port1
+    );
+
+    // Enough data to overrun the 16KB buffers many times over, with content
+    // we can hash: dropped or reordered chunks fail loudly.
+    const CHUNK = 1024;
+    const COUNT = 256; // 256KB total
+    const sent = createHash("sha256");
+    // The producer must be PACED: an unpaced loop posts everything into the
+    // port queue before the first DRAIN can round-trip, and the pause path
+    // never runs. Yielding to the event loop between chunks is how a real
+    // render behaves (flight flushes interleave with I/O).
+    async function* chunks() {
+      for (let i = 0; i < COUNT; i++) {
+        const buf = Buffer.alloc(CHUNK, i % 251);
+        sent.update(buf);
+        yield buf;
+        await new Promise((r) => setImmediate(r));
+      }
+    }
+
+    // A deliberately slow sink so the readable's buffer fills and the pause
+    // path actually runs — the regression lived exactly there.
+    const received = createHash("sha256");
+    let receivedBytes = 0;
+    const slowSink = new Writable({
+      highWaterMark: 1024,
+      write(chunk: Buffer, _enc, cb) {
+        received.update(chunk);
+        receivedBytes += chunk.length;
+        setTimeout(cb, 1);
+      },
+    });
+
+    const producerDone = new Promise<void>((resolve, reject) =>
+      pipeline(Readable.from(chunks()), writable, (err) =>
+        err ? reject(err) : resolve()
+      )
+    );
+    const consumerDone = new Promise<void>((resolve, reject) =>
+      pipeline(readable, slowSink, (err) => (err ? reject(err) : resolve()))
+    );
+
+    // The old protocol never resumed a paused producer: this timeout is the
+    // regression trip-wire.
+    const guard = new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error("backpressure protocol stalled (no RESUME)")),
+        15000
+      ).unref()
+    );
+
+    await Promise.race([Promise.all([producerDone, consumerDone]), guard]);
+
+    expect(receivedBytes).toBe(CHUNK * COUNT);
+    expect(received.digest("hex")).toBe(sent.digest("hex"));
+
+    dataChannel.port1.close();
+    controlChannel.port1.close();
+  }, 30000);
+});


### PR DESCRIPTION
Completes the isolated-runner suspended-render stall (the dev-variant residue left open by #391). Two defects, one deadlock:

- **The worker-side `MessagePortWritable`'s paused `_write` kept nothing**: the chunk was silently dropped and the write callback never completed, wedging the Writable — React's flight pipe then waits forever.
- **The consumer-side `MessagePortReadable`'s “resume” was a `DRAIN` posted on the DATA port** — the writable only listens on the control port, and `DRAIN` is the pause signal. `RESUME` existed only on the html-worker path, so once an RSC-path producer paused, nothing could ever un-pause it.

`_write` now parks the single in-flight `{chunk, callback}` (the Writable contract guarantees one pending write) and `RESUME` flushes it; `_read` sends `RESUME` on the control port; `_destroy` fails a parked write instead of leaving it dangling; the readable no longer posts control objects onto the data stream.

**Reachable** whenever an isolated-runner flight stream outgrows the 16KB buffer before the render completes — in practice a suspended render under dev-variant transport builds (`NODE_ENV != production`), whose payload is roughly double the production one. The build hung with the `.rsc` write never finishing while the flushed HTML froze an **unresolved Suspense boundary on disk** (the #419 artifact). Production payloads never engaged the pause path, which is how it survived.

**Pinned twice:**
- a protocol unit test — paced producer, slow consumer, content hashes; red on the old code at the no-RESUME trip-wire (15s guard), green now;
- a spawned `NODE_ENV=test` isolated build of a suspended client-reference render, asserting the build completes and both artifacts carry the resolved boundary.

Full gate green under both conditions; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA