### PR TITLE
docs: edge runner documented as shipped; esm refusal states the real constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ The execution topology is a declared choice: the `runner` option names where
 react-server executes. `"isolated"` gives a worker thread react-server
 resolution with no launch flags; `"main"` puts it on the main thread — a bit
 faster, better stack traces, React usable in `vite.config.ts` — paired with
-`--conditions react-server` stated once in your scripts. Either way a worker
-mirrors the other half (server components need a react-server context, client
-hydration a react-client one), and runner and flag are validated against each
-other at config-resolve time.
+`--conditions react-server` stated once in your scripts; `"edge"` bakes React
+per environment into a single-isolate pair that IS the production serving
+artifact (webpack transport, no `node:` imports — Workers/Deno-ready), while
+its dev server runs the isolated worker shape. Runner and flag are validated
+against each other at config-resolve time.
 
 ## Quick start
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -41,7 +41,7 @@ export const config = {
 | `htmlTimeout` | `number` | Timeout in milliseconds for HTML generation operations | `15000` |
 | `htmlWorkerStartupTimeout` | `number` | Timeout in milliseconds for HTML worker startup | `5000` |
 | `rscWorkerStartupTimeout` | `number` | Timeout in milliseconds for RSC worker startup | `5000` |
-| `runner` | `"main" \| "isolated" \| "edge"` | **Required.** The execution paradigm: where react-server executes (see [Configuration → Runner](./configuration.md#runner)); validated against the process condition at config-resolve time. `"edge"` is recognized but rejected until the edge runner ships in a later 4.x minor | - |
+| `runner` | `"main" \| "isolated" \| "edge"` | **Required.** The execution paradigm: where react-server executes (see [Configuration → Runner](./configuration.md#runner)); validated against the process condition at config-resolve time. `"edge"` requires `transport: "webpack"` and makes the baked pair the serving artifact; its dev server runs the isolated worker shape (the pair serves prod) | - |
 | `transport` | `"esm" \| "webpack"` | The deploy's flight flavor; `"webpack"` renders the static snapshots through the baked pair and the dev server serves webpack flight, so every surface agrees (see [Configuration → Transport](./configuration.md#transport)) | `"esm"` |
 | `onMetrics` | `OnMetrics` | Callback for build metrics (render, worker-startup, module-resolution, edge-bake, inline-flight and ssg-render metrics) | - |
 | `onEvent` | `(event: PluginEvent) => void` | Callback for plugin events | - |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,7 @@ different topology.
 |--------|---------------|-------------|-------|
 | `"isolated"` | no flag | Worker thread | No launch flags, better isolation |
 | `"main"` | `NODE_OPTIONS='--conditions react-server'` | Main thread | A bit faster, better stack traces, React usable in `vite.config.ts` |
-| `"edge"` | no flag | Single isolate (baked pair) | Portability; requires `transport: "webpack"`, and the pair is the serving artifact (`build.edge: false` errors) |
+| `"edge"` | no flag | Single isolate (baked pair) | Portability; requires `transport: "webpack"`, the pair is the serving artifact (`build.edge: false` errors, a failed bake fails the build), and dev runs the isolated worker shape — the pair serves prod |
 
 `"main"` and `"isolated"` produce identical output. Under `"main"`, the RSC
 worker is skipped in dev — Vite's environment runner handles HMR directly.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,9 +163,9 @@ different topology.
 |--------|---------------|-------------|-------|
 | `"isolated"` | no flag | Worker thread | No launch flags, better isolation |
 | `"main"` | `NODE_OPTIONS='--conditions react-server'` | Main thread | A bit faster, better stack traces, React usable in `vite.config.ts` |
-| `"edge"` | no flag | Single isolate (baked pair) | Portability; not implemented yet — use `"isolated"` (or `"main"`) with `build.edge` meanwhile |
+| `"edge"` | no flag | Single isolate (baked pair) | Portability; requires `transport: "webpack"`, and the pair is the serving artifact (`build.edge: false` errors) |
 
-Both implemented runners produce identical output. Under `"main"`, the RSC
+`"main"` and `"isolated"` produce identical output. Under `"main"`, the RSC
 worker is skipped in dev — Vite's environment runner handles HMR directly.
 
 ## Build Scripts

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -30,8 +30,16 @@ the **transport** the render path uses, picked at build time
   `vite-plugin-react-server/edge/web` — see
   [Workers / Deno](#workers--deno-the-baked-consumer-and-edgeweb) below.
 
-It is **additive**: the normal `dist/server` / `dist/static` output is untouched.
-Dev is unaffected.
+Under runner `"main"` or `"isolated"` the bake is **additive**: the normal
+`dist/server` / `dist/static` output is untouched, dev is unaffected, and a
+bake failure warns without failing the build. Declaring **`runner: "edge"`**
+promotes the pair to the paradigm: the build requires `transport: "webpack"`,
+`build.edge: false` is a config-time contradiction, the SSG snapshots render
+through the pair, and a bake failure fails the build — an edge-runner build
+without its serving artifact is a broken deploy. The edge runner is a
+**production serving choice**: its dev server runs the isolated worker shape
+(same app code, worker-owned react-server resolution), and the baked pair is
+what deploys.
 
 ## How it works
 

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -100,9 +100,12 @@ vitePluginReactServer({
 });
 ```
 
-`build.edge` is `boolean | { outDir?, minify? }`, default **`true`** (the bundle
-is additive — the worker-based `dist/server` build is untouched — and a bake
-failure is a warning, never a build failure).
+`build.edge` is `boolean | { outDir?, minify? }`, default **`true`**. Under
+runner `"main"` or `"isolated"` the bundle is additive — the worker-based
+`dist/server` build is untouched, and a bake failure is a warning, never a
+build failure. Under runner `"edge"` the same knob describes the serving
+artifact itself: a bake failure fails the build, and `edge: false` is a
+config-time contradiction (see above).
 
 | form                     | meaning |
 | ------------------------ | ------- |

--- a/docs/internals/runner-spec.md
+++ b/docs/internals/runner-spec.md
@@ -79,7 +79,7 @@ than a signal.
 | react-in-config (React usable in `vite.config.ts`) | **yes** — the only runner that can; config executes in plain Node, outside any Vite environment, so only the process flag reaches it | no | no |
 | Render pipeline | in-process render | worker protocol (`RSC_CHUNK`/`RSC_END`), html-worker for SSG | baked pair (`dist/server-edge/render.js`), Web streams end-to-end |
 | Streams | Node streams | Node streams over the worker bridge | Web streams only, no `node:*` |
-| Dev shape | `vite` under the process flag (today's `dev:rsc`) | plain `vite` — the rsc-worker carries the condition internally (today's client-first dev) | plain `vite` + baked-pair preview |
+| Dev shape | `vite` under the process flag (today's `dev:rsc`) | plain `vite` — the rsc-worker carries the condition internally (today's client-first dev) | plain `vite` on the isolated worker shape; the pair serves prod (baked-pair preview arrives with `createHost`) |
 | Prod shape | host `dist/server` under the flag (`handleServerAction` sealed helper) | worker-based serving | `handleRouteAction` baked gate, no `--conditions` process |
 | Action dispatch | sealed executor in-process | delegate to worker | baked sealed gate |
 | Stack traces / debugging | best (one thread, one graph) | split across bridge | bundled |
@@ -133,6 +133,13 @@ dependency edge.
   process. A `build.edge` artifact emitted from a `main`/`isolated` config
   sits outside this invariant: it is an additional output, and deploying it
   is choosing the edge paradigm's transport for that deployment.
+- **Shipped deviation for `edge` (4.1):** the edge runner is a production
+  serving choice. Its dev server runs the isolated worker shape — same app
+  code, worker-owned react-server resolution — because baking the pair per
+  edit is not a dev loop, and pair-flavored preview belongs to `createHost`
+  (the host spec's worked example is exactly that server). Until then the
+  same-transport invariant holds for the artifact that deploys, not for the
+  dev server.
 - Prod action dispatch goes through sealed references baked into the
   manifest; dev's permissive dispatch surface is structurally absent from
   the artifacts.

--- a/docs/migrating-4.md
+++ b/docs/migrating-4.md
@@ -54,10 +54,12 @@ vitePluginReactServer({
 })
 ```
 
-`"edge"` (single isolate, React baked per environment) is a recognized value
-but is currently rejected: declaring it is a config-time error until the edge
-runner ships in a later 4.x minor. Use `"isolated"` or `"main"` with
-`build.edge` to emit the baked pair meanwhile.
+`"edge"` (single isolate, React baked per environment) validates like
+`"isolated"` — no process flag — and makes the baked pair the serving
+artifact: `build.edge: false` is a config-time contradiction. It requires
+`transport: "webpack"` (the pair's consumer half needs the webpack module
+map; the esm transport has no equivalent seam yet) — esm apps use
+`"isolated"`, with `build.edge` if they want the producer artifact.
 
 ## Install react-server-loader yourself
 

--- a/docs/migrating-4.md
+++ b/docs/migrating-4.md
@@ -56,10 +56,12 @@ vitePluginReactServer({
 
 `"edge"` (single isolate, React baked per environment) validates like
 `"isolated"` — no process flag — and makes the baked pair the serving
-artifact: `build.edge: false` is a config-time contradiction. It requires
-`transport: "webpack"` (the pair's consumer half needs the webpack module
-map; the esm transport has no equivalent seam yet) — esm apps use
-`"isolated"`, with `build.edge` if they want the producer artifact.
+artifact: `build.edge: false` is a config-time contradiction and a failed
+bake fails the build. It requires `transport: "webpack"` (the pair's
+consumer half needs the webpack module map; the esm transport has no
+equivalent seam yet) — esm apps use `"isolated"`, with `build.edge` if they
+want the producer artifact. The edge runner is a production serving choice:
+dev runs the isolated worker shape, and the pair is what deploys.
 
 ## Install react-server-loader yourself
 

--- a/plugin/config/resolveOptions.ts
+++ b/plugin/config/resolveOptions.ts
@@ -996,16 +996,19 @@ export const resolveOptions: ResolveOptionsFn = function _resolveOptions(
           "'isolated'/'main' if you don't want the bake)."
       );
     }
-    // C1 scope: the edge runner's SSG renders through the pair, which today
-    // exists only under transport "webpack". The esm-through-pair leg ships
-    // in the next slice — refuse it loudly rather than silently running the
-    // esm SSG pass outside the declared paradigm.
+    // The edge runner's SSG renders through the pair, and the pair's
+    // consumer half exists only under transport "webpack": the esm client
+    // transport resolves modules at request time (import(moduleBaseURL+id))
+    // and has no module-map seam a baked, closed registry can bind to.
+    // Until that manifest-resolved esm consumer exists, refuse loudly
+    // rather than silently running the esm SSG pass outside the declared
+    // paradigm.
     if (options.runner === "edge" && options.transport !== "webpack") {
       throw new Error(
-        "[vite-plugin-react-server] runner 'edge' currently requires " +
-          'transport:"webpack" (the SSG freeze renders through the baked ' +
-          "pair). The esm leg ships in a following release — use runner " +
-          "'isolated' with build.edge meanwhile."
+        "[vite-plugin-react-server] runner 'edge' requires " +
+          'transport:"webpack": the baked pair\'s consumer half needs the ' +
+          "webpack module map, and the esm transport has no equivalent " +
+          "seam yet. Use runner 'isolated' for the esm transport."
       );
     }
     // transport:"webpack" contracts the whole build around the baked pair:


### PR DESCRIPTION
Stacked on #411 (base is its branch, so this shows only the C2 delta; retarget to main lands automatically when #411 merges).

The esm refusal turned out not to be a temporary scope guard: the baked pair's consumer half binds a closed client-module registry to the **webpack module map**, and the esm transport resolves modules at request time (`import(moduleBaseURL + id)`) with no equivalent seam — the manifest-resolved esm consumer is its own design track. The error message and its comment now state that constraint instead of promising a following release.

Docs flip with it: `migrating-4.md` and the configuration matrix move from "currently rejected / not implemented" to the shipped contract — validates like `isolated`, the pair is the serving artifact (`build.edge: false` errors), webpack transport required.

Deliberately not in this slice: baked-pair preview serving (it falls out of `createHost`, the next arc item), and the per-environment conditions behavior is already proven end-to-end by the C1 build suite (the bake resolves react-server per environment or the freeze could not render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
