### PR TITLE
release: 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.11.2",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-react-server",
-      "version": "3.11.2",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-react-server",
-  "version": "3.11.2",
+  "version": "4.0.0",
   "description": "Vite plugin for React Server Components (RSC)",
   "type": "module",
   "main": "./dist/plugin/index.js",


### PR DESCRIPTION
Version bump to 4.0.0 on the fully merged, fully green main (`4d87d39`).

What 4.0 ships, all CI-proven on this tree:
- **Runner paradigm**: `runner` required (`"main" | "isolated"`, `"edge"` reserved), `.` entry de-split, `react-server-loader` as a peer dependency (docs/migrating-4.md covers all three).
- **Flight transaction contract for server actions**: return + automatic route refresh (client state survives), `redirect()` as a followed 303 to the target's flight, `notFound()` as the SPA outcome, errors as flight envelopes — identical across Node, Web, baked edge, and both worker delegates; browser-proven in both topologies, workerd-proven on-platform.
- **Prerendered HTML is the page**: `react-dom/static` renders SSG on both transports (esm and the webpack pair freeze); suspended boundaries carry final markup, hydrate from dumb hosts, and fail loudly (shell errors, `htmlTimeout`) instead of hanging or writing degraded documents.
- **Guarded action endpoint by default**: same-origin CSRF enforcement (`allowedOrigins` extends, `"any"` opts out), 1 MiB body cap (`Infinity` lifts).
- **Base-aware router**: history writes and `Link` hrefs compose the deploy base; subpath contracts pinned end to end.
- **Dev error recovery**: a broken server-component edit shows in place and heals on the fix, with client state preserved across healthy updates.

After merging: `git tag v4.0.0` on the merge commit, then `npm publish` (prepublishOnly verifies the tag, rebuilds, and runs the package gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MePhN69LSQqaub7A2mrMuA