### PR TITLE
feat: server actions complete the Flight transaction contract

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,4 +211,4 @@ jobs:
           VPRS_REQUIRE_BROWSER: "1"
         run: |
           npm run build
-          ./scripts/test-both.sh static-suspense-hydration static-navigation static-notfound-navigation dev-error-recovery
+          ./scripts/test-both.sh static-suspense-hydration static-navigation static-notfound-navigation dev-error-recovery action-outcomes

--- a/docs/server-actions.md
+++ b/docs/server-actions.md
@@ -232,6 +232,29 @@ Arguments and results ride the transport's own flight codec, end to end:
 A hand-rolled caller (no `encodeReply`) may POST the JSON envelope
 `{ "id": "path#export", "args": [...] }` instead; its args are taken as-is.
 
+### Terminal outcomes
+
+An action ends in exactly one of four ways, and each is a declared wire
+shape — the flight decoder never receives anything it cannot read:
+
+| Outcome | The action | The response | The router client |
+|---|---|---|---|
+| return | returns a value | `200`, flight `{ returnValue }` | resolves with the value, then refreshes the current route (drops its cached flight, refetches, swaps) so mutations show without app wiring |
+| redirect | throws `redirect(to)` | `303` to the target's flight, `x-vprs-outcome: redirect` | `fetch` follows the 303; the decoded response IS the target page — delivered to the view, address bar updated, no document load |
+| not found | throws `notFound()` | `404`, `x-vprs-outcome: not-found`, no body | fetches the `/404/` route's flight through its own GET path and swaps it in; the address stays |
+| error | throws anything else | tagged status (`403`/`413`) or `500`, `x-vprs-outcome: error`, flight `{ error: { message } }` | rejects the action call with the server's message — the message only, never the stack |
+
+`redirect` and `notFound` are the same signals loaders throw
+(`vite-plugin-react-server/router`), and the mapping is identical in every
+execution topology: the react-server process, the rsc-worker delegate, and
+the baked edge gate.
+
+Outside the router (a bare `createReactFetcher` with no `callServerHooks`),
+the defaults still hold the contract: a redirect becomes a document
+navigation, not-found rejects with a `notFound()`-marked error (test with
+`isNotFound`), and a non-flight response is reported as an error instead of
+being fed to the decoder.
+
 ### Endpoint hardening
 
 The sealed gate decides *which function* a request may resolve — it confirms the

--- a/plugin/dev-server/handleServerAction.client.ts
+++ b/plugin/dev-server/handleServerAction.client.ts
@@ -7,6 +7,7 @@ import {
   setupServerActionHeaders,
   createServerActionStream,
   handleServerActionError,
+  writeServerActionOutcome,
 } from "../helpers/handleServerAction.client.js";
 import { readServerActionForWorker } from "../helpers/handleServerActionHelper.js";
 import type { MessageHandler } from "../types.js";
@@ -53,22 +54,20 @@ export const handleServerAction: HandleWorkerServerActionFn =
               cleanupServerAction(passThrough, worker, messageHandler, res);
             }
           } else if (message.type === "SERVER_ACTION_RESPONSE") {
-            // Server action completed — the worker rendered `{ returnValue }`
-            // through the transport's flight renderer; write it verbatim (this
-            // thread holds no react-server context to re-encode with). The
-            // JSON row remains only for errors and the legacy result shape.
-            if (message.error?.message) {
-              logger.error(`[handleServerAction] Server action error: ${message.error?.message}`);
-              passThrough.write(`0:${JSON.stringify({ error: message.error.message })}\n`);
-            } else if(typeof message.error === "string") {
-              logger.error(`[handleServerAction] Server action error: ${message.error}`);
-              passThrough.write(`0:${JSON.stringify({ error: message.error })}\n`);
-            } else if (typeof (message as { flight?: string }).flight === "string") {
-              passThrough.write((message as { flight: string }).flight);
-            } else {
-              // Legacy: write the raw result as a JSON row.
-              passThrough.write(`0:${JSON.stringify(message.result)}\n`);
-            }
+            // Server action completed — the worker rendered the payload
+            // through the transport's flight renderer; the shared writer maps
+            // terminal outcomes (redirect/not-found/error) identically to the
+            // react-server handler.
+            writeServerActionOutcome(
+              message as {
+                error?: string | Record<string, unknown>;
+                flight?: string;
+                result?: unknown;
+              },
+              passThrough,
+              res,
+              logger
+            );
             if (messageHandler) {
               cleanupServerAction(passThrough, worker, messageHandler, res);
             }

--- a/plugin/helpers/createRequestHandler.server.ts
+++ b/plugin/helpers/createRequestHandler.server.ts
@@ -4,6 +4,7 @@ import { Readable } from "node:stream";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { MIME_TYPES } from "../config/mimeTypes.js";
 import { isPathWithin } from "./isPathWithin.js";
+import { OUTCOME, OUTCOME_HEADER } from "../utils/outcomeHeader.js";
 import type { ServerActionHandlerOptions } from "./handleServerActionHelper.js";
 
 /**
@@ -150,8 +151,8 @@ export function createRequestHandler(
             {
               status: 404,
               headers: {
-                "Content-Type": "text/x-component; charset=utf-8",
-                "x-vprs-outcome": "not-found",
+                  "Content-Type": "text/x-component; charset=utf-8",
+                [OUTCOME_HEADER]: OUTCOME.notFound,
               },
             }
           );

--- a/plugin/helpers/handleServerAction.client.ts
+++ b/plugin/helpers/handleServerAction.client.ts
@@ -10,6 +10,12 @@ import type {
   ServerActionHandlerOptions,
 } from "./handleServerActionHelper.js";
 import { readServerActionForWorker, createServerActionResponse, setupServerActionHeaders } from "./handleServerActionHelper.js";
+import { isNotFound, isRedirect } from "../router/loaderSignals.js";
+import {
+  OUTCOME,
+  OUTCOME_HEADER,
+  actionRedirectLocation,
+} from "../utils/outcomeHeader.js";
 
 // Use shared helper instead of duplicating logic
 
@@ -35,6 +41,63 @@ export function handleServerActionError(error: unknown, res: ServerResponse, log
   logError(err, logger);
   res.statusCode = 500;
   res.end(JSON.stringify(createServerActionResponse(undefined, err.message)));
+}
+
+/**
+ * Write a worker SERVER_ACTION_RESPONSE onto the HTTP response, mapping the
+ * terminal outcomes the react-server handler answers directly: a loader
+ * signal (redirect()/notFound() thrown by the action, its marker fields
+ * rehydrated by toError from the serializeError object that crossed the
+ * thread boundary) becomes the 303/404 outcome; any other error becomes the
+ * error outcome, whose body is the worker's flight-rendered
+ * `{ error: { message } }` envelope — valid flight, never JSON into a flight
+ * decoder. Nothing has been flushed yet (headers alone don't send), so
+ * status and headers are still assignable here. Shared by both worker
+ * delegates so the protocol exists exactly once.
+ */
+export function writeServerActionOutcome(
+  message: {
+    error?: string | Record<string, unknown>;
+    flight?: string;
+    result?: unknown;
+  },
+  passThrough: PassThrough,
+  res: ServerResponse,
+  logger?: Logger
+): void {
+  if (message.error) {
+    const err = toError(message.error) as Error & {
+      statusCode?: number;
+      to?: string;
+    };
+    if (isRedirect(err)) {
+      res.statusCode = 303;
+      res.removeHeader("Content-Type");
+      res.setHeader("location", actionRedirectLocation(err.to ?? "/"));
+      res.setHeader(OUTCOME_HEADER, OUTCOME.redirect);
+      return;
+    }
+    if (isNotFound(err)) {
+      res.statusCode = 404;
+      res.removeHeader("Content-Type");
+      res.setHeader(OUTCOME_HEADER, OUTCOME.notFound);
+      return;
+    }
+    logError(err, logger);
+    res.statusCode = typeof err.statusCode === "number" ? err.statusCode : 500;
+    res.setHeader(OUTCOME_HEADER, OUTCOME.error);
+    if (typeof message.flight === "string") {
+      passThrough.write(message.flight);
+    } else {
+      passThrough.write(`0:${JSON.stringify({ error: err.message })}\n`);
+    }
+    return;
+  }
+  if (typeof message.flight === "string") {
+    passThrough.write(message.flight);
+    return;
+  }
+  passThrough.write(`0:${JSON.stringify(message.result)}\n`);
 }
 
 /**
@@ -98,20 +161,7 @@ export async function delegateServerActionToWorker(
           cleanupServerAction(passThrough, options.worker!, messageHandler, res);
         }
       } else if (message.type === "SERVER_ACTION_RESPONSE") {
-        // The worker rendered `{ returnValue }` through the transport's flight
-        // renderer — write it verbatim; the JSON row remains for errors and
-        // the legacy result shape.
-        if (message.error) {
-          const text =
-            typeof message.error === "string"
-              ? message.error
-              : message.error?.message;
-          passThrough.write(`0:${JSON.stringify({ error: text })}\n`);
-        } else if (typeof message.flight === "string") {
-          passThrough.write(message.flight);
-        } else {
-          passThrough.write(`0:${JSON.stringify(message.result)}\n`);
-        }
+        writeServerActionOutcome(message, passThrough, res, options.logger);
         if (messageHandler) {
           cleanupServerAction(passThrough, options.worker!, messageHandler, res);
         }

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -22,6 +22,12 @@ import type {
   ServerActionRequest,
 } from "./handleServerActionHelper.js";
 import { hasReactServerCondition } from "../config/getCondition.js";
+import { isNotFound, isRedirect } from "../router/loaderSignals.js";
+import {
+  OUTCOME,
+  OUTCOME_HEADER,
+  actionRedirectLocation,
+} from "../utils/outcomeHeader.js";
 import { createSealedServerReferenceGate } from "../references/createSealedServerReferenceGate.server.js";
 import type { ReferenceGate } from "react-server-loader/references";
 // node:fs / node:path load lazily inside the disk-manifest fallback ONLY (see
@@ -230,17 +236,49 @@ export async function resolveAndExecuteServerAction(
 }
 
 /**
- * Stream a flight-rendered `{ returnValue }` payload into a Node response.
- * The codec may hand back either a Node pipeable or a Web stream — the edge
- * codec renders Web streams; the built-in Node pair renders pipeables.
+ * Map a thrown action error to its terminal outcome. `null` means "not a
+ * declared outcome" — a real failure, which the caller answers as the error
+ * outcome (flight envelope when a codec exists, legacy JSON otherwise).
+ */
+function actionSignalOutcome(
+  error: unknown
+): { status: number; headers: Record<string, string> } | null {
+  if (isRedirect(error)) {
+    return {
+      status: 303,
+      headers: {
+        location: actionRedirectLocation(error.to),
+        [OUTCOME_HEADER]: OUTCOME.redirect,
+      },
+    };
+  }
+  if (isNotFound(error)) {
+    // Marker only, no body: the client router fetches the 404 route's flight
+    // through its own (cached) GET path, so this stays identical on hosts
+    // that cannot render — static file servers and the bare Web handler
+    // included.
+    return { status: 404, headers: { [OUTCOME_HEADER]: OUTCOME.notFound } };
+  }
+  return null;
+}
+
+/** The error-outcome envelope: message only — never the stack or paths. */
+const actionErrorPayload = (error: Error) => ({
+  error: { message: error.message },
+});
+
+/**
+ * Stream a flight-rendered payload into a Node response. The codec may hand
+ * back either a Node pipeable or a Web stream — the edge codec renders Web
+ * streams; the built-in Node pair renders pipeables.
  */
 async function sendFlightActionResponse(
   res: ServerResponse,
   codec: ServerActionFlightCodec,
-  result: unknown
+  payload: unknown
 ): Promise<void> {
   res.setHeader("Content-Type", "text/x-component; charset=utf-8");
-  const stream = codec.renderResponse({ returnValue: result });
+  const stream = codec.renderResponse(payload);
   if (isWebStream(stream)) {
     const { Readable } = (await importAtRuntime("node:stream")) as
       typeof import("node:stream");
@@ -253,9 +291,10 @@ async function sendFlightActionResponse(
 /** The Web counterpart: wrap the rendered payload in a `Response`. */
 async function flightActionWebResponse(
   codec: ServerActionFlightCodec,
-  result: unknown
+  payload: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {}
 ): Promise<Response> {
-  const stream = codec.renderResponse({ returnValue: result });
+  const stream = codec.renderResponse(payload);
   let webStream: ReadableStream;
   if (isWebStream(stream)) {
     webStream = stream;
@@ -271,7 +310,11 @@ async function flightActionWebResponse(
     webStream = Readable.toWeb(passThrough) as unknown as ReadableStream;
   }
   return new Response(webStream, {
-    headers: { "Content-Type": "text/x-component; charset=utf-8" },
+    status: init.status ?? 200,
+    headers: {
+      "Content-Type": "text/x-component; charset=utf-8",
+      ...init.headers,
+    },
   });
 }
 
@@ -305,7 +348,7 @@ export async function handleServerAction(
     if (codec) {
       // The complete protocol: the payload rides the transport's own flight
       // renderer, so non-JSON values (Dates, streams, elements) survive.
-      await sendFlightActionResponse(res, codec, result);
+      await sendFlightActionResponse(res, codec, { returnValue: result });
     } else {
       // Legacy JSON row — a condition-less process with no codec cannot
       // flight-render; plain JSON results keep working as before.
@@ -316,6 +359,36 @@ export async function handleServerAction(
       logger?.info("[handleServerAction:server] Server action completed successfully");
     }
   } catch (error: unknown) {
+    // Loader-signal outcomes (redirect() / notFound() thrown by the action)
+    // answer the transaction, they are not failures.
+    const signal = actionSignalOutcome(error);
+    if (signal) {
+      res.statusCode = signal.status;
+      for (const [key, value] of Object.entries(signal.headers)) {
+        res.setHeader(key, value);
+      }
+      res.end();
+      return;
+    }
+    // The error outcome: with a codec the body is valid flight — a
+    // { error: { message } } envelope the client decodes and re-throws —
+    // never JSON/text fed to a flight decoder. Codec-less keeps the legacy
+    // JSON error row (the client refuses to decode non-flight).
+    const err = toError(error) as Error & { statusCode?: number };
+    let codec: ServerActionFlightCodec | null = null;
+    try {
+      codec = await resolveActionFlightCodec(options);
+    } catch {
+      // The codec itself is unavailable — the legacy JSON path stands.
+    }
+    if (codec && !res.headersSent) {
+      logError(err, logger);
+      res.statusCode =
+        typeof err.statusCode === "number" ? err.statusCode : 500;
+      res.setHeader(OUTCOME_HEADER, OUTCOME.error);
+      await sendFlightActionResponse(res, codec, actionErrorPayload(err));
+      return;
+    }
     handleServerActionErrorHelper(error, res, logger);
   }
 }
@@ -350,22 +423,44 @@ export async function handleServerActionRequest(
     const result = await resolveAndExecuteServerAction(parsed, options, codec);
 
     if (codec) {
-      return await flightActionWebResponse(codec, result);
+      return await flightActionWebResponse(codec, { returnValue: result });
     }
     // Legacy RSC wire row, matching the Node sendServerActionResponse output.
     return new Response(`0:${JSON.stringify(result)}\n`, {
       headers: { "Content-Type": "text/x-component" },
     });
   } catch (error: unknown) {
+    // Loader-signal outcomes (redirect() / notFound() thrown by the action)
+    // answer the transaction, they are not failures.
+    const signal = actionSignalOutcome(error);
+    if (signal) {
+      return new Response(null, { status: signal.status, headers: signal.headers });
+    }
     const err = toError(error) as Error & { statusCode?: number };
     logError(err, logger);
     // Honor a tagged status (403 origin, 413 oversized) else 500. Never ship the
     // stack to the client — it exposes absolute paths and internal module ids;
     // the full error is logged above.
+    const status = typeof err.statusCode === "number" ? err.statusCode : 500;
+    let codec: ServerActionFlightCodec | null = null;
+    try {
+      codec = await resolveActionFlightCodec(options);
+    } catch {
+      // The codec itself is unavailable — the legacy JSON path stands.
+    }
+    if (codec) {
+      // The error outcome: valid flight, never JSON/text into a flight
+      // decoder. The client decodes the envelope and rejects the action with
+      // the server's message.
+      return await flightActionWebResponse(codec, actionErrorPayload(err), {
+        status,
+        headers: { [OUTCOME_HEADER]: OUTCOME.error },
+      });
+    }
     return new Response(
       JSON.stringify({ success: false, error: err.message }),
       {
-        status: typeof err.statusCode === "number" ? err.statusCode : 500,
+        status,
         headers: { "Content-Type": "application/json" },
       }
     );

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -103,9 +103,13 @@ export type ServerActionRequest = {
  */
 export type ServerActionFlightCodec = {
   decodeReply: (body: string | FormData) => Promise<unknown[]>;
-  renderResponse: (payload: {
-    returnValue: unknown;
-  }) => { pipe: (destination: unknown) => unknown } | ReadableStream;
+  /**
+   * Flight-render a response payload: `{ returnValue }` for a settled action,
+   * `{ error: { message } }` for the error outcome.
+   */
+  renderResponse: (
+    payload: unknown
+  ) => { pipe: (destination: unknown) => unknown } | ReadableStream;
 };
 
 /** Reconstruct a multipart body as FormData via the standard parser. */

--- a/plugin/router/createRouter.ts
+++ b/plugin/router/createRouter.ts
@@ -32,6 +32,10 @@ export type Router<T> = {
   prefetch: (to: ToPath) => void;
   /** The (cached) flight for a url; reuses a warmed/in-flight fetch. */
   flight: (url: string) => Promise<T>;
+  /** Store an already-decoded flight for a url (a followed action redirect
+   *  delivers the target page's flight; priming it makes the navigation
+   *  swap without a second fetch). */
+  prime: (url: string, flight: T) => void;
   /** Drop a cached flight (one url, or all) so the next `flight()` refetches. */
   invalidate: (url?: string) => void;
 };
@@ -93,6 +97,7 @@ export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
       cache.prefetch(to, { fetcher: opts.fetchFlight, ttlMs: ttlFor(to) });
     },
     flight,
+    prime: (url, value) => cache.prime(url, value),
     invalidate: (url) => cache.invalidate(url),
   };
 }

--- a/plugin/router/flightCache.ts
+++ b/plugin/router/flightCache.ts
@@ -25,6 +25,9 @@ export type FlightGetOptions<T> = {
 export type FlightCache<T> = {
   get(url: string, opts: FlightGetOptions<T>): Promise<T>;
   prefetch(url: string, opts: FlightGetOptions<T>): void;
+  /** Store an already-decoded flight (e.g. one delivered by a followed
+   *  action redirect), so the next `get` for the url needs no fetch. */
+  prime(url: string, flight: T): void;
   has(url: string): boolean;
   invalidate(url?: string): void;
 };
@@ -67,6 +70,9 @@ export function createFlightCache<T>(
     get,
     prefetch: (url, opts) => {
       void get(url, opts);
+    },
+    prime: (url, flight) => {
+      store(url, { promise: Promise.resolve(flight), at: now() });
     },
     has: (url) => cache.has(url),
     invalidate: (url) => {

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -113,10 +113,15 @@ function RouteView({
   router,
   initialNode,
   rootId,
+  deliverRef,
 }: {
   router: Router<ReactNode>;
   initialNode: ReactNode;
   rootId: string;
+  /** Out-of-band delivery slot: action outcomes (refresh, not-found) swap
+   *  the view without a navigation, so they arrive here instead of through
+   *  the location effect. */
+  deliverRef?: { current: ((node: ReactNode) => void) | null };
 }) {
   const location = useLocation();
   // The view plus a GENERATION that bumps on every delivered flight: in dev
@@ -132,6 +137,14 @@ function RouteView({
     []
   );
   const shown = React.useRef<string>(router.getState().url);
+
+  React.useEffect(() => {
+    if (!deliverRef) return;
+    deliverRef.current = swap;
+    return () => {
+      deliverRef.current = null;
+    };
+  }, [deliverRef, swap]);
 
   // The matched route's head.ts contribution rides the tree as an inert
   // template (hoistables can't ride the hydration flight — see
@@ -227,6 +240,43 @@ export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
   // re-navigate (replace) to the final route so history matches the content.
   // Deferred assignment: the fetcher closure exists before the router does.
   let followRedirect: (response: Response) => void = () => {};
+  // Out-of-band view delivery for action outcomes; RouteView fills the slot.
+  const deliverRef: { current: ((node: ReactNode) => void) | null } = {
+    current: null,
+  };
+  // Server-action outcomes, wired into the router so each lands as an SPA
+  // transition: a redirect() delivers the target page (prime + navigate — no
+  // second fetch); a notFound() swaps in the 404 route's flight with the
+  // address unchanged; any successful action refreshes the current route
+  // (drop its cached flight, refetch, swap), so mutations show without the
+  // app wiring anything.
+  const callServerHooks = {
+    onRedirect: (route: string, page: unknown) => {
+      router.prime(route, page as ReactNode);
+      router.navigate(route);
+    },
+    onNotFound: () => {
+      Promise.resolve(router.flight("/404/")).then(
+        (node) => deliverRef.current?.(node),
+        () => {
+          // No decodable 404 flight on this host — leave the view alone; the
+          // action already settled.
+        },
+      );
+    },
+    onSuccess: () => {
+      const url = router.getState().url;
+      router.invalidate(url);
+      Promise.resolve(router.flight(url)).then(
+        (node) => {
+          if (router.getState().url === url) deliverRef.current?.(node);
+        },
+        () => {
+          // The refresh fetch failed; the current view stands.
+        },
+      );
+    },
+  };
   const fetchFlight = (url: string): Promise<ReactNode> =>
     Promise.resolve(
       createReactFetcher({
@@ -234,6 +284,7 @@ export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
         moduleBaseURL,
         publicOrigin,
         onResponse: (response) => followRedirect(response),
+        callServerHooks,
       }),
     ) as Promise<ReactNode>;
 
@@ -258,7 +309,12 @@ export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
     const initialNode = await router.flight(router.getState().url);
     const tree = (
       <RouterProvider router={router} patterns={patterns}>
-        <RouteView router={router} initialNode={initialNode} rootId={rootId} />
+        <RouteView
+          router={router}
+          initialNode={initialNode}
+          rootId={rootId}
+          deliverRef={deliverRef}
+        />
       </RouterProvider>
     );
     return wrap ? wrap(tree) : tree;

--- a/plugin/utils/createCallServer.ts
+++ b/plugin/utils/createCallServer.ts
@@ -10,29 +10,125 @@
 // follows the same flavor for symmetry with the server's decodeReply.
 
 import { loadBrowserFlightClient } from "./flightClient.browser.js";
+import { OUTCOME, OUTCOME_HEADER } from "./outcomeHeader.js";
+import { NOT_FOUND_FIELD } from "../router/loaderSignals.js";
 
-export const createCallServer = (moduleBaseURL: string) => {
+/**
+ * How an action's terminal outcomes reach the app. The router wires these
+ * (startClient) so outcomes land as SPA transitions; without hooks the
+ * defaults still behave correctly, just without a router: a redirect becomes
+ * a document navigation, not-found rejects with a `notFound()`-marked error
+ * (check it with `isNotFound` from the router exports), and success simply
+ * returns the value.
+ */
+export type CallServerHooks = {
+  /**
+   * A followed action `redirect()` delivered the TARGET page's decoded
+   * flight. `route` is the final route path (the address bar's new value).
+   */
+  onRedirect?: (route: string, page: unknown) => void;
+  /** The action answered the not-found outcome. */
+  onNotFound?: () => void;
+  /** A normal action response settled — the refresh/revalidation trigger. */
+  onSuccess?: () => void;
+};
+
+const routeFromFlightUrl = (url: string): string => {
+  let route = new URL(url).pathname;
+  if (route.endsWith("/index.rsc")) {
+    route = route.slice(0, -"/index.rsc".length) || "/";
+  }
+  return route;
+};
+
+export const createCallServer = (
+  moduleBaseURL: string,
+  hooks: CallServerHooks = {}
+) => {
   const callServer = async (id: string, args: unknown[]) => {
     const { createFromFetch, encodeReply } = await loadBrowserFlightClient();
-    const response = await createFromFetch(
-      fetch(moduleBaseURL, {
-        method: "POST",
-        body: await encodeReply(args),
-        headers: {
-          Accept: "text/x-component",
-          "x-rsc-action": id,
-        },
-      }),
-      { callServer, moduleBaseURL }
-    );
+    const response = await fetch(moduleBaseURL, {
+      method: "POST",
+      body: await encodeReply(args),
+      headers: {
+        Accept: "text/x-component",
+        "x-rsc-action": id,
+      },
+    });
 
-    // Check if this is a server action response
-    if (response && typeof response === "object" && "returnValue" in response) {
-      const serverResponse = response as { returnValue: unknown };
-      return serverResponse.returnValue;
+    // Terminal outcomes are a CONTRACT, not body-sniffing: the server declares
+    // them (outcome header / content type / a followed 303), and anything that
+    // is not declared flight NEVER reaches the flight decoder — a decoder fed
+    // JSON or an HTML error page throws parser garbage instead of the actual
+    // failure, which is the exact class the outcome protocol retires.
+    const declaredFlight = (response.headers.get("content-type") ?? "")
+      .includes("text/x-component");
+    const decode = () =>
+      createFromFetch(Promise.resolve(response), { callServer, moduleBaseURL });
+
+    if (response.headers.get(OUTCOME_HEADER) === OUTCOME.notFound) {
+      if (hooks.onNotFound) {
+        hooks.onNotFound();
+        return undefined;
+      }
+      const error = new Error("[vprs] server action answered notFound()");
+      Object.assign(error, { [NOT_FOUND_FIELD]: true });
+      throw error;
     }
 
-    return response;
+    // An action redirect() answers 303 to the TARGET's flight; fetch follows
+    // it transparently, so what arrived here is the target page's flight and
+    // only the address bar is behind (same shape as a followed loader
+    // redirect on a GET).
+    if (response.redirected && response.ok && declaredFlight) {
+      const route = routeFromFlightUrl(response.url);
+      const page = await decode();
+      if (hooks.onRedirect) hooks.onRedirect(route, page);
+      else if (typeof window !== "undefined") window.location.assign(route);
+      return undefined;
+    }
+
+    if (!response.ok) {
+      if (declaredFlight) {
+        // The error outcome: a flight-rendered { error: { message } }
+        // envelope. Decode it as flight — that is the point — and reject the
+        // action with the server's actual message.
+        const payload = (await decode()) as {
+          error?: { message?: string };
+        } | null;
+        throw new Error(
+          payload?.error?.message ??
+            `[vprs] server action failed (${response.status})`
+        );
+      }
+      // Legacy / codec-less JSON error (or a proxy's error page): report it
+      // without ever touching the decoder.
+      let message = `[vprs] server action failed (${response.status})`;
+      try {
+        const parsed = JSON.parse(await response.text()) as {
+          error?: unknown;
+        };
+        if (parsed?.error) message = String(parsed.error);
+      } catch {
+        // Not JSON — the status alone is the report.
+      }
+      throw new Error(message);
+    }
+
+    if (!declaredFlight) {
+      throw new Error(
+        "[vprs] server action response is not a flight payload " +
+          `(content-type ${response.headers.get("content-type") ?? "<none>"})`
+      );
+    }
+
+    const result = await decode();
+    hooks.onSuccess?.();
+
+    if (result && typeof result === "object" && "returnValue" in result) {
+      return (result as { returnValue: unknown }).returnValue;
+    }
+    return result;
   };
   return callServer;
 };

--- a/plugin/utils/createReactFetcher.ts
+++ b/plugin/utils/createReactFetcher.ts
@@ -1,5 +1,5 @@
 import type React from "react";
-import { createCallServer } from "./createCallServer.js";
+import { createCallServer, type CallServerHooks } from "./createCallServer.js";
 import { loadBrowserFlightClient } from "./flightClient.browser.js";
 import { env } from "#env";
 import { createPageURL } from "./urls.js";
@@ -103,6 +103,7 @@ export function createReactFetcher({
   },
   signal,
   onResponse,
+  callServerHooks,
 }: {
   url?: string;
   moduleBaseURL?: string;
@@ -124,6 +125,13 @@ export function createReactFetcher({
    * (`response.redirected`) and fix the address bar.
    */
   onResponse?: (response: Response) => void;
+  /**
+   * Router hooks for server-action outcomes (redirect, not-found,
+   * refresh-on-success). Every action dispatched from content decoded by this
+   * fetcher reports through them; see {@link CallServerHooks} for the
+   * hookless defaults.
+   */
+  callServerHooks?: CallServerHooks;
 } = {}): PromiseLike<React.ReactNode> {
   const parsedURL = createPageURL(
     moduleBaseURL,
@@ -145,7 +153,7 @@ export function createReactFetcher({
   // references coherent too.
   const flightBaseURL = parsedURL.moduleBaseURL.replace(/\/+$/, "");
   const decodeOptions = {
-    callServer: createCallServer(flightBaseURL),
+    callServer: createCallServer(flightBaseURL, callServerHooks),
     moduleBaseURL: flightBaseURL,
   };
 

--- a/plugin/utils/outcomeHeader.ts
+++ b/plugin/utils/outcomeHeader.ts
@@ -1,0 +1,34 @@
+/**
+ * The terminal-outcome header: `x-vprs-outcome`. A response that is NOT plain
+ * page/action content declares what it is, so clients branch on a contract
+ * instead of sniffing bodies. Values:
+ *
+ *  - `not-found` — the request resolved to the not-found outcome. A GET flight
+ *    miss carries the 404 route's flight as its body (createRequestHandler);
+ *    an action answering `notFound()` carries no body and the client router
+ *    fetches the 404 route's flight itself.
+ *  - `redirect` — an action answered `redirect()`; rides the 303 whose
+ *    `location` is the TARGET's flight. `fetch` follows it transparently, so
+ *    browser clients observe `response.redirected` instead of this header.
+ *  - `error` — the action failed; the body is a flight-rendered
+ *    `{ error: { message } }` envelope (never JSON/text for a flight client).
+ *
+ * Plain constants, importable from every runtime (browser, Node, edge bake).
+ */
+export const OUTCOME_HEADER = "x-vprs-outcome";
+
+export const OUTCOME = {
+  notFound: "not-found",
+  redirect: "redirect",
+  error: "error",
+} as const;
+
+export type Outcome = (typeof OUTCOME)[keyof typeof OUTCOME];
+
+/**
+ * The action redirect target as a flight URL: an action `redirect("/next/")`
+ * answers 303 pointing at the TARGET's flight — fetch follows it, the client
+ * decodes the target page, and the router fixes the address bar.
+ */
+export const actionRedirectLocation = (to: string): string =>
+  (to === "/" ? "" : to.replace(/\/$/, "")) + "/index.rsc";

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -12,6 +12,7 @@ import type {
   ComponentsResolvedMessage,
 } from "./types.js";
 import { toError } from "../../error/toError.js";
+import { serializeError } from "../../error/serializeError.js";
 // Transport-aware flight seams for server actions: the reply decoder for
 // arguments (text or reconstructed multipart) and the renderer for the
 // `{ returnValue }` response payload.
@@ -1412,12 +1413,53 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
           // Send success response
           effectiveHandlers.onServerActionResponse?.(msg.id, result, undefined, flight);
         } catch (error: unknown) {
-          const errorMessage = toError(error).message;
-          // Send error response
+          const err = toError(error);
+          // Loader signals (redirect()/notFound() thrown by the action)
+          // answer the transaction: cross the thread boundary as a
+          // serializeError object so the plain marker fields survive and the
+          // delegate maps them to the outcome responses.
+          if (isLoaderSignal(err)) {
+            effectiveHandlers.onServerActionResponse?.(
+              msg.id,
+              undefined,
+              serializeError(err)
+            );
+            return;
+          }
+          // The error outcome: render the { error: { message } } envelope
+          // through the SAME flight renderer as a success, so the main thread
+          // streams valid flight — never JSON/text into a flight decoder.
+          // Message only; the stack stays in this process's log.
+          let flight: string | undefined;
+          try {
+            const serverActionUserOptions = getUserOptions();
+            const renderer = resolveFlightRenderer({
+              transport: serverActionUserOptions.transport,
+              moduleBasePath: serverActionUserOptions.moduleBasePath,
+              moduleBaseURL: serverActionUserOptions.moduleBaseURL,
+            });
+            flight = await new Promise<string>((resolve, reject) => {
+              const chunks: Buffer[] = [];
+              const sink = new PassThrough();
+              sink.on("data", (chunk: Buffer) => chunks.push(chunk));
+              sink.on("end", () =>
+                resolve(Buffer.concat(chunks).toString("utf8"))
+              );
+              sink.on("error", reject);
+              const pipeable = renderer.render(
+                { error: { message: err.message } },
+                { onError: reject }
+              );
+              pipeable.pipe(sink);
+            });
+          } catch {
+            // The envelope render itself failed; the legacy JSON row stands.
+          }
           effectiveHandlers.onServerActionResponse?.(
             msg.id,
             undefined,
-            errorMessage
+            serializeError(err),
+            flight
           );
         }
         return;

--- a/plugin/worker/types.ts
+++ b/plugin/worker/types.ts
@@ -99,7 +99,9 @@ export type ServerActionResponseMessage = {
   flight?: string;
   /** Legacy raw result (pre-flight protocol); main thread JSON-rows it. */
   result?: unknown;
-  error?: string;
+  /** A string, or a serializeError object whose plain marker fields
+   *  (loader signals, tagged statusCode) survive the thread boundary. */
+  error?: string | Record<string, unknown>;
 } & WorkerMessage;
 
 export type HmrAcceptMessage = {
@@ -166,7 +168,9 @@ export type ServerOnlyStreamHandlers = {
   onServerActionResponse?: (
     id: string,
     result?: unknown,
-    error?: string,
+    /** A string, or a serializeError object whose plain marker fields
+     *  (loader signals, tagged statusCode) survive the thread boundary. */
+    error?: string | Record<string, unknown>,
     flight?: string
   ) => void;
   onError: (id: string, error: unknown, errorInfo?: { route?: string; context?: string }) => void;

--- a/test/examples/action-outcomes.test.ts
+++ b/test/examples/action-outcomes.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { createServer, type ViteDevServer } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// The user-visible half of the Flight transaction contract, in a real
+// browser against the dev server (both runner topologies via test-both):
+//
+//  - refresh: a successful action revalidates the current route — the
+//    mutated value shows WITHOUT a reload, and client-component state
+//    survives the swap.
+//  - error: a throwing action rejects with the server's message (decoded
+//    from the flight error envelope) and the page stays alive.
+//  - redirect: an action redirect() lands on the target route — address bar
+//    and content both, no document load.
+//  - notFound: an action notFound() swaps in the 404 route's flight with
+//    the address unchanged.
+//
+// The store the mutating action writes is a FILE, not module state: under
+// runner "isolated" the action executes in the plugin's process while the
+// page renders in the RSC worker, so anything less shared would prove the
+// wrong thing.
+const browserAvailable = (() => {
+  try {
+    return existsSync(chromium.executablePath());
+  } catch {
+    return false;
+  }
+})();
+if (!browserAvailable && process.env["VPRS_REQUIRE_BROWSER"]) {
+  throw new Error(
+    "VPRS_REQUIRE_BROWSER is set but Playwright Chromium is not installed"
+  );
+}
+
+const testDir = resolve(__dirname, "../fixtures/action-outcomes.test");
+const STORE = join(testDir, "store.txt");
+const PORT = 4211;
+
+async function setupFixture() {
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(join(testDir, "src/page"), { recursive: true });
+  await writeFile(STORE, "0");
+
+  await writeFile(
+    join(testDir, "src/page/actions.ts"),
+    `"use server";\n` +
+      `import { readFile, writeFile } from "node:fs/promises";\n` +
+      `import { redirect, notFound } from "vite-plugin-react-server/router";\n` +
+      `const STORE = ${JSON.stringify(STORE)};\n` +
+      `export async function bump() {\n` +
+      `  const next = Number(await readFile(STORE, "utf8")) + 1;\n` +
+      `  await writeFile(STORE, String(next));\n` +
+      `  return next;\n` +
+      `}\n` +
+      `export async function go() {\n` +
+      `  redirect("/target/");\n` +
+      `}\n` +
+      `export async function vanish() {\n` +
+      `  notFound();\n` +
+      `}\n` +
+      `export async function explode() {\n` +
+      `  throw new Error("kaboom");\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/page/Actions.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function Actions(props: {\n` +
+      `  bump: () => Promise<number>;\n` +
+      `  go: () => Promise<void>;\n` +
+      `  vanish: () => Promise<void>;\n` +
+      `  explode: () => Promise<void>;\n` +
+      `}) {\n` +
+      `  const [n, setN] = React.useState(0);\n` +
+      `  const [caught, setCaught] = React.useState("");\n` +
+      `  return (\n` +
+      `    <div>\n` +
+      `      <button id="counter" onClick={() => setN((v) => v + 1)}>{"count:" + n}</button>\n` +
+      `      <button id="bump" onClick={() => void props.bump()}>bump</button>\n` +
+      `      <button id="go" onClick={() => void props.go()}>go</button>\n` +
+      `      <button id="vanish" onClick={() => void props.vanish()}>vanish</button>\n` +
+      `      <button id="explode" onClick={() => props.explode().catch((e) => setCaught(e.message))}>explode</button>\n` +
+      `      {caught ? <output id="caught">{caught}</output> : null}\n` +
+      `    </div>\n` +
+      `  );\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/page/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Actions } from "./Actions.client.js";\n` +
+      `import { bump, go, vanish, explode } from "./actions.js";\n` +
+      `export const Page = ({ value }: { value: number }) => (\n` +
+      `  <main>\n` +
+      `    <h1 id="heading">home</h1>\n` +
+      `    <p id="value">{"value:" + value}</p>\n` +
+      `    <Actions bump={bump} go={go} vanish={vanish} explode={explode} />\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/page/target.tsx"),
+    `import * as React from "react";\n` +
+      `import { Actions } from "./Actions.client.js";\n` +
+      `import { bump, go, vanish, explode } from "./actions.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1 id="heading">target-page</h1>\n` +
+      `    <Actions bump={bump} go={go} vanish={vanish} explode={explode} />\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/page/notfound.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = () => <h1 id="heading">not-found-page</h1>;\n`
+  );
+  await writeFile(
+    join(testDir, "src/page/props.ts"),
+    `import { readFileSync } from "node:fs";\n` +
+      `const STORE = ${JSON.stringify(STORE)};\n` +
+      `export const props = () => ({ value: Number(readFileSync(STORE, "utf8")) });\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\n` +
+      `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+const pageFor = (route: string) =>
+  route.includes("target")
+    ? "src/page/target.tsx"
+    : route.includes("404")
+      ? "src/page/notfound.tsx"
+      : "src/page/page.tsx";
+
+describe.skipIf(!browserAvailable)("server-action outcomes (browser)", () => {
+  let server: ViteDevServer;
+  let browser: Browser;
+  let page: Page;
+  let port: number;
+  const documentRequests: string[] = [];
+  let documentBaseline = 0;
+
+  const text = async (selector: string) => {
+    try {
+      return await page.locator(selector).textContent({ timeout: 2000 });
+    } catch {
+      return "<none>";
+    }
+  };
+  const waitFor = (fn: () => Promise<boolean>, ms = 15000) =>
+    new Promise<void>((res, rej) => {
+      const start = Date.now();
+      const tick = async () => {
+        if (await fn()) return res();
+        if (Date.now() - start > ms) return rej(new Error("waitFor timeout"));
+        setTimeout(tick, 300);
+      };
+      void tick();
+    });
+
+  beforeAll(async () => {
+    await setupFixture();
+    const mainLeg = getCondition() === REACT_CONDITION.server;
+    server = await createServer({
+      mode: "test",
+      root: testDir,
+      esbuild: { jsx: "automatic" },
+      // Isolated dep-optimizer cache: the symlinked node_modules is shared
+      // across fixtures and a stale pre-bundle silently tests old code.
+      cacheDir: ".vite-action-outcomes-test",
+      optimizeDeps: { force: true },
+      plugins: [
+        vitePluginReactServer({
+          runner: mainLeg ? "main" : "isolated",
+          moduleBase: "src",
+          Page: pageFor,
+          props: () => "src/page/props.ts",
+          moduleBasePath: "",
+          moduleBaseURL: "/",
+          projectRoot: testDir,
+        }),
+      ],
+      server: { port: PORT },
+    });
+    await server.listen();
+    port = server.config.server.port ?? PORT;
+
+    browser = await chromium.launch();
+    page = await browser.newPage();
+    page.on("request", (r) => {
+      if (r.resourceType() === "document") documentRequests.push(r.url());
+    });
+    await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
+    await page.waitForFunction(
+      () => {
+        const b = document.querySelector("#counter") as HTMLButtonElement;
+        if (!b) return false;
+        b.click();
+        return b.textContent !== "count:0";
+      },
+      undefined,
+      { timeout: 20000, polling: 300 }
+    );
+    // Startup settles before the baseline (cold-cache re-optimize can reload
+    // once in linked dev); the contract under test is the action cycle.
+    await new Promise((r) => setTimeout(r, 1500));
+    documentBaseline = documentRequests.length;
+  }, 120000);
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("a successful action refreshes the route and client state survives", async () => {
+    expect(await text("#value")).toBe("value:0");
+    await page.click("#counter");
+    const before = await text("#counter");
+
+    await page.click("#bump");
+    await waitFor(async () => (await text("#value")) === "value:1");
+    expect(await text("#counter")).toBe(before);
+    expect(documentRequests.length).toBe(documentBaseline);
+  }, 60000);
+
+  it("a throwing action rejects with the server's message; the page stays alive", async () => {
+    await page.click("#explode");
+    await waitFor(async () => (await text("#caught")) === "kaboom");
+    // Still interactive after the failure.
+    const before = await text("#counter");
+    await page.click("#counter");
+    expect(await text("#counter")).not.toBe(before);
+    expect(documentRequests.length).toBe(documentBaseline);
+  }, 60000);
+
+  it("an action redirect() lands on the target route, address included", async () => {
+    await page.click("#go");
+    await waitFor(async () => (await text("#heading")) === "target-page");
+    expect(new URL(page.url()).pathname).toBe("/target");
+    expect(documentRequests.length).toBe(documentBaseline);
+  }, 60000);
+
+  it("an action notFound() shows the 404 route without leaving the address", async () => {
+    await page.click("#vanish");
+    await waitFor(async () => (await text("#heading")) === "not-found-page");
+    expect(new URL(page.url()).pathname).toBe("/target");
+    expect(documentRequests.length).toBe(documentBaseline);
+  }, 60000);
+});

--- a/test/examples/workerd-smoke.test.ts
+++ b/test/examples/workerd-smoke.test.ts
@@ -51,8 +51,18 @@ async function setupFixture() {
   await writeFile(
     join(testDir, "src/ping.ts"),
     `"use server";\n` +
+      `import { redirect, notFound } from "vite-plugin-react-server/router";\n` +
       `export async function ping(n: number): Promise<{ doubled: number }> {\n` +
       `  return { doubled: n * 2 };\n` +
+      `}\n` +
+      `export async function bounce() {\n` +
+      `  redirect("/next/");\n` +
+      `}\n` +
+      `export async function vanish() {\n` +
+      `  notFound();\n` +
+      `}\n` +
+      `export async function explode() {\n` +
+      `  throw new Error("edge-kaboom");\n` +
       `}\n`
   );
   await writeFile(
@@ -206,6 +216,33 @@ describe.skipIf(!Miniflare)("workerd smoke (webpack bake pair)", () => {
     });
     expect(res.status).toBe(200);
     expect(await res.text()).toContain('{"doubled":42}');
+  });
+
+  it("maps action terminal outcomes on-platform (redirect / notFound / error)", async () => {
+    const act = (id: string) =>
+      mf!.dispatchFetch("http://localhost/", {
+        method: "POST",
+        headers: { "x-rsc-action": `src/ping.ts#${id}` },
+        body: "[]",
+        redirect: "manual",
+      });
+
+    const redirected = await act("bounce");
+    expect(redirected.status).toBe(303);
+    expect(redirected.headers.get("location")).toBe("/next/index.rsc");
+    expect(redirected.headers.get("x-vprs-outcome")).toBe("redirect");
+
+    const missing = await act("vanish");
+    expect(missing.status).toBe(404);
+    expect(missing.headers.get("x-vprs-outcome")).toBe("not-found");
+    expect(await missing.text()).toBe("");
+
+    // The error outcome is VALID FLIGHT from the baked renderer, never JSON.
+    const failed = await act("explode");
+    expect(failed.status).toBe(500);
+    expect(failed.headers.get("x-vprs-outcome")).toBe("error");
+    expect(failed.headers.get("content-type")).toContain("text/x-component");
+    expect(await failed.text()).toContain("edge-kaboom");
   });
 
   it("rejects a malformed action id loudly", async () => {

--- a/test/unit/actionFlightCodecWebpack.test.ts
+++ b/test/unit/actionFlightCodecWebpack.test.ts
@@ -75,3 +75,26 @@ describe("server-action flight codec (webpack transport)", () => {
     );
   });
 });
+
+describe("server-action terminal outcomes (webpack transport)", () => {
+  it("a thrown error answers a webpack-decodable flight envelope", async () => {
+    const { createFromReadableStream } = await import(
+      "react-server-loader/webpack/client.edge"
+    );
+    const res = await handleServerActionRequest(requestFor("[]"), {
+      ...options({
+        run: () => {
+          throw new Error("webpack-kaboom");
+        },
+      }),
+      transport: "webpack",
+    });
+    expect(res.status).toBe(500);
+    expect(res.headers.get("x-vprs-outcome")).toBe("error");
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    const payload = (await createFromReadableStream(res.body as ReadableStream, {
+      serverConsumerManifest: { moduleMap: {}, serverModuleMap: null, moduleLoading: null },
+    })) as { error: { message: string } };
+    expect(payload.error.message).toBe("webpack-kaboom");
+  });
+});

--- a/test/unit/actionOutcomes.test.ts
+++ b/test/unit/actionOutcomes.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Terminal outcomes of a server action, on both handler envelopes (Web
+ * Request/Response and Node req/res):
+ *
+ *  - `redirect()` answers 303 to the TARGET's flight (fetch follows it, so
+ *    the browser client decodes the target page).
+ *  - `notFound()` answers the marker: 404 + the outcome header, no body —
+ *    the client router fetches the 404 route's flight through its own GET
+ *    path, so the shape is identical on hosts that cannot render.
+ *  - a thrown error answers VALID FLIGHT: a `{ error: { message } }`
+ *    envelope decoded with the transport's real client — never JSON/text
+ *    fed to a flight decoder. Tagged statuses (403/413) survive.
+ *
+ * Runs under the react-server condition (test:unit), where the built-in
+ * codec resolves from the vendored transport pair.
+ */
+import { describe, it, expect } from "vitest";
+import { PassThrough } from "node:stream";
+import { encodeReply, createFromReadableStream } from "react-server-dom-esm/client.edge";
+import {
+  handleServerAction,
+  handleServerActionRequest,
+} from "../../dist/plugin/helpers/handleServerAction.server.js";
+import {
+  redirect,
+  notFound,
+} from "../../dist/plugin/router/loaderSignals.js";
+import {
+  OUTCOME,
+  OUTCOME_HEADER,
+} from "../../dist/plugin/utils/outcomeHeader.js";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+type ActionModule = Record<string, (...args: never[]) => unknown>;
+
+const options = (impl: ActionModule) => ({
+  projectRoot: process.cwd(),
+  devOpen: true,
+  ssrLoadModule: async () => impl,
+});
+
+async function webRequestFor(id = "src/actions.ts#run") {
+  return new Request("https://example.test/action", {
+    method: "POST",
+    headers: { "x-rsc-action": id },
+    body: (await encodeReply([])) as string,
+  });
+}
+
+/**
+ * A Node ServerResponse stand-in the flight renderer can PIPE into: a real
+ * writable (PassThrough) carrying statusCode/headers, with the written body
+ * collected for decoding.
+ */
+function nodeResponse() {
+  const stream = new PassThrough();
+  const headers: Record<string, string> = {};
+  const chunks: Buffer[] = [];
+  stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+  const res = Object.assign(stream, {
+    statusCode: 200,
+    headersSent: false,
+    setHeader: (key: string, value: string) => {
+      headers[key.toLowerCase()] = value;
+    },
+  });
+  const finished = new Promise<void>((resolve) => stream.on("finish", () => resolve()));
+  return {
+    res: res as unknown as ServerResponse,
+    headers,
+    finished,
+    body: () => Buffer.concat(chunks),
+    status: () => res.statusCode,
+  };
+}
+
+async function nodeRequestFor(id = "src/actions.ts#run") {
+  const body = (await encodeReply([])) as string;
+  const req = new PassThrough();
+  req.end(body);
+  return Object.assign(req, {
+    method: "POST",
+    url: "/action",
+    headers: {
+      "x-rsc-action": id,
+      "content-type": "text/plain;charset=UTF-8",
+    },
+  }) as unknown as IncomingMessage;
+}
+
+const decodeFlight = async (bytes: Uint8Array | ReadableStream) => {
+  const stream =
+    bytes instanceof Uint8Array
+      ? new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(bytes);
+            controller.close();
+          },
+        })
+      : bytes;
+  return createFromReadableStream(stream, { moduleBaseURL: "/" });
+};
+
+describe("server-action terminal outcomes (Web handler)", () => {
+  it("redirect() answers 303 to the target's flight", async () => {
+    const res = await handleServerActionRequest(
+      await webRequestFor(),
+      options({ run: () => redirect("/next/") })
+    );
+    expect(res.status).toBe(303);
+    expect(res.headers.get("location")).toBe("/next/index.rsc");
+    expect(res.headers.get(OUTCOME_HEADER)).toBe(OUTCOME.redirect);
+  });
+
+  it("redirect('/') maps to the root flight", async () => {
+    const res = await handleServerActionRequest(
+      await webRequestFor(),
+      options({ run: () => redirect("/") })
+    );
+    expect(res.headers.get("location")).toBe("/index.rsc");
+  });
+
+  it("notFound() answers the bodyless 404 marker", async () => {
+    const res = await handleServerActionRequest(
+      await webRequestFor(),
+      options({ run: () => notFound() })
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get(OUTCOME_HEADER)).toBe(OUTCOME.notFound);
+    expect(await res.text()).toBe("");
+  });
+
+  it("a thrown error answers a decodable flight envelope, not JSON", async () => {
+    const res = await handleServerActionRequest(
+      await webRequestFor(),
+      options({
+        run: () => {
+          throw new Error("kaboom");
+        },
+      })
+    );
+    expect(res.status).toBe(500);
+    expect(res.headers.get(OUTCOME_HEADER)).toBe(OUTCOME.error);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    const payload = (await decodeFlight(res.body as ReadableStream)) as {
+      error: { message: string };
+    };
+    expect(payload.error.message).toBe("kaboom");
+  });
+
+  it("a tagged status (413) survives onto the error outcome", async () => {
+    const res = await handleServerActionRequest(
+      await webRequestFor(),
+      options({
+        run: () => {
+          const err = new Error("too big") as Error & { statusCode?: number };
+          err.statusCode = 413;
+          throw err;
+        },
+      })
+    );
+    expect(res.status).toBe(413);
+    expect(res.headers.get(OUTCOME_HEADER)).toBe(OUTCOME.error);
+  });
+});
+
+describe("server-action terminal outcomes (Node handler)", () => {
+  it("redirect() answers 303 to the target's flight", async () => {
+    const { res, headers, status } = nodeResponse();
+    await handleServerAction(
+      await nodeRequestFor(),
+      res,
+      options({ run: () => redirect("/next/") })
+    );
+    expect(status()).toBe(303);
+    expect(headers["location"]).toBe("/next/index.rsc");
+    expect(headers[OUTCOME_HEADER]).toBe(OUTCOME.redirect);
+  });
+
+  it("notFound() answers the bodyless 404 marker", async () => {
+    const { res, headers, status, finished, body } = nodeResponse();
+    await handleServerAction(
+      await nodeRequestFor(),
+      res,
+      options({ run: () => notFound() })
+    );
+    await finished;
+    expect(status()).toBe(404);
+    expect(headers[OUTCOME_HEADER]).toBe(OUTCOME.notFound);
+    expect(body().length).toBe(0);
+  });
+
+  it("a thrown error answers a decodable flight envelope, not JSON", async () => {
+    const { res, headers, status, finished, body } = nodeResponse();
+    await handleServerAction(
+      await nodeRequestFor(),
+      res,
+      options({
+        run: () => {
+          throw new Error("kaboom");
+        },
+      })
+    );
+    await finished;
+    expect(status()).toBe(500);
+    expect(headers[OUTCOME_HEADER]).toBe(OUTCOME.error);
+    expect(headers["content-type"]).toContain("text/x-component");
+    const payload = (await decodeFlight(new Uint8Array(body()))) as {
+      error: { message: string };
+    };
+    expect(payload.error.message).toBe("kaboom");
+  });
+});

--- a/test/unit/export-parity.test.ts
+++ b/test/unit/export-parity.test.ts
@@ -302,7 +302,13 @@ const STATIC_ASYMMETRIC: Record<string, { serverOnly: string[]; browserOnly: str
       // rsc-worker instead.
       "resolveActionFlightCodec",
     ],
-    browserOnly: ["delegateServerActionToWorker"],
+    browserOnly: [
+      "delegateServerActionToWorker",
+      // The worker delegates' shared outcome writer: maps the terminal
+      // outcomes onto the HTTP response in the non-react-server process; the
+      // server side answers outcomes inside its own handlers instead.
+      "writeServerActionOutcome",
+    ],
   },
   "./react-static": {
     serverOnly: ["collectHtmlContent"],

--- a/test/unit/flightClientChooser.test.ts
+++ b/test/unit/flightClientChooser.test.ts
@@ -64,7 +64,10 @@ describe("createCallServer transport dispatch", () => {
       "fetch",
       vi.fn(async (_url: unknown, init?: RequestInit) => {
         seen.push(init ?? {});
-        return new Response("", { status: 200 });
+        return new Response("", {
+          status: 200,
+          headers: { "content-type": "text/x-component" },
+        });
       })
     );
     const result = await createCallServer("/")("some/action#run", [1]);
@@ -78,7 +81,13 @@ describe("createCallServer transport dispatch", () => {
     );
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response("", { status: 200 }))
+      vi.fn(
+        async () =>
+          new Response("", {
+            status: 200,
+            headers: { "content-type": "text/x-component" },
+          })
+      )
     );
     const result = await createCallServer("/")("some/action#run", [1]);
     expect(result).toBe("esm");


### PR DESCRIPTION
Closes the transaction-contract gap for server actions: every action now ends in one of four DECLARED wire shapes, and the flight decoder never receives anything it cannot read.

## The contract

| Outcome | The action | The response | The router client |
|---|---|---|---|
| return | returns a value | 200, flight `{ returnValue }` | resolves with the value, then refreshes the current route (invalidate, refetch, swap) so mutations show without app wiring |
| redirect | throws `redirect(to)` | 303 to the target's flight, `x-vprs-outcome: redirect` | fetch follows; the decoded response IS the target page — cache primed, one round trip, address bar updated, no document load |
| not found | throws `notFound()` | 404, `x-vprs-outcome: not-found`, no body | fetches the `/404/` route's flight through its own cached GET path and swaps it in; address stays |
| error | throws anything else | tagged status (403/413) or 500, `x-vprs-outcome: error`, flight `{ error: { message } }` | rejects the action call with the server's message (message only, never the stack) |

The signals are the loaders' own `redirect()`/`notFound()`, so loader and action control flow are one model.

## Identical across every topology

- The shared react-server core answers outcomes once — Node, Web, and the baked edge gate all inherit it (`handleServerActionRequest` is what the bake bundles).
- Both worker delegates (dev isolated) share one `writeServerActionOutcome`; the worker crosses the thread boundary as a `serializeError` object so marker fields survive, and renders the error envelope with its own transport renderer.
- Codec-less hosts keep the legacy JSON error row; the client refuses to decode anything not declared `text/x-component`, so the decoder-garbage class is closed from both ends.
- Hookless consumers (bare `createReactFetcher`) get safe defaults: document navigation on redirect, a `notFound()`-marked rejection, no decode of non-flight.

## Proofs

- Unit: both handler envelopes (redirect location mapping, bodyless 404 marker, decodable error envelope with the real esm client, tagged 413), plus the webpack-transport error envelope with the real webpack client.
- Browser (both runner topologies, in the fail-closed CI job): successful action refreshes the route with client state surviving; a throwing action rejects with the server's message and the page stays alive; redirect lands on the target (address + content, no document load); notFound swaps in the 404 route with the address unchanged.
- workerd: the baked edge maps all three outcomes on-platform (303 + location + header, bodyless 404, flight error envelope), on real miniflare.

docs/server-actions.md gains the outcome table; the router's flight cache gains `prime()` (redirect delivery without a refetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA