### PR TITLE
feat: runner 'edge' ships — the baked pair is the paradigm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,29 @@ jobs:
       - name: Peer install on both tracks
         run: npm run test:peer-install
 
+  root-install-bake:
+    name: packed-consumer root-install edge bake
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # The layout the repo's own fixtures cannot take (they resolve the
+      # plugin by self-reference — always the hoisted path): the plugin
+      # installed at a consumer's root, a server page importing the package
+      # client barrel, edge bake on. Proves dist/server-edge stays free of
+      # statically-evaluated node builtins (bd y4l3's Cloudflare 10021 class).
+      - name: Root-install edge bake gate
+        run: npm run test:root-install-bake
+
   # The webpack bake pair on REAL workerd. The edge-bundle guard proves
   # "no node builtins" by static analysis; this job proves the runtime claims
   # by execution: one isolate, no nodejs_compat — boot, flight render,

--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ The execution topology is a declared choice: the `runner` option names where
 react-server executes. `"isolated"` gives a worker thread react-server
 resolution with no launch flags; `"main"` puts it on the main thread — a bit
 faster, better stack traces, React usable in `vite.config.ts` — paired with
-`--conditions react-server` stated once in your scripts. Either way a worker
-mirrors the other half (server components need a react-server context, client
-hydration a react-client one), and runner and flag are validated against each
-other at config-resolve time.
+`--conditions react-server` stated once in your scripts; `"edge"` bakes React
+per environment into a single-isolate pair that IS the production serving
+artifact (webpack transport, no `node:` imports — Workers/Deno-ready), while
+its dev server runs the isolated worker shape. Runner and flag are validated
+against each other at config-resolve time.
 
 ## Quick start
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -41,7 +41,7 @@ export const config = {
 | `htmlTimeout` | `number` | Timeout in milliseconds for HTML generation operations | `15000` |
 | `htmlWorkerStartupTimeout` | `number` | Timeout in milliseconds for HTML worker startup | `5000` |
 | `rscWorkerStartupTimeout` | `number` | Timeout in milliseconds for RSC worker startup | `5000` |
-| `runner` | `"main" \| "isolated" \| "edge"` | **Required.** The execution paradigm: where react-server executes (see [Configuration → Runner](./configuration.md#runner)); validated against the process condition at config-resolve time. `"edge"` is recognized but rejected until the edge runner ships in a later 4.x minor | - |
+| `runner` | `"main" \| "isolated" \| "edge"` | **Required.** The execution paradigm: where react-server executes (see [Configuration → Runner](./configuration.md#runner)); validated against the process condition at config-resolve time. `"edge"` requires `transport: "webpack"` and makes the baked pair the serving artifact; its dev server runs the isolated worker shape (the pair serves prod) | - |
 | `transport` | `"esm" \| "webpack"` | The deploy's flight flavor; `"webpack"` renders the static snapshots through the baked pair and the dev server serves webpack flight, so every surface agrees (see [Configuration → Transport](./configuration.md#transport)) | `"esm"` |
 | `onMetrics` | `OnMetrics` | Callback for build metrics (render, worker-startup, module-resolution, edge-bake, inline-flight and ssg-render metrics) | - |
 | `onEvent` | `(event: PluginEvent) => void` | Callback for plugin events | - |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,9 +163,9 @@ different topology.
 |--------|---------------|-------------|-------|
 | `"isolated"` | no flag | Worker thread | No launch flags, better isolation |
 | `"main"` | `NODE_OPTIONS='--conditions react-server'` | Main thread | A bit faster, better stack traces, React usable in `vite.config.ts` |
-| `"edge"` | no flag | Single isolate (baked pair) | Portability; not implemented yet — use `"isolated"` (or `"main"`) with `build.edge` meanwhile |
+| `"edge"` | no flag | Single isolate (baked pair) | Portability; requires `transport: "webpack"`, the pair is the serving artifact (`build.edge: false` errors, a failed bake fails the build), and dev runs the isolated worker shape — the pair serves prod |
 
-Both implemented runners produce identical output. Under `"main"`, the RSC
+`"main"` and `"isolated"` produce identical output. Under `"main"`, the RSC
 worker is skipped in dev — Vite's environment runner handles HMR directly.
 
 ## Build Scripts

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -30,8 +30,16 @@ the **transport** the render path uses, picked at build time
   `vite-plugin-react-server/edge/web` — see
   [Workers / Deno](#workers--deno-the-baked-consumer-and-edgeweb) below.
 
-It is **additive**: the normal `dist/server` / `dist/static` output is untouched.
-Dev is unaffected.
+Under runner `"main"` or `"isolated"` the bake is **additive**: the normal
+`dist/server` / `dist/static` output is untouched, dev is unaffected, and a
+bake failure warns without failing the build. Declaring **`runner: "edge"`**
+promotes the pair to the paradigm: the build requires `transport: "webpack"`,
+`build.edge: false` is a config-time contradiction, the SSG snapshots render
+through the pair, and a bake failure fails the build — an edge-runner build
+without its serving artifact is a broken deploy. The edge runner is a
+**production serving choice**: its dev server runs the isolated worker shape
+(same app code, worker-owned react-server resolution), and the baked pair is
+what deploys.
 
 ## How it works
 
@@ -92,9 +100,12 @@ vitePluginReactServer({
 });
 ```
 
-`build.edge` is `boolean | { outDir?, minify? }`, default **`true`** (the bundle
-is additive — the worker-based `dist/server` build is untouched — and a bake
-failure is a warning, never a build failure).
+`build.edge` is `boolean | { outDir?, minify? }`, default **`true`**. Under
+runner `"main"` or `"isolated"` the bundle is additive — the worker-based
+`dist/server` build is untouched, and a bake failure is a warning, never a
+build failure. Under runner `"edge"` the same knob describes the serving
+artifact itself: a bake failure fails the build, and `edge: false` is a
+config-time contradiction (see above).
 
 | form                     | meaning |
 | ------------------------ | ------- |

--- a/docs/internals/runner-spec.md
+++ b/docs/internals/runner-spec.md
@@ -79,7 +79,7 @@ than a signal.
 | react-in-config (React usable in `vite.config.ts`) | **yes** — the only runner that can; config executes in plain Node, outside any Vite environment, so only the process flag reaches it | no | no |
 | Render pipeline | in-process render | worker protocol (`RSC_CHUNK`/`RSC_END`), html-worker for SSG | baked pair (`dist/server-edge/render.js`), Web streams end-to-end |
 | Streams | Node streams | Node streams over the worker bridge | Web streams only, no `node:*` |
-| Dev shape | `vite` under the process flag (today's `dev:rsc`) | plain `vite` — the rsc-worker carries the condition internally (today's client-first dev) | plain `vite` + baked-pair preview |
+| Dev shape | `vite` under the process flag (today's `dev:rsc`) | plain `vite` — the rsc-worker carries the condition internally (today's client-first dev) | plain `vite` on the isolated worker shape; the pair serves prod (baked-pair preview arrives with `createHost`) |
 | Prod shape | host `dist/server` under the flag (`handleServerAction` sealed helper) | worker-based serving | `handleRouteAction` baked gate, no `--conditions` process |
 | Action dispatch | sealed executor in-process | delegate to worker | baked sealed gate |
 | Stack traces / debugging | best (one thread, one graph) | split across bridge | bundled |
@@ -133,6 +133,13 @@ dependency edge.
   process. A `build.edge` artifact emitted from a `main`/`isolated` config
   sits outside this invariant: it is an additional output, and deploying it
   is choosing the edge paradigm's transport for that deployment.
+- **Shipped deviation for `edge` (4.1):** the edge runner is a production
+  serving choice. Its dev server runs the isolated worker shape — same app
+  code, worker-owned react-server resolution — because baking the pair per
+  edit is not a dev loop, and pair-flavored preview belongs to `createHost`
+  (the host spec's worked example is exactly that server). Until then the
+  same-transport invariant holds for the artifact that deploys, not for the
+  dev server.
 - Prod action dispatch goes through sealed references baked into the
   manifest; dev's permissive dispatch surface is structurally absent from
   the artifacts.

--- a/docs/migrating-4.md
+++ b/docs/migrating-4.md
@@ -54,10 +54,14 @@ vitePluginReactServer({
 })
 ```
 
-`"edge"` (single isolate, React baked per environment) is a recognized value
-but is currently rejected: declaring it is a config-time error until the edge
-runner ships in a later 4.x minor. Use `"isolated"` or `"main"` with
-`build.edge` to emit the baked pair meanwhile.
+`"edge"` (single isolate, React baked per environment) validates like
+`"isolated"` — no process flag — and makes the baked pair the serving
+artifact: `build.edge: false` is a config-time contradiction and a failed
+bake fails the build. It requires `transport: "webpack"` (the pair's
+consumer half needs the webpack module map; the esm transport has no
+equivalent seam yet) — esm apps use `"isolated"`, with `build.edge` if they
+want the producer artifact. The edge runner is a production serving choice:
+dev runs the isolated worker shape, and the pair is what deploys.
 
 ## Install react-server-loader yourself
 

--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
     "build:vite": "vite build",
     "test:package": "node scripts/verify-package-entrypoints.mjs",
     "test:peer-install": "./scripts/verify-peer-install.sh",
+    "test:root-install-bake": "./scripts/verify-root-install-bake.sh",
     "lint:package": "publint",
     "lint:no-bead-ids": "./scripts/check-no-bead-ids.sh",
     "verify:package": "npm run lint:package && npm run test:package && npm run lint:no-bead-ids",

--- a/plugin/bundle/buildConsumerBundle.ts
+++ b/plugin/bundle/buildConsumerBundle.ts
@@ -54,6 +54,15 @@ export async function buildConsumerBundle(opts: {
   const clientDir = join(outRoot, userOptions.build.client);
   const clientManifestPath = join(clientDir, ".vite/manifest.json");
   if (!existsSync(clientManifestPath)) {
+    // Under runner "edge" the pair is the serving artifact and the freeze
+    // imports this consumer — a missing client manifest is a broken build,
+    // not a skippable extra.
+    if (userOptions.runner === "edge") {
+      throw new Error(
+        `${tag} no client manifest at ${clientManifestPath} — runner 'edge' ` +
+          `cannot emit its consumer without it.`
+      );
+    }
     logger.warn(
       `${tag} no client manifest at ${clientManifestPath}; skipping the consumer bake ` +
         `(the runtime consumer still serves this build)`
@@ -96,7 +105,22 @@ export async function buildConsumerBundle(opts: {
   const idByFile = new Map<string, string>();
   let divergent = 0;
 
+  // With zero client references the client env has no explicit inputs, so
+  // Vite builds its index.html default into this tree: the html root and the
+  // browser entry it imports (whose top level calls startClient). Neither is
+  // a flight-referenceable module, and importing the entry eagerly executes
+  // document access inside the bake — exclude the html-claimed graph roots.
+  const htmlClaimed = new Set<string>();
   for (const [key, entry] of Object.entries(clientManifest)) {
+    if (!key.endsWith(".html")) continue;
+    htmlClaimed.add(key);
+    for (const imported of (entry as { imports?: string[] })?.imports ?? []) {
+      htmlClaimed.add(imported);
+    }
+  }
+
+  for (const [key, entry] of Object.entries(clientManifest)) {
+    if (htmlClaimed.has(key)) continue;
     const file = entry?.file;
     if (!file || !/\.[cm]?js$/.test(file)) continue;
     const abs = join(clientDir, file);
@@ -121,10 +145,12 @@ export async function buildConsumerBundle(opts: {
   }
 
   if (importLines.length === 0) {
-    logger.warn(
-      `${tag} no client modules found in ${clientDir}; skipping the consumer bake`
+    // A server-only app is a valid build: no client references means an
+    // empty registry, not a missing consumer — the renderer half is what the
+    // SSG freeze (and any baked-pair host) imports.
+    logger.info(
+      `${tag} no client references — baking the consumer with an empty registry`
     );
-    return;
   }
 
   const { consumerFileName, consumerExport } = DEFAULT_CONFIG.EDGE;

--- a/plugin/bundle/buildConsumerBundle.ts
+++ b/plugin/bundle/buildConsumerBundle.ts
@@ -1,3 +1,4 @@
+import { sourceHasTopLevelClientDirective } from "react-server-loader/directives";
 import { build as viteBuild, type Logger } from "vite";
 import { createRequire } from "node:module";
 import { join } from "node:path";
@@ -111,6 +112,28 @@ export async function buildConsumerBundle(opts: {
   // a flight-referenceable module, and importing the entry eagerly executes
   // document access inside the bake — exclude the html-claimed graph roots.
   const htmlClaimed = new Set<string>();
+  // Only DIRECTIVE modules belong in the registry: flight payloads can
+  // reference exactly the modules that registered a client reference, i.e.
+  // sources carrying "use client" — first-party *.client.tsx and package
+  // modules alike (the root-install barrel case). Bundling every manifest
+  // chunk instead used to drag transport libraries in STATICALLY — the
+  // vendored CJS webpack flight client's interop preamble put
+  // `import { createRequire } from "node:module"` into consumer.js, which a
+  // fetch runtime's validator rejects at deploy while every Node-based
+  // check stays green. Fail closed: a key whose source can't be read is not
+  // a reference either — virtual chunks (rolldown's own runtime helper is a
+  // manifest entry, and its hosted copy carries that same preamble) have no
+  // source file, and a real reference always does.
+  const isReferenceSource = (key: string): boolean => {
+    try {
+      return sourceHasTopLevelClientDirective(
+        readFileSync(join(projectRoot, key), "utf8")
+      );
+    } catch {
+      return false;
+    }
+  };
+
   for (const [key, entry] of Object.entries(clientManifest)) {
     if (!key.endsWith(".html")) continue;
     htmlClaimed.add(key);
@@ -123,6 +146,7 @@ export async function buildConsumerBundle(opts: {
     if (htmlClaimed.has(key)) continue;
     const file = entry?.file;
     if (!file || !/\.[cm]?js$/.test(file)) continue;
+    if (!isReferenceSource(key)) continue;
     const abs = join(clientDir, file);
     if (!existsSync(abs)) continue;
 
@@ -290,11 +314,48 @@ export async function prerenderFlightToHtml(options) {
 `;
   writeFileSync(entryPath, entrySource, "utf8");
 
+  // Package client modules (the root-install barrel case) lazily reference
+  // their own transport runtime — rsl's webpack runtime and the vendored
+  // flight clients get HOSTED copies under dist/client. In the isolate those
+  // branches are dead: this bundle carries its own client.edge + globals, and
+  // registry modules are only ever rendered, never asked to decode flight.
+  // Bundling the hosted copies anyway dragged the node-flavored CJS client in
+  // and its interop preamble (`import { createRequire } from "node:module"`)
+  // failed fetch-runtime validators at deploy. Stub exactly those hosted
+  // copies — loudly, so a path that ever DOES reach one fails with a name,
+  // not a silent undefined. The entry's own rsl imports resolve from
+  // node_modules, not dist/client, and stay real.
+  // (rolldown resolves plain relative imports without consulting plugin
+  // resolveId, so the interception lives in `load`, keyed on the resolved
+  // absolute path.)
+  const isHostedTransportPath = (id: string): boolean =>
+    id.startsWith(clientDir) && /[\/]react-server-loader[\/]/.test(id);
+  const hostedTransportStub = {
+    name: "vprs:consumer-hosted-transport-stub",
+    load(id: string) {
+      if (!isHostedTransportPath(id)) return null;
+      return (
+        `const explain = () => { throw new Error(` +
+        `"[edge:consumer] a baked client module reached its hosted transport ` +
+        `runtime — dead in the isolate (the consumer carries its own ` +
+        `client.edge). This stub exists to keep node-flavored CJS out of ` +
+        `the bake."); };\n` +
+        `export default new Proxy(explain, { get: explain, apply: explain });\n` +
+        `export const createWebpackClient = explain;\n` +
+        `export const installWebpackGlobals = explain;\n` +
+        `export const createFromReadableStream = explain;\n` +
+        `export const createFromFetch = explain;\n` +
+        `export const encodeReply = explain;\n`
+      );
+    },
+  };
+
   try {
     await viteBuild({
       root: clientDir,
       logLevel: "warn",
       configFile: false,
+      plugins: [hostedTransportStub],
       // No react-server aliasing here — that is the producer's job. This graph
       // resolves React normally, which is what makes it the CLIENT half.
       define: { "process.env.NODE_ENV": JSON.stringify("production") },

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -923,6 +923,15 @@ export async function ${actionExport}(request, opts = {}) {
         "baked bundle has no filesystem. Read files at build time instead " +
         "(import.meta.glob, optionally with ?raw) or set build.edge:false."
       : "";
+    // Under runner "edge" the pair IS the serving artifact — a build that
+    // exits green without it is a broken deploy discovered in production.
+    // Warn-and-continue is only sound where the bake is an additive extra.
+    if (userOptions.runner === "edge") {
+      throw new Error(
+        `${tag} edge bundle bake failed and runner 'edge' has no serving ` +
+          `artifact without it: ${message}${stubHint}`
+      );
+    }
     logger.warn(
       `${tag} skipped — edge bundle bake failed (the main build is unaffected; ` +
         `set build.edge:false to silence): ${message}${stubHint}`

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -1031,6 +1031,10 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
     const userOptions: ResolvedUserOptions = {
       projectRoot,
       transport: options.transport ?? "esm",
+      // The declared paradigm travels with the resolved options so build
+      // steps can enforce runner-specific contracts (fatal bake under
+      // "edge"). Optional: hand-built handler options carry no runner.
+      runner: options.runner,
       moduleBase,
       moduleBasePath,
       moduleBaseURL,

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -986,6 +986,28 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
 
   // Return resolved options
   try {
+    // Under runner "edge" the baked pair IS the serving artifact — the
+    // paradigm, not an add-on. Disabling the bake contradicts the declared
+    // runner; refuse it before any transport-level guidance.
+    if (options.runner === "edge" && !build.edge.enabled) {
+      throw new Error(
+        "[vite-plugin-react-server] runner 'edge': the baked pair IS the " +
+          "serving artifact — remove `build.edge: false` (or declare runner " +
+          "'isolated'/'main' if you don't want the bake)."
+      );
+    }
+    // C1 scope: the edge runner's SSG renders through the pair, which today
+    // exists only under transport "webpack". The esm-through-pair leg ships
+    // in the next slice — refuse it loudly rather than silently running the
+    // esm SSG pass outside the declared paradigm.
+    if (options.runner === "edge" && options.transport !== "webpack") {
+      throw new Error(
+        "[vite-plugin-react-server] runner 'edge' currently requires " +
+          'transport:"webpack" (the SSG freeze renders through the baked ' +
+          "pair). The esm leg ships in a following release — use runner " +
+          "'isolated' with build.edge meanwhile."
+      );
+    }
     // transport:"webpack" contracts the whole build around the baked pair:
     // the esm SSG pass is skipped and the freeze IS the SSG backend. A config
     // that disables the bake (or pins it to esm) would silently produce no

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -996,16 +996,19 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
           "'isolated'/'main' if you don't want the bake)."
       );
     }
-    // C1 scope: the edge runner's SSG renders through the pair, which today
-    // exists only under transport "webpack". The esm-through-pair leg ships
-    // in the next slice — refuse it loudly rather than silently running the
-    // esm SSG pass outside the declared paradigm.
+    // The edge runner's SSG renders through the pair, and the pair's
+    // consumer half exists only under transport "webpack": the esm client
+    // transport resolves modules at request time (import(moduleBaseURL+id))
+    // and has no module-map seam a baked, closed registry can bind to.
+    // Until that manifest-resolved esm consumer exists, refuse loudly
+    // rather than silently running the esm SSG pass outside the declared
+    // paradigm.
     if (options.runner === "edge" && options.transport !== "webpack") {
       throw new Error(
-        "[vite-plugin-react-server] runner 'edge' currently requires " +
-          'transport:"webpack" (the SSG freeze renders through the baked ' +
-          "pair). The esm leg ships in a following release — use runner " +
-          "'isolated' with build.edge meanwhile."
+        "[vite-plugin-react-server] runner 'edge' requires " +
+          'transport:"webpack": the baked pair\'s consumer half needs the ' +
+          "webpack module map, and the esm transport has no equivalent " +
+          "seam yet. Use runner 'isolated' for the esm transport."
       );
     }
     // transport:"webpack" contracts the whole build around the baked pair:

--- a/plugin/config/runner.ts
+++ b/plugin/config/runner.ts
@@ -15,7 +15,7 @@ const RUNNER_PITCH: Record<RunnerName, string> = {
   main: "react-server on the main thread; best stack traces, React usable in vite.config.ts; requires NODE_OPTIONS='--conditions react-server'",
   isolated:
     "worker_threads rsc-worker owns react-server resolution; no process flag",
-  edge: "single isolate, React baked per environment at build time; Web streams, no process flag (not implemented yet — ships in a later 4.x minor)",
+  edge: "single isolate, React baked per environment at build time; Web streams, no process flag",
 };
 
 const runnerList = (): string =>
@@ -49,14 +49,6 @@ export function validateRunner(runner: unknown): RunnerName {
     );
   }
   const name = runner as RunnerName;
-  // Not-implemented before the condition invariant: a consumer who declared
-  // 'edge' should hear that first, not be walked through flag changes toward
-  // a value that then rejects anyway.
-  if (name === "edge") {
-    throw new Error(
-      "[vite-plugin-react-server] runner 'edge' is not implemented yet — use runner 'isolated' (or 'main') with build.edge to emit the baked pair meanwhile."
-    );
-  }
   const conditionPresent = getCondition() === REACT_CONDITION.server;
   if (name === "main" && !conditionPresent) {
     throw new Error(

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -396,6 +396,8 @@ export type StreamError = {
 export type PanicThreshold = "none" | "critical_errors" | "all_errors";
 
 export type ResolvedUserOptions = {
+  /** The declared execution paradigm; absent on hand-built handler options. */
+  runner?: RunnerName;
   // Core required properties
   projectRoot: string;
   /**

--- a/scripts/edge-builtin-guard.mjs
+++ b/scripts/edge-builtin-guard.mjs
@@ -1,0 +1,43 @@
+// Shared assertion for edge-bake gates: dist/server-edge must carry no
+// statically-evaluated node builtin imports — a fetch runtime's validator
+// rejects them at deploy while every Node-based check stays green.
+// Usage: node scripts/edge-builtin-guard.mjs <path-to-dist/server-edge>
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { builtinModules } from "node:module";
+import { init, parse } from "es-module-lexer";
+
+const edgeDir = process.argv[2];
+if (!edgeDir) {
+  console.error("usage: node scripts/edge-builtin-guard.mjs <edge-dir>");
+  process.exit(2);
+}
+await init;
+const files = (await readdir(edgeDir, { recursive: true })).filter((f) =>
+  f.endsWith(".js")
+);
+if (files.length === 0) {
+  console.error(`✗ no .js bundles found in ${edgeDir}`);
+  process.exit(1);
+}
+const isBuiltin = (spec) =>
+  spec.startsWith("node:") || builtinModules.includes(spec);
+const offenders = [];
+for (const f of files) {
+  const code = await readFile(join(edgeDir, f), "utf8");
+  const [imports] = parse(code, f);
+  for (const imp of imports) {
+    if (!imp.n || !isBuiltin(imp.n)) continue;
+    if (imp.d > -1) continue; // dynamic import(): lazy, boot-safe
+    offenders.push(`${f}: ${imp.n}`);
+  }
+}
+if (offenders.length > 0) {
+  console.error(
+    "✗ statically-evaluated node builtins in the edge bake " +
+      "(a fetch runtime's validator rejects this at deploy):\n  " +
+      offenders.join("\n  ")
+  );
+  process.exit(1);
+}
+console.log("✓ dist/server-edge is free of static node builtin imports");

--- a/scripts/verify-root-install-bake.sh
+++ b/scripts/verify-root-install-bake.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Packed-consumer proof of the ROOT-INSTALL edge bake (bd y4l3): a server page
+# importing a PACKAGE module that carries "use client" (router/client's Link),
+# with the plugin installed at the project root — the one layout the repo's own
+# fixtures cannot take (their plugin resolves by self-reference, which is
+# always the hoisted path; the hoisted guard is edge-package-client-boundary).
+#
+# Under root install the main build hosts the client reference fine, but
+# buildEdgeBundle bakes the barrel statically: the vendored CJS webpack flight
+# client rides along and the bundler emits its CJS-interop preamble
+# (`import { createRequire } from "node:module"`) into dist/server-edge —
+# which a fetch runtime's validator rejects at deploy while every Node-based
+# check stays green. This gate makes that class fail HERE instead.
+#
+# NOTE: npm pack's prepack wipes dist and re-emits it with tsc; run
+# `npm run build` afterwards before any vitest gate.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+react_stable="$(node -p "require('$root/package.json').peerDependencies.react.split('||')[0].trim().replace(/^\^/, '')")"
+stable_rsl="$(node -p "require('$root/package.json').peerDependencies['react-server-loader'].split('||')[0].trim().replace(/^\^/, '')")"
+
+workdir="$(mktemp -d)"
+if [ "${KEEP:-}" != "1" ]; then trap 'rm -rf "$workdir"' EXIT; else echo "KEEP=1: $workdir"; fi
+
+echo "→ npm pack (the bytes a consumer installs)"
+(cd "$root" && npm pack --loglevel=error --pack-destination "$workdir" >/dev/null)
+tarball="$(ls "$workdir"/vite-plugin-react-server-*.tgz)"
+
+dir="$workdir/consumer"
+mkdir -p "$dir/src/page"
+echo "→ root install: tarball + stable peers"
+(cd "$dir" &&
+  npm init -y >/dev/null &&
+  npm pkg set type=module >/dev/null &&
+  npm install --no-audit --no-fund --loglevel=error "$tarball" \
+    "react@$react_stable" "react-dom@$react_stable" \
+    "react-server-loader@$stable_rsl" vite@8.1.0)
+
+cat > "$dir/src/page/page.tsx" <<'EOF'
+import { Link } from "vite-plugin-react-server/router/client";
+export const Page = ({ name }: { name: string }) => (
+  <div id="root">Hello {name} <Link to="/">home</Link></div>
+);
+EOF
+cat > "$dir/src/page/props.ts" <<'EOF'
+export const props = (_url: string) => ({ name: "root-install" });
+EOF
+cat > "$dir/src/client.tsx" <<'EOF'
+import { startClient } from "vite-plugin-react-server/router/client";
+startClient({ patterns: ["/"] });
+EOF
+cat > "$dir/index.html" <<'EOF'
+<!DOCTYPE html><html><head><meta charset="utf-8" /></head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>
+EOF
+cat > "$dir/vite.config.mjs" <<'EOF'
+import { defineConfig } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+
+export default defineConfig({
+  plugins: [
+    vitePluginReactServer({
+      runner: "isolated",
+      moduleBase: "src",
+      Page: "src/page/page.tsx",
+      props: "src/page/props.ts",
+      transport: "webpack",
+      build: { pages: ["/"], edge: true },
+    }),
+  ],
+});
+EOF
+
+echo "→ vite build --app (root-install consumer)"
+(cd "$dir" && npx vite build --app) 2>&1 | tail -20
+
+echo "→ guard: no statically-evaluated node builtins in dist/server-edge"
+(cd "$root" && node scripts/edge-builtin-guard.mjs "$dir/dist/server-edge")
+
+# Variant: ZERO client references (a server-only page). The registry filters
+# to nothing — the consumer must still emit with an empty registry (the
+# server-only-app contract), not skip, and stay builtin-free.
+dir2="$workdir/consumer-zero-refs"
+mkdir -p "$dir2/src/page"
+cp -r "$dir/node_modules" "$dir2/node_modules"
+cp "$dir/package.json" "$dir2/package.json"
+cp "$dir/index.html" "$dir2/index.html"
+cp "$dir/vite.config.mjs" "$dir2/vite.config.mjs"
+cp "$dir/src/client.tsx" "$dir2/src/client.tsx"
+cat > "$dir2/src/page/page.tsx" <<'EOF2'
+export const Page = ({ name }: { name: string }) => (
+  <div id="root">Hello {name}</div>
+);
+EOF2
+cat > "$dir2/src/page/props.ts" <<'EOF2'
+export const props = (_url: string) => ({ name: "zero-refs" });
+EOF2
+echo "→ vite build --app (zero client references)"
+(cd "$dir2" && npx vite build --app) 2>&1 | tail -4
+if [ ! -f "$dir2/dist/server-edge/consumer.js" ]; then
+  echo "✗ zero-reference build skipped the consumer bake — the empty registry must still emit" >&2
+  exit 1
+fi
+echo "→ guard: zero-reference bake"
+(cd "$root" && node scripts/edge-builtin-guard.mjs "$dir2/dist/server-edge")
+
+echo "✓ root-install edge bake is deploy-clean"

--- a/test/examples/edge-runner-build.test.ts
+++ b/test/examples/edge-runner-build.test.ts
@@ -22,12 +22,28 @@ const testDir = resolve(__dirname, "../fixtures/edge-runner-build.test");
 async function setupFixture(edgeOption: string) {
   await rm(testDir, { recursive: true, force: true });
   await mkdir(join(testDir, "src/routes"), { recursive: true });
+  // The page carries a real client reference: a webpack bake with ZERO
+  // client references bundles the browser entry into the consumer and
+  // executes it at import ("document is not defined") — a pre-existing
+  // freeze bug on every runner, tracked separately; this suite pins the
+  // RUNNER contract, not that bug.
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `export function Counter() {\n` +
+      `  const [n, setN] = React.useState(0);\n` +
+      `  return <button onClick={() => setN((v) => v + 1)}>{"n:" + n}</button>;\n` +
+      `}\n`
+  );
   await writeFile(
     join(testDir, "src/routes/page.tsx"),
     `import * as React from "react";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
       `export const Page = () => (\n` +
       `  <main id="app">\n` +
       `    <h1>{"edge-runner-build"}</h1>\n` +
+      `    <Counter />\n` +
       `  </main>\n` +
       `);\n`
   );

--- a/test/examples/edge-runner-build.test.ts
+++ b/test/examples/edge-runner-build.test.ts
@@ -3,6 +3,7 @@ import { mkdir, rm, writeFile, readFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { resolve, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   getCondition,
   REACT_CONDITION,
@@ -19,31 +20,34 @@ const isolatedLeg = getCondition() !== REACT_CONDITION.server;
 
 const testDir = resolve(__dirname, "../fixtures/edge-runner-build.test");
 
-async function setupFixture(edgeOption: string) {
+async function setupFixture(
+  edgeOption: string,
+  opts: { clientRef?: boolean; pages?: string } = {}
+) {
+  const { clientRef = true, pages = "fr.build.pages" } = opts;
   await rm(testDir, { recursive: true, force: true });
   await mkdir(join(testDir, "src/routes"), { recursive: true });
-  // The page carries a real client reference: a webpack bake with ZERO
-  // client references bundles the browser entry into the consumer and
-  // executes it at import ("document is not defined") — a pre-existing
-  // freeze bug on every runner, tracked separately; this suite pins the
-  // RUNNER contract, not that bug.
-  await writeFile(
-    join(testDir, "src/routes/Counter.client.tsx"),
-    `"use client";\n` +
-      `import * as React from "react";\n` +
-      `export function Counter() {\n` +
-      `  const [n, setN] = React.useState(0);\n` +
-      `  return <button onClick={() => setN((v) => v + 1)}>{"n:" + n}</button>;\n` +
-      `}\n`
-  );
+  if (clientRef) {
+    await writeFile(
+      join(testDir, "src/routes/Counter.client.tsx"),
+      `"use client";\n` +
+        `import * as React from "react";\n` +
+        `export function Counter() {\n` +
+        `  const [n, setN] = React.useState(0);\n` +
+        `  return <button onClick={() => setN((v) => v + 1)}>{"n:" + n}</button>;\n` +
+        `}\n`
+    );
+  }
   await writeFile(
     join(testDir, "src/routes/page.tsx"),
     `import * as React from "react";\n` +
-      `import { Counter } from "./Counter.client.js";\n` +
+      (clientRef
+        ? `import { Counter } from "./Counter.client.js";\n`
+        : ``) +
       `export const Page = () => (\n` +
       `  <main id="app">\n` +
       `    <h1>{"edge-runner-build"}</h1>\n` +
-      `    <Counter />\n` +
+      (clientRef ? `    <Counter />\n` : ``) +
       `  </main>\n` +
       `);\n`
   );
@@ -76,7 +80,7 @@ async function setupFixture(edgeOption: string) {
       `    Page: fr.Page,\n` +
       `    props: fr.props,\n` +
       `    routePatterns: fr.routePatterns,\n` +
-      `    build: { pages: fr.build.pages, outDir: "dist"${edgeOption} },\n` +
+      `    build: { pages: ${pages}, outDir: "dist"${edgeOption} },\n` +
       `    moduleBasePath: "",\n` +
       `    moduleBaseURL: "/",\n` +
       `    projectRoot: process.cwd(),\n` +
@@ -155,3 +159,77 @@ describe.skipIf(!isolatedLeg)(
     }, 240000);
   }
 );
+
+describe.skipIf(!isolatedLeg)(
+  "runner 'edge' with ZERO client references (a server-only app is valid)",
+  () => {
+    beforeAll(async () => {
+      await setupFixture("", { clientRef: false });
+      const proc = runBuild();
+      expect(
+        proc.stdout,
+        `build failed (status ${proc.status}):\n${proc.stderr}`
+      ).toContain("EDGE_RUNNER_BUILD_OK");
+    }, 240000);
+
+    afterAll(async () => {
+      if (!process.env["KEEP_FIXTURE"])
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("emits the pair, and the consumer imports and renders", async () => {
+      expect(existsSync(join(testDir, "dist/server-edge/render.js"))).toBe(
+        true
+      );
+      const consumerPath = join(testDir, "dist/server-edge/consumer.js");
+      expect(existsSync(consumerPath)).toBe(true);
+      // The freeze already imported the consumer during the build; import it
+      // here too and prove the renderer half works with an empty registry.
+      const consumer = await import(pathToFileURL(consumerPath).href);
+      expect(typeof consumer.prerenderFlightToHtml).toBe("function");
+    });
+
+    it("the frozen page is final markup through the pair", async () => {
+      const html = await readFile(
+        join(testDir, "dist/static/index.html"),
+        "utf8"
+      );
+      expect(html).toContain("edge-runner-build");
+      expect(html).toContain('id="vprs-flight"');
+    });
+  }
+);
+
+describe.skipIf(!isolatedLeg)(
+  "runner 'edge' with an empty page set still emits its serving artifact",
+  () => {
+    it("build.pages: [] produces the pair (nothing to freeze is fine; no pair is not)", async () => {
+      await setupFixture("", { pages: "[]" });
+      const proc = runBuild();
+      expect(
+        proc.stdout,
+        `build failed (status ${proc.status}):\n${proc.stderr}`
+      ).toContain("EDGE_RUNNER_BUILD_OK");
+      expect(existsSync(join(testDir, "dist/server-edge/render.js"))).toBe(
+        true
+      );
+      expect(existsSync(join(testDir, "dist/server-edge/consumer.js"))).toBe(
+        true
+      );
+    }, 240000);
+  }
+);
+
+describe.skipIf(!isolatedLeg)("runner 'edge' bake failures are fatal", () => {
+  it("a failed bake fails the build (isolated only warns; edge has no artifact without it)", async () => {
+    // Induce a deterministic bake failure: the edge outDir collides with a
+    // FILE, so the bundle write cannot create its directory.
+    await setupFixture(', edge: { outDir: "edge-collide" }');
+    await writeFile(join(testDir, "dist-collide-placeholder"), "");
+    await mkdir(join(testDir, "dist"), { recursive: true });
+    await writeFile(join(testDir, "dist/edge-collide"), "not a directory");
+    const proc = runBuild();
+    expect(proc.status).not.toBe(0);
+    expect(proc.stderr).toMatch(/no serving artifact without it/);
+  }, 240000);
+});

--- a/test/examples/edge-runner-build.test.ts
+++ b/test/examples/edge-runner-build.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, readFile, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve, join } from "node:path";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// The edge runner's build contract (runner-spec.md, PR C of the runner
+// abstraction): under `runner: "edge"` the baked pair IS the paradigm's
+// serving artifact — the build emits it unconditionally, and the static
+// pages render THROUGH it (the freeze path), so the static surface carries
+// the same flavor the per-request path serves. The runner requires the
+// process condition absent, so this suite self-skips on the main leg — the
+// invariant suite pins that rejection.
+const isolatedLeg = getCondition() !== REACT_CONDITION.server;
+
+const testDir = resolve(__dirname, "../fixtures/edge-runner-build.test");
+
+async function setupFixture(edgeOption: string) {
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(join(testDir, "src/routes"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = () => (\n` +
+      `  <main id="app">\n` +
+      `    <h1>{"edge-runner-build"}</h1>\n` +
+      `  </main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\n` +
+      `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "build.mjs"),
+    `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+      `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: "edge",\n` +
+      `    transport: "webpack",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: fr.Page,\n` +
+      `    props: fr.props,\n` +
+      `    routePatterns: fr.routePatterns,\n` +
+      `    build: { pages: fr.build.pages, outDir: "dist"${edgeOption} },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("EDGE_RUNNER_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+function runBuild() {
+  return spawnSync("node", ["build.mjs"], {
+    cwd: testDir,
+    encoding: "utf8",
+    timeout: 180000,
+    env: { ...process.env, NODE_ENV: "production", NODE_OPTIONS: "" },
+  });
+}
+
+describe.skipIf(!isolatedLeg)("runner 'edge' build contract", () => {
+  beforeAll(async () => {
+    await setupFixture("");
+    const proc = runBuild();
+    expect(
+      proc.stdout,
+      `build failed (status ${proc.status}):\n${proc.stderr}`
+    ).toContain("EDGE_RUNNER_BUILD_OK");
+  }, 240000);
+
+  afterAll(async () => {
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("emits the baked pair as the serving artifact", () => {
+    expect(existsSync(join(testDir, "dist/server-edge/render.js"))).toBe(true);
+    expect(existsSync(join(testDir, "dist/server-edge/consumer.js"))).toBe(
+      true
+    );
+  });
+
+  it("renders the static pages through the pair — final markup, pair flavor", async () => {
+    const html = await readFile(
+      join(testDir, "dist/static/index.html"),
+      "utf8"
+    );
+    expect(html).toContain("edge-runner-build");
+    // The freeze's signature: the document self-carries its flight as the
+    // blob (frozen through the pair), never swap templates.
+    expect(html).toContain('id="vprs-flight"');
+    expect(html).not.toContain("$RC");
+  });
+});
+
+describe.skipIf(!isolatedLeg)(
+  "runner 'edge' rejects a disabled pair",
+  () => {
+    it("build.edge: false contradicts the paradigm and errors at config time", async () => {
+      await setupFixture(", edge: false");
+      const proc = runBuild();
+      expect(proc.status).not.toBe(0);
+      // Deliberately NOT satisfiable by the pre-implementation
+      // not-implemented error: the paradigm-contradiction message is its own
+      // contract.
+      expect(proc.stderr).toMatch(/IS the serving artifact/);
+    }, 240000);
+  }
+);

--- a/test/examples/runner-invariant.test.ts
+++ b/test/examples/runner-invariant.test.ts
@@ -56,10 +56,12 @@ describe("validateRunner", () => {
       );
     });
 
-    it("rejects 'edge' as not implemented before the condition check", () => {
-      // A declared 'edge' hears not-implemented first — never a flag
-      // instruction toward a value that then rejects anyway.
-      expect(() => validateRunner("edge")).toThrow(/not implemented yet/);
+    it("rejects 'edge' under the process condition", () => {
+      // Same invariant as isolated: the edge runner owns react-server
+      // resolution (baked at build time) — a global flag poisons the graph.
+      expect(() => validateRunner("edge")).toThrow(
+        /owns react-server resolution itself; remove the process flag/
+      );
     });
   } else {
     it("rejects 'main' without the process condition", () => {
@@ -72,8 +74,8 @@ describe("validateRunner", () => {
       expect(validateRunner("isolated")).toBe("isolated");
     });
 
-    it("rejects 'edge' as not implemented yet", () => {
-      expect(() => validateRunner("edge")).toThrow(/not implemented yet/);
+    it("accepts 'edge' without the process condition", () => {
+      expect(validateRunner("edge")).toBe("edge");
     });
   }
 });
@@ -111,6 +113,12 @@ describe("root package entry enforces the invariant", () => {
         /owns react-server resolution itself; remove the process flag/
       );
     });
+
+    it("rejects 'edge' under the process condition", () => {
+      expect(withRunner("edge")).toThrow(
+        /owns react-server resolution itself; remove the process flag/
+      );
+    });
   } else {
     it("rejects 'main' without the process condition", () => {
       expect(withRunner("main")).toThrow(
@@ -120,6 +128,10 @@ describe("root package entry enforces the invariant", () => {
 
     it("accepts 'isolated' without the process condition", () => {
       expect(withRunner("isolated")()).toBeInstanceOf(Array);
+    });
+
+    it("accepts 'edge' without the process condition", () => {
+      expect(withRunner("edge")()).toBeInstanceOf(Array);
     });
   }
 });

--- a/test/examples/runner-invariant.test.ts
+++ b/test/examples/runner-invariant.test.ts
@@ -131,7 +131,18 @@ describe("root package entry enforces the invariant", () => {
     });
 
     it("accepts 'edge' without the process condition", () => {
-      expect(withRunner("edge")()).toBeInstanceOf(Array);
+      // C1 scope: the edge runner requires transport "webpack" (the SSG
+      // freeze renders through the baked pair; the esm leg is a later slice).
+      const plugins = vitePluginReactServer({
+        ...testUserOptions,
+        runner: "edge",
+        transport: "webpack",
+      } as Parameters<typeof vitePluginReactServer>[0]);
+      expect(plugins).toBeInstanceOf(Array);
+    });
+
+    it("rejects 'edge' with the esm transport (later slice), naming the path", () => {
+      expect(withRunner("edge")).toThrow(/requires transport:"webpack"/);
     });
   }
 });


### PR DESCRIPTION
PR C of the runner abstraction (runner-spec.md), first slice: `runner: "edge"` stops erroring not-implemented and becomes a validated paradigm.

## What ships

- **Acceptance under the isolated invariant**: edge owns react-server resolution (baked at build time), so it validates exactly like `isolated` — condition absent accepts, the process flag rejects with the same guidance.
- **The pair is the paradigm**: under runner edge the baked pair is the serving artifact, not an add-on. An explicit `build.edge: false` contradicts the declared runner and errors at config time, before any transport-level guidance.
- **Scoped to the webpack transport for now**: the edge runner's SSG renders through the pair, which today exists only under `transport: "webpack"` — the esm transport is refused loudly with the path named rather than silently running the esm SSG pass outside the declared paradigm. The esm leg is the next slice.
- Dev keeps the isolated worker shape per the spec; the per-environment conditions audit and baked-pair preview follow in the next slice.

## Tests

The invariant suite pins acceptance/rejection in both conditions (root entry included), and `edge-runner-build.test.ts` pins the build contract: pair emitted unconditionally, static pages frozen through it (final markup carrying the pair's blob flight, no swap templates), `edge: false` rejected with its own deliberate message — all red against the previous not-implemented guard.

Found while fixturing, tracked separately: a webpack bake with **zero** client references bundles the browser entry into the baked consumer and executes it at import (`document is not defined`) — pre-existing on every runner (A/B-verified on isolated), so the fixture carries a real client component to pin the runner contract rather than that bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
