### PR TITLE
fix(edge): the fs stub's error speaks to application code first

### DIFF
--- a/plugin/bundle/nodeStub.ts
+++ b/plugin/bundle/nodeStub.ts
@@ -10,14 +10,22 @@
  * fail a Workers build of an otherwise Node-free bundle. Aliasing the dead
  * branches here removes the specifier; if one is ever reached anyway, the
  * throw below names the real problem instead of a runtime-missing-module error.
+ *
+ * The alias covers the WHOLE bundle, application modules included — a `use
+ * server` action doing ordinary file IO lands here too, so the message serves
+ * that caller first and the internal invariant second.
  */
 const unreachable =
   (name: string) =>
   (): never => {
     throw new Error(
-      `[edge] ${name} was called inside a baked bundle. These disk-fallback ` +
-        `branches are unreachable when the baked entry provides its own ` +
-        `resolver — reaching one means the handler was invoked without it.`
+      `[edge] ${name} is not available inside the baked edge bundle: the ` +
+        `bake targets isolates without a filesystem, so node:fs and ` +
+        `node:path are stubbed out bundle-wide, application code included. ` +
+        `Keep file access outside baked actions and reach platform data ` +
+        `through the host's bindings. If nothing in the application calls ` +
+        `this, a vprs disk-fallback branch was reached — the handler was ` +
+        `invoked without the baked entry's own resolver.`
     );
   };
 


### PR DESCRIPTION
A `use server` action calling `node:fs` inside the baked pair answered with the stub's internal-invariant text ('disk-fallback branches are unreachable when the baked entry provides its own resolver'), which reads as a framework bug and gives the author nothing to act on — the alias covers the whole bundle, application modules included, but the message was written only for vprs's own dead disk branches.

The message now leads with what the calling author needs (file and path APIs are not available in the baked edge bundle; keep file access outside baked actions, reach platform data through the host's bindings) and keeps the internal-invariant note second. Message-only change, no behavior difference; verified end to end against a packed bundle — the server log and the flight error envelope both carry the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Cxc7sRNJ9KW5oTvdHELbP