### PR TITLE
fix(dev): edited use-server modules reach action execution — imports keyed by mtime

### DIFF
--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -26,6 +26,7 @@ import { createHandlers } from "./handlers.js";
 import {
   addCssFileContent,
   addModuleId,
+  importByMtime,
   referenceGate,
   cssFiles,
   hmrState,
@@ -1562,10 +1563,15 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
       case "MODULE_REQUEST": {
         const { id, path } = msg;
         try {
-          const module = await import(
+          // mtime-keyed for the same edit-freshness as the reference gate —
+          // a bare import() would pin the first-loaded version for the
+          // worker's lifetime (see importByMtime).
+          const module = await importByMtime(
             join(workerData.userOptions?.projectRoot, path)
           );
-          effectiveHandlers.onServerModule?.(id, path, module);
+          // The handler type says `source: string` but this path has always
+          // passed the imported namespace; the bare import()'s `any` hid it.
+          effectiveHandlers.onServerModule?.(id, path, module as unknown as string);
         } catch (error) {
           effectiveHandlers.onError(id, toError(error));
         }

--- a/plugin/worker/rsc/state.server.ts
+++ b/plugin/worker/rsc/state.server.ts
@@ -1,4 +1,6 @@
 import { workerData } from "node:worker_threads";
+import { statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import { createCssProps } from "../../helpers/createCssProps.js";
 import type { CssContent, ResolvedUserOptions, HmrState } from "../../types.js";
 import type { PassThrough } from "node:stream";
@@ -51,6 +53,28 @@ function tagServerExports(
   return out;
 }
 
+/**
+ * Import a module keyed by its file mtime, so an edited file re-imports while
+ * an unchanged one stays cached. A bare dynamic import() hits Node's ESM
+ * cache, which never invalidates — the first import of a `use server` module
+ * would keep answering every action POST for the worker's lifetime while the
+ * render path (invalidation-aware component cache) reloaded the same file
+ * fresh, making the edit LOOK live. Vite's runner is not in scope on this
+ * resolution path, so the mtime query is the invalidation: same mtime → same
+ * cached instance, new mtime → one new instance per actual edit.
+ */
+export async function importByMtime(
+  fullPath: string
+): Promise<Record<string, unknown>> {
+  const url = pathToFileURL(fullPath);
+  try {
+    url.searchParams.set("t", String(statSync(fullPath).mtimeMs));
+  } catch {
+    // Unstatable (virtual/deleted): the plain import's own error is clearer.
+  }
+  return (await import(url.href)) as Record<string, unknown>;
+}
+
 // Open mode for now: an unregistered id falls back to devResolve — a raw import
 // of the real path (NOT derived from the id beyond the basePath strip), with its
 // exports tagged so the gate can verify them. Sealing — the prod trust boundary
@@ -73,7 +97,7 @@ export const referenceGate = createReferenceGate({
         `Server action id resolves outside the project root: ${key}`
       );
     }
-    const mod = (await import(fullPath)) as Record<string, unknown>;
+    const mod = await importByMtime(fullPath);
     return tagServerExports(key, mod);
   },
 });
@@ -178,7 +202,13 @@ export function getInvalidatedModules(): string[] {
 
 export function addModuleId(id: string, url: string) {
   moduleIds.set(id, url);
-  referenceGate.register({ id, kind: "server", load: () => import(url) });
+  // Registered entries load per call, so key absolute on-disk paths by mtime
+  // for the same edit-freshness as devResolve; URLs, virtual ids, and
+  // relative specifiers (resolved against this module) import as before.
+  const load = url.startsWith("/")
+    ? () => importByMtime(url)
+    : () => import(url);
+  referenceGate.register({ id, kind: "server", load });
 }
 
 // Helper to cache a resolved component

--- a/test/examples/dev-action-module-staleness.test.ts
+++ b/test/examples/dev-action-module-staleness.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { resolve, join } from "node:path";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+import { spawnViteDev, stopViteDev, waitForServer } from "../e2e/devServer.js";
+
+// Editing a `use server` module in dev must reach ACTION EXECUTION, not just
+// the render. The dev rsc worker resolves actions through the reference gate,
+// whose load paths bottom out in bare dynamic import() — Node's ESM cache
+// never invalidates, so the first-imported action body kept running for every
+// POST (across full page reloads) until the dev server restarted, while the
+// render path reloaded the same module fresh and made the edit LOOK live.
+// This drives the dev server over HTTP alone: POST the action, edit the file,
+// POST again — the second reply must carry the edited behavior.
+//
+// The bug lives in the worker topology, so this spec pins the isolated leg
+// and self-skips under --conditions react-server (the main leg resolves
+// actions on the main thread through a different path).
+const isolatedLeg = getCondition() !== REACT_CONDITION.server;
+
+const testDir = resolve(__dirname, "../fixtures/dev-action-module-staleness.test");
+const PORT = 4223;
+const BASE_URL = `http://localhost:${PORT}`;
+
+const actionSource = (version: string): string =>
+  `"use server";\n` +
+  `export async function greet(n: number): Promise<string> {\n` +
+  `  return "${version}:" + n;\n` +
+  `}\n`;
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/routes"), { recursive: true });
+  await writeFile(join(testDir, "src/action.ts"), actionSource("v1"));
+  await writeFile(
+    join(testDir, "src/GreetButton.client.tsx"),
+    `"use client";\n` +
+      `export function GreetButton({ greet }: { greet: (n: number) => Promise<string> }) {\n` +
+      `  return <button onClick={() => greet(1)}>greet</button>;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { greet } from "../action.js";\n` +
+      `import { GreetButton } from "../GreetButton.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main>\n` +
+      `    <h1>{"dev-action-staleness"}</h1>\n` +
+      `    <GreetButton greet={greet} />\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\n` +
+      `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "vite.config.ts"),
+    `import { defineConfig } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+      `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+      `export default defineConfig({\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: "isolated",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: fr.Page,\n` +
+      `    props: fr.props,\n` +
+      `    routePatterns: fr.routePatterns,\n` +
+      `    build: { pages: fr.build.pages },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+/**
+ * POST the action the way the browser proxy does: x-rsc-action id, encoded
+ * reply body, flight envelope back. Returns the decoded returnValue.
+ */
+async function callGreet(): Promise<string> {
+  const { encodeReply } = await import("react-server-dom-esm/client.edge");
+  const body = await encodeReply([7]);
+  const res = await fetch(`${BASE_URL}/`, {
+    method: "POST",
+    headers: { "x-rsc-action": "src/action.ts#greet" },
+    body: body as string,
+  });
+  const text = await res.text();
+  expect(res.status, `action answered ${res.status}: ${text.slice(0, 200)}`).toBe(200);
+  const match = text.match(/"returnValue":"([^"]*)"/);
+  expect(match, `no returnValue in: ${text.slice(0, 200)}`).not.toBeNull();
+  return match![1]!;
+}
+
+describe.skipIf(!isolatedLeg)(
+  "dev: editing a use-server module reaches action execution",
+  () => {
+    let server: ChildProcess | undefined;
+
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+      server = spawnViteDev({
+        dir: testDir,
+        port: PORT,
+        env: { NODE_OPTIONS: "", NODE_ENV: "development" },
+      });
+      await waitForServer(BASE_URL, 60_000);
+      // The worker registers routes lazily; make sure the page renders once
+      // before any action call, like a browser session would.
+      const page = await fetch(`${BASE_URL}/`);
+      expect(page.status).toBe(200);
+      await page.text();
+    }, 90_000);
+
+    afterAll(async () => {
+      await stopViteDev(server);
+      if (!process.env["KEEP_FIXTURE"])
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("the edited action body answers the next POST", async () => {
+      expect(await callGreet()).toBe("v1:7");
+
+      await writeFile(join(testDir, "src/action.ts"), actionSource("v2"));
+      // Give the watcher and invalidation a moment; poll rather than sleep
+      // a fixed window so the test stays fast when the fix lands.
+      const deadline = Date.now() + 10_000;
+      let result = "";
+      for (;;) {
+        result = await callGreet();
+        if (result === "v2:7" || Date.now() > deadline) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(result).toBe("v2:7");
+    }, 30_000);
+  }
+);


### PR DESCRIPTION
In dev, editing a `use server` module never reached action execution: the
first-imported version kept answering every POST — across full page
reloads — until the dev server restarted. The render path reloads edited
modules through its invalidation-aware component cache, so the page
re-rendered with the new code and the edit *looked* live while the action
executor ran the old body. A developer iterating on an action sees stale
behavior with no signal that anything is cached.

## Mechanism

The rsc worker resolves an action POST through the reference gate
(`referenceGate.resolveServerReference`). The gate itself doesn't memoize,
but every one of its load paths bottomed out in a bare dynamic `import()`:
registered entries (`addModuleId`) closed over `() => import(url)`, the
open-mode `devResolve` fallback did `await import(fullPath)`, and the
`MODULE_REQUEST` handler had the same pattern. Node's ESM cache is keyed
by URL and never invalidates, so the first import won for the worker's
lifetime.

## Fix

`importByMtime`: resolve the file's mtime and import
`file://…?t=<mtimeMs>`. Same mtime resolves to the same cached instance —
no reload churn and no unbounded growth while nothing changes; a new mtime
imports exactly one new instance per actual edit. No HMR wiring needed,
and build-time behavior is untouched (files don't change mid-build, so the
key is stable). All three bare-import sites now go through it; registered
URLs that aren't absolute paths (virtual ids, specifiers) import exactly
as before.

## Test

`test/examples/dev-action-module-staleness.test.ts` — a self-contained
fixture driven over HTTP alone (no browser): spawn `vite dev`, POST the
action (`x-rsc-action` + `encodeReply`), edit the action file, POST again
and poll briefly. Red on the previous code (the second POST answered the
old body through the full poll window), green in under a second with the
fix. Runs on the isolated leg and self-skips under
`--conditions react-server`, where action resolution takes a different
path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cxc7sRNJ9KW5oTvdHELbP
