### PR TITLE
feat: not-found is a flight outcome the decoder passes through

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,4 +211,4 @@ jobs:
           VPRS_REQUIRE_BROWSER: "1"
         run: |
           npm run build
-          ./scripts/test-both.sh static-suspense-hydration static-navigation
+          ./scripts/test-both.sh static-suspense-hydration static-navigation static-notfound-navigation

--- a/plugin/helpers/createRequestHandler.server.ts
+++ b/plugin/helpers/createRequestHandler.server.ts
@@ -45,6 +45,13 @@ export interface CreateRequestHandlerOptions {
   ) => Promise<Response | null> | Response | null;
   /** Header that marks a POST as a server action. Default `x-rsc-action`. */
   actionHeader?: string;
+  /**
+   * The per-route flight artifact's filename, matching the build's
+   * `build.rscOutputPath` (default `index.rsc`). The not-found outcome reads
+   * the 404 route's flight from `/404/<rscOutputPath>`, and a miss on a path
+   * ending in it counts as a flight request.
+   */
+  rscOutputPath?: string;
 }
 
 async function resolveStaticFile(
@@ -82,7 +89,13 @@ async function resolveStaticFile(
 export function createRequestHandler(
   options: CreateRequestHandlerOptions
 ): (request: Request) => Promise<Response> {
-  const { staticDir, action, render, actionHeader = "x-rsc-action" } = options;
+  const {
+    staticDir,
+    action,
+    render,
+    actionHeader = "x-rsc-action",
+    rscOutputPath = "index.rsc",
+  } = options;
 
   return async function handler(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -124,11 +137,12 @@ export function createRequestHandler(
       // the client falls back to a full navigation.
       if (
         url.pathname.endsWith(".rsc") ||
+        url.pathname.endsWith(`/${rscOutputPath}`) ||
         (request.headers.get("accept") ?? "").includes("text/x-component")
       ) {
         const notFoundFlight = await resolveStaticFile(
           staticDir,
-          "/404/index.rsc"
+          `/404/${rscOutputPath}`
         );
         if (notFoundFlight) {
           return new Response(

--- a/plugin/helpers/createRequestHandler.server.ts
+++ b/plugin/helpers/createRequestHandler.server.ts
@@ -114,6 +114,35 @@ export function createRequestHandler(
           headers: { "Content-Type": file.contentType },
         });
       }
+
+      // A FLIGHT request that missed answers with the 404 route's flight when
+      // the app prerendered one: status 404 (a shared cache must not treat a
+      // miss as content), but a body the flight DECODER can read — the client
+      // router then shows the 404 route without leaving the SPA. Text or HTML
+      // here would poison the decoder; that class is what this exists to
+      // retire. Without a prerendered /404, the plain 404 below stands and
+      // the client falls back to a full navigation.
+      if (
+        url.pathname.endsWith(".rsc") ||
+        (request.headers.get("accept") ?? "").includes("text/x-component")
+      ) {
+        const notFoundFlight = await resolveStaticFile(
+          staticDir,
+          "/404/index.rsc"
+        );
+        if (notFoundFlight) {
+          return new Response(
+            request.method === "HEAD" ? null : (notFoundFlight.body as BodyInit),
+            {
+              status: 404,
+              headers: {
+                "Content-Type": "text/x-component; charset=utf-8",
+                "x-vprs-outcome": "not-found",
+              },
+            }
+          );
+        }
+      }
     }
 
     return new Response("Not Found", { status: 404 });

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -197,8 +197,27 @@ export function createReactFetcher({
         () => {}
       );
     }
+    // Only flight reaches the decoder. The gate is the CONTENT TYPE, not the
+    // status: a 404 whose body is the 404 route's flight (the handler's
+    // not-found outcome) decodes and renders in the SPA, while a host's
+    // text/HTML miss or error page REJECTS here — fast and descriptive —
+    // instead of surfacing as decoder garbage. The router's existing
+    // rejection fallback then performs a full navigation, so the server's
+    // real response is what the user sees.
+    const flightResponse = responsePromise.then((response) => {
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("text/x-component")) {
+        throw new Error(
+          `[vprs] flight fetch for ${parsedURL.indexRSC} answered ` +
+            `${response.status} with content-type ${JSON.stringify(
+              contentType
+            )} — not a flight payload; falling back to a full navigation`
+        );
+      }
+      return response;
+    });
     return flightClient().then(({ createFromFetch }) =>
-      createFromFetch(responsePromise, decodeOptions)
+      createFromFetch(flightResponse, decodeOptions)
     );
   };
 

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -197,16 +197,23 @@ export function createReactFetcher({
         () => {}
       );
     }
-    // Only flight reaches the decoder. The gate is the CONTENT TYPE, not the
-    // status: a 404 whose body is the 404 route's flight (the handler's
-    // not-found outcome) decodes and renders in the SPA, while a host's
-    // text/HTML miss or error page REJECTS here — fast and descriptive —
-    // instead of surfacing as decoder garbage. The router's existing
-    // rejection fallback then performs a full navigation, so the server's
-    // real response is what the user sees.
+    // Only flight reaches the decoder — but "deploy dist/static to any static
+    // host" is a documented contract, and a host that has never heard of
+    // .rsc serves the file as application/octet-stream (or text/plain) with
+    // a 200. The gate therefore accepts BOTH shapes of legitimacy:
+    //   - a response DECLARED as flight (text/x-component), at any status —
+    //     that is how the not-found outcome rides a 404; and
+    //   - an OK response that is not a DOCUMENT — the dumb-host case above.
+    // Everything else rejects fast and descriptive: an HTML body (an
+    // SPA-fallback host answering index.html for any path, an error page)
+    // or a non-OK non-flight miss. The router's rejection fallback then
+    // performs a full navigation, so the server's real response is what the
+    // user sees — never decoder garbage.
     const flightResponse = responsePromise.then((response) => {
       const contentType = response.headers.get("content-type") ?? "";
-      if (!contentType.includes("text/x-component")) {
+      const declaredFlight = contentType.includes("text/x-component");
+      const documentish = contentType.includes("text/html");
+      if (!declaredFlight && (documentish || !response.ok)) {
         throw new Error(
           `[vprs] flight fetch for ${parsedURL.indexRSC} answered ` +
             `${response.status} with content-type ${JSON.stringify(

--- a/test/examples/static-navigation.test.ts
+++ b/test/examples/static-navigation.test.ts
@@ -42,7 +42,10 @@ const MIME: Record<string, string> = {
   ".mjs": "text/javascript",
   ".css": "text/css",
   ".map": "application/json",
-  ".rsc": "text/x-component; charset=utf-8",
+  // A host that has never heard of .rsc serves it like this — the fixtures
+  // must NOT flatter the deploy target with the correct flight MIME, or the
+  // fetcher's dumb-host compatibility path goes unexercised.
+  ".rsc": "application/octet-stream",
 };
 
 async function setupFixture() {
@@ -79,6 +82,7 @@ async function setupFixture() {
       `    <h1 id="heading">{"home"}</h1>\n` +
       `    <Counter id="home-counter" />\n` +
       `    <Link id="to-about" to="/about/">{"go to about"}</Link>\n` +
+      `    <Link id="to-void" to="/void/">{"go nowhere"}</Link>\n` +
       `  </main>\n` +
       `);\n`
   );
@@ -253,6 +257,51 @@ describe.skipIf(!browserAvailable)(
         expect(
           consoleErrors.filter((e) => /#4(18|19|23|25)|hydrat/i.test(e))
         ).toEqual([]);
+      } finally {
+        await browser.close();
+      }
+    });
+
+    it("falls back to a FULL navigation when the host answers a miss with text", async () => {
+      // The negative half of the decode gate: this dumb host has no 404
+      // flight — a missing route's .rsc fetch gets a text/plain 404. That
+      // must never reach the decoder; the router performs a full document
+      // navigation instead, so the host's real response is what shows.
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        const documentRequests: string[] = [];
+        page.on("request", (r) => {
+          if (r.resourceType() === "document")
+            documentRequests.push(new URL(r.url()).pathname);
+        });
+
+        await page.goto(`http://localhost:${PORT}/`, {
+          waitUntil: "networkidle",
+        });
+        await page.waitForFunction(
+          () => {
+            const b = document.querySelector(
+              "#home-counter"
+            ) as HTMLButtonElement;
+            if (!b) return false;
+            b.click();
+            return b.textContent !== "count:0";
+          },
+          undefined,
+          { timeout: 20000, polling: 400 }
+        );
+
+        await page.click("#to-void");
+        // Full document load of the target: the address moves AND the host's
+        // plain 404 body is what renders — no decoder involvement.
+        await page.waitForURL(/\/void\/?$/, { timeout: 15000 });
+        await page.waitForFunction(
+          () => document.body.textContent?.includes("not found"),
+          undefined,
+          { timeout: 10000 }
+        );
+        expect(documentRequests).toContain("/void/");
       } finally {
         await browser.close();
       }

--- a/test/examples/static-notfound-navigation.test.ts
+++ b/test/examples/static-notfound-navigation.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { resolve, join, extname } from "node:path";
+import { spawnSync } from "node:child_process";
+import { chromium } from "playwright";
+
+// The NOT-FOUND terminal outcome, end to end in a real browser: navigating to
+// a route that does not exist must stay IN the SPA. The host answers the
+// flight miss with the prerendered /404 route's flight (status 404,
+// x-vprs-outcome: not-found), the fetcher decodes it because it IS flight —
+// the gate is the content type, not the status — and the router renders the
+// 404 route without a document load. Text or HTML reaching the decoder is
+// the failure class this retires; a host that answers a miss with anything
+// non-flight still triggers the router's full-navigation fallback instead.
+const browserAvailable = (() => {
+  try {
+    return existsSync(chromium.executablePath());
+  } catch {
+    return false;
+  }
+})();
+// Fail CLOSED where a browser is guaranteed (the CI browser-regressions job
+// sets this): a missing Chromium must fail the job, never skip it green.
+if (!browserAvailable && process.env["VPRS_REQUIRE_BROWSER"]) {
+  throw new Error(
+    "VPRS_REQUIRE_BROWSER is set but Playwright Chromium is not installed"
+  );
+}
+
+const testDir = resolve(__dirname, "../fixtures/static-notfound-navigation.test");
+const PORT = 4199;
+
+const MIME: Record<string, string> = {
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".map": "application/json",
+};
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/routes/404"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function Counter({ id }: { id: string }) {\n` +
+      `  const [n, setN] = React.useState(0);\n` +
+      `  return (\n` +
+      `    <button id={id} onClick={() => setN((v) => v + 1)}>\n` +
+      `      {"count:" + n}\n` +
+      `    </button>\n` +
+      `  );\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/NavLink.client.tsx"),
+    `"use client";\n` +
+      `export { Link } from "vite-plugin-react-server/router/client";\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Link } from "./NavLink.client.js";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1 id="heading">{"home"}</h1>\n` +
+      `    <Counter id="home-counter" />\n` +
+      `    <Link id="to-missing" to="/missing/">{"go somewhere that does not exist"}</Link>\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/404/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1 id="heading">{"lost-page"}</h1>\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "build.mjs"),
+    `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+      `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: process.env.VPRS_PROBE_RUNNER || "isolated",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: fr.Page,\n` +
+      `    props: fr.props,\n` +
+      `    routePatterns: fr.routePatterns,\n` +
+      `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("NOTFOUND_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+describe.skipIf(!browserAvailable)(
+  "not-found navigation — the 404 route's flight keeps the SPA alive",
+  () => {
+    let server: Server | undefined;
+
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+
+      // Deploy-realistic build in a spawned NODE_ENV=production process; the
+      // runner follows this leg's ambient condition (test-both covers both).
+      const mainLeg = !!process.env["NODE_OPTIONS"]?.includes("react-server");
+      const env = { ...process.env, NODE_ENV: "production" };
+      env["NODE_OPTIONS"] = mainLeg ? "--conditions react-server" : "";
+      env["VPRS_PROBE_RUNNER"] = mainLeg ? "main" : "isolated";
+      const proc = spawnSync("node", ["build.mjs"], {
+        cwd: testDir,
+        encoding: "utf8",
+        timeout: 120000,
+        env,
+      });
+      expect(
+        proc.stdout,
+        `build failed (status ${proc.status}):\n${proc.stderr}`
+      ).toContain("NOTFOUND_BUILD_OK");
+
+      // The REAL Node host: createRequestHandler over dist/static (the layer
+      // that owns the not-found flight outcome), with the built client
+      // modules served beside it like any asset host would.
+      const { createRequestHandler, toNodeListener } = await import(
+        "vite-plugin-react-server/request-handler"
+      );
+      const handler = createRequestHandler({
+        staticDir: join(testDir, "dist/static"),
+      });
+      const listener = toNodeListener(handler);
+      // Asset shim beside the handler, dist/static FIRST: both roots emit a
+      // routes/<Component>-<hash>.js, and only the static one is the
+      // browser-flavored bundle (the client root's copy imports bare "react"
+      // for Node SSR). Root order is load-bearing.
+      const assetRoots = [join(testDir, "dist/static"), join(testDir, "dist/client")];
+      server = createServer((req: IncomingMessage, res: ServerResponse) => {
+        const pathname = decodeURIComponent(
+          new URL(req.url ?? "/", `http://localhost:${PORT}`).pathname
+        ).replace(/\/{2,}/g, "/");
+        if (extname(pathname) && !pathname.endsWith(".rsc")) {
+          for (const root of assetRoots) {
+            const file = join(root, pathname);
+            if (existsSync(file) && file.startsWith(root)) {
+              res.writeHead(200, {
+                "content-type":
+                  MIME[extname(file)] ?? "application/octet-stream",
+              });
+              return void res.end(readFileSync(file));
+            }
+          }
+        }
+        listener(req, res);
+      });
+      await new Promise<void>((r) => server!.listen(PORT, r));
+    }, 180000);
+
+    afterAll(async () => {
+      await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+      if (!process.env["KEEP_FIXTURE"])
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("renders the 404 route in place: no reload, one 404-status flight fetch", async () => {
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        const pageErrors: string[] = [];
+        const flightResponses: { url: string; status: number; outcome: string | null }[] = [];
+        const documentRequests: string[] = [];
+        page.on("pageerror", (e) => pageErrors.push(String(e)));
+        page.on("response", (r) => {
+          if (new URL(r.url()).pathname.endsWith(".rsc")) {
+            flightResponses.push({
+              url: new URL(r.url()).pathname,
+              status: r.status(),
+              outcome: r.headers()["x-vprs-outcome"] ?? null,
+            });
+          }
+        });
+        page.on("request", (r) => {
+          if (r.resourceType() === "document")
+            documentRequests.push(new URL(r.url()).pathname);
+        });
+
+        await page.goto(`http://localhost:${PORT}/`, {
+          waitUntil: "networkidle",
+        });
+
+        // Hydration gate (an unhydrated Link click is a full navigation —
+        // a legitimate failure of everything below).
+        await page.waitForFunction(
+          () => {
+            const b = document.querySelector(
+              "#home-counter"
+            ) as HTMLButtonElement;
+            if (!b) return false;
+            b.click();
+            return b.textContent !== "count:0";
+          },
+          undefined,
+          { timeout: 20000, polling: 400 }
+        );
+
+        const timeOriginBefore = await page.evaluate(
+          () => performance.timeOrigin
+        );
+
+        await page.click("#to-missing");
+        await page.waitForFunction(
+          () => document.querySelector("#heading")?.textContent === "lost-page",
+          undefined,
+          { timeout: 15000 }
+        );
+
+        // The SPA survived the miss: no reload, no document request.
+        expect(await page.evaluate(() => performance.timeOrigin)).toBe(
+          timeOriginBefore
+        );
+        expect(documentRequests).toEqual(["/"]);
+
+        // Exactly one flight fetch for the missing route, answered as the
+        // not-found outcome: status 404, flight body, outcome header.
+        const missing = flightResponses.filter((f) =>
+          f.url.includes("missing")
+        );
+        expect(missing).toHaveLength(1);
+        expect(missing[0]!.status).toBe(404);
+        expect(missing[0]!.outcome).toBe("not-found");
+
+        expect(pageErrors).toEqual([]);
+      } finally {
+        await browser.close();
+      }
+    });
+  }
+);

--- a/test/examples/static-notfound-navigation.test.ts
+++ b/test/examples/static-notfound-navigation.test.ts
@@ -9,11 +9,12 @@ import { chromium } from "playwright";
 // The NOT-FOUND terminal outcome, end to end in a real browser: navigating to
 // a route that does not exist must stay IN the SPA. The host answers the
 // flight miss with the prerendered /404 route's flight (status 404,
-// x-vprs-outcome: not-found), the fetcher decodes it because it IS flight —
-// the gate is the content type, not the status — and the router renders the
-// 404 route without a document load. Text or HTML reaching the decoder is
-// the failure class this retires; a host that answers a miss with anything
-// non-flight still triggers the router's full-navigation fallback instead.
+// x-vprs-outcome: not-found), and the fetcher decodes it under the gate's
+// dual rule — DECLARED flight (text/x-component, any status), or an OK
+// response that is not a document — so the router renders the 404 route
+// without a document load. Text or HTML reaching the decoder is the failure
+// class this retires; a host that answers a miss with anything that fails
+// both halves of the rule still triggers the full-navigation fallback.
 const browserAvailable = (() => {
   try {
     return existsSync(chromium.executablePath());

--- a/test/examples/static-suspense-hydration.test.ts
+++ b/test/examples/static-suspense-hydration.test.ts
@@ -45,7 +45,10 @@ const MIME: Record<string, string> = {
   ".mjs": "text/javascript",
   ".css": "text/css",
   ".map": "application/json",
-  ".rsc": "text/x-component; charset=utf-8",
+  // A host that has never heard of .rsc serves it like this — the fixtures
+  // must NOT flatter the deploy target with the correct flight MIME, or the
+  // fetcher's dumb-host compatibility path goes unexercised.
+  ".rsc": "application/octet-stream",
 };
 
 async function setupFixture() {

--- a/test/unit/createRequestHandler.test.ts
+++ b/test/unit/createRequestHandler.test.ts
@@ -94,3 +94,57 @@ describe("createRequestHandler", () => {
     expect(JSON.parse(row![1]!)).toEqual({ returnValue: { got: "hi" } });
   });
 });
+
+describe("createRequestHandler — not-found flight outcome", () => {
+  let dir: string;
+  let h: (request: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vprs-req-404-"));
+    await mkdir(join(dir, "404"), { recursive: true });
+    await writeFile(join(dir, "404", "index.rsc"), '0:["$","h1",null,{"children":"lost"}]\n');
+    await writeFile(join(dir, "index.html"), "<!doctype html><title>home</title>");
+    h = createRequestHandler({ staticDir: dir });
+  });
+
+  afterAll(() => rm(dir, { recursive: true, force: true }));
+
+  it("answers a flight miss with the 404 route's flight, status 404", async () => {
+    const res = await h(new Request("https://example.test/nope/index.rsc"));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    expect(res.headers.get("x-vprs-outcome")).toBe("not-found");
+    expect(await res.text()).toContain("lost");
+  });
+
+  it("answers an Accept-negotiated flight miss the same way", async () => {
+    const res = await h(
+      new Request("https://example.test/nope/", {
+        headers: { accept: "text/x-component" },
+      })
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("x-vprs-outcome")).toBe("not-found");
+    expect(await res.text()).toContain("lost");
+  });
+
+  it("keeps the plain 404 for document misses — the outcome is flight-path only", async () => {
+    const res = await h(new Request("https://example.test/nope/"));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type") ?? "").not.toContain("text/x-component");
+  });
+
+  it("keeps the plain 404 when the app prerendered no /404 route", async () => {
+    const bare = await mkdtemp(join(tmpdir(), "vprs-req-bare-"));
+    try {
+      const bareHandler = createRequestHandler({ staticDir: bare });
+      const res = await bareHandler(
+        new Request("https://example.test/nope/index.rsc")
+      );
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type") ?? "").not.toContain("text/x-component");
+    } finally {
+      await rm(bare, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/createRequestHandler.test.ts
+++ b/test/unit/createRequestHandler.test.ts
@@ -134,6 +134,29 @@ describe("createRequestHandler — not-found flight outcome", () => {
     expect(res.headers.get("content-type") ?? "").not.toContain("text/x-component");
   });
 
+  it("honors a custom build.rscOutputPath for the 404 flight lookup", async () => {
+    const custom = await mkdtemp(join(tmpdir(), "vprs-req-custom-"));
+    try {
+      await mkdir(join(custom, "404"), { recursive: true });
+      await writeFile(
+        join(custom, "404", "payload.rsc"),
+        '0:["$","h1",null,{"children":"lost-custom"}]\n'
+      );
+      const customHandler = createRequestHandler({
+        staticDir: custom,
+        rscOutputPath: "payload.rsc",
+      });
+      const res = await customHandler(
+        new Request("https://example.test/nope/payload.rsc")
+      );
+      expect(res.status).toBe(404);
+      expect(res.headers.get("x-vprs-outcome")).toBe("not-found");
+      expect(await res.text()).toContain("lost-custom");
+    } finally {
+      await rm(custom, { recursive: true, force: true });
+    }
+  });
+
   it("keeps the plain 404 when the app prerendered no /404 route", async () => {
     const bare = await mkdtemp(join(tmpdir(), "vprs-req-bare-"));
     try {


### PR DESCRIPTION
The ylou.2 slice of terminal-outcome coherence on the flight path. With it, all three terminal outcomes behave (redirects already did, via the 3xx-to-target-flight follow):

- **Not-found stays in the SPA.** `createRequestHandler` answers a flight miss (a path ending in the build's `rscOutputPath` / `.rsc`, or `Accept: text/x-component`) with the prerendered `/404` route's **flight** when the app has one: status 404 so caches treat it as a miss, `x-vprs-outcome: not-found`, and a body the decoder can actually read — the client router renders the 404 route in place. The lookup follows `build.rscOutputPath` (option on the handler, default `index.rsc`; `payload.rsc` unit regression). No prerendered `/404` → the plain 404 stands and the client falls back.
- **The decoder only ever sees flight — under a dual rule that keeps the any-static-host contract.** `createReactFetcher` accepts a response that is **declared flight** (`text/x-component`, at any status — how the not-found outcome rides a 404) **or** a **successful non-document** response — the `application/octet-stream` 200 a host that has never heard of `.rsc` serves, per the "deploy `dist/static` anywhere" promise. HTML bodies (SPA-fallback hosts, error pages) and non-OK non-flight misses reject fast with a descriptive error; the router's existing rejection fallback then performs a full navigation, so the server's real 404/500 page is what the user sees. The dumb-host browser fixtures serve `.rsc` as `application/octet-stream` so the compatibility half is exercised rather than flattered away, and a negative browser regression pins the fallback half: a `text/plain` miss produces a full document navigation rendering the host's real body.
- **Errors**: fast-reject + full navigation (above). The *in-flight* error envelope — an error payload the decoder reads instead of a fallback — belongs to the transaction contract (ylou.4) and is deliberately not preempted here.

**Proven in a real browser against the real Node host** (`createRequestHandler` + `toNodeListener`): a `<Link>` to a missing route renders the 404 route in place — `performance.timeOrigin` unchanged, zero document requests, exactly one flight fetch answered 404 with the outcome header — under both topologies, in the fail-closed browser-regressions job. Unit tests pin the handler shapes: `.rsc` miss, Accept-negotiated miss, document miss stays plain, no-`/404`-route stays plain, custom `rscOutputPath`.

Full gate green under both conditions; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA