### PR TITLE
feat: SSG renders through react-dom/static, prerendered HTML is the page

### DIFF
--- a/docs/build-output.md
+++ b/docs/build-output.md
@@ -249,6 +249,17 @@ RSC directly instead of a worker; a bit faster, better stack traces), and
 `runner: "isolated"` rejects it (the rsc-worker owns react-server
 resolution). Same output either way.
 
+### Suspense in prerendered pages
+
+The static HTML is the FINAL markup: prerendering renders each route through
+`react-dom/static`, so a Suspense boundary that suspended during the build
+ships its resolved content at its position — no fallback templates, no hidden
+segments, no inline completion scripts. The file is the page, with or without
+JavaScript, under any Content-Security-Policy. Per-request renders (the edge
+document path, the worker per-request path, dev) keep streaming: progressive
+flushes are what time-to-first-byte and inline-flight interleaving are made
+of, and a live connection is where they mean something.
+
 ### Parallel Rendering
 
 For sites with many pages:

--- a/plugin/helpers/createSerializableHandlerOptions.ts
+++ b/plugin/helpers/createSerializableHandlerOptions.ts
@@ -81,6 +81,9 @@ export interface SerializableHandlerOptions {
   
   // Timeouts
   htmlTimeout?: number;
+
+  // Static prerender mode (SSG renders only; live renders stay streaming)
+  prerender?: boolean;
   
   // Stream options
   clientPipeableStreamOptions?: Omit<NonNullable<CreateHandlerOptions["clientPipeableStreamOptions"]>, `on${string}` | 'filterStackFrame'>;
@@ -163,6 +166,7 @@ export function createSerializableHandlerOptions(
     }));
   }
   if (typeof projectRoot === 'string') result.projectRoot = projectRoot;
+  if (options.prerender === true) result.prerender = true;
   if (typeof moduleRootPath === 'string') result.moduleRootPath = moduleRootPath;
   if (typeof moduleBaseURL === 'string') result.moduleBaseURL = moduleBaseURL;
   if (typeof moduleBasePath === 'string') result.moduleBasePath = moduleBasePath;

--- a/plugin/react-static/renderPage.client.ts
+++ b/plugin/react-static/renderPage.client.ts
@@ -440,6 +440,8 @@ export const renderPage: RenderPageFn = async function* _renderPageClient(
     // Create HTML stream using the full RSC stream (which reuses headless stream elements)
     const htmlTransformStream = createRscToHtmlStream({
       ...newHandlerOptions,
+      // SSG render: the emitted HTML must BE the page (react-dom/static).
+      prerender: true,
       htmlTimeout: handlerOptions.htmlTimeout || 15000,
       route: handlerOptions.route,
       logger: handlerOptions.logger,
@@ -589,6 +591,7 @@ export const renderPage: RenderPageFn = async function* _renderPageClient(
       
       // Create HTML stream that processes the fallback RSC stream to ensure performance timing script is injected
       const fallbackHtmlStream = createRscToHtmlStream({
+        prerender: true,
         id: handlerOptions.id,
         route: handlerOptions.route,
         url: handlerOptions.url,

--- a/plugin/react-static/renderPage.server.ts
+++ b/plugin/react-static/renderPage.server.ts
@@ -423,6 +423,8 @@ export const renderPage: RenderPageFn = async function* renderPage(
 
     // Create HTML transform stream - need createRscToHtmlStream for async server actions
     htmlTransformStream = createRscToHtmlStream({
+      // SSG render: the emitted HTML must BE the page (react-dom/static).
+      prerender: true,
       id: handlerOptions.id,
       worker: handlerOptions.worker,
       route: handlerOptions.route,

--- a/plugin/react-static/rscToHtmlStream.server.ts
+++ b/plugin/react-static/rscToHtmlStream.server.ts
@@ -51,6 +51,7 @@ export const createRscToHtmlStream: RscToHtmlStreamFn = function _createRscToHtm
     onMetrics: options.onMetrics,
     onError: options.onError,
     htmlTimeout: options.htmlTimeout,
+    prerender: options.prerender,
   });
 
   // Handle abort signal

--- a/plugin/react-static/types.ts
+++ b/plugin/react-static/types.ts
@@ -178,6 +178,7 @@ export type RenderStreamsFn = <
 export type RscToHtmlOptions = Pick<
   CreateHandlerOptions,
   | "id"
+  | "prerender"
   | "worker"
   | "htmlWorker"
   | "route"

--- a/plugin/stream/createHtmlStream.client.ts
+++ b/plugin/stream/createHtmlStream.client.ts
@@ -23,6 +23,7 @@ export const createHtmlStream: CreateHtmlStreamFn = function _createHtmlStream(
   // This replaces the original createFromNodeStream logic
   
   return createRenderToPipeableStreamHandler({
+    prerender: options.prerender,
     route: options.route,
     logger: options.logger,
     verbose: options.verbose || DEFAULT_CONFIG.VERBOSE,

--- a/plugin/stream/createHtmlStream.types.ts
+++ b/plugin/stream/createHtmlStream.types.ts
@@ -8,6 +8,7 @@ import type { PassThrough, Readable } from "node:stream";
  */
 export type CreateHtmlStreamOptions = Pick<
   CreateHandlerOptions<ResolvedUserOptions>,
+  | "prerender"
   | "moduleRootPath"
   | "moduleBasePath"
   | "moduleBaseURL"

--- a/plugin/stream/createRenderToPipeableStreamHandler.client.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.client.ts
@@ -78,6 +78,82 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       );
     }
 
+    // The stream the fileWriter consumes, shared by both render modes.
+    const htmlStream = new PassThrough();
+
+    // Add error handler to prevent unhandled errors
+    htmlStream.on('error', (error) => {
+      // Ignore errors during abort - they're expected
+      if (verbose) {
+        logger?.info(`[createRenderToPipeableStreamHandler.client:${route}] HTML stream error (ignored): ${error.message}`);
+      }
+    });
+
+    // Shared panic-policy mapping for a render error in either mode.
+    const reportRenderError = (error: unknown) => {
+      const panicError = handleError({
+        error: error,
+        logger: logger,
+        panicThreshold: options.panicThreshold,
+        context: `RSC stream onError for route ${route}`,
+      });
+      options.onEvent?.({
+        type: "route.error",
+        data: { route: route, error: panicError ?? error },
+      });
+    };
+
+    let abortRender: () => void;
+    if (options.prerender) {
+      // STATIC prerender (SSG): react-dom/static waits for every Suspense
+      // boundary and emits the FINAL markup inline — no fallback templates,
+      // no hidden segments, no inline $RC swap scripts. The prerendered HTML
+      // is the page, with or without JavaScript. This handler's chain is
+      // SSG-only today, but the mode is FLAG-driven so a future live consumer
+      // keeps streaming semantics by default.
+      const controller = new AbortController();
+      abortRender = () => controller.abort();
+      void import("react-dom/static").then(
+        async ({ prerenderToNodeStream }) => {
+          try {
+            const { prelude } = await prerenderToNodeStream(reactElements, {
+              bootstrapModules:
+                clientPipeableStreamOptions?.bootstrapModules || [],
+              // A static file has no progressive delivery: without this,
+              // React OUTLINES boundary content larger than the default
+              // progressive chunk size (~12KB) behind a $RC swap script even
+              // in a completed prerender — the exact shape this mode exists
+              // to retire. Effectively infinite unless the consumer set one.
+              progressiveChunkSize:
+                (clientPipeableStreamOptions as { progressiveChunkSize?: number } | undefined)
+                  ?.progressiveChunkSize ?? 1 << 30,
+              signal: controller.signal,
+              // Boundary errors: the render continues (the boundary falls
+              // back) — same policy surface as the streaming onError.
+              onError(error: unknown) {
+                if (verbose) {
+                  logger?.error(
+                    `[createRenderToPipeableStreamHandler.client:${route}] React prerender error: ${error instanceof Error ? error.message : String(error)}`
+                  );
+                }
+                reportRenderError(error);
+              },
+            } as never);
+            prelude.pipe(htmlStream);
+          } catch (error) {
+            // A SHELL error REJECTS here (react-dom/static has no
+            // onShellError seam). Destroy the output so downstream settles
+            // (the guarded pipe below propagates), and route the panic logic.
+            reportRenderError(error);
+            htmlStream.destroy(
+              error instanceof Error ? error : new Error(String(error))
+            );
+          }
+        }
+      );
+      return buildResult();
+    }
+
     // Create the React HTML stream using ReactDOMServer.renderToPipeableStream
     let rendererAborted = false;
     const { pipe, abort } = ReactDOMServer.renderToPipeableStream(reactElements, {
@@ -129,33 +205,8 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
           });
         }
         
-        // Handle error according to panic threshold
-        const panicError = handleError({
-          error: error,
-          logger: logger,
-          panicThreshold: options.panicThreshold,
-          context: `RSC stream onError for route ${route}`,
-        });
-
-        if (panicError != null) {
-          // This is a panic threshold error, emit event to notify parent
-          options.onEvent?.({
-            type: "route.error",
-            data: {
-              route: route,
-              error: panicError,
-            },
-          });
-        } else {
-          // For non-panic errors, just log and send event
-          options.onEvent?.({
-            type: "route.error",
-            data: {
-              route: route,
-              error: error,
-            },
-          });
-        }
+        // Handle error according to panic threshold (shared mapping).
+        reportRenderError(error);
       },
       // A SHELL error (thrown outside every Suspense boundary) also reaches
       // onError above, which destroys htmlStream and routes the panic logic.
@@ -172,17 +223,7 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       },
     });
 
-    // Create a PassThrough stream that the fileWriter can consume
-    // This follows the HTML worker pattern but provides a proper stream interface
-    const htmlStream = new PassThrough();
-    
-    // Add error handler to prevent unhandled errors
-    htmlStream.on('error', (error) => {
-      // Ignore errors during abort - they're expected
-      if (verbose) {
-        logger?.info(`[createRenderToPipeableStreamHandler.client:${route}] HTML stream error (ignored): ${error.message}`);
-      }
-    });
+    abortRender = abort;
 
     // Pipe React into the REAL PassThrough — never a faked writable. React's
     // pipe() honors the write() return value and waits for 'drain' on
@@ -200,8 +241,13 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       );
     }
 
-    // Return a result that provides a proper stream for fileWriter
-    return {
+    return buildResult();
+
+    // Both render modes hand the fileWriter the SAME contract over htmlStream:
+    // the guarded pipe (propagates a pre-subscription render failure), abort,
+    // and the raw stream/elements/metrics.
+    function buildResult() {
+      return {
       type: "client" as const,
       pipe: <Writable extends NodeJS.WritableStream>(destination: Writable) => {
         // A React render error destroys htmlStream (see onError above) — and it
@@ -238,7 +284,7 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       },
       abort: (reason?: unknown) => {
         try {
-          abort();
+          abortRender();
         } catch (error) {
           // React abort may already be called, ignore
         }
@@ -256,5 +302,6 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       htmlStream: htmlStream,
       elements: reactElements,
       metrics: streamMetrics,
-    };
+      };
+    }
   };

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1121,6 +1121,15 @@ export type CreateHandlerOptions<
    */
   transport?: "esm" | "webpack";
   /**
+   * STATIC prerender mode for the HTML render: react-dom/static waits for
+   * every Suspense boundary and emits the FINAL markup inline — no fallback
+   * templates, no hidden segments, no inline $RC swap scripts — so the
+   * prerendered HTML is the page, with or without JavaScript. Set by the SSG
+   * render paths only; live per-request renders stay streaming (TTFB, and
+   * inlineFlight "stream" interleaving depends on progressive flushes).
+   */
+  prerender?: boolean;
+  /**
    * Params parsed from the request url against the matched route pattern
    * (`/profile/123` → `{ id: "123" }`). Passed to a loader as
    * `props(url, { params, request })`. When absent, vprs derives it from

--- a/plugin/worker/html/handleHtmlRender.client.ts
+++ b/plugin/worker/html/handleHtmlRender.client.ts
@@ -24,7 +24,7 @@ assertNonReactServer();
  * @param handlers
  * @param logger
  */
-export const handleHtmlRender: HandleHtmlRenderFn = function _handleHtmlRender(
+export const handleHtmlRender: HandleHtmlRenderFn = async function _handleHtmlRender(
   handlerOptions,
   handlers
 ) {
@@ -121,6 +121,73 @@ export const handleHtmlRender: HandleHtmlRenderFn = function _handleHtmlRender(
           mergedPipeableStreamOptions
         )}`
       );
+    }
+
+    if (handlerOptions.prerender) {
+      // STATIC prerender (SSG renders only — the INIT message carries the
+      // flag from the build's render path): react-dom/static waits for every
+      // Suspense boundary and emits the FINAL markup inline — no fallback
+      // templates, no hidden segments, no inline $RC swap scripts. The
+      // prerendered HTML is the page, with or without JavaScript. Live
+      // per-request renders through this same worker (the inline-flight
+      // document path) never set the flag and keep streaming: TTFB and the
+      // inlineFlight "stream" interleave depend on progressive flushes.
+      const prerenderWritable = new Writable({
+        write(chunk: any, _encoding, callback) {
+          handlers.onData(id, chunk);
+          callback();
+        },
+        final(callback) {
+          handlers.onEnd(id);
+          callback();
+        },
+      });
+      try {
+        const { prerenderToNodeStream } = await import("react-dom/static");
+        const { prelude } = await prerenderToNodeStream(result.children, {
+          ...mergedPipeableStreamOptions,
+          // A static file has no progressive delivery: without this, React
+          // OUTLINES boundary content larger than the default progressive
+          // chunk size (~12KB) behind a $RC swap script even in a completed
+          // prerender. Effectively infinite unless the consumer set one.
+          progressiveChunkSize:
+            (mergedPipeableStreamOptions as { progressiveChunkSize?: number })
+              ?.progressiveChunkSize ?? 1 << 30,
+          onError(error: unknown, errorInfo?: unknown) {
+            // Boundary errors: the render continues (the boundary falls
+            // back); same reporting seam as the streaming render.
+            logger.error(
+              `[html-worker:${route}] React prerender error: ${error}`
+            );
+            handlers.onError(route, error, errorInfo as never);
+            mergedPipeableStreamOptions?.onError?.(error, errorInfo as never);
+          },
+        } as never);
+        prelude.pipe(prerenderWritable);
+      } catch (error) {
+        // A SHELL error REJECTS (react-dom/static has no onShellError seam):
+        // nothing was piped; the ERROR message lets the main thread destroy
+        // its stream, exactly like the streaming path's shell failure.
+        logger.error(
+          `[html-worker:${route}] HTML static prerender failed (nothing was piped): ${error}`
+        );
+        handlers.onError(route, error, {
+          componentStack: undefined,
+          digest: undefined,
+        });
+        mergedPipeableStreamOptions?.onShellError?.(error);
+      }
+      // RSC stream errors surface the same way in both modes.
+      rscStream.on("error", (error) => {
+        if (verbose) {
+          logger.error(`[html-worker:${route}] RSC stream error: ${error}`);
+        }
+        handlers.onError(id, error, {
+          componentStack: undefined,
+          digest: undefined,
+        });
+      });
+      return;
     }
 
     // Create the stream once and pipe directly with onData

--- a/plugin/worker/html/messageHandler.client.tsx
+++ b/plugin/worker/html/messageHandler.client.tsx
@@ -115,6 +115,9 @@ export async function messageHandler(msg: HtmlWorkerInputMessage) {
           {
             id,
             route: options.route,
+            // Static-prerender flag from the SSG render path; live renders
+            // through this worker never set it and keep streaming.
+            prerender: options?.prerender === true,
             rscStream,
             projectRoot:
               options?.projectRoot ??

--- a/plugin/worker/html/types.ts
+++ b/plugin/worker/html/types.ts
@@ -86,6 +86,8 @@ export type HtmlRenderMessage = {
     htmlTimeout?: number;
     panicThreshold?: PanicThreshold;
     publicOrigin?: string;
+    /** Static-prerender flag (SSG renders); live renders keep streaming. */
+    prerender?: boolean;
   };
 };
 
@@ -141,6 +143,7 @@ export type HandleHtmlRenderFn = (
   options: Pick<
     CreateHandlerOptions,
     | "id"
+    | "prerender"
     | "clientPipeableStreamOptions"
     | "route"
     | "htmlStream"

--- a/plugin/worker/types.ts
+++ b/plugin/worker/types.ts
@@ -123,6 +123,7 @@ export type HtmlRenderMessage = {
 } & WorkerMessage &
   Pick<
     CreateHandlerOptions,
+    | "prerender"
     | "projectRoot"
     | "moduleRootPath"
     | "moduleBasePath"

--- a/test/examples/static-suspense-hydration.test.ts
+++ b/test/examples/static-suspense-hydration.test.ts
@@ -215,6 +215,22 @@ describe.skipIf(!browserAvailable)(
       expect(html).toContain("padding-to-split-the-flush");
     });
 
+    it("the prerendered HTML IS the page: no swap scripts, content at position", () => {
+      // The static artifact contract (react-dom/static prerender): a suspended
+      // boundary's resolved markup sits AT its position — never the streamed
+      // shape of fallback-in-place + hidden content + an inline $RC swap that
+      // only JavaScript can perform. This is what makes the file correct under
+      // no-JS and inline-script-blocking CSP.
+      expect(html).not.toContain("$RC");
+      expect(html).not.toContain("<template");
+      expect(html).not.toContain("div hidden");
+      // Resolved content precedes where the fallback would have been; the
+      // fallback markup is absent entirely.
+      expect(html).not.toContain('id="fallback"');
+      const h1 = html.indexOf("</h1>");
+      expect(html.slice(h1, h1 + 120)).toContain('data-resolved="yes"');
+    });
+
     it("hydrates without #419: the boundary stays resolved and answers a click", async () => {
       const browser = await chromium.launch();
       try {


### PR DESCRIPTION
The 9zga port, per the decision that it rides 4.0: **the static build's HTML is the final markup**.

A Suspense boundary that suspended during the build previously shipped the STREAMED shape — fallback at the content's position, resolved content in a hidden segment at the end of the file, an inline `$RC` swap script as the only bridge. JS-off or inline-script-blocking CSP showed "loading" forever on a fully static page. The prerendered file now carries the resolved markup **at its position, script-free** (~35% smaller on the probe fixture).

**How:** both SSG seams render through `react-dom/static`'s `prerenderToNodeStream`, selected by a `prerender` flag — the html-worker (runner `main`) gets it on the INIT message; the client-condition main-thread handler (runner `isolated`) on its options. All three SSG call sites set it. **Live renders through the same seams never do and keep streaming** — TTFB and the inlineFlight `"stream"` interleave depend on progressive flushes.

**Two React facts the port had to absorb** (both found empirically, not from docs):
- `prerender` **rejects** on shell errors instead of calling `onShellError` — mapped onto the existing panic-policy reporting and stream destruction;
- a **completed** prerender still **outlines** boundary content larger than `progressiveChunkSize` (~12KB default) behind a `$RC` script. A static file has no progressive delivery, so the static branches set it effectively infinite (honoring an explicit consumer value). Without this, large boundaries silently kept the streamed shape — the strengthened browser proof caught it.

**Proof:** the fail-closed browser suite now pins the artifact contract on both topologies — no `$RC`, no templates, no hidden segments, content at position, fallback absent — plus the unchanged hydration-and-click proof inside the boundary. Docs state the contract in build-output.md. Full gate green under both conditions; typecheck green.

**Merge order note:** land after #393 and #394 — their branches touch the same test fixtures (this branch's suspense-proof assertions and #394's fixture MIME changes are separate hunks in the same files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA