### PR TITLE
fix: prerender failure semantics pinned, and the pins found three real gaps

### DIFF
--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -1074,6 +1074,13 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
       autoDiscover: autoDiscover,
       loader: loader,
       pipeableStreamOptions,
+      // The VARIANT stream options must survive resolution: dropping them
+      // here silently discarded a consumer's explicit
+      // clientPipeableStreamOptions (progressiveChunkSize included) on every
+      // path downstream. The legacy shared bag backfills the server variant.
+      serverPipeableStreamOptions:
+        options.serverPipeableStreamOptions ?? options.pipeableStreamOptions,
+      clientPipeableStreamOptions: options.clientPipeableStreamOptions,
       rscTimeout:
         typeof options.rscTimeout === "number"
           ? options.rscTimeout

--- a/plugin/stream/createRenderToPipeableStreamHandler.client.ts
+++ b/plugin/stream/createRenderToPipeableStreamHandler.client.ts
@@ -113,6 +113,22 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
       // keeps streaming semantics by default.
       const controller = new AbortController();
       abortRender = () => controller.abort();
+      // A prerender waits for EVERY boundary, so a render that never settles
+      // (a hung data source) would wait forever — htmlTimeout turns that into
+      // a clean rejection through the same signal the consumer's abort uses.
+      const timeoutMs = (options as { htmlTimeout?: number }).htmlTimeout;
+      const timeout =
+        typeof timeoutMs === "number" && timeoutMs > 0
+          ? setTimeout(
+              () =>
+                controller.abort(
+                  new Error(
+                    `[createRenderToPipeableStreamHandler.client:${route}] prerender did not complete within htmlTimeout (${timeoutMs}ms)`
+                  )
+                ),
+              timeoutMs
+            )
+          : null;
       void import("react-dom/static").then(
         async ({ prerenderToNodeStream }) => {
           try {
@@ -139,14 +155,27 @@ export const createRenderToPipeableStreamHandler: CreateRenderToPipeableStreamHa
                 reportRenderError(error);
               },
             } as never);
+            if (timeout) clearTimeout(timeout);
+            // An abort AFTER the shell resolves the prerender with fallback
+            // markup and client-render holes — a degraded document. A static
+            // build must fail instead of silently writing it.
+            if (controller.signal.aborted) {
+              throw controller.signal.reason ?? new Error("prerender aborted");
+            }
             prelude.pipe(htmlStream);
           } catch (error) {
+            if (timeout) clearTimeout(timeout);
             // A SHELL error REJECTS here (react-dom/static has no
-            // onShellError seam). Destroy the output so downstream settles
-            // (the guarded pipe below propagates), and route the panic logic.
-            reportRenderError(error);
+            // onShellError seam), and so does an htmlTimeout abort — the
+            // signal's reason carries the message. Destroy the output so
+            // downstream settles (the guarded pipe below propagates), and
+            // route the panic logic.
+            const cause = controller.signal.aborted
+              ? (controller.signal.reason ?? error)
+              : error;
+            reportRenderError(cause);
             htmlStream.destroy(
-              error instanceof Error ? error : new Error(String(error))
+              cause instanceof Error ? cause : new Error(String(cause))
             );
           }
         }

--- a/plugin/worker/html/handleHtmlRender.client.ts
+++ b/plugin/worker/html/handleHtmlRender.client.ts
@@ -142,10 +142,28 @@ export const handleHtmlRender: HandleHtmlRenderFn = async function _handleHtmlRe
           callback();
         },
       });
+      // Same clean-failure contract as the client-condition seam: a
+      // prerender waits for EVERY boundary, so a render that never settles
+      // trips htmlTimeout into an abort instead of hanging the build.
+      const prerenderController = new AbortController();
+      const prerenderTimeoutMs = workerData.userOptions?.htmlTimeout;
+      const prerenderTimeout =
+        typeof prerenderTimeoutMs === "number" && prerenderTimeoutMs > 0
+          ? setTimeout(
+              () =>
+                prerenderController.abort(
+                  new Error(
+                    `[html-worker:${route}] prerender did not complete within htmlTimeout (${prerenderTimeoutMs}ms)`
+                  )
+                ),
+              prerenderTimeoutMs
+            )
+          : null;
       try {
         const { prerenderToNodeStream } = await import("react-dom/static");
         const { prelude } = await prerenderToNodeStream(result.children, {
           ...mergedPipeableStreamOptions,
+          signal: prerenderController.signal,
           // A static file has no progressive delivery: without this, React
           // OUTLINES boundary content larger than the default progressive
           // chunk size (~12KB) behind a $RC swap script even in a completed
@@ -163,19 +181,34 @@ export const handleHtmlRender: HandleHtmlRenderFn = async function _handleHtmlRe
             mergedPipeableStreamOptions?.onError?.(error, errorInfo as never);
           },
         } as never);
+        if (prerenderTimeout) clearTimeout(prerenderTimeout);
+        // An abort AFTER the shell resolves the prerender with fallback
+        // markup and client-render holes — a degraded document. A static
+        // build must fail instead of silently writing it.
+        if (prerenderController.signal.aborted) {
+          throw (
+            prerenderController.signal.reason ?? new Error("prerender aborted")
+          );
+        }
         prelude.pipe(prerenderWritable);
       } catch (error) {
-        // A SHELL error REJECTS (react-dom/static has no onShellError seam):
-        // nothing was piped; the ERROR message lets the main thread destroy
-        // its stream, exactly like the streaming path's shell failure.
+        if (prerenderTimeout) clearTimeout(prerenderTimeout);
+        // A SHELL error REJECTS (react-dom/static has no onShellError seam),
+        // and so does an htmlTimeout abort — the signal's reason carries the
+        // message. Nothing was piped; the ERROR message lets the main thread
+        // destroy its stream, exactly like the streaming path's shell
+        // failure.
+        const cause = prerenderController.signal.aborted
+          ? (prerenderController.signal.reason ?? error)
+          : error;
         logger.error(
-          `[html-worker:${route}] HTML static prerender failed (nothing was piped): ${error}`
+          `[html-worker:${route}] HTML static prerender failed (nothing was piped): ${cause}`
         );
-        handlers.onError(route, error, {
+        handlers.onError(route, cause, {
           componentStack: undefined,
           digest: undefined,
         });
-        mergedPipeableStreamOptions?.onShellError?.(error);
+        mergedPipeableStreamOptions?.onShellError?.(cause);
       }
       // RSC stream errors surface the same way in both modes.
       rscStream.on("error", (error) => {

--- a/test/examples/prerender-failure-semantics.test.ts
+++ b/test/examples/prerender-failure-semantics.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { symlink } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { resolve, join } from "node:path";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// The prerender port's FAILURE semantics, pinned by building instead of by
+// reading (both seams via test-both: the client-condition handler on the
+// main-runner leg, the html-worker INIT prerender on the isolated leg):
+//
+//  1. a page that throws at the SHELL during SSG fails the build loudly with
+//     the error named — never a hang, never a half artifact on disk;
+//  2. a render that never completes trips htmlTimeout into a clean failure;
+//  3. an EXPLICIT consumer progressiveChunkSize is honored — the static
+//     1<<30 default applies only when unset, so a small explicit value
+//     outlines the boundary back into the streamed shape on purpose.
+const testDir = resolve(
+  __dirname,
+  "../fixtures/prerender-failure-semantics.test"
+);
+
+const PAGE = join(testDir, "src/routes/page.tsx");
+
+const GOOD_SUSPENDED_PAGE =
+  `import * as React from "react";\n` +
+  `import { Suspense } from "react";\n` +
+  `async function Delayed() {\n` +
+  `  await new Promise((r) => setTimeout(r, 30));\n` +
+  `  return (\n` +
+  `    <section data-resolved="yes">\n` +
+  `      {Array.from({ length: 300 }, (_, i) => (\n` +
+  `        <p key={i}>resolved-row-{i}-padding-to-split-the-flush</p>\n` +
+  `      ))}\n` +
+  `    </section>\n` +
+  `  );\n` +
+  `}\n` +
+  `export const Page = () => (\n` +
+  `  <main>\n` +
+  `    <h1>{"prerender-semantics"}</h1>\n` +
+  `    <Suspense fallback={<div id="fallback">{"loading"}</div>}>\n` +
+  `      <Delayed />\n` +
+  `    </Suspense>\n` +
+  `  </main>\n` +
+  `);\n`;
+
+const SHELL_THROW_PAGE =
+  `import * as React from "react";\n` +
+  `export const Page = () => {\n` +
+  `  throw new Error("shell-boom");\n` +
+  `};\n`;
+
+// The hang lives in the HTML PRERENDER, not the flight: a client component
+// that suspends forever during SSR. The flight completes (the component is a
+// reference row), so this isolates the seam htmlTimeout guards — a server
+// component that never resolves would hang the RSC render first, a separate
+// (pre-existing) timeout surface.
+const NEVER_RESOLVES_PAGE =
+  `import * as React from "react";\n` +
+  `import { Suspense } from "react";\n` +
+  `import { Stuck } from "./Stuck.client.js";\n` +
+  `export const Page = () => (\n` +
+  `  <main>\n` +
+  `    <Suspense fallback={<div>{"loading"}</div>}>\n` +
+  `      <Stuck />\n` +
+  `    </Suspense>\n` +
+  `  </main>\n` +
+  `);\n`;
+
+async function setupFixture() {
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(join(testDir, "src/routes"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/routes/Stuck.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `const never = new Promise<never>(() => {});\n` +
+      `export function Stuck() {\n` +
+      `  React.use(never);\n` +
+      `  return null;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>`
+  );
+  await writeFile(
+    join(testDir, "build.mjs"),
+    `import { readFileSync } from "node:fs";\n` +
+      `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+      `const extra = JSON.parse(readFileSync("case.json", "utf8"));\n` +
+      `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: process.env.VPRS_TEST_RUNNER,\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: fr.Page,\n` +
+      `    props: fr.props,\n` +
+      `    routePatterns: fr.routePatterns,\n` +
+      `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `    ...extra,\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("PRERENDER_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+function build(extraOptions: Record<string, unknown>) {
+  const mainLeg = getCondition() === REACT_CONDITION.server;
+  const env = {
+    ...process.env,
+    NODE_ENV: "production",
+    VPRS_TEST_RUNNER: mainLeg ? "main" : "isolated",
+  };
+  env["NODE_OPTIONS"] = mainLeg ? "--conditions react-server" : "";
+  return spawnSync("node", ["build.mjs"], {
+    cwd: testDir,
+    encoding: "utf8",
+    // Generous for a build, tight enough that a hung prerender FAILS the
+    // test instead of eating the suite's budget: pin 1's "never a hang".
+    timeout: 150000,
+    env,
+  });
+}
+
+const writeCase = async (page: string, extra: Record<string, unknown>) => {
+  await rm(join(testDir, "dist"), { recursive: true, force: true });
+  await writeFile(PAGE, page);
+  await writeFile(join(testDir, "case.json"), JSON.stringify(extra));
+};
+
+describe("prerender failure semantics (SSG builds, spawned)", () => {
+  beforeAll(setupFixture, 60000);
+  afterAll(async () => {
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("a SHELL throw fails the build loudly and leaves no artifact", async () => {
+    await writeCase(SHELL_THROW_PAGE, {});
+    const proc = build({});
+    expect(proc.status, `expected a failing build:\n${proc.stdout}`).not.toBe(0);
+    const output = proc.stdout + proc.stderr;
+    expect(output).toContain("shell-boom");
+    // A failed build's dist may retain Vite's RAW entry template (the prune
+    // only runs on success) — the pin is that no RENDERED or degraded
+    // document was written for the failed route.
+    const artifact = join(testDir, "dist/static/index.html");
+    if (existsSync(artifact)) {
+      const { readFileSync } = await import("node:fs");
+      const html = readFileSync(artifact, "utf8");
+      expect(html).not.toContain("prerender-semantics");
+      expect(html).not.toContain("shell-boom");
+    }
+  }, 180000);
+
+  it("a render that never completes trips htmlTimeout into a clean failure", async () => {
+    await writeCase(NEVER_RESOLVES_PAGE, { htmlTimeout: 5000 });
+    const proc = build({});
+    expect(proc.error, "the build HUNG past the spawn timeout").toBeUndefined();
+    expect(proc.status, `expected a failing build:\n${proc.stdout}`).not.toBe(0);
+    // The two seams name it differently: the prerender abort says
+    // htmlTimeout; the main-runner leg's stream watchdog reports the abort.
+    // Both are the same contract — a failure that NAMES a timeout.
+    const output = proc.stdout + proc.stderr;
+    expect(output).toMatch(/htmlTimeout|aborted due to timeout/i);
+  }, 180000);
+
+  it("an explicit progressiveChunkSize is honored over the static default", async () => {
+    await writeCase(GOOD_SUSPENDED_PAGE, {
+      clientPipeableStreamOptions: { progressiveChunkSize: 256 },
+    });
+    const proc = build({});
+    expect(
+      proc.stdout,
+      `build failed (status ${proc.status}):\n${proc.stderr}`
+    ).toContain("PRERENDER_BUILD_OK");
+    const { readFileSync } = await import("node:fs");
+    const html = readFileSync(join(testDir, "dist/static/index.html"), "utf8");
+    // 256 bytes cannot hold the 300-row boundary: React outlines it into the
+    // streamed shape — which is exactly what an EXPLICIT chunk size asks for.
+    expect(html).toContain("<template");
+    // And the unset default (1<<30) is what the artifact-contract suites pin
+    // as the opposite: no templates at all (static-suspense-hydration).
+  }, 180000);
+});


### PR DESCRIPTION
4.0 coverage closer: the prerender port mapped react-dom/static's rejection model onto the panic policy by reading, not by test. Building the failure cases found three real gaps, all fixed here:

1. **`resolveOptions` dropped the variant stream options.** `serverPipeableStreamOptions` and `clientPipeableStreamOptions` never made it into the resolved object, so a consumer's explicit `progressiveChunkSize` (and every other variant stream option) silently died at config time on all paths. They now survive resolution; the legacy shared `pipeableStreamOptions` backfills the server variant.
2. **`htmlTimeout` never reached the prerender seams.** A prerender that never settles (a client component suspending forever in SSR) hung the isolated-leg build past any budget. Both seams — the client-condition handler and the html-worker INIT prerender — now arm an AbortController from `htmlTimeout`.
3. **An aborted prerender wrote a degraded document with exit 0.** An abort AFTER the shell *resolves* a prerender with fallback markup and client-render holes, and the build wrote that file silently. An aborted prerender is now a build failure in both seams, never an artifact.

The pins (`prerender-failure-semantics.test.ts`, spawned production builds, both runner topologies):
- a SHELL throw fails the build naming the error, and no rendered or degraded document lands on disk (a failed build's dist may retain Vite's raw entry template — the prune only runs on success);
- a render that never completes fails cleanly NAMING a timeout (the prerender abort says `htmlTimeout`; the main-runner leg's stream watchdog reports the abort — same contract, different watchdog);
- an explicit `progressiveChunkSize` outlines the boundary back into the streamed shape on purpose, proving the static `1<<30` default applies only when unset.

Full gate green under both conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA