### PR TITLE
feat: createHost — the manifest-driven host, Node convenience form first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           npm run build
           ./scripts/test-both.sh test/examples/workerd-smoke.test.ts
+          ./scripts/test-both.sh test/examples/host-edge-entry.test.ts
 
   # Drive a REAL browser against a REAL installed consumer.
   #

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -290,6 +290,23 @@ createEdgeHandler({
 > actually host the client build — and verify in a real prod build at the real
 > base.
 
+## Platform bindings
+
+Whatever the runtime passes to your fetch handler after the request (workerd's
+`env` and `ctx`, or nothing on Node) travels through the handler as
+`platform` and surfaces in two places:
+
+- **Loaders**: `props(url, ctx)` receives it as `ctx.platform` — an array of
+  the extra arguments, so `ctx.platform[0]` is workerd's `env`.
+- **Server actions**: every action is called with a trailing context argument,
+  `action(...args, { platform })`. Existing actions ignore it; an action that
+  declares the extra parameter reads its bindings from it. The shape is
+  identical in dev and on Node — `platform` is just empty there — so action
+  code behaves the same everywhere.
+
+There is no global to reach for: bindings arrive per request, which is also
+the only form workerd supports.
+
 ## Run it on Node
 
 On a real edge platform you export the handler directly. On Node, wrap it in a

--- a/docs/internals/host-spec.md
+++ b/docs/internals/host-spec.md
@@ -56,8 +56,11 @@ http.createServer(toNodeListener(createHost({ buildDir: "./dist" }))).listen(300
 // Any fetch runtime (portable form): the build emits dist/server-edge/host.js —
 // a generated module that statically imports its render/consumer bundles and
 // inlines its manifest, then calls the same core with resolved artifacts.
-import handler from "./dist/server-edge/host.js";
-export default { fetch: handler };               // workerd / Bun / Deno
+// The default export IS the module-worker mount — a workerd deploy points
+// its main at host.js with no wrapper file at all. Runtimes that want the
+// bare function import it by name:
+import hostModule, { handler } from "./dist/server-edge/host.js";
+export default hostModule;                       // workerd / Bun / Deno ({ fetch: handler })
 export default handler;                          // Vercel function
 ```
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
       "types": "./dist/plugin/edge/web.d.ts",
       "default": "./dist/plugin/edge/web.js"
     },
+    "./host": {
+      "types": "./dist/plugin/host/index.d.ts",
+      "default": "./dist/plugin/host/index.js"
+    },
     "./stream": {
       "react-server": "./dist/plugin/stream/index.server.js",
       "default": "./dist/plugin/stream/index.client.js"

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -723,7 +723,7 @@ ${patternRouteLines.join("\n")}
 };
 
 /** Resolve a route's Page component + live props through the canonical helper. */
-async function resolveRoute(url, request) {
+async function resolveRoute(url, request, platform) {
   // Exact match for the enumerated/prerendered set; else fall back to matching
   // the url against the route patterns so any concrete dynamic url (e.g. a
   // /profile/<id> that wasn't prerendered) renders per-request on the edge.
@@ -749,6 +749,7 @@ async function resolveRoute(url, request) {
     // authenticated route. Present only for per-request edge renders (the
     // handler passes it); undefined at prerender.
     request,
+    platform,
     url,
     loader: async (id) => {
       // resolvePage/resolveProps may pass "<path>#<export>"; key by the path.
@@ -765,8 +766,8 @@ async function resolveRoute(url, request) {
 }
 
 /** Headless page flight (Page only) — the simple producer. */
-export async function ${flightExport}(url, request) {
-  const resolved = await resolveRoute(url, request);
+export async function ${flightExport}(url, request, platform) {
+  const resolved = await resolveRoute(url, request, platform);
   // Page-only compose (Html/Root as Fragment) so nested layouts fold around the
   // leaf; equivalent to createElement(Page, props) when there is no chain.
   return renderToReadableStream(
@@ -789,7 +790,7 @@ export async function ${flightExport}(url, request) {
  * (Map<string, CssContent>) so both carry the page styles.
  */
 export async function ${documentExport}(url, opts = {}) {
-  const resolved = await resolveRoute(url, opts.request);
+  const resolved = await resolveRoute(url, opts.request, opts.platform);
   const base = {
     PageComponent: resolved.PageComponent,
     RootComponent,
@@ -846,6 +847,7 @@ const actionGate = createSealedServerReferenceGate({
 export async function ${actionExport}(request, opts = {}) {
   return handleServerActionRequest(request, {
     projectRoot: opts.projectRoot ?? "",
+    platform: opts.platform,
     base: MODULE_BASE_URL,
     resolveServerReference: (id) => actionGate.resolveServerReference(id),
     // The baked flight pair: arguments decode through THIS bundle's transport

--- a/plugin/bundle/buildHostEntry.ts
+++ b/plugin/bundle/buildHostEntry.ts
@@ -1,0 +1,152 @@
+import { build as viteBuild, type Logger } from "vite";
+import { join, dirname } from "node:path";
+import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { ResolvedUserOptions } from "../types.js";
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+
+/**
+ * The generated portable host entry (host-spec, "The API"):
+ * `dist/server-edge/host.js` — statically imports the baked pair, inlines
+ * its host manifest, and exports the fetch-shaped handler. A fetch runtime
+ * mounts it directly (`export default { fetch: handler }`); its imports are
+ * discoverable at bundle time, so no filesystem and no directory inspection
+ * exist at runtime. Statics are the platform's job in this form: a known
+ * static path that still reaches the handler is answered plainly by the
+ * core's missing-artifact rule.
+ */
+export async function buildHostEntry(opts: {
+  userOptions: ResolvedUserOptions;
+  projectRoot: string;
+  logger: Logger;
+}): Promise<void> {
+  const { userOptions, projectRoot, logger } = opts;
+  const tag = "[build.host]";
+  const outRoot = join(projectRoot, userOptions.build.outDir);
+  const edgeDir = join(
+    outRoot,
+    userOptions.build.edge.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir
+  );
+
+  // Only a complete pair with its manifest can host — the esm bake has no
+  // consumer half, and without a manifest there is no contract to inline.
+  const manifestPath = join(edgeDir, "host-manifest.json");
+  const producerPath = join(edgeDir, DEFAULT_CONFIG.EDGE.entryFileName);
+  const consumerPath = join(edgeDir, "consumer.js");
+  if (
+    !existsSync(manifestPath) ||
+    !existsSync(producerPath) ||
+    !existsSync(consumerPath)
+  ) {
+    return;
+  }
+  const manifestJson = readFileSync(manifestPath, "utf8");
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const corePath = join(here, "../host/createHostFromManifest.js");
+  const edgeHandlerPath = join(here, "../edge/web.js");
+
+  const entryPath = join(edgeDir, ".vprs-host.js");
+  const entrySource = `import * as bundle from "./${DEFAULT_CONFIG.EDGE.entryFileName}";
+import * as consumer from "./consumer.js";
+import {
+  createHostFromManifest,
+  HOST_OUTCOME_HEADER,
+} from ${JSON.stringify(corePath)};
+import { createEdgeRequestHandler } from ${JSON.stringify(edgeHandlerPath)};
+
+const MANIFEST = ${manifestJson.trim()};
+
+/**
+ * Per-request render (see the host core's loadRender contract): a handler
+ * per request so error attribution never crosses requests; a loader
+ * notFound() rides the sentinel header to the manifest 404 document; a
+ * degraded 200 (React reported through onError while the boundary degraded)
+ * becomes the thrown failure the core maps to the 500 page.
+ */
+const loadRender = async () => ({
+  render: async (request, platform) => {
+    const renderErrors = [];
+    const render = createEdgeRequestHandler(bundle, {
+      renderFlightToHtml: consumer.renderFlightToHtml,
+      onError: (error) => renderErrors.push(error),
+      onNotFound: () =>
+        new Response(null, {
+          status: 404,
+          headers: { [HOST_OUTCOME_HEADER]: "not-found" },
+        }),
+    });
+    const response = await render(request, ...platform);
+    if (renderErrors.length > 0) throw renderErrors[0];
+    return response;
+  },
+  action: (request, platform) => bundle.handleRouteAction(request, { platform }),
+});
+
+export const handler = createHostFromManifest({
+  manifest: MANIFEST,
+  // Platform statics: the CDN/platform serves the emitted files; a known
+  // artifact that still reaches the handler is answered plainly by the
+  // core's missing-artifact rule, never by a render.
+  serveStatic: async () => null,
+  loadRender,
+});
+
+// Mountable directly as a Cloudflare module worker; Vercel-style runtimes
+// that want the bare function import the named \`handler\`.
+export default { fetch: handler };
+`;
+
+  try {
+    writeFileSync(entryPath, entrySource);
+    await viteBuild({
+      root: edgeDir,
+      logLevel: "warn",
+      configFile: false,
+      define: { "process.env.NODE_ENV": JSON.stringify("production") },
+      ssr: { target: "webworker", noExternal: true },
+      build: {
+        ssr: true,
+        outDir: edgeDir,
+        emptyOutDir: false,
+        minify: userOptions.build.edge.minify,
+        rollupOptions: {
+          input: { host: entryPath },
+          // The pair stays external: host.js sits NEXT TO render.js and
+          // consumer.js and imports them relatively — re-bundling them here
+          // would duplicate React per artifact.
+          external: (id: string) =>
+            id === `./${DEFAULT_CONFIG.EDGE.entryFileName}` ||
+            id === "./consumer.js" ||
+            id.endsWith(`/${DEFAULT_CONFIG.EDGE.entryFileName}`) ||
+            id.endsWith("/consumer.js"),
+          output: {
+            preserveModules: false,
+            format: "es",
+            paths: (id: string) =>
+              id.endsWith(`/${DEFAULT_CONFIG.EDGE.entryFileName}`)
+                ? `./${DEFAULT_CONFIG.EDGE.entryFileName}`
+                : id.endsWith("/consumer.js")
+                ? "./consumer.js"
+                : id,
+          },
+        },
+      },
+    });
+    logger.info(`${tag} portable host entry → ${join(edgeDir, "host.js")}`);
+  } catch (error) {
+    // Under runner "edge" the entry is part of the paradigm's artifact set —
+    // a green build without it is a broken deploy. (Defensive read: the
+    // runner field ships on the resolved options with the runner branch.)
+    if ((userOptions as { runner?: string }).runner === "edge") {
+      throw new Error(
+        `${tag} host entry build failed and runner 'edge' treats it as a ` +
+          `serving artifact: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`${tag} skipped — host entry build failed: ${message}`);
+  } finally {
+    rmSync(entryPath, { force: true });
+  }
+}

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -136,7 +136,8 @@ export function createEdgeRenderHook(
 
   return async function edgeRender(
     route: string,
-    request: Request
+    request: Request,
+    ...platform: unknown[]
   ): Promise<Response | null> {
     // `route` arrives as the raw pathname from createRequestHandler; normalize it
     // the same way the document handler's getURL does, so both agree on the key.
@@ -150,7 +151,10 @@ export function createEdgeRenderHook(
       // Client navigation: the Root-only payload, from the same producer (and so
       // the same live props) the document path inlines on first paint.
       try {
-        const { headless } = await bundle.renderRouteToDocument(url, { request });
+        const { headless } = await bundle.renderRouteToDocument(url, {
+          request,
+          platform,
+        });
         return new Response(headless as unknown as BodyInit, {
           headers: {
             "content-type": "text/x-component; charset=utf-8",
@@ -177,7 +181,7 @@ export function createEdgeRenderHook(
       }
     }
 
-    const response = await (await getDocumentHandler())(request);
+    const response = await (await getDocumentHandler())(request, ...platform);
     // An unbaked route is a fall-through for a hook, not an answer.
     return response === NOT_HANDLED ? null : response;
   };
@@ -237,7 +241,8 @@ export function createEdgeRequestHandler(
   const render = createEdgeRenderHook(bundle, options);
 
   return async function edgeRequestHandler(
-    request: Request
+    request: Request,
+    ...platform: unknown[]
   ): Promise<Response> {
     const { pathname } = new URL(request.url);
 
@@ -246,11 +251,11 @@ export function createEdgeRequestHandler(
       request.headers.get(actionHeader) &&
       bundle.handleRouteAction
     ) {
-      return bundle.handleRouteAction(request, { projectRoot });
+      return bundle.handleRouteAction(request, { projectRoot, platform });
     }
 
     if (request.method === "GET" || request.method === "HEAD") {
-      const response = await render(pathname, request);
+      const response = await render(pathname, request, ...platform);
       if (response) return response;
     }
 

--- a/plugin/edge/createEdgeRequestHandler.types.ts
+++ b/plugin/edge/createEdgeRequestHandler.types.ts
@@ -24,6 +24,7 @@ export type EdgeBundleExports = {
     opts?: {
       request?: Request;
       cssFiles?: Map<string, CssContent>;
+      platform?: unknown[];
       globalCss?: unknown;
     }
   ) => Promise<{
@@ -36,7 +37,7 @@ export type EdgeBundleExports = {
    */
   handleRouteAction?: (
     request: Request,
-    opts?: { projectRoot?: string }
+    opts?: { projectRoot?: string; platform?: unknown[] }
   ) => Promise<Response>;
   /** `bootstrapModules`: the content-hashed browser entry, baked at build time. */
   bootstrapModules?: string[];
@@ -111,5 +112,6 @@ export type CreateEdgeRequestHandlerOptions = Omit<
  */
 export type EdgeRenderHook = (
   route: string,
-  request: Request
+  request: Request,
+  ...platform: unknown[]
 ) => Promise<Response | null>;

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -584,6 +584,16 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
               logger,
               viteBase: config.base,
             });
+            // Step 8: the portable host entry over the pair + its manifest
+            // (host-spec "The API") — after the manifest, which it inlines.
+            const { buildHostEntry } = await import(
+              "../bundle/buildHostEntry.js"
+            );
+            await buildHostEntry({
+              userOptions,
+              projectRoot: userOptions.projectRoot,
+              logger,
+            });
           },
         },
       };

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -232,7 +232,7 @@ export async function resolveAndExecuteServerAction(
   }
 
   const args = await decodeActionBody(body, codec);
-  return executeServerAction(action, args, verbose, logger);
+  return executeServerAction(action, args, verbose, logger, options.platform);
 }
 
 /**

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -6,6 +6,8 @@ import type { ServerResponse } from "node:http";
 import type { IncomingMessage } from "node:http";
 
 export type ServerActionHandlerOptions = {
+  /** The fetch runtime's extra handler arguments — the bindings seam. */
+  platform?: unknown[];
   projectRoot: string;
   verbose?: boolean;
   logger?: Logger;
@@ -545,13 +547,19 @@ export async function executeServerAction(
   action: Function,
   args: unknown[],
   verbose = false,
-  logger?: Logger
+  logger?: Logger,
+  platform?: unknown[]
 ): Promise<unknown> {
   if (verbose) {
     logger?.info(`[handleServerActionHelper] Executing action with args: ${JSON.stringify(args)}`);
   }
 
-  const result = await action(...args);
+  // The bindings seam (host-spec Resolution 4): every action receives a
+  // trailing ctx argument carrying the runtime's extra handler arguments
+  // (workerd's env/ctx; empty on Node/dev). Additive — an action that
+  // ignores it keeps working; one that declares it reads ctx.platform.
+  // Concurrency-safe by construction: no request-scoped globals.
+  const result = await action(...args, { platform: platform ?? [] });
   
   if (verbose) {
     logger?.info(`[handleServerActionHelper] Action executed successfully: ${JSON.stringify(result)}`);

--- a/plugin/helpers/resolvePageAndProps.ts
+++ b/plugin/helpers/resolvePageAndProps.ts
@@ -74,7 +74,11 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
               )
             )?.params ?? {}
           : {});
-      const loaderCtx: LoaderCtx = { params, request: handlerOptions.request };
+      const loaderCtx: LoaderCtx = {
+        params,
+        request: handlerOptions.request,
+        ...(handlerOptions.platform ? { platform: handlerOptions.platform } : {}),
+      };
 
       const resolvePagePromise = resolvePage({
         id: handlerOptions.pagePath,
@@ -344,6 +348,7 @@ export type ResolvePageAndPropsFn = <T extends PagePropOpt = PagePropOpt>(
     | "stripHtmlSuffix"
     | "params"
     | "request"
+    | "platform"
   > & {
     moduleBaseURL?: string;
     route?: string;

--- a/plugin/helpers/resolveProps.ts
+++ b/plugin/helpers/resolveProps.ts
@@ -10,6 +10,9 @@ export type LoaderCtx = {
   params: Record<string, string>;
   /** In-flight request; present only on the dev request thread (see CreateHandlerOptions). */
   request?: Request;
+  /** The fetch runtime's extra handler arguments (workerd's env/ctx) — the
+   *  bindings seam, threaded by createHost. Empty on Node hosts. */
+  platform?: unknown[];
 };
 
 type ResolvePropsOptions = {

--- a/plugin/host/createHostFromManifest.ts
+++ b/plugin/host/createHostFromManifest.ts
@@ -1,14 +1,17 @@
 // Web-standard by construction (no node:*): this core must run wherever a
 // fetch handler runs. The Node conveniences live in ./index.ts.
 
+import { matchRoutes } from "../router/matchRoute.js";
+
 /**
  * The runtime-agnostic host core (docs/internals/host-spec.md): one
  * `(Request) => Promise<Response>` implementing the request algorithm over a
- * host manifest — exact-match assets before routing, prerendered documents,
- * per-request renders for dynamic matches, the action gate on POST, and
- * DISTINCT failures (404 document for a miss, 500 after `onError` for a
- * render failure, 405 elsewhere). Conditional requests and cache profiles
- * derive from the manifest at startup; nothing is recomputed per request.
+ * host manifest — prerendered documents (and their `.rsc` siblings, by
+ * suffix or Accept) before the asset inventory, per-request renders for
+ * dynamic matches, the action gate on POST, and DISTINCT failures (404
+ * document for a miss, 500 after `onError` for a render failure, 405
+ * elsewhere). Conditional requests and cache profiles derive from the
+ * manifest at startup; nothing is recomputed per request.
  */
 
 export type HostManifest = {
@@ -39,18 +42,24 @@ export type StaticFile = {
   size?: number;
 };
 
+/** The render seam marks a loader notFound() with this header so the host
+ *  serves the manifest 404 document instead of a bare inner body. */
+export const HOST_OUTCOME_HEADER = "x-vprs-host-outcome";
+
 export type HostCoreOptions = {
   manifest: HostManifest;
   /** Read an emitted static file by its manifest-relative path, or null. */
   serveStatic: (path: string) => Promise<StaticFile | null>;
   /**
-   * Lazily provide the per-request renderer and the action gate — the
-   * flavor the manifest records (the baked pair under transport "webpack").
-   * Called once, on first need.
+   * Provide the per-request renderer and the action gate for ONE request —
+   * called per request so error attribution can never cross requests. Both
+   * receive the platform tail (a fetch runtime's env/ctx) for the bindings
+   * seam. A render marking {@link HOST_OUTCOME_HEADER}: "not-found" is a
+   * loader notFound() and gets the manifest 404 document.
    */
   loadRender: () => Promise<{
-    render: (request: Request) => Promise<Response>;
-    action: (request: Request) => Promise<Response>;
+    render: (request: Request, platform: unknown[]) => Promise<Response>;
+    action: (request: Request, platform: unknown[]) => Promise<Response>;
   }>;
   onError?: (error: unknown) => void;
   /** A hung render answers 500 instead of hanging the connection. */
@@ -88,16 +97,9 @@ const contentType = (path: string): string =>
 const FALLBACK_404 = `<!doctype html><html><head><meta charset="utf-8"><title>Not found</title></head><body style="font-family:system-ui;padding:3rem"><h1>404</h1><p>This page does not exist.</p></body></html>`;
 const FALLBACK_500 = `<!doctype html><html><head><meta charset="utf-8"><title>Server error</title></head><body style="font-family:system-ui;padding:3rem"><h1>500</h1><p>The server failed to render this page.</p></body></html>`;
 
-function matchPattern(pattern: string, pathname: string): boolean {
-  const p = pattern.split("/").filter(Boolean);
-  const u = pathname.split("/").filter(Boolean);
-  if (p.length !== u.length) return false;
-  return p.every((seg, i) => seg.startsWith("$") || seg === u[i]);
-}
-
 export function createHostFromManifest(
   options: HostCoreOptions
-): (request: Request) => Promise<Response> {
+): (request: Request, ...platform: unknown[]) => Promise<Response> {
   const {
     manifest,
     serveStatic,
@@ -121,13 +123,12 @@ export function createHostFromManifest(
   const rscSuffixRe = new RegExp(
     `^(.*/)${rscName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`
   );
+  const patterns = manifest.routes.map((r) => r.pattern);
+  const dynamicByPattern = new Map(
+    manifest.routes.map((r) => [r.pattern, r.dynamic])
+  );
 
-  let renderPair:
-    | Promise<{
-        render: (request: Request) => Promise<Response>;
-        action: (request: Request) => Promise<Response>;
-      }>
-    | undefined;
+  let renderPair: ReturnType<HostCoreOptions["loadRender"]> | undefined;
   const pair = () => (renderPair ??= loadRender());
 
   const staticHeaders = (
@@ -153,30 +154,40 @@ export function createHostFromManifest(
     profile: "asset" | "document",
     status = 200
   ): Promise<Response> => {
-    const etag = manifest.etags[path];
-    if (etag && request.headers.get("if-none-match") === etag) {
-      return new Response(null, {
-        status: 304,
-        headers: staticHeaders(path, profile),
-      });
-    }
+    // Existence first: a 304 for an artifact the adapter cannot produce
+    // would hide a broken deploy behind the client's cache.
     const file = await serveStatic(path);
     if (!file) {
-      // A manifest-known artifact the adapter cannot produce is a deploy
-      // defect — answer plainly, never fall through to a render.
       return new Response(`missing static artifact: ${path}`, {
         status: 404,
         headers: { "content-type": "text/plain; charset=utf-8" },
       });
     }
+    const cancelBody = () => {
+      if (file.body instanceof ReadableStream) {
+        void file.body.cancel().catch(() => {});
+      }
+    };
     const headers = staticHeaders(path, profile);
-    if (file.size !== undefined && request.method !== "HEAD") {
+    if (file.size !== undefined) {
       headers.set("content-length", String(file.size));
     }
-    return new Response(
-      request.method === "HEAD" ? null : (file.body as BodyInit),
-      { status, headers }
-    );
+    // Error/404 pages carry their required status — never a 304.
+    const etag = manifest.etags[path];
+    if (
+      status === 200 &&
+      etag &&
+      request.headers.get("if-none-match") === etag
+    ) {
+      cancelBody();
+      headers.delete("content-length");
+      return new Response(null, { status: 304, headers });
+    }
+    if (request.method === "HEAD") {
+      cancelBody();
+      return new Response(null, { status, headers });
+    }
+    return new Response(file.body as BodyInit, { status, headers });
   };
 
   const notFound = (request: Request): Promise<Response> =>
@@ -199,19 +210,38 @@ export function createHostFromManifest(
           })
         );
 
-  return async function hostHandler(request: Request): Promise<Response> {
+  /** Re-base an app-relative Location coming out of the inner renderer. */
+  const rebaseLocation = (location: string): string =>
+    base !== "/" && location.startsWith("/") && !location.startsWith(base)
+      ? `${base.slice(0, -1)}${location}`
+      : location;
+
+  return async function hostHandler(
+    request: Request,
+    ...platform: unknown[]
+  ): Promise<Response> {
     const url = new URL(request.url);
     let pathname = decodeURIComponent(url.pathname);
 
-    // Base strip: the router speaks app-relative paths.
-    if (base !== "/" && pathname.startsWith(base)) {
+    // The route base scopes the app: strip it, and refuse anything outside
+    // it — an un-based path must not remain routable under a based deploy.
+    if (base !== "/") {
+      if (pathname === base.slice(0, -1)) {
+        return new Response(null, {
+          status: 308,
+          headers: { location: `${base}${url.search}` },
+        });
+      }
+      if (!pathname.startsWith(base)) {
+        return notFound(request);
+      }
       pathname = `/${pathname.slice(base.length)}`;
     }
 
     if (request.method === "POST") {
       if (request.headers.get("x-rsc-action")) {
         const { action } = await pair();
-        return action(request);
+        return action(request, platform);
       }
       return new Response("method not allowed", {
         status: 405,
@@ -225,55 +255,89 @@ export function createHostFromManifest(
       });
     }
 
-    // Exact asset lookup before any routing: once a path is a known static
+    // Document detection BEFORE the asset inventory: the prerendered `.rsc`
+    // siblings live in `assets`, but they are documents — immutable caching
+    // on them would pin stale flight forever. Either the suffix or an
+    // Accept: text/x-component on the page url selects the flight shape.
+    const rscMatch = pathname.match(rscSuffixRe);
+    const acceptsFlight = (request.headers.get("accept") ?? "").includes(
+      "text/x-component"
+    );
+    const docPathname = rscMatch ? rscMatch[1]! : pathname;
+    const routeUrl = docPathname === "/" ? "/" : docPathname.replace(/\/$/, "");
+
+    if ((rscMatch || acceptsFlight) && prerendered.has(routeUrl)) {
+      const dir = routeUrl === "/" ? "" : `${routeUrl.slice(1)}/`;
+      return serveFile(request, `${dir}${rscName}`, "document");
+    }
+
+    // Exact asset lookup before routing: once a path is a known static
     // artifact, route matching never sees it.
     const assetPath = pathname.replace(/^\//, "");
-    if (assets.has(assetPath)) {
+    if (!rscMatch && assets.has(assetPath)) {
       return serveFile(request, assetPath, "asset");
     }
 
-    // The `.rsc` sibling of a prerendered/dynamic document.
-    const rscMatch = pathname.match(rscSuffixRe);
-    const docPathname = rscMatch ? rscMatch[1]! : pathname;
-
-    // Trailing-slash canonicalization for document urls: one URL per page,
-    // matching what the prerender emitted.
+    // Trailing-slash canonicalization for document urls — preserving base
+    // and query: one URL per page, matching what the prerender emitted.
     if (!rscMatch && !pathname.endsWith("/") && extOf(pathname) === "") {
+      const basedPath =
+        base === "/" ? pathname : `${base.slice(0, -1)}${pathname}`;
       return new Response(null, {
         status: 308,
-        headers: { location: `${pathname}/` },
+        headers: { location: `${basedPath}/${url.search}` },
       });
     }
-
-    const routeUrl =
-      docPathname === "/" ? "/" : docPathname.replace(/\/$/, "");
 
     if (prerendered.has(routeUrl)) {
       const dir = routeUrl === "/" ? "" : `${routeUrl.slice(1)}/`;
-      const file = rscMatch ? `${dir}${rscName}` : `${dir}${htmlName}`;
-      return serveFile(request, file, "document");
+      return serveFile(request, `${dir}${htmlName}`, "document");
     }
 
-    const matched = manifest.routes.find((r) =>
-      matchPattern(r.pattern, routeUrl)
-    );
-    if (!matched || !matched.dynamic) {
+    // vprs routing (bare $ consumes the remaining segments) — never a
+    // private re-implementation.
+    const matched = matchRoutes(patterns, routeUrl);
+    if (!matched || !dynamicByPattern.get(matched.pattern)) {
       return notFound(request);
     }
 
+    // The inner renderer sees the APP-RELATIVE url: forward a rewritten
+    // request, chained to our deadline so a hung upstream aborts instead of
+    // rendering on after the 500.
+    const controller = new AbortController();
+    if (request.signal.aborted) controller.abort();
+    else request.signal.addEventListener("abort", () => controller.abort());
+    const forwardUrl = new URL(request.url);
+    forwardUrl.pathname = pathname;
+    const forward = new Request(forwardUrl, {
+      method: request.method,
+      headers: request.headers,
+      signal: controller.signal,
+    });
+
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
     try {
       const { render } = await pair();
       const deadline = new Promise<never>((_, reject) => {
-        const t = setTimeout(
-          () => reject(new Error(`render deadline (${renderDeadlineMs}ms) hit`)),
-          renderDeadlineMs
-        );
-        (t as { unref?: () => void }).unref?.();
+        deadlineTimer = setTimeout(() => {
+          controller.abort();
+          reject(new Error(`render deadline (${renderDeadlineMs}ms) hit`));
+        }, renderDeadlineMs);
+        (deadlineTimer as { unref?: () => void }).unref?.();
       });
-      const response = await Promise.race([render(request), deadline]);
+      const response = await Promise.race([
+        render(forward, platform),
+        deadline,
+      ]);
+      if (response.headers.get(HOST_OUTCOME_HEADER) === "not-found") {
+        return notFound(request);
+      }
       const headers = new Headers(response.headers);
+      headers.delete(HOST_OUTCOME_HEADER);
       headers.set("cache-control", "no-store");
       headers.set("vary", "Accept");
+      const location = headers.get("location");
+      if (location) headers.set("location", rebaseLocation(location));
       return new Response(response.body, {
         status: response.status,
         headers,
@@ -281,6 +345,8 @@ export function createHostFromManifest(
     } catch (error) {
       onError?.(error);
       return errorPage(request);
+    } finally {
+      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
     }
   };
 }

--- a/plugin/host/createHostFromManifest.ts
+++ b/plugin/host/createHostFromManifest.ts
@@ -228,13 +228,13 @@ export function createHostFromManifest(
     }
   };
 
-  // Static inventories hold decoded paths, so lookups must decode — but
-  // SEGMENT-WISE, refusing any decode that forges a separator: with
-  // prerendered /docs/a/b and dynamic /docs/$slug, /docs/a%2Fb must stay one
-  // parameter, never the nested static page. `malformed` (any segment that
-  // fails to decode) is the controlled-404 signal; `value: null` with
-  // well-formed input means a forged separator — no static artifact can
-  // match, but routing may still see the encoded path.
+  // Static-inventory lookups decode — but SEGMENT-WISE, refusing any decode
+  // that forges a separator: with prerendered /docs/a/b and dynamic
+  // /docs/$slug, /docs/a%2Fb must stay one parameter, never the nested
+  // static page. `malformed` (any segment that fails to decode) is the
+  // controlled-404 signal; `value: null` with well-formed input means a
+  // forged separator — only the raw encoded key can then match a static
+  // artifact, and routing may still see the encoded path.
   const decodeForLookup = (
     path: string
   ): { malformed: boolean; value: string | null } => {
@@ -249,6 +249,22 @@ export function createHostFromManifest(
     }
     return { malformed: false, value: out.join("/") };
   };
+
+  // Inventory keys are the literal on-disk paths, and fillPattern emits
+  // ENCODED urls the writer preserves — a staticPaths param "a b" is
+  // prerendered AS /u/a%20b (an intentional "a/b" as /u/a%2Fb). So the raw
+  // encoded key is tried first, the guarded decode second, and serving uses
+  // whichever spelling actually matched.
+  const inventoryKey = (
+    inventory: Set<string>,
+    raw: string,
+    decoded: string | null
+  ): string | null =>
+    inventory.has(raw)
+      ? raw
+      : decoded !== null && inventory.has(decoded)
+        ? decoded
+        : null;
 
   return async function hostHandler(
     request: Request,
@@ -308,23 +324,26 @@ export function createHostFromManifest(
     if (routeLookup.malformed || assetLookup.malformed) {
       return notFound(request);
     }
-    const decodedRouteUrl = routeLookup.value;
+    const prerenderedKey = inventoryKey(
+      prerendered,
+      routeUrl,
+      routeLookup.value
+    );
 
-    if (
-      (rscMatch || acceptsFlight) &&
-      decodedRouteUrl !== null &&
-      prerendered.has(decodedRouteUrl)
-    ) {
-      const dir =
-        decodedRouteUrl === "/" ? "" : `${decodedRouteUrl.slice(1)}/`;
+    if ((rscMatch || acceptsFlight) && prerenderedKey !== null) {
+      const dir = prerenderedKey === "/" ? "" : `${prerenderedKey.slice(1)}/`;
       return serveFile(request, `${dir}${rscName}`, "document");
     }
 
     // Exact asset lookup before routing: once a path is a known static
     // artifact, route matching never sees it.
-    const decodedAsset = assetLookup.value;
-    if (!rscMatch && decodedAsset !== null && assets.has(decodedAsset)) {
-      return serveFile(request, decodedAsset, "asset");
+    const assetKey = inventoryKey(
+      assets,
+      pathname.replace(/^\//, ""),
+      assetLookup.value
+    );
+    if (!rscMatch && assetKey !== null) {
+      return serveFile(request, assetKey, "asset");
     }
 
     // Trailing-slash canonicalization for document urls — preserving base
@@ -338,9 +357,8 @@ export function createHostFromManifest(
       });
     }
 
-    if (decodedRouteUrl !== null && prerendered.has(decodedRouteUrl)) {
-      const dir =
-        decodedRouteUrl === "/" ? "" : `${decodedRouteUrl.slice(1)}/`;
+    if (prerenderedKey !== null) {
+      const dir = prerenderedKey === "/" ? "" : `${prerenderedKey.slice(1)}/`;
       return serveFile(request, `${dir}${htmlName}`, "document");
     }
 

--- a/plugin/host/createHostFromManifest.ts
+++ b/plugin/host/createHostFromManifest.ts
@@ -1,0 +1,277 @@
+// Web-standard by construction (no node:*): this core must run wherever a
+// fetch handler runs. The Node conveniences live in ./index.ts.
+
+/**
+ * The runtime-agnostic host core (docs/internals/host-spec.md): one
+ * `(Request) => Promise<Response>` implementing the request algorithm over a
+ * host manifest — exact-match assets before routing, prerendered documents,
+ * per-request renders for dynamic matches, the action gate on POST, and
+ * DISTINCT failures (404 document for a miss, 500 after `onError` for a
+ * render failure, 405 elsewhere). Conditional requests and cache profiles
+ * derive from the manifest at startup; nothing is recomputed per request.
+ */
+
+export type HostManifest = {
+  version: number;
+  target: "node" | "edge";
+  base: string;
+  routes: Array<{ pattern: string; dynamic: boolean }>;
+  prerendered: string[];
+  assets: string[];
+  cssByPattern: Record<string, string[]>;
+  inlineThreshold?: number;
+  bootstrapModules: string[];
+  notFoundPage?: string;
+  errorPage?: string;
+  etags: Record<string, string>;
+  precompressed: string[];
+  transport: "esm" | "webpack";
+  renderBundle?: string;
+  consumerBundle?: string;
+};
+
+export type StaticFile = {
+  body: ReadableStream<Uint8Array> | Uint8Array;
+  size?: number;
+};
+
+export type HostCoreOptions = {
+  manifest: HostManifest;
+  /** Read an emitted static file by its manifest-relative path, or null. */
+  serveStatic: (path: string) => Promise<StaticFile | null>;
+  /**
+   * Lazily provide the per-request renderer and the action gate — the
+   * flavor the manifest records (the baked pair under transport "webpack").
+   * Called once, on first need.
+   */
+  loadRender: () => Promise<{
+    render: (request: Request) => Promise<Response>;
+    action: (request: Request) => Promise<Response>;
+  }>;
+  onError?: (error: unknown) => void;
+  /** A hung render answers 500 instead of hanging the connection. */
+  renderDeadlineMs?: number;
+};
+
+const MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".rsc": "text/x-component; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+  ".txt": "text/plain; charset=utf-8",
+  ".map": "application/json",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+const extOf = (path: string): string => {
+  const i = path.lastIndexOf(".");
+  return i === -1 ? "" : path.slice(i).toLowerCase();
+};
+
+const contentType = (path: string): string =>
+  MIME[extOf(path)] ?? "application/octet-stream";
+
+const FALLBACK_404 = `<!doctype html><html><head><meta charset="utf-8"><title>Not found</title></head><body style="font-family:system-ui;padding:3rem"><h1>404</h1><p>This page does not exist.</p></body></html>`;
+const FALLBACK_500 = `<!doctype html><html><head><meta charset="utf-8"><title>Server error</title></head><body style="font-family:system-ui;padding:3rem"><h1>500</h1><p>The server failed to render this page.</p></body></html>`;
+
+function matchPattern(pattern: string, pathname: string): boolean {
+  const p = pattern.split("/").filter(Boolean);
+  const u = pathname.split("/").filter(Boolean);
+  if (p.length !== u.length) return false;
+  return p.every((seg, i) => seg.startsWith("$") || seg === u[i]);
+}
+
+export function createHostFromManifest(
+  options: HostCoreOptions
+): (request: Request) => Promise<Response> {
+  const {
+    manifest,
+    serveStatic,
+    loadRender,
+    onError,
+    renderDeadlineMs = 30_000,
+  } = options;
+
+  if (manifest.version !== 1) {
+    throw new Error(
+      `[createHost] host-manifest version ${manifest.version} is not ` +
+        `understood by this host (expected 1) — rebuild, or update the plugin.`
+    );
+  }
+
+  const base = manifest.base.endsWith("/") ? manifest.base : `${manifest.base}/`;
+  const assets = new Set(manifest.assets);
+  const prerendered = new Set(manifest.prerendered);
+
+  let renderPair:
+    | Promise<{
+        render: (request: Request) => Promise<Response>;
+        action: (request: Request) => Promise<Response>;
+      }>
+    | undefined;
+  const pair = () => (renderPair ??= loadRender());
+
+  const staticHeaders = (
+    path: string,
+    profile: "asset" | "document"
+  ): Headers => {
+    const headers = new Headers();
+    headers.set("content-type", contentType(path));
+    headers.set("x-content-type-options", "nosniff");
+    headers.set(
+      "cache-control",
+      profile === "asset" ? "public, max-age=31536000, immutable" : "no-cache"
+    );
+    const etag = manifest.etags[path];
+    if (etag) headers.set("etag", etag);
+    if (profile === "document") headers.set("vary", "Accept");
+    return headers;
+  };
+
+  const serveFile = async (
+    request: Request,
+    path: string,
+    profile: "asset" | "document",
+    status = 200
+  ): Promise<Response> => {
+    const etag = manifest.etags[path];
+    if (etag && request.headers.get("if-none-match") === etag) {
+      return new Response(null, {
+        status: 304,
+        headers: staticHeaders(path, profile),
+      });
+    }
+    const file = await serveStatic(path);
+    if (!file) {
+      // A manifest-known artifact the adapter cannot produce is a deploy
+      // defect — answer plainly, never fall through to a render.
+      return new Response(`missing static artifact: ${path}`, {
+        status: 404,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+    const headers = staticHeaders(path, profile);
+    if (file.size !== undefined && request.method !== "HEAD") {
+      headers.set("content-length", String(file.size));
+    }
+    return new Response(
+      request.method === "HEAD" ? null : (file.body as BodyInit),
+      { status, headers }
+    );
+  };
+
+  const notFound = (request: Request): Promise<Response> =>
+    manifest.notFoundPage
+      ? serveFile(request, manifest.notFoundPage, "document", 404)
+      : Promise.resolve(
+          new Response(FALLBACK_404, {
+            status: 404,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          })
+        );
+
+  const errorPage = (request: Request): Promise<Response> =>
+    manifest.errorPage
+      ? serveFile(request, manifest.errorPage, "document", 500)
+      : Promise.resolve(
+          new Response(FALLBACK_500, {
+            status: 500,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          })
+        );
+
+  return async function hostHandler(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    let pathname = decodeURIComponent(url.pathname);
+
+    // Base strip: the router speaks app-relative paths.
+    if (base !== "/" && pathname.startsWith(base)) {
+      pathname = `/${pathname.slice(base.length)}`;
+    }
+
+    if (request.method === "POST") {
+      if (request.headers.get("x-rsc-action")) {
+        const { action } = await pair();
+        return action(request);
+      }
+      return new Response("method not allowed", {
+        status: 405,
+        headers: { allow: "GET, HEAD, POST" },
+      });
+    }
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("method not allowed", {
+        status: 405,
+        headers: { allow: "GET, HEAD, POST" },
+      });
+    }
+
+    // Exact asset lookup before any routing: once a path is a known static
+    // artifact, route matching never sees it.
+    const assetPath = pathname.replace(/^\//, "");
+    if (assets.has(assetPath)) {
+      return serveFile(request, assetPath, "asset");
+    }
+
+    // The `.rsc` sibling of a prerendered/dynamic document.
+    const rscMatch = pathname.match(/^(.*\/)index\.rsc$/);
+    const docPathname = rscMatch ? rscMatch[1]! : pathname;
+
+    // Trailing-slash canonicalization for document urls: one URL per page,
+    // matching what the prerender emitted.
+    if (!rscMatch && !pathname.endsWith("/") && extOf(pathname) === "") {
+      return new Response(null, {
+        status: 308,
+        headers: { location: `${pathname}/` },
+      });
+    }
+
+    const routeUrl =
+      docPathname === "/" ? "/" : docPathname.replace(/\/$/, "");
+
+    if (prerendered.has(routeUrl)) {
+      const dir = routeUrl === "/" ? "" : `${routeUrl.slice(1)}/`;
+      const file = rscMatch ? `${dir}index.rsc` : `${dir}index.html`;
+      return serveFile(request, file, "document");
+    }
+
+    const matched = manifest.routes.find((r) =>
+      matchPattern(r.pattern, routeUrl)
+    );
+    if (!matched || !matched.dynamic) {
+      return notFound(request);
+    }
+
+    try {
+      const { render } = await pair();
+      const deadline = new Promise<never>((_, reject) => {
+        const t = setTimeout(
+          () => reject(new Error(`render deadline (${renderDeadlineMs}ms) hit`)),
+          renderDeadlineMs
+        );
+        (t as { unref?: () => void }).unref?.();
+      });
+      const response = await Promise.race([render(request), deadline]);
+      const headers = new Headers(response.headers);
+      headers.set("cache-control", "no-store");
+      headers.set("vary", "Accept");
+      return new Response(response.body, {
+        status: response.status,
+        headers,
+      });
+    } catch (error) {
+      onError?.(error);
+      return errorPage(request);
+    }
+  };
+}

--- a/plugin/host/createHostFromManifest.ts
+++ b/plugin/host/createHostFromManifest.ts
@@ -217,15 +217,37 @@ export function createHostFromManifest(
       : location;
 
   // Malformed percent-encoding must be a controlled 404, never a handler
-  // rejection — and matching happens on the ENCODED pathname (the canonical
-  // router decodes individual segments defensively itself; a top-level
-  // decode would turn %2F into a segment boundary).
+  // rejection or a dynamic render — and matching happens on the ENCODED
+  // pathname (the canonical router decodes individual segments defensively
+  // itself; a top-level decode would turn %2F into a segment boundary).
   const safeDecode = (value: string): string | null => {
     try {
       return decodeURIComponent(value);
     } catch {
       return null;
     }
+  };
+
+  // Static inventories hold decoded paths, so lookups must decode — but
+  // SEGMENT-WISE, refusing any decode that forges a separator: with
+  // prerendered /docs/a/b and dynamic /docs/$slug, /docs/a%2Fb must stay one
+  // parameter, never the nested static page. `malformed` (any segment that
+  // fails to decode) is the controlled-404 signal; `value: null` with
+  // well-formed input means a forged separator — no static artifact can
+  // match, but routing may still see the encoded path.
+  const decodeForLookup = (
+    path: string
+  ): { malformed: boolean; value: string | null } => {
+    const out: string[] = [];
+    for (const seg of path.split("/")) {
+      const dec = safeDecode(seg);
+      if (dec === null) return { malformed: true, value: null };
+      if (dec.includes("/") || dec.includes("\\")) {
+        return { malformed: false, value: null };
+      }
+      out.push(dec);
+    }
+    return { malformed: false, value: out.join("/") };
   };
 
   return async function hostHandler(
@@ -278,10 +300,15 @@ export function createHostFromManifest(
     const docPathname = rscMatch ? rscMatch[1]! : pathname;
     const routeUrl = docPathname === "/" ? "/" : docPathname.replace(/\/$/, "");
 
-    // Static inventories hold decoded file paths: decode the candidate
-    // through the guard for lookups only. A malformed encoding simply never
-    // matches an artifact and falls through to the controlled 404.
-    const decodedRouteUrl = safeDecode(routeUrl);
+    // Segment-wise guarded decode for the static inventories. A malformed
+    // segment is the promised controlled 404 — answered HERE, before route
+    // matching, so a dynamic /docs/$slug can never render /docs/%zz.
+    const routeLookup = decodeForLookup(routeUrl);
+    const assetLookup = decodeForLookup(pathname.replace(/^\//, ""));
+    if (routeLookup.malformed || assetLookup.malformed) {
+      return notFound(request);
+    }
+    const decodedRouteUrl = routeLookup.value;
 
     if (
       (rscMatch || acceptsFlight) &&
@@ -295,7 +322,7 @@ export function createHostFromManifest(
 
     // Exact asset lookup before routing: once a path is a known static
     // artifact, route matching never sees it.
-    const decodedAsset = safeDecode(pathname.replace(/^\//, ""));
+    const decodedAsset = assetLookup.value;
     if (!rscMatch && decodedAsset !== null && assets.has(decodedAsset)) {
       return serveFile(request, decodedAsset, "asset");
     }

--- a/plugin/host/createHostFromManifest.ts
+++ b/plugin/host/createHostFromManifest.ts
@@ -26,6 +26,10 @@ export type HostManifest = {
   etags: Record<string, string>;
   precompressed: string[];
   transport: "esm" | "webpack";
+  moduleBaseURL: string;
+  htmlOutputPath: string;
+  rscOutputPath: string;
+  stripHtmlSuffix: boolean;
   renderBundle?: string;
   consumerBundle?: string;
 };
@@ -112,6 +116,11 @@ export function createHostFromManifest(
   const base = manifest.base.endsWith("/") ? manifest.base : `${manifest.base}/`;
   const assets = new Set(manifest.assets);
   const prerendered = new Set(manifest.prerendered);
+  const htmlName = manifest.htmlOutputPath || "index.html";
+  const rscName = manifest.rscOutputPath || "index.rsc";
+  const rscSuffixRe = new RegExp(
+    `^(.*/)${rscName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`
+  );
 
   let renderPair:
     | Promise<{
@@ -224,7 +233,7 @@ export function createHostFromManifest(
     }
 
     // The `.rsc` sibling of a prerendered/dynamic document.
-    const rscMatch = pathname.match(/^(.*\/)index\.rsc$/);
+    const rscMatch = pathname.match(rscSuffixRe);
     const docPathname = rscMatch ? rscMatch[1]! : pathname;
 
     // Trailing-slash canonicalization for document urls: one URL per page,
@@ -241,7 +250,7 @@ export function createHostFromManifest(
 
     if (prerendered.has(routeUrl)) {
       const dir = routeUrl === "/" ? "" : `${routeUrl.slice(1)}/`;
-      const file = rscMatch ? `${dir}index.rsc` : `${dir}index.html`;
+      const file = rscMatch ? `${dir}${rscName}` : `${dir}${htmlName}`;
       return serveFile(request, file, "document");
     }
 

--- a/plugin/host/createHostFromManifest.ts
+++ b/plugin/host/createHostFromManifest.ts
@@ -216,12 +216,24 @@ export function createHostFromManifest(
       ? `${base.slice(0, -1)}${location}`
       : location;
 
+  // Malformed percent-encoding must be a controlled 404, never a handler
+  // rejection — and matching happens on the ENCODED pathname (the canonical
+  // router decodes individual segments defensively itself; a top-level
+  // decode would turn %2F into a segment boundary).
+  const safeDecode = (value: string): string | null => {
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return null;
+    }
+  };
+
   return async function hostHandler(
     request: Request,
     ...platform: unknown[]
   ): Promise<Response> {
     const url = new URL(request.url);
-    let pathname = decodeURIComponent(url.pathname);
+    let pathname = url.pathname;
 
     // The route base scopes the app: strip it, and refuse anything outside
     // it — an un-based path must not remain routable under a based deploy.
@@ -266,16 +278,26 @@ export function createHostFromManifest(
     const docPathname = rscMatch ? rscMatch[1]! : pathname;
     const routeUrl = docPathname === "/" ? "/" : docPathname.replace(/\/$/, "");
 
-    if ((rscMatch || acceptsFlight) && prerendered.has(routeUrl)) {
-      const dir = routeUrl === "/" ? "" : `${routeUrl.slice(1)}/`;
+    // Static inventories hold decoded file paths: decode the candidate
+    // through the guard for lookups only. A malformed encoding simply never
+    // matches an artifact and falls through to the controlled 404.
+    const decodedRouteUrl = safeDecode(routeUrl);
+
+    if (
+      (rscMatch || acceptsFlight) &&
+      decodedRouteUrl !== null &&
+      prerendered.has(decodedRouteUrl)
+    ) {
+      const dir =
+        decodedRouteUrl === "/" ? "" : `${decodedRouteUrl.slice(1)}/`;
       return serveFile(request, `${dir}${rscName}`, "document");
     }
 
     // Exact asset lookup before routing: once a path is a known static
     // artifact, route matching never sees it.
-    const assetPath = pathname.replace(/^\//, "");
-    if (!rscMatch && assets.has(assetPath)) {
-      return serveFile(request, assetPath, "asset");
+    const decodedAsset = safeDecode(pathname.replace(/^\//, ""));
+    if (!rscMatch && decodedAsset !== null && assets.has(decodedAsset)) {
+      return serveFile(request, decodedAsset, "asset");
     }
 
     // Trailing-slash canonicalization for document urls — preserving base
@@ -289,8 +311,9 @@ export function createHostFromManifest(
       });
     }
 
-    if (prerendered.has(routeUrl)) {
-      const dir = routeUrl === "/" ? "" : `${routeUrl.slice(1)}/`;
+    if (decodedRouteUrl !== null && prerendered.has(decodedRouteUrl)) {
+      const dir =
+        decodedRouteUrl === "/" ? "" : `${decodedRouteUrl.slice(1)}/`;
       return serveFile(request, `${dir}${htmlName}`, "document");
     }
 

--- a/plugin/host/index.ts
+++ b/plugin/host/index.ts
@@ -1,0 +1,106 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { open } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { Readable } from "node:stream";
+import {
+  createHostFromManifest,
+  type HostManifest,
+  type StaticFile,
+} from "./createHostFromManifest.js";
+
+export { createHostFromManifest } from "./createHostFromManifest.js";
+export type { HostManifest, HostCoreOptions, StaticFile } from "./createHostFromManifest.js";
+export { toNodeListener } from "../helpers/createRequestHandler.server.js";
+
+export type CreateHostOptions = {
+  /** The build output root (the directory holding `server`, `static`, `server-edge`). */
+  buildDir: string;
+  onError?: (error: unknown) => void;
+  renderDeadlineMs?: number;
+};
+
+/**
+ * The Node convenience form (host-spec, "The API"): inspect `buildDir` at
+ * startup, read the emitted host manifest, and serve — static files from
+ * disk, per-request renders and actions through the flavor the manifest
+ * records. Currently follows the baked pair (`transport: "webpack"`); a
+ * build without it is a startup error naming the config that emits one.
+ */
+export function createHost(
+  options: CreateHostOptions
+): (request: Request) => Promise<Response> {
+  const { buildDir, onError, renderDeadlineMs } = options;
+
+  const edgeManifestPath = join(buildDir, "server-edge/host-manifest.json");
+  if (!existsSync(edgeManifestPath)) {
+    throw new Error(
+      `[createHost] no host manifest at ${edgeManifestPath} — build with ` +
+        `transport:"webpack" (runner "edge", or "isolated"/"main" with ` +
+        `build.edge) so the baked pair and its manifest are emitted.`
+    );
+  }
+  const manifest = JSON.parse(
+    readFileSync(edgeManifestPath, "utf8")
+  ) as HostManifest;
+
+  const staticDir = join(buildDir, "static");
+  const serveStatic = async (path: string): Promise<StaticFile | null> => {
+    const abs = join(staticDir, path);
+    // Containment: the manifest inventory is the allowlist, but join()
+    // collapses `../` — refuse anything that escapes.
+    if (!abs.startsWith(staticDir)) return null;
+    if (!existsSync(abs)) return null;
+    const size = statSync(abs).size;
+    const handle = await open(abs, "r");
+    const body = Readable.toWeb(
+      handle.createReadStream()
+    ) as unknown as ReadableStream<Uint8Array>;
+    return { body, size };
+  };
+
+  const loadRender = async () => {
+    const edgeDir = join(buildDir, "server-edge");
+    const bundle = (await import(
+      pathToFileURL(join(edgeDir, "render.js")).href
+    )) as {
+      handleRouteAction: (request: Request) => Promise<Response>;
+    };
+    const consumer = (await import(
+      pathToFileURL(join(edgeDir, "consumer.js")).href
+    )) as { renderFlightToHtml: unknown };
+    const { createEdgeRequestHandler } = await import("../edge/index.js");
+    // React reports component failures through onError while the boundary
+    // DEGRADES and the buffered document still answers 200 — the same
+    // silent-bad-response the SSG freeze guards against. The document branch
+    // buffers before responding, so every onError for a request has fired by
+    // the time its Response exists: a grown error list turns the degraded
+    // 200 into the thrown failure the host maps to the 500 page. (Under
+    // concurrent failing renders the count-delta can blame an overlapping
+    // request — the conservative direction: never a degraded 200.)
+    const renderErrors: unknown[] = [];
+    const render = createEdgeRequestHandler(bundle as never, {
+      renderFlightToHtml: consumer.renderFlightToHtml as never,
+      onError: (error: unknown) => renderErrors.push(error),
+    });
+    return {
+      render: async (request: Request) => {
+        const before = renderErrors.length;
+        const response = await render(request);
+        if (renderErrors.length > before) {
+          throw renderErrors[before];
+        }
+        return response;
+      },
+      action: (request: Request) => bundle.handleRouteAction(request),
+    };
+  };
+
+  return createHostFromManifest({
+    manifest,
+    serveStatic,
+    loadRender,
+    ...(onError ? { onError } : {}),
+    ...(renderDeadlineMs !== undefined ? { renderDeadlineMs } : {}),
+  });
+}

--- a/plugin/host/index.ts
+++ b/plugin/host/index.ts
@@ -43,6 +43,35 @@ export function createHost(
   const manifest = JSON.parse(
     readFileSync(edgeManifestPath, "utf8")
   ) as HostManifest;
+  // Startup validation, per the spec: a mismatch is a startup error naming
+  // the config that fixes it — never a first-request import failure. An
+  // ordinary esm bake emits a manifest too, but no consumer half.
+  if (manifest.target !== "edge") {
+    throw new Error(
+      `[createHost] ${edgeManifestPath} describes target "${manifest.target}" — expected the edge target.`
+    );
+  }
+  if (
+    manifest.transport !== "webpack" ||
+    !manifest.renderBundle ||
+    !manifest.consumerBundle
+  ) {
+    throw new Error(
+      `[createHost] the manifest at ${edgeManifestPath} has no complete ` +
+        `baked pair (transport "${manifest.transport}", renderBundle ` +
+        `${JSON.stringify(manifest.renderBundle)}, consumerBundle ` +
+        `${JSON.stringify(manifest.consumerBundle)}) — this host renders ` +
+        `through the pair, which requires transport:"webpack".`
+    );
+  }
+  for (const rel of [manifest.renderBundle, manifest.consumerBundle]) {
+    if (!existsSync(join(buildDir, "server-edge", rel))) {
+      throw new Error(
+        `[createHost] the manifest names ${rel} but it does not exist in ` +
+          `${join(buildDir, "server-edge")} — rebuild.`
+      );
+    }
+  }
 
   const staticDir = join(buildDir, "static");
   const serveStatic = async (path: string): Promise<StaticFile | null> => {
@@ -62,33 +91,39 @@ export function createHost(
   const loadRender = async () => {
     const edgeDir = join(buildDir, "server-edge");
     const bundle = (await import(
-      pathToFileURL(join(edgeDir, "render.js")).href
+      pathToFileURL(join(edgeDir, manifest.renderBundle!)).href
     )) as {
       handleRouteAction: (request: Request) => Promise<Response>;
     };
     const consumer = (await import(
-      pathToFileURL(join(edgeDir, "consumer.js")).href
+      pathToFileURL(join(edgeDir, manifest.consumerBundle!)).href
     )) as { renderFlightToHtml: unknown };
     const { createEdgeRequestHandler } = await import("../edge/index.js");
-    // React reports component failures through onError while the boundary
-    // DEGRADES and the buffered document still answers 200 — the same
-    // silent-bad-response the SSG freeze guards against. The document branch
-    // buffers before responding, so every onError for a request has fired by
-    // the time its Response exists: a grown error list turns the degraded
-    // 200 into the thrown failure the host maps to the 500 page. (Under
-    // concurrent failing renders the count-delta can blame an overlapping
-    // request — the conservative direction: never a degraded 200.)
-    const renderErrors: unknown[] = [];
-    const render = createEdgeRequestHandler(bundle as never, {
-      renderFlightToHtml: consumer.renderFlightToHtml as never,
-      onError: (error: unknown) => renderErrors.push(error),
-    });
+    const { HOST_OUTCOME_HEADER } = await import(
+      "./createHostFromManifest.js"
+    );
     return {
+      // A handler per REQUEST: React reports component failures through
+      // onError while the boundary degrades and the buffered document still
+      // answers 200 (the silent-bad-response the SSG freeze guards
+      // against). Per-request construction gives each render its own error
+      // list, so attribution can never cross concurrent requests.
       render: async (request: Request) => {
-        const before = renderErrors.length;
+        const renderErrors: unknown[] = [];
+        const render = createEdgeRequestHandler(bundle as never, {
+          renderFlightToHtml: consumer.renderFlightToHtml as never,
+          onError: (error: unknown) => renderErrors.push(error),
+          // A loader notFound() must reach the manifest 404 document, not
+          // the inner handler's bare-text default — mark it for the core.
+          onNotFound: () =>
+            new Response(null, {
+              status: 404,
+              headers: { [HOST_OUTCOME_HEADER]: "not-found" },
+            }),
+        });
         const response = await render(request);
-        if (renderErrors.length > before) {
-          throw renderErrors[before];
+        if (renderErrors.length > 0) {
+          throw renderErrors[0];
         }
         return response;
       },
@@ -99,7 +134,13 @@ export function createHost(
   return createHostFromManifest({
     manifest,
     serveStatic,
-    loadRender,
+    loadRender: async () => {
+      const inner = await loadRender();
+      return {
+        render: (request: Request) => inner.render(request),
+        action: (request: Request) => inner.action(request),
+      };
+    },
     ...(onError ? { onError } : {}),
     ...(renderDeadlineMs !== undefined ? { renderDeadlineMs } : {}),
   });

--- a/plugin/host/index.ts
+++ b/plugin/host/index.ts
@@ -128,6 +128,8 @@ export function createHost(
         return response;
       },
       action: (request: Request) => bundle.handleRouteAction(request),
+      // (Node hosts have an empty platform; the executor appends the ctx
+      // uniformly, so action code behaves identically across hosts.)
     };
   };
 

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -110,7 +110,10 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
           headers: { "content-type": "text/plain; charset=utf-8" },
         });
 
-  return async function edgeHandler(request: Request): Promise<Response> {
+  return async function edgeHandler(
+    request: Request,
+    ...platform: unknown[]
+  ): Promise<Response> {
     const url = getURL(request);
 
     // Full flash-free document: render the Html-wrapped `full` flight to a
@@ -122,7 +125,7 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
       try {
         // Pass the request so a loader can gate an authenticated route on
         // cookies/headers (the baked producer forwards it to props).
-        flights = await renderDocument(url, { request });
+        flights = await renderDocument(url, { request, platform });
       } catch (error) {
         if (isUnknownRoute(error)) return notFound(url, request);
         // Loader control flow: a redirect() answers with the 3xx itself; a
@@ -175,7 +178,7 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
 
     let rscStream: ReadableStream<Uint8Array>;
     try {
-      rscStream = await render!(url, request);
+      rscStream = await render!(url, request, ...platform);
     } catch (error) {
       // The producer is a closed manifest over `build.pages`; an unknown url is
       // a 404, not a 500. Everything else is a real failure — surface it.

--- a/plugin/stream/createEdgeHandler.types.ts
+++ b/plugin/stream/createEdgeHandler.types.ts
@@ -5,7 +5,10 @@ import type { RenderFlightToHtmlFn } from "./renderFlightToHtml.types.js";
  * A Web `fetch` handler: the standard edge-runtime entrypoint shape
  * (Cloudflare Workers, Deno Deploy, Vercel Edge, Bun, Node via an adapter).
  */
-export type EdgeFetchHandler = (request: Request) => Promise<Response>;
+export type EdgeFetchHandler = (
+  request: Request,
+  ...platform: unknown[]
+) => Promise<Response>;
 
 /**
  * Options for {@link CreateEdgeHandlerFn}. Composes the baked per-route flight
@@ -34,7 +37,8 @@ export type CreateEdgeHandlerOptions = {
    */
   render?: (
     url: string,
-    request?: Request
+    request?: Request,
+    ...platform: unknown[]
   ) => Promise<ReadableStream<Uint8Array>>;
   /**
    * The baked full-document producer: the `renderRouteToDocument` export of the
@@ -46,7 +50,7 @@ export type CreateEdgeHandlerOptions = {
    */
   renderDocument?: (
     url: string,
-    opts?: { request?: Request }
+    opts?: { request?: Request; platform?: unknown[] }
   ) => Promise<EdgeDocumentFlights>;
   /**
    * Base URL the client transport uses to resolve client-reference modules —

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1144,6 +1144,9 @@ export type CreateHandlerOptions<
    * across the worker boundary).
    */
   request?: Request;
+  /** The fetch runtime's extra handler arguments (workerd env/ctx) —
+   *  threaded into the loader ctx by hosts. Empty on Node. */
+  platform?: unknown[];
   /**
    * Cloneable stand-in for {@link request} sent to the RSC worker: the absolute
    * url + method + headers (enough for a loader to read cookies/headers to gate

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -1385,8 +1385,10 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             );
           }
 
-          // Execute the server action
-          const result = await action(...decodedArgs);
+          // Execute the server action. The trailing ctx matches the sealed
+          // gate's shape (bindings seam) — dev has no platform, so it is
+          // empty, and action code behaves identically across environments.
+          const result = await action(...decodedArgs, { platform: [] });
 
           // Render `{ returnValue }` through the transport's flight renderer
           // so non-JSON values survive, and hand the finished payload to the

--- a/test/examples/host-edge-entry.test.ts
+++ b/test/examples/host-edge-entry.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, readdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// The generated portable host entry (host-spec, "The API"): the build emits
+// dist/server-edge/host.js — a module that statically imports its pair and
+// inlines its manifest, exporting the fetch-shaped handler. It is the form a
+// filesystem-less runtime mounts (`export default { fetch: handler }`), and
+// the seam of Resolution 4: extra runtime arguments (workerd's env/ctx)
+// thread as `platform` into loader context, so binding-backed data has a
+// contract instead of a globalThis stash. Statics are the platform's job in
+// this form — a prerendered URL that still reaches the handler is answered
+// plainly, never re-rendered.
+const isolatedLeg = getCondition() !== REACT_CONDITION.server;
+
+// The portability claim ("mountable in a filesystem-less runtime") is proven
+// by actually mounting host.js in workerd, not by importing it in Node.
+// miniflare is deliberately NOT a dependency — the dedicated CI job installs
+// it (`npm i --no-save miniflare@4`) and sets VPRS_REQUIRE_MINIFLARE=1 so
+// its absence there fails loudly instead of green-skipping.
+const MINIFLARE = "miniflare";
+let Miniflare:
+  | (new (options: unknown) => {
+      dispatchFetch: (url: string, init?: RequestInit) => Promise<Response>;
+      dispose: () => Promise<void>;
+    })
+  | undefined;
+try {
+  ({ Miniflare } = await import(/* @vite-ignore */ MINIFLARE));
+} catch (error) {
+  if (process.env.VPRS_REQUIRE_MINIFLARE === "1") throw error;
+}
+
+async function collectModules(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, {
+    withFileTypes: true,
+    recursive: true,
+  })) {
+    if (entry.isFile() && /\.m?js$/.test(entry.name)) {
+      out.push(join(entry.parentPath, entry.name));
+    }
+  }
+  return out.sort();
+}
+
+const testDir = resolve(__dirname, "../fixtures/host-edge-entry.test");
+
+async function setupFixture() {
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(join(testDir, "src/routes/hello/$name"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/action.ts"),
+    `"use server";\n` +
+      `type Ctx = { platform?: Array<Record<string, unknown>> };\n` +
+      `export async function greet(n: number, ctx?: Ctx): Promise<string> {\n` +
+      `  const bound = (ctx?.platform?.[0] as { GREETING?: string } | undefined)?.GREETING;\n` +
+      `  return "entry:" + n + ":" + String(bound ?? "none");\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `import { greet } from "../action.js";\n` +
+      `export function Counter() {\n` +
+      `  void greet;\n` +
+      `  return <button>{"c"}</button>;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main><h1>{"host-edge-entry-home"}</h1><Counter /></main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/hello/$name/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = ({ name, greeting }: { name: string; greeting: string }) => (\n` +
+      `  <article>{"hello:" + name + ":" + greeting}</article>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/hello/$name/props.ts"),
+    `type Ctx = { platform?: Array<Record<string, unknown>> };\n` +
+      `export const props = (url: string, ctx?: Ctx) => ({\n` +
+      `  name: url.split("/").filter(Boolean).pop() ?? "",\n` +
+      `  greeting: String(\n` +
+      `    (ctx?.platform?.[0] as { GREETING?: string } | undefined)?.GREETING ??\n` +
+      `      "none",\n` +
+      `  ),\n` +
+      `});\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\n` +
+      `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "build.mjs"),
+    `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+      `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      // runner "isolated" until the edge-runner branch merges — the pair,
+      // manifest, and host entry emit identically under webpack transport.
+      `    runner: "isolated",\n` +
+      `    transport: "webpack",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: fr.Page,\n` +
+      `    props: fr.props,\n` +
+      `    routePatterns: fr.routePatterns,\n` +
+      `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("HOST_EDGE_ENTRY_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+describe.skipIf(!isolatedLeg)("generated portable host entry", () => {
+  let handler: (
+    request: Request,
+    ...platform: unknown[]
+  ) => Promise<Response>;
+
+  beforeAll(async () => {
+    await setupFixture();
+    const proc = spawnSync("node", ["build.mjs"], {
+      cwd: testDir,
+      encoding: "utf8",
+      timeout: 180000,
+      env: { ...process.env, NODE_ENV: "production", NODE_OPTIONS: "" },
+    });
+    expect(
+      proc.stdout,
+      `build failed (status ${proc.status}):\n${proc.stderr}`
+    ).toContain("HOST_EDGE_ENTRY_BUILD_OK");
+
+    const entryPath = join(testDir, "dist/server-edge/host.js");
+    expect(existsSync(entryPath), "dist/server-edge/host.js missing").toBe(
+      true
+    );
+    const mod = (await import(pathToFileURL(entryPath).href)) as {
+      default: { fetch: typeof handler };
+      handler: typeof handler;
+    };
+    // The default is the module-worker mount; the bare function is named.
+    expect(typeof mod.default).toBe("object");
+    expect(typeof mod.default.fetch).toBe("function");
+    expect(typeof mod.handler).toBe("function");
+    handler = mod.default.fetch;
+  }, 240000);
+
+  afterAll(async () => {
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(!Miniflare)(
+    "mounts in workerd: document render and platform-bound action in-isolate",
+    async () => {
+      const edgeDir = join(testDir, "dist/server-edge");
+      const hostPath = join(edgeDir, "host.js");
+      const chunkPaths = (await collectModules(edgeDir)).filter(
+        (p) => p !== hostPath
+      );
+      // No nodejs_compat: the entry must run without node shims, like the
+      // pair it imports. Bindings become workerd's env — platform[0].
+      const mf = new Miniflare!({
+        compatibilityDate: "2026-07-01",
+        modulesRoot: edgeDir,
+        modules: [
+          { type: "ESModule", path: hostPath },
+          ...chunkPaths.map((path) => ({ type: "ESModule", path })),
+        ],
+        bindings: { GREETING: "workerd" },
+      });
+      try {
+        const doc = await mf.dispatchFetch("http://edge.test/hello/bindings/");
+        expect(doc.status).toBe(200);
+        expect(await doc.text()).toContain("hello:bindings:workerd");
+
+        const { encodeReply } = await import(
+          "react-server-dom-esm/client.edge"
+        );
+        const act = await mf.dispatchFetch("http://edge.test/", {
+          method: "POST",
+          headers: { "x-rsc-action": "src/action.ts#greet" },
+          body: (await encodeReply([7])) as string,
+        });
+        expect(act.status).toBe(200);
+        expect(await act.text()).toContain('"entry:7:workerd"');
+      } finally {
+        await mf.dispose();
+      }
+    },
+    120000
+  );
+
+  it("renders a dynamic match with baked imports and inlined manifest", async () => {
+    const res = await handler(new Request("http://edge.test/hello/world/"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("hello:world");
+  });
+
+  it("threads the runtime's extra arguments as platform into loader context", async () => {
+    const res = await handler(
+      new Request("http://edge.test/hello/bindings/"),
+      { GREETING: "from-env" },
+      { waitUntil: () => {} }
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("hello:bindings:from-env");
+  });
+
+  it("statics are the platform's job — a prerendered URL is answered plainly", async () => {
+    const res = await handler(new Request("http://edge.test/"));
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    // A plain naming answer for the misrouted artifact, never a re-render
+    // and never the app's 404 document.
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    expect(body).toContain("index.html");
+  });
+
+  it("routes action POSTs through the baked gate — and platform reaches the action", async () => {
+    const { encodeReply } = await import("react-server-dom-esm/client.edge");
+    const body = await encodeReply([3]);
+    const res = await handler(
+      new Request("http://edge.test/", {
+        method: "POST",
+        headers: { "x-rsc-action": "src/action.ts#greet" },
+        body: body as string,
+      }),
+      { GREETING: "bound" },
+      { waitUntil: () => {} }
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('"entry:3:bound"');
+
+    // Without runtime arguments the ctx is present but empty.
+    const bare = await handler(
+      new Request("http://edge.test/", {
+        method: "POST",
+        headers: { "x-rsc-action": "src/action.ts#greet" },
+        body: (await encodeReply([4])) as string,
+      })
+    );
+    expect(await bare.text()).toContain('"entry:4:none"');
+  });
+
+  it("a miss is the 404 fallback document", async () => {
+    const res = await handler(new Request("http://edge.test/no/such/route/"));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+});

--- a/test/examples/host-serving.test.ts
+++ b/test/examples/host-serving.test.ts
@@ -216,9 +216,10 @@ describe.skipIf(!isolatedLeg)("createHost (Node convenience form)", () => {
     const res = await fetch(`${BASE}/docs/explode/`);
     expect(res.status).toBe(500);
     expect(res.headers.get("content-type")).toContain("text/html");
-    expect(seenErrors.some((e) => e.includes("deliberate render failure"))).toBe(
-      true
-    );
+    // The baked pair runs production React: the flight carries a digest,
+    // not the component message — the contract is that onError FIRED and
+    // the response is the 500 page, never a degraded 200.
+    expect(seenErrors.length).toBeGreaterThan(0);
   });
 
   it("routes action POSTs through the gate", async () => {

--- a/test/examples/host-serving.test.ts
+++ b/test/examples/host-serving.test.ts
@@ -61,9 +61,13 @@ async function setupFixture() {
   );
   await writeFile(
     join(testDir, "src/routes/docs/$slug/props.ts"),
-    `export const props = (url: string) => ({\n` +
-      `  slug: url.split("/").filter(Boolean).pop() ?? "",\n` +
-      `});\n`
+    `import { notFound } from "vite-plugin-react-server/router";\n` +
+      `export const props = (url: string) => {\n` +
+      `  const slug = url.split("/").filter(Boolean).pop() ?? "";\n` +
+      `  if (slug === "gone") notFound();\n` +
+      `  if (slug === "hang") return new Promise(() => {});\n` +
+      `  return { slug };\n` +
+      `};\n`
   );
   await writeFile(
     join(testDir, "src/client.tsx"),
@@ -85,10 +89,12 @@ async function setupFixture() {
       `  root: process.cwd(),\n` +
       `  staticPaths: { "/docs/$slug": () => [{ slug: "alpha" }] },\n` +
       `});\n` +
+      `const BASE_PATH = process.env.BASE_PATH || undefined;\n` +
       `const builder = await createBuilder({\n` +
       `  configFile: false,\n` +
       `  root: process.cwd(),\n` +
       `  mode: "production",\n` +
+      `  base: BASE_PATH,\n` +
       `  esbuild: { jsx: "automatic" },\n` +
       `  plugins: vitePluginReactServer({\n` +
       `    runner: "isolated",\n` +
@@ -99,7 +105,7 @@ async function setupFixture() {
       `    routePatterns: fr.routePatterns,\n` +
       `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
       `    moduleBasePath: "",\n` +
-      `    moduleBaseURL: "/",\n` +
+      `    moduleBaseURL: BASE_PATH || "/",\n` +
       `    projectRoot: process.cwd(),\n` +
       `  }),\n` +
       `});\n` +
@@ -238,5 +244,132 @@ describe.skipIf(!isolatedLeg)("createHost (Node convenience form)", () => {
     const res = await fetch(`${BASE}/`, { method: "PUT" });
     expect(res.status).toBe(405);
     expect(res.headers.get("allow")).toBeTruthy();
+  });
+
+  it("a prerendered .rsc is a document: no-cache and Vary, never immutable", async () => {
+    const res = await fetch(`${BASE}/docs/alpha/index.rsc`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    expect(res.headers.get("cache-control")).toContain("no-cache");
+    expect(res.headers.get("cache-control")).not.toContain("immutable");
+    expect(res.headers.get("vary") ?? "").toContain("Accept");
+  });
+
+  it("Accept: text/x-component on a prerendered route serves the flight", async () => {
+    const res = await fetch(`${BASE}/docs/alpha/`, {
+      headers: { accept: "text/x-component" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+  });
+
+  it("a 404 answer never turns into a 304", async () => {
+    const first = await fetch(`${BASE}/no/such/route/`);
+    expect(first.status).toBe(404);
+    const etag = first.headers.get("etag");
+    const again = await fetch(`${BASE}/no/such/route/`, {
+      headers: { "if-none-match": etag ?? 'W/"whatever"' },
+    });
+    expect(again.status).toBe(404);
+  });
+
+  it("HEAD carries Content-Length for known-length statics", async () => {
+    const res = await fetch(`${BASE}/`, { method: "HEAD" });
+    expect(res.status).toBe(200);
+    expect(Number(res.headers.get("content-length"))).toBeGreaterThan(0);
+  });
+
+  it("loader notFound() reaches the manifest 404 document, not a bare body", async () => {
+    const res = await fetch(`${BASE}/docs/gone/`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("a hung render answers 500 fast — the deadline aborts, nothing lingers", async () => {
+    const { createHost } = (await import(
+      "vite-plugin-react-server/host"
+    )) as {
+      createHost: (opts: {
+        buildDir: string;
+        renderDeadlineMs?: number;
+      }) => (req: Request) => Promise<Response>;
+    };
+    const impatient = createHost({
+      buildDir: join(testDir, "dist"),
+      renderDeadlineMs: 500,
+    });
+    const started = Date.now();
+    const res = await impatient(new Request(`${BASE}/docs/hang/`));
+    expect(res.status).toBe(500);
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+});
+
+describe.skipIf(!isolatedLeg)("createHost under a subpath base", () => {
+  let server: Server | undefined;
+  const PORT2 = 4226;
+  const BASE2 = `http://localhost:${PORT2}`;
+
+  beforeAll(async () => {
+    await setupFixture();
+    const proc = spawnSync("node", ["build.mjs"], {
+      cwd: testDir,
+      encoding: "utf8",
+      timeout: 180000,
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        NODE_OPTIONS: "",
+        BASE_PATH: "/app/",
+      },
+    });
+    expect(
+      proc.stdout,
+      `build failed (status ${proc.status}):\n${proc.stderr}`
+    ).toContain("HOST_SERVING_BUILD_OK");
+    const { createHost, toNodeListener } = (await import(
+      "vite-plugin-react-server/host"
+    )) as {
+      createHost: (opts: {
+        buildDir: string;
+      }) => (req: Request) => Promise<Response>;
+      toNodeListener: (
+        h: (req: Request) => Promise<Response>
+      ) => Parameters<typeof createServer>[1];
+    };
+    const handler = createHost({ buildDir: join(testDir, "dist") });
+    server = createServer(toNodeListener(handler));
+    await new Promise<void>((r) => server!.listen(PORT2, r));
+  }, 240000);
+
+  afterAll(async () => {
+    await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("renders a dynamic match under the base — the inner renderer sees the app-relative url", async () => {
+    const res = await fetch(`${BASE2}/app/docs/beta/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("doc:beta");
+  });
+
+  it("a path outside the base is not routable", async () => {
+    const res = await fetch(`${BASE2}/docs/beta/`);
+    expect(res.status).toBe(404);
+  });
+
+  it("canonicalization preserves base and query", async () => {
+    const res = await fetch(`${BASE2}/app/docs/beta?q=1`, {
+      redirect: "manual",
+    });
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe("/app/docs/beta/?q=1");
+  });
+
+  it("serves the based prerendered document", async () => {
+    const res = await fetch(`${BASE2}/app/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("host-serving-home");
   });
 });

--- a/test/examples/host-serving.test.ts
+++ b/test/examples/host-serving.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { resolve, join } from "node:path";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// createHost over the emitted artifacts (host-spec: the API + request
+// algorithm + prod-grade HTTP). The Node convenience form inspects buildDir,
+// reads the host manifest, and serves: exact-match assets before routing,
+// prerendered documents, per-request renders for dynamic matches (through
+// the flavor the manifest records — the baked pair for a webpack build),
+// the action gate on POST, and DISTINCT failure pages — 404 for a miss,
+// 500 after onError for a render failure, 405 elsewhere. Conditional
+// requests and cache profiles derive from the manifest at startup.
+const isolatedLeg = getCondition() !== REACT_CONDITION.server;
+
+const testDir = resolve(__dirname, "../fixtures/host-serving.test");
+const PORT = 4225;
+const BASE = `http://localhost:${PORT}`;
+
+async function setupFixture() {
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(join(testDir, "src/routes/docs/$slug"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/action.ts"),
+    `"use server";\n` +
+      `export async function greet(n: number): Promise<string> {\n` +
+      `  return "host:" + n;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `import { greet } from "../action.js";\n` +
+      `export function Counter() {\n` +
+      `  const [n] = React.useState(0);\n` +
+      `  void greet;\n` +
+      `  return <button>{"n:" + n}</button>;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main><h1>{"host-serving-home"}</h1><Counter /></main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/docs/$slug/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = ({ slug }: { slug: string }) => {\n` +
+      `  if (slug === "explode") throw new Error("deliberate render failure");\n` +
+      `  return <article>{"doc:" + slug}</article>;\n` +
+      `};\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/docs/$slug/props.ts"),
+    `export const props = (url: string) => ({\n` +
+      `  slug: url.split("/").filter(Boolean).pop() ?? "",\n` +
+      `});\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\n` +
+      `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "build.mjs"),
+    `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+      `const fr = fileRouter("src/routes", {\n` +
+      `  root: process.cwd(),\n` +
+      `  staticPaths: { "/docs/$slug": () => [{ slug: "alpha" }] },\n` +
+      `});\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: "isolated",\n` +
+      `    transport: "webpack",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: fr.Page,\n` +
+      `    props: fr.props,\n` +
+      `    routePatterns: fr.routePatterns,\n` +
+      `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("HOST_SERVING_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+describe.skipIf(!isolatedLeg)("createHost (Node convenience form)", () => {
+  let server: Server | undefined;
+  const seenErrors: string[] = [];
+
+  beforeAll(async () => {
+    await setupFixture();
+    const proc = spawnSync("node", ["build.mjs"], {
+      cwd: testDir,
+      encoding: "utf8",
+      timeout: 180000,
+      env: { ...process.env, NODE_ENV: "production", NODE_OPTIONS: "" },
+    });
+    expect(
+      proc.stdout,
+      `build failed (status ${proc.status}):\n${proc.stderr}`
+    ).toContain("HOST_SERVING_BUILD_OK");
+
+    const { createHost, toNodeListener } = (await import(
+      "vite-plugin-react-server/host"
+    )) as {
+      createHost: (opts: {
+        buildDir: string;
+        onError?: (e: unknown) => void;
+      }) => (req: Request) => Promise<Response>;
+      toNodeListener: (
+        h: (req: Request) => Promise<Response>
+      ) => Parameters<typeof createServer>[1];
+    };
+    const handler = createHost({
+      buildDir: join(testDir, "dist"),
+      onError: (e) => seenErrors.push(String(e)),
+    });
+    server = createServer(toNodeListener(handler));
+    await new Promise<void>((r) => server!.listen(PORT, r));
+  }, 240000);
+
+  afterAll(async () => {
+    await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("serves a prerendered document with revalidation semantics", async () => {
+    const res = await fetch(`${BASE}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("content-type")).toContain("charset=utf-8");
+    expect(await res.text()).toContain("host-serving-home");
+    const etag = res.headers.get("etag");
+    expect(etag).toBeTruthy();
+    expect(res.headers.get("cache-control")).toContain("no-cache");
+    const cached = await fetch(`${BASE}/`, {
+      headers: { "if-none-match": etag! },
+    });
+    expect(cached.status).toBe(304);
+  });
+
+  it("serves manifest assets before routing, with the immutable profile", async () => {
+    const home = await fetch(`${BASE}/`).then((r) => r.text());
+    const asset = home.match(/src="(\/[^"]+\.js)"/)?.[1];
+    expect(asset).toBeTruthy();
+    const res = await fetch(`${BASE}${asset}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("immutable");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("renders a dynamic match per-request through the manifest's flavor", async () => {
+    const res = await fetch(`${BASE}/docs/beta/`);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("doc:beta");
+    expect(res.headers.get("cache-control")).toContain("no-store");
+  });
+
+  it("serves the .rsc variant with the flight type and Vary: Accept", async () => {
+    const res = await fetch(`${BASE}/docs/beta/index.rsc`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/x-component");
+    expect(res.headers.get("vary") ?? "").toContain("Accept");
+  });
+
+  it("canonicalizes the trailing slash with a 308", async () => {
+    const res = await fetch(`${BASE}/docs/beta`, { redirect: "manual" });
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe("/docs/beta/");
+  });
+
+  it("answers a miss with a 404 document, never a bare body", async () => {
+    const res = await fetch(`${BASE}/no/such/route/`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("a render failure is a 500 after onError — never a 404, never a 200", async () => {
+    const res = await fetch(`${BASE}/docs/explode/`);
+    expect(res.status).toBe(500);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(seenErrors.some((e) => e.includes("deliberate render failure"))).toBe(
+      true
+    );
+  });
+
+  it("routes action POSTs through the gate", async () => {
+    const { encodeReply } = await import("react-server-dom-esm/client.edge");
+    const body = await encodeReply([7]);
+    const res = await fetch(`${BASE}/`, {
+      method: "POST",
+      headers: { "x-rsc-action": "src/action.ts#greet" },
+      body: body as string,
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('"host:7"');
+  });
+
+  it("everything else is 405 with Allow", async () => {
+    const res = await fetch(`${BASE}/`, { method: "PUT" });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBeTruthy();
+  });
+});

--- a/test/examples/host-serving.test.ts
+++ b/test/examples/host-serving.test.ts
@@ -240,6 +240,20 @@ describe.skipIf(!isolatedLeg)("createHost (Node convenience form)", () => {
     expect(await res.text()).toContain('"host:7"');
   });
 
+  it("malformed percent-encoding is a controlled 404, never a rejection", async () => {
+    const res = await fetch(`${BASE}/%zz/`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("an encoded slash stays one segment — it cannot forge boundaries", async () => {
+    // /docs/a%2Fb matches /docs/$slug as ONE segment; a decoded /docs/a/b
+    // would be two segments and no route.
+    const res = await fetch(`${BASE}/docs/a%2Fb/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("doc:");
+  });
+
   it("everything else is 405 with Allow", async () => {
     const res = await fetch(`${BASE}/`, { method: "PUT" });
     expect(res.status).toBe(405);

--- a/test/examples/host-serving.test.ts
+++ b/test/examples/host-serving.test.ts
@@ -75,6 +75,20 @@ async function setupFixture() {
     `import * as React from "react";\n` +
       `export const Page = () => <article>{"nested-static-ab"}</article>;\n`
   );
+  await mkdir(join(testDir, "src/routes/files/$name"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/routes/files/$name/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = ({ name }: { name: string }) => (\n` +
+      `  <article>{"file:" + name}</article>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/files/$name/props.ts"),
+    `export const props = (url: string) => ({\n` +
+      `  name: url.split("/").filter(Boolean).pop() ?? "",\n` +
+      `});\n`
+  );
   await writeFile(
     join(testDir, "src/client.tsx"),
     `"use client";\n` +
@@ -93,7 +107,10 @@ async function setupFixture() {
       `import { fileRouter } from "vite-plugin-react-server/router";\n` +
       `const fr = fileRouter("src/routes", {\n` +
       `  root: process.cwd(),\n` +
-      `  staticPaths: { "/docs/$slug": () => [{ slug: "alpha" }] },\n` +
+      `  staticPaths: {\n` +
+      `    "/docs/$slug": () => [{ slug: "alpha" }, { slug: "a b" }],\n` +
+      `    "/files/$name": () => [{ name: "a/b" }],\n` +
+      `  },\n` +
       `});\n` +
       `const BASE_PATH = process.env.BASE_PATH || undefined;\n` +
       `const builder = await createBuilder({\n` +
@@ -266,6 +283,33 @@ describe.skipIf(!isolatedLeg)("createHost (Node convenience form)", () => {
     const nested = await fetch(`${BASE}/docs/a/b/`);
     expect(nested.status).toBe(200);
     expect(await nested.text()).toContain("nested-static-ab");
+  });
+
+  it("an encoded staticPaths parameter serves its prerendered artifact", async () => {
+    // fillPattern emitted /docs/a%20b and the writer preserved it: the raw
+    // encoded inventory key must serve the snapshot — the no-cache document
+    // profile, never the no-store dynamic render of the decoded path.
+    const res = await fetch(`${BASE}/docs/a%20b/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("no-cache");
+    expect(res.headers.get("cache-control")).not.toContain("no-store");
+    expect(res.headers.get("etag")).toBeTruthy();
+    expect(await res.text()).toContain("doc:");
+
+    const rsc = await fetch(`${BASE}/docs/a%20b/index.rsc`);
+    expect(rsc.status).toBe(200);
+    expect(rsc.headers.get("content-type")).toContain("text/x-component");
+  });
+
+  it("an encoded slash prerendered on purpose serves its snapshot", async () => {
+    // /files/a%2Fb IS in the inventory: the raw encoded key matches before
+    // the decode guard voids the lookup. The forge guard above still holds —
+    // an UN-prerendered /docs/a%2Fb never reaches the nested static page.
+    const res = await fetch(`${BASE}/files/a%2Fb/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("no-cache");
+    expect(res.headers.get("cache-control")).not.toContain("no-store");
+    expect(await res.text()).toContain("file:");
   });
 
   it("a malformed segment inside a dynamic-shaped path is the controlled 404", async () => {

--- a/test/examples/host-serving.test.ts
+++ b/test/examples/host-serving.test.ts
@@ -25,6 +25,7 @@ const BASE = `http://localhost:${PORT}`;
 async function setupFixture() {
   await rm(testDir, { recursive: true, force: true });
   await mkdir(join(testDir, "src/routes/docs/$slug"), { recursive: true });
+  await mkdir(join(testDir, "src/routes/docs/a/b"), { recursive: true });
   await writeFile(
     join(testDir, "src/action.ts"),
     `"use server";\n` +
@@ -68,6 +69,11 @@ async function setupFixture() {
       `  if (slug === "hang") return new Promise(() => {});\n` +
       `  return { slug };\n` +
       `};\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/docs/a/b/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = () => <article>{"nested-static-ab"}</article>;\n`
   );
   await writeFile(
     join(testDir, "src/client.tsx"),
@@ -247,11 +253,27 @@ describe.skipIf(!isolatedLeg)("createHost (Node convenience form)", () => {
   });
 
   it("an encoded slash stays one segment — it cannot forge boundaries", async () => {
-    // /docs/a%2Fb matches /docs/$slug as ONE segment; a decoded /docs/a/b
-    // would be two segments and no route.
+    // A COLLIDING static page exists: /docs/a/b is prerendered. The encoded
+    // /docs/a%2Fb must still be the dynamic $slug render with one parameter,
+    // never the nested static artifact.
     const res = await fetch(`${BASE}/docs/a%2Fb/`);
     expect(res.status).toBe(200);
-    expect(await res.text()).toContain("doc:");
+    const body = await res.text();
+    expect(body).toContain("doc:");
+    expect(body).not.toContain("nested-static-ab");
+
+    // And the real nested page still serves plainly.
+    const nested = await fetch(`${BASE}/docs/a/b/`);
+    expect(nested.status).toBe(200);
+    expect(await nested.text()).toContain("nested-static-ab");
+  });
+
+  it("a malformed segment inside a dynamic-shaped path is the controlled 404", async () => {
+    // /docs/$slug would match /docs/<anything> — but %zz cannot decode, so
+    // the promise is the 404 document, not a dynamic render of raw bytes.
+    const res = await fetch(`${BASE}/docs/%zz/`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/html");
   });
 
   it("everything else is 405 with Allow", async () => {


### PR DESCRIPTION
Second `createHost` slice, stacked on the manifest emission PR (#413 — base is its branch so this shows only the host delta; retargets to main when it merges).

**The core** (`plugin/host/createHostFromManifest`, web-standard, no `node:*`) implements the spec's request algorithm over the emitted manifest: exact-match assets before routing (immutable profile, etag/304, nosniff), prerendered documents with revalidation semantics and `Vary: Accept` across the document/.rsc split, 308 trailing-slash canonicalization, per-request renders for dynamic matches under a render deadline with `no-store`, the action gate on POST, 405 with `Allow` elsewhere — and the spec's distinct failures: a 404 **document** for misses (manifest page or a styled fallback), a 500 **after `onError`** for render failures.

**The Node form** — `createHost({ buildDir })` under the new `./host` entry — reads the edge target's manifest, streams statics from disk with containment, and renders through the baked pair via `createEdgeRequestHandler`. One subtlety worth review attention: React degrades failed subtrees while the buffered document answers 200, so the freeze's silent-bad-response guard is applied per request — a grown `onError` delta turns the degraded 200 into the 500 page (count-delta blame is conservative under concurrent failures: never a degraded 200). The pair runs production React, so `onError` carries the digest shape and the suite asserts exactly that.

Red-first suite: nine serving contracts against a real built app over HTTP. Deferred to the next slice: the generated portable edge entry (`dist/server-edge/host.js`), `statics: "platform"`, precompression (the build emits no siblings yet), and the `ctx.platform` threading that is the bindings seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
