### PR TITLE
fix(router): history and hrefs compose the deploy base

### DIFF
--- a/plugin/router/createRouter.ts
+++ b/plugin/router/createRouter.ts
@@ -14,6 +14,13 @@ export type RouterState = { url: string; shownUrl: string };
 export type CreateRouterOptions<T> = {
   /** Fetch the RSC flight for a url (e.g. createReactFetcher({ url })). */
   fetchFlight: (url: string) => T | Promise<T>;
+  /**
+   * Subpath the app is deployed under (a GH-Pages-style base, e.g. "/app/").
+   * Router STATE stays app-relative; the base is composed exactly at the
+   * document boundary — history writes and <Link> hrefs — and stripped when
+   * reading window.location. Default "/".
+   */
+  base?: string;
   /** Whether a url is a dynamic route → its flight gets a short cache ttl. */
   isDynamic?: (url: string) => boolean;
   /** Cache ttl (ms) for dynamic-route flights. Default 2000. */
@@ -30,16 +37,37 @@ export type Router<T> = {
    *  pending window that `useNavigation()` reports. */
   markShown: (url: string) => void;
   prefetch: (to: ToPath) => void;
+  /** The document href for an app-relative path (the base composed in) —
+   *  what <Link> renders so open-in-new-tab works under a subpath deploy. */
+  toHref: (to: ToPath) => string;
   /** The (cached) flight for a url; reuses a warmed/in-flight fetch. */
   flight: (url: string) => Promise<T>;
   /** Drop a cached flight (one url, or all) so the next `flight()` refetches. */
   invalidate: (url?: string) => void;
 };
 
-const currentUrl = () =>
-  typeof location === "undefined" ? "/" : location.pathname + location.search;
+const normalizeBase = (base?: string): string => {
+  if (!base || base === "/") return "/";
+  let b = base;
+  if (!b.startsWith("/")) b = `/${b}`;
+  if (!b.endsWith("/")) b = `${b}/`;
+  return b;
+};
 
 export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
+  const base = normalizeBase(opts.base);
+  // App-relative on the inside, based at the document boundary: reading the
+  // location strips the base; history writes and hrefs compose it back. With
+  // the default "/" both are identity.
+  const stripBase = (url: string): string =>
+    base !== "/" && url.startsWith(base) ? url.slice(base.length - 1) : url;
+  const withBase = (to: string): string =>
+    base === "/" ? to : base.slice(0, -1) + to;
+  const currentUrl = () =>
+    typeof location === "undefined"
+      ? "/"
+      : stripBase(location.pathname) + location.search;
+
   const cache = opts.cache ?? createFlightCache<T>();
   const listeners = new Set<() => void>();
   const initialUrl = currentUrl();
@@ -79,8 +107,9 @@ export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
     navigate: (to, { replace = false } = {}) => {
       void flight(to); // warm (or reuse a prefetch) before we swap
       if (typeof history !== "undefined") {
-        if (replace) history.replaceState({ url: to }, "", to);
-        else history.pushState({ url: to }, "", to);
+        const href = withBase(to);
+        if (replace) history.replaceState({ url: to }, "", href);
+        else history.pushState({ url: to }, "", href);
       }
       setUrl(to);
     },
@@ -93,6 +122,7 @@ export function createRouter<T>(opts: CreateRouterOptions<T>): Router<T> {
       cache.prefetch(to, { fetcher: opts.fetchFlight, ttlMs: ttlFor(to) });
     },
     flight,
+    toHref: (to) => withBase(to),
     invalidate: (url) => cache.invalidate(url),
   };
 }

--- a/plugin/router/link.tsx
+++ b/plugin/router/link.tsx
@@ -75,7 +75,7 @@ export function Link({
 
   return (
     <a
-      href={to}
+      href={router ? router.toHref(to) : to}
       target={target}
       data-pending={pending || undefined}
       aria-busy={pending || undefined}

--- a/plugin/router/startClient.tsx
+++ b/plugin/router/startClient.tsx
@@ -227,6 +227,22 @@ export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
   // re-navigate (replace) to the final route so history matches the content.
   // Deferred assignment: the fetcher closure exists before the router does.
   let followRedirect: (response: Response) => void = () => {};
+  // The deploy base (a subpath like "/app/"), derived from moduleBaseURL's
+  // path. The router keeps app-relative state and composes/strips this at
+  // the document boundary; redirect follows below strip it the same way.
+  let basePath = "/";
+  if (moduleBaseURL) {
+    try {
+      basePath = new URL(moduleBaseURL, "http://placeholder.local").pathname;
+      if (!basePath.endsWith("/")) basePath += "/";
+    } catch {
+      basePath = "/";
+    }
+  }
+  const stripBasePath = (pathname: string): string =>
+    basePath !== "/" && pathname.startsWith(basePath)
+      ? pathname.slice(basePath.length - 1)
+      : pathname;
   const fetchFlight = (url: string): Promise<ReactNode> =>
     Promise.resolve(
       createReactFetcher({
@@ -237,10 +253,15 @@ export function startClient(opts: StartClientOptions = {}): Router<ReactNode> {
       }),
     ) as Promise<ReactNode>;
 
-  const router = createRouter<ReactNode>({ fetchFlight, isDynamic, dynamicTtlMs });
+  const router = createRouter<ReactNode>({
+    fetchFlight,
+    isDynamic,
+    dynamicTtlMs,
+    base: basePath,
+  });
   followRedirect = (response) => {
     if (!response.redirected || !response.ok) return;
-    let finalRoute = new URL(response.url).pathname;
+    let finalRoute = stripBasePath(new URL(response.url).pathname);
     if (finalRoute.endsWith("/index.rsc")) {
       finalRoute = finalRoute.slice(0, -"/index.rsc".length) || "/";
     }

--- a/test/examples/static-subpath-contracts.test.ts
+++ b/test/examples/static-subpath-contracts.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { spawnSync } from "node:child_process";
+import { resolve, join, extname } from "node:path";
+import { readFile } from "node:fs/promises";
+import { chromium } from "playwright";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// The subpath-deploy leg for the 4.0 static contracts, per the standing
+// lesson that dev+root+single-load gives false passes. One GH-Pages-style
+// build (base "/app/") pins, under the base, everything the root-based
+// suites pin at "/":
+//   - the prerendered suspended artifact carries final markup and HYDRATES
+//     (a client component inside the boundary answers clicks);
+//   - client navigation is exactly ONE .rsc GET against the BASED url, no
+//     document re-request, session survives;
+//   - a navigation miss answered with the 404 route's flight (the #394
+//     outcome, as a based host serves it) swaps the 404 view in without
+//     leaving the SPA.
+const browserAvailable = (() => {
+  try {
+    return existsSync(chromium.executablePath());
+  } catch {
+    return false;
+  }
+})();
+if (!browserAvailable && process.env["VPRS_REQUIRE_BROWSER"]) {
+  throw new Error(
+    "VPRS_REQUIRE_BROWSER is set but Playwright Chromium is not installed"
+  );
+}
+
+const testDir = resolve(__dirname, "../fixtures/static-subpath-contracts.test");
+const PORT = 4219;
+const BASE = "/app/";
+
+const MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript",
+  ".mjs": "text/javascript",
+  ".css": "text/css",
+  ".map": "application/json",
+  ".rsc": "application/octet-stream",
+};
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/routes/about"), { recursive: true });
+  await mkdir(join(testDir, "src/routes/404"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function Counter({ id }: { id: string }) {\n` +
+      `  const [n, setN] = React.useState(0);\n` +
+      `  return (\n` +
+      `    <button id={id} onClick={() => setN((v) => v + 1)}>\n` +
+      `      {"count:" + n}\n` +
+      `    </button>\n` +
+      `  );\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/NavLink.client.tsx"),
+    `"use client";\n` +
+      `export { Link } from "vite-plugin-react-server/router/client";\n`
+  );
+  // The home page carries a suspended boundary WITH the interactive client
+  // component inside it, so the based artifact contract and based hydration
+  // are proven at the same spot the root-based suite proves them.
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Suspense } from "react";\n` +
+      `import { Link } from "./NavLink.client.js";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `async function Delayed() {\n` +
+      `  await new Promise((r) => setTimeout(r, 30));\n` +
+      `  return (\n` +
+      `    <section data-resolved="yes">\n` +
+      `      <Counter id="home-counter" />\n` +
+      `      {Array.from({ length: 300 }, (_, i) => (\n` +
+      `        <p key={i}>resolved-row-{i}-padding-to-split-the-flush</p>\n` +
+      `      ))}\n` +
+      `    </section>\n` +
+      `  );\n` +
+      `}\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1 id="heading">{"home"}</h1>\n` +
+      `    <Link id="to-about" to="/about/">{"go to about"}</Link>\n` +
+      `    <Link id="to-void" to="/void/">{"go nowhere"}</Link>\n` +
+      `    <Suspense fallback={<div id="fallback">{"loading"}</div>}>\n` +
+      `      <Delayed />\n` +
+      `    </Suspense>\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/about/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Counter } from "../Counter.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1 id="heading">{"about"}</h1>\n` +
+      `    <Counter id="about-counter" />\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/404/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = () => <h1 id="heading">{"not-found-page"}</h1>;\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\n` +
+      `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: ${JSON.stringify(BASE)} });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+/**
+ * A GH-Pages-style host: everything lives UNDER the base. Requests outside
+ * the base 404; a flight request that misses is answered with the
+ * prerendered 404 route's flight and the not-found outcome header (what a
+ * vprs-aware based host — createRequestHandler behind a base-stripping
+ * mount — serves per the #394 contract).
+ */
+function serveBased(roots: string[]): Server {
+  return createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+    let pathname = decodeURIComponent(url.pathname).replace(/\/{2,}/g, "/");
+    if (!pathname.startsWith(BASE)) {
+      res.writeHead(404, { "content-type": "text/plain" });
+      return void res.end("outside base");
+    }
+    pathname = pathname.slice(BASE.length - 1); // keep the leading slash
+    if (pathname.endsWith("/")) pathname += "index.html";
+    else if (!extname(pathname)) pathname += "/index.html";
+    for (const root of roots) {
+      const file = join(root, pathname);
+      if (existsSync(file) && file.startsWith(root)) {
+        res.writeHead(200, {
+          "content-type": MIME[extname(file)] ?? "application/octet-stream",
+        });
+        res.end(readFileSync(file));
+        return;
+      }
+    }
+    if (pathname.endsWith(".rsc")) {
+      const notFoundFlight = join(roots[0]!, "404/index.rsc");
+      if (existsSync(notFoundFlight)) {
+        res.writeHead(404, {
+          "content-type": "text/x-component; charset=utf-8",
+          "x-vprs-outcome": "not-found",
+        });
+        return void res.end(readFileSync(notFoundFlight));
+      }
+    }
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+}
+
+describe.skipIf(!browserAvailable)(
+  "subpath deploy — the static contracts hold under a GH-Pages-style base",
+  () => {
+    let server: Server | undefined;
+    let html = "";
+
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+
+      // Spawned production build (see static-suspense-hydration for the
+      // NODE_ENV rationale); the runner follows this leg's condition.
+      const mainLeg = getCondition() === REACT_CONDITION.server;
+      await writeFile(
+        join(testDir, "build.mjs"),
+        `import { createBuilder } from "vite";\n` +
+          `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+          `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+          `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+          `const builder = await createBuilder({\n` +
+          `  configFile: false,\n` +
+          `  root: process.cwd(),\n` +
+          `  base: ${JSON.stringify(BASE)},\n` +
+          `  mode: "production",\n` +
+          `  esbuild: { jsx: "automatic" },\n` +
+          `  plugins: vitePluginReactServer({\n` +
+          `    runner: ${JSON.stringify(mainLeg ? "main" : "isolated")},\n` +
+          `    moduleBase: "src",\n` +
+          `    Page: fr.Page,\n` +
+          `    props: fr.props,\n` +
+          `    routePatterns: fr.routePatterns,\n` +
+          `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
+          `    moduleBasePath: "",\n` +
+          `    moduleBaseURL: ${JSON.stringify(BASE)},\n` +
+          `    projectRoot: process.cwd(),\n` +
+          `  }),\n` +
+          `});\n` +
+          `await builder.buildApp();\n` +
+          `console.log("SUBPATH_BUILD_OK");\n` +
+          `process.exit(0);\n`
+      );
+      const env = { ...process.env, NODE_ENV: "production" };
+      env["NODE_OPTIONS"] = mainLeg ? "--conditions react-server" : "";
+      const proc = spawnSync("node", ["build.mjs"], {
+        cwd: testDir,
+        encoding: "utf8",
+        timeout: 180000,
+        env,
+      });
+      expect(
+        proc.stdout,
+        `build failed (status ${proc.status}):\n${proc.stderr}`
+      ).toContain("SUBPATH_BUILD_OK");
+
+      html = await readFile(join(testDir, "dist/static/index.html"), "utf8");
+      server = serveBased([
+        join(testDir, "dist/static"),
+        join(testDir, "dist/client"),
+      ]);
+      await new Promise<void>((r) => server!.listen(PORT, r));
+    }, 240000);
+
+    afterAll(async () => {
+      await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+      if (!process.env["KEEP_FIXTURE"])
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("the based artifact keeps the static contract: final markup, based asset urls", () => {
+      expect(html).toContain('data-resolved="yes"');
+      expect(html).not.toContain("$RC");
+      expect(html).not.toContain("<template");
+      expect(html).not.toContain('id="fallback"');
+      // Everything the document references is under the base.
+      expect(html).toContain(`src="${BASE}`);
+    });
+
+    it("hydrates, navigates with ONE based .rsc GET, and shows the 404 flight on a miss", async () => {
+      const browser = await chromium.launch();
+      try {
+        const page = await browser.newPage();
+        const pageErrors: string[] = [];
+        const rscRequests: string[] = [];
+        const documentRequests: string[] = [];
+        page.on("pageerror", (e) => pageErrors.push(String(e)));
+        page.on("request", (r) => {
+          if (r.url().includes(".rsc")) rscRequests.push(r.url());
+          if (r.resourceType() === "document") documentRequests.push(r.url());
+        });
+
+        await page.goto(`http://localhost:${PORT}${BASE}`, {
+          waitUntil: "networkidle",
+        });
+
+        // Hydration gate under the base: a client component INSIDE the
+        // prerendered suspended boundary answers clicks.
+        await page.waitForFunction(
+          () => {
+            const b = document.querySelector(
+              "#home-counter"
+            ) as HTMLButtonElement;
+            if (!b) return false;
+            b.click();
+            return b.textContent !== "count:0";
+          },
+          undefined,
+          { timeout: 20000, polling: 300 }
+        );
+        const documentBaseline = documentRequests.length;
+        const timeOrigin = await page.evaluate(() => performance.timeOrigin);
+        const rscBaseline = rscRequests.length;
+
+        // Client navigation: exactly one .rsc GET, against the BASED url.
+        await page.click("#to-about");
+        await page.waitForFunction(
+          () => document.querySelector("#heading")?.textContent === "about",
+          undefined,
+          { timeout: 15000, polling: 300 }
+        );
+        const navRequests = rscRequests.slice(rscBaseline);
+        expect(navRequests).toEqual([
+          `http://localhost:${PORT}${BASE}about/index.rsc`,
+        ]);
+        expect(new URL(page.url()).pathname).toBe(`${BASE}about/`);
+
+        // Interactive after the based navigation.
+        await page.waitForFunction(
+          () => {
+            const b = document.querySelector(
+              "#about-counter"
+            ) as HTMLButtonElement;
+            if (!b) return false;
+            b.click();
+            return b.textContent !== "count:0";
+          },
+          undefined,
+          { timeout: 15000, polling: 300 }
+        );
+
+        // Back home (cached flight), then a MISS: the based host answers the
+        // 404 route's flight with the not-found outcome — the SPA shows it
+        // without a document load.
+        await page.goBack();
+        await page.waitForFunction(
+          () => document.querySelector("#heading")?.textContent === "home",
+          undefined,
+          { timeout: 15000, polling: 300 }
+        );
+        await page.click("#to-void");
+        await page.waitForFunction(
+          () =>
+            document.querySelector("#heading")?.textContent ===
+            "not-found-page",
+          undefined,
+          { timeout: 15000, polling: 300 }
+        );
+
+        expect(await page.evaluate(() => performance.timeOrigin)).toBe(
+          timeOrigin
+        );
+        expect(documentRequests.length).toBe(documentBaseline);
+        expect(pageErrors).toEqual([]);
+      } finally {
+        await browser.close();
+      }
+    });
+  }
+);


### PR DESCRIPTION
Coverage closer for the subpath-deploy legs (per the standing lesson that dev+root+single-load gives false passes) — and the leg found the false-pass class it exists for: under a GH-Pages-style base (`/app/`), client navigation fetched the correctly BASED flight (`/app/about/index.rsc`) but `history.pushState` wrote the app-relative path — the address bar left the site, and a reload would 404 outside the deploy.

**The fix**: the router keeps app-relative STATE and touches the base at exactly the document boundary — reading `window.location` strips it, history writes and `<Link>` hrefs (a new `router.toHref`) compose it back, and `startClient` derives it from `moduleBaseURL`'s path (also stripping it from followed loader redirects). With the default `/` every operation is identity; the root-based suites prove that unchanged.

**The pin** (`static-subpath-contracts.test.ts`, spawned production build with `base: "/app/"`, both runner topologies):
- the based artifact keeps the static contract: final markup (no `$RC`/templates/fallback), every referenced asset under the base;
- hydration inside the prerendered suspended boundary (clicks land);
- client navigation is exactly ONE `.rsc` GET against the BASED url, the address bar lands on the based route, `performance.timeOrigin` unchanged, no document re-request;
- a navigation miss answered with the 404 route's flight and the not-found outcome header (as a based host serves it) swaps the 404 view in without leaving the SPA.

Full gate green under both conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA