### PR TITLE
fix: directive-marked action modules are discovered, not just gated

### DIFF
--- a/plugin/config/autoDiscover/createDirectiveServerAutoDiscover.ts
+++ b/plugin/config/autoDiscover/createDirectiveServerAutoDiscover.ts
@@ -1,0 +1,100 @@
+import type { ResolvedUserOptions } from "../../types.js";
+import { glob, readFile } from "node:fs/promises";
+import { resolve, join } from "node:path";
+import { analyzeModule } from "react-server-loader/directives";
+import { transformTsSource } from "../../loader/transformTsSource.js";
+
+/**
+ * Auto-discovers first-party server-action modules detected by a top-of-file
+ * `"use server"` DIRECTIVE rather than the `.server.` filename convention —
+ * the server twin of {@link createDirectiveClientAutoDiscover}.
+ *
+ * Why this exists: `createGlobAutoDiscover("**\/*.server.*")` only finds
+ * filename-convention action modules. A directive-only action module
+ * (e.g. `src/routes/edgePing.ts` starting with `"use server"`) that only a
+ * CLIENT component imports was never added as a server build input: the
+ * browser got a correct `createServerReference` proxy, but the server build
+ * never emitted the module, so the sealed gate had nothing to resolve and
+ * every call died at runtime with "Unknown server reference" — with no
+ * build-time signal. The 3.9.1 gate fix made gate MEMBERSHIP directive-driven;
+ * this makes DISCOVERY match, so the standard client-imports-an-action
+ * topology registers and executes like any other action module.
+ *
+ * Detection is the same scanner the transform and the gate use: strip TS with
+ * the running Vite's transform (raw TS does not parse under rsl's JS-only
+ * grammar), then require a FILE-LEVEL `"use server"` via `analyzeModule` —
+ * quoted strings and comments rejected, function-level directives excluded
+ * (those ride whichever module already owns them).
+ */
+export function createDirectiveServerAutoDiscover(
+  modulePattern = "**/*.{tsx,jsx,mts,cts,ts,js,mjs,cjs}"
+) {
+  return async function _directiveServerAutoDiscover({
+    inputs,
+    userOptions,
+  }: {
+    inputs: Record<string, string>;
+    userOptions: Pick<
+      ResolvedUserOptions,
+      "moduleBase" | "projectRoot" | "normalizer"
+    >;
+  }): Promise<{ inputs: Record<string, string> }> {
+    const baseDir = resolve(userOptions.projectRoot, userOptions.moduleBase);
+    const absolutePattern = resolve(baseDir, modulePattern);
+
+    let allFiles: AsyncIterable<string>;
+    try {
+      allFiles = glob(absolutePattern);
+    } catch {
+      return { inputs };
+    }
+
+    for (const file of await collect(allFiles)) {
+      // Skip files already covered by the `.server.` filename convention —
+      // `createGlobAutoDiscover` discovers those separately.
+      if (/\.server\.[cm]?[jt]sx?$/.test(file)) continue;
+      // Never treat dependencies as first-party action inputs.
+      if (file.includes("node_modules")) continue;
+
+      let source: string;
+      try {
+        source = await readFile(file, "utf-8");
+      } catch {
+        continue;
+      }
+      // Cheap pre-filter before any parse.
+      if (!source.includes("use server")) continue;
+
+      try {
+        const lang = /\.[cm]?tsx$|\.jsx$/.test(file) ? "tsx" : "ts";
+        const { code } = await transformTsSource(source, file, lang);
+        const analysis = await analyzeModule(code);
+        if (
+          analysis.type !== "success" ||
+          analysis.directiveInfo?.fileLevel?.type !== "server"
+        ) {
+          continue;
+        }
+      } catch {
+        // Unparseable source is not silently an action module.
+        continue;
+      }
+
+      const relativePath = file.replace(baseDir, "").replace(/^\/+/, "");
+      const [key, value] = userOptions.normalizer(
+        join(userOptions.moduleBase, relativePath)
+      );
+      if (!inputs[key]) {
+        inputs[key] = value;
+      }
+    }
+
+    return { inputs };
+  };
+}
+
+async function collect(files: AsyncIterable<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const f of files) out.push(f);
+  return out;
+}

--- a/plugin/config/autoDiscover/resolveAutoDiscover.ts
+++ b/plugin/config/autoDiscover/resolveAutoDiscover.ts
@@ -7,6 +7,7 @@ import { resolvePages } from "../resolvePages.js";
 import type { Logger, ResolvedConfig } from "vite";
 import { createGlobAutoDiscover } from "./createGlobAutoDiscover.js";
 import { createDirectiveClientAutoDiscover } from "./createDirectiveClientAutoDiscover.js";
+import { createDirectiveServerAutoDiscover } from "./createDirectiveServerAutoDiscover.js";
 import { patternProbeUrl } from "../../router/matchRoute.js";
 import { customWorkerFiles } from "./customWorkerFiles.js";
 import { pageAndPropFiles } from "./pageAndPropFiles.js";
@@ -115,6 +116,11 @@ export const resolveAutoDiscover: ResolveAutoDiscoverFn =
     // First-party modules detected by a top-of-file `"use client"` directive
     // (no `.client.` suffix) must also be emitted to dist/client.
     const directiveClientFiles = createDirectiveClientAutoDiscover();
+    // First-party action modules detected by a top-of-file `"use server"`
+    // directive (no `.server.` suffix) must also be BUILT server-side, or a
+    // client-only-imported action ships a working browser proxy pointing at a
+    // module the sealed gate has never heard of.
+    const directiveServerFiles = createDirectiveServerAutoDiscover();
     const serverFiles = createGlobAutoDiscover(userOptions.autoDiscover.serverEntry);
     const cssFiles = createGlobAutoDiscover(userOptions.autoDiscover.cssEntry);
     const jsonFiles = createGlobAutoDiscover(userOptions.autoDiscover.jsonEntry);
@@ -141,10 +147,18 @@ export const resolveAutoDiscover: ResolveAutoDiscoverFn =
         inputs: {},
         userOptions,
       });
-    const serverActions = await serverFiles({
+    const globServerActions = await serverFiles({
       inputs: {},
       userOptions,
     });
+    const { inputs: directiveServerActions } = await directiveServerFiles({
+      inputs: {},
+      userOptions,
+    });
+    // One action set, discovered two ways: the `.server.` filename glob and
+    // the file-level directive scan. Downstream consumers (server inputs, the
+    // baked gate's walk) see them uniformly.
+    const serverActions = { ...globServerActions, ...directiveServerActions };
 
     const pageAndPropInputs = pageAndPropFiles({
       files,

--- a/test/examples/directive-action-discovery.test.ts
+++ b/test/examples/directive-action-discovery.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, readFile, symlink } from "node:fs/promises";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+/**
+ * The standard client-imports-an-action topology, end to end: an action
+ * module marked by a top-of-file `"use server"` DIRECTIVE (no `.server.`
+ * filename), imported ONLY by a client component. Before directive-driven
+ * discovery, the browser shipped a correct proxy pointing at a module the
+ * server build never emitted — the sealed gate had nothing to resolve and
+ * every call died at runtime with "Unknown server reference", with no
+ * build-time signal (the original vr4q). Discovery now matches the gate's
+ * 3.9.1 directive rule, so the module is BUILT, gated, and executes.
+ */
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const testDir = resolve(__dirname, "../fixtures/directive-action-discovery");
+
+async function setupFixture() {
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(join(testDir, "src/routes"), { recursive: true });
+  // The action: directive-marked, conventionally named — NOT *.server.*.
+  await writeFile(
+    join(testDir, "src/routes/edgePing.ts"),
+    `"use server";\nexport async function ping(n: number) {\n  return n + 1;\n}\n`
+  );
+  // The ONLY importer is a client component.
+  await writeFile(
+    join(testDir, "src/routes/PingButton.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `import { ping } from "./edgePing.js";\n` +
+      `export function PingButton() {\n` +
+      `  const [out, setOut] = React.useState("");\n` +
+      `  return <button id="ping" onClick={async () => setOut(String(await ping(41)))}>{"ping:" + out}</button>;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { PingButton } from "./PingButton.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1>directive-action</h1>\n` +
+      `    <PingButton />\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "build.mjs"),
+    `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: process.env.VPRS_PROBE_RUNNER || "isolated",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: "src/routes/page.tsx",\n` +
+      `    build: { pages: ["/"], outDir: "dist" },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("DIRECTIVE_ACTION_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+describe("directive-marked action imported only by a client component", () => {
+  beforeAll(async () => {
+    await setupFixture();
+    const mainLeg = !!process.env["NODE_OPTIONS"]?.includes("react-server");
+    const env = { ...process.env, NODE_ENV: "production" };
+    env["NODE_OPTIONS"] = mainLeg ? "--conditions react-server" : "";
+    env["VPRS_PROBE_RUNNER"] = mainLeg ? "main" : "isolated";
+    const proc = spawnSync("node", ["build.mjs"], {
+      cwd: testDir,
+      encoding: "utf8",
+      timeout: 120000,
+      env,
+    });
+    expect(
+      proc.stdout,
+      `build failed (status ${proc.status}):\n${proc.stderr}`
+    ).toContain("DIRECTIVE_ACTION_BUILD_OK");
+  }, 180000);
+
+  afterAll(async () => {
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("the server build emits and manifests the module", async () => {
+    const manifest = JSON.parse(
+      await readFile(join(testDir, "dist/server/.vite/manifest.json"), "utf8")
+    ) as Record<string, { file: string }>;
+    expect(manifest["src/routes/edgePing.ts"]?.file).toBeTruthy();
+  });
+
+  it("the browser bundle carries the call-server PROXY, not the SSR stub", () => {
+    const routesDir = join(testDir, "dist/static/routes");
+    const pingBundle = readdirSync(routesDir).find((f) =>
+      f.startsWith("PingButton.client-")
+    );
+    expect(pingBundle).toBeTruthy();
+    const code = readFileSync(join(routesDir, pingBundle!), "utf8");
+    expect(code).toContain("edgePing.ts#ping");
+    expect(code).not.toContain("cannot run during SSR");
+  });
+
+  it("the SSR-root copy stays the render guard (by design)", async () => {
+    const ssrCopy = await readFile(
+      join(testDir, "dist/client/routes/edgePing.js"),
+      "utf8"
+    );
+    expect(ssrCopy).toContain("cannot run during SSR");
+  });
+
+  it("the baked gate resolves and executes it — the original vr4q click", async () => {
+    const { handleRouteAction } = (await import(
+      pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+    )) as { handleRouteAction: (r: Request, o?: object) => Promise<Response> };
+    const { encodeReply, createFromReadableStream } = await import(
+      "react-server-dom-esm/client.edge"
+    );
+    const body = await encodeReply([41]);
+    const res = await handleRouteAction(
+      new Request("http://edge.test/", {
+        method: "POST",
+        headers: { "x-rsc-action": "src/routes/edgePing.ts#ping" },
+        body: body as string,
+      }),
+      { projectRoot: testDir }
+    );
+    expect(res.status).toBe(200);
+    const decoded = (await createFromReadableStream(
+      res.body as ReadableStream,
+      { moduleBaseURL: "/" }
+    )) as { returnValue: number };
+    expect(decoded.returnValue).toBe(42);
+  });
+});


### PR DESCRIPTION
Closes vr4q's remaining scope by making the standard topology WORK instead of erroring on it.

**Re-examined on current main:** the 3.9-era "SSR stub in the browser bundle" symptom is gone — the browser gets the correct `createServerReference` proxy (the SSR-root copy in `dist/client` stays the render guard, by design). The deeper hole was still open, and quieter than the bead described: a directive-marked action module imported ONLY by a client component (the standard client-imports-an-action shape) produced **no build-time signal at all** — no warning, no server build entry, no gate membership — and every call died at runtime with `Unknown server reference`.

**Root cause:** the 3.9.1 fix made sealed-gate MEMBERSHIP directive-driven, but server-entry DISCOVERY still keyed on the `*.server.*` filename glob. Directive and filename disagreeing meant the flight layer registered what the build never emitted.

**Fix:** `createDirectiveServerAutoDiscover` — the exact server twin of the existing `createDirectiveClientAutoDiscover`: walk `moduleBase`, cheap `use server` pre-filter, then the same `transformTsSource` + `analyzeModule` scanner the transform and the gate already use, requiring a FILE-LEVEL directive. Discovered modules merge into the one `serverActions` set, so discovery = gate membership = what the flight layer registered.

**Regression** (both legs, spawned production builds): the module is manifested by the server build; the browser bundle carries the proxy and never the stub; the SSR-root render guard stays; and the baked gate executes the original vr4q click — real `encodeReply` body in, `returnValue: 42` decoded by the real flight client out.

The edge bake's ungated warning stays for the now-exotic residual (action modules outside the scanned root). Full gate green under both conditions; typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA