### PR TITLE
feat: the generated portable host entry — dist/server-edge/host.js, and the platform seam completes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           npm run build
           ./scripts/test-both.sh test/examples/workerd-smoke.test.ts
+          ./scripts/test-both.sh test/examples/host-edge-entry.test.ts
 
   # Drive a REAL browser against a REAL installed consumer.
   #

--- a/docs/edge.md
+++ b/docs/edge.md
@@ -290,6 +290,23 @@ createEdgeHandler({
 > actually host the client build — and verify in a real prod build at the real
 > base.
 
+## Platform bindings
+
+Whatever the runtime passes to your fetch handler after the request (workerd's
+`env` and `ctx`, or nothing on Node) travels through the handler as
+`platform` and surfaces in two places:
+
+- **Loaders**: `props(url, ctx)` receives it as `ctx.platform` — an array of
+  the extra arguments, so `ctx.platform[0]` is workerd's `env`.
+- **Server actions**: every action is called with a trailing context argument,
+  `action(...args, { platform })`. Existing actions ignore it; an action that
+  declares the extra parameter reads its bindings from it. The shape is
+  identical in dev and on Node — `platform` is just empty there — so action
+  code behaves the same everywhere.
+
+There is no global to reach for: bindings arrive per request, which is also
+the only form workerd supports.
+
 ## Run it on Node
 
 On a real edge platform you export the handler directly. On Node, wrap it in a

--- a/docs/internals/host-spec.md
+++ b/docs/internals/host-spec.md
@@ -56,8 +56,11 @@ http.createServer(toNodeListener(createHost({ buildDir: "./dist" }))).listen(300
 // Any fetch runtime (portable form): the build emits dist/server-edge/host.js —
 // a generated module that statically imports its render/consumer bundles and
 // inlines its manifest, then calls the same core with resolved artifacts.
-import handler from "./dist/server-edge/host.js";
-export default { fetch: handler };               // workerd / Bun / Deno
+// The default export IS the module-worker mount — a workerd deploy points
+// its main at host.js with no wrapper file at all. Runtimes that want the
+// bare function import it by name:
+import hostModule, { handler } from "./dist/server-edge/host.js";
+export default hostModule;                       // workerd / Bun / Deno ({ fetch: handler })
 export default handler;                          // Vercel function
 ```
 

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -847,6 +847,7 @@ const actionGate = createSealedServerReferenceGate({
 export async function ${actionExport}(request, opts = {}) {
   return handleServerActionRequest(request, {
     projectRoot: opts.projectRoot ?? "",
+    platform: opts.platform,
     base: MODULE_BASE_URL,
     resolveServerReference: (id) => actionGate.resolveServerReference(id),
     // The baked flight pair: arguments decode through THIS bundle's transport

--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -723,7 +723,7 @@ ${patternRouteLines.join("\n")}
 };
 
 /** Resolve a route's Page component + live props through the canonical helper. */
-async function resolveRoute(url, request) {
+async function resolveRoute(url, request, platform) {
   // Exact match for the enumerated/prerendered set; else fall back to matching
   // the url against the route patterns so any concrete dynamic url (e.g. a
   // /profile/<id> that wasn't prerendered) renders per-request on the edge.
@@ -749,6 +749,7 @@ async function resolveRoute(url, request) {
     // authenticated route. Present only for per-request edge renders (the
     // handler passes it); undefined at prerender.
     request,
+    platform,
     url,
     loader: async (id) => {
       // resolvePage/resolveProps may pass "<path>#<export>"; key by the path.
@@ -765,8 +766,8 @@ async function resolveRoute(url, request) {
 }
 
 /** Headless page flight (Page only) — the simple producer. */
-export async function ${flightExport}(url, request) {
-  const resolved = await resolveRoute(url, request);
+export async function ${flightExport}(url, request, platform) {
+  const resolved = await resolveRoute(url, request, platform);
   // Page-only compose (Html/Root as Fragment) so nested layouts fold around the
   // leaf; equivalent to createElement(Page, props) when there is no chain.
   return renderToReadableStream(
@@ -789,7 +790,7 @@ export async function ${flightExport}(url, request) {
  * (Map<string, CssContent>) so both carry the page styles.
  */
 export async function ${documentExport}(url, opts = {}) {
-  const resolved = await resolveRoute(url, opts.request);
+  const resolved = await resolveRoute(url, opts.request, opts.platform);
   const base = {
     PageComponent: resolved.PageComponent,
     RootComponent,

--- a/plugin/bundle/buildHostEntry.ts
+++ b/plugin/bundle/buildHostEntry.ts
@@ -1,0 +1,143 @@
+import { build as viteBuild, type Logger } from "vite";
+import { join, dirname } from "node:path";
+import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { ResolvedUserOptions } from "../types.js";
+import { DEFAULT_CONFIG } from "../config/defaults.js";
+
+/**
+ * The generated portable host entry (host-spec, "The API"):
+ * `dist/server-edge/host.js` — statically imports the baked pair, inlines
+ * its host manifest, and exports the fetch-shaped handler. A fetch runtime
+ * mounts it directly (`export default { fetch: handler }`); its imports are
+ * discoverable at bundle time, so no filesystem and no directory inspection
+ * exist at runtime. Statics are the platform's job in this form: a known
+ * static path that still reaches the handler is answered plainly by the
+ * core's missing-artifact rule.
+ */
+export async function buildHostEntry(opts: {
+  userOptions: ResolvedUserOptions;
+  projectRoot: string;
+  logger: Logger;
+}): Promise<void> {
+  const { userOptions, projectRoot, logger } = opts;
+  const tag = "[build.host]";
+  const outRoot = join(projectRoot, userOptions.build.outDir);
+  const edgeDir = join(
+    outRoot,
+    userOptions.build.edge.outDir ?? DEFAULT_CONFIG.BUILD.edge.outDir
+  );
+
+  // Only a complete pair with its manifest can host — the esm bake has no
+  // consumer half, and without a manifest there is no contract to inline.
+  const manifestPath = join(edgeDir, "host-manifest.json");
+  const producerPath = join(edgeDir, DEFAULT_CONFIG.EDGE.entryFileName);
+  const consumerPath = join(edgeDir, "consumer.js");
+  if (
+    !existsSync(manifestPath) ||
+    !existsSync(producerPath) ||
+    !existsSync(consumerPath)
+  ) {
+    return;
+  }
+  const manifestJson = readFileSync(manifestPath, "utf8");
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const corePath = join(here, "../host/createHostFromManifest.js");
+  const edgeHandlerPath = join(here, "../edge/web.js");
+
+  const entryPath = join(edgeDir, ".vprs-host.js");
+  const entrySource = `import * as bundle from "./${DEFAULT_CONFIG.EDGE.entryFileName}";
+import * as consumer from "./consumer.js";
+import {
+  createHostFromManifest,
+  HOST_OUTCOME_HEADER,
+} from ${JSON.stringify(corePath)};
+import { createEdgeRequestHandler } from ${JSON.stringify(edgeHandlerPath)};
+
+const MANIFEST = ${manifestJson.trim()};
+
+/**
+ * Per-request render (see the host core's loadRender contract): a handler
+ * per request so error attribution never crosses requests; a loader
+ * notFound() rides the sentinel header to the manifest 404 document; a
+ * degraded 200 (React reported through onError while the boundary degraded)
+ * becomes the thrown failure the core maps to the 500 page.
+ */
+const loadRender = async () => ({
+  render: async (request, platform) => {
+    const renderErrors = [];
+    const render = createEdgeRequestHandler(bundle, {
+      renderFlightToHtml: consumer.renderFlightToHtml,
+      onError: (error) => renderErrors.push(error),
+      onNotFound: () =>
+        new Response(null, {
+          status: 404,
+          headers: { [HOST_OUTCOME_HEADER]: "not-found" },
+        }),
+    });
+    const response = await render(request, ...platform);
+    if (renderErrors.length > 0) throw renderErrors[0];
+    return response;
+  },
+  action: (request) => bundle.handleRouteAction(request),
+});
+
+const handler = createHostFromManifest({
+  manifest: MANIFEST,
+  // Platform statics: the CDN/platform serves the emitted files; a known
+  // artifact that still reaches the handler is answered plainly by the
+  // core's missing-artifact rule, never by a render.
+  serveStatic: async () => null,
+  loadRender,
+});
+
+export default handler;
+`;
+
+  try {
+    writeFileSync(entryPath, entrySource);
+    await viteBuild({
+      root: edgeDir,
+      logLevel: "warn",
+      configFile: false,
+      define: { "process.env.NODE_ENV": JSON.stringify("production") },
+      ssr: { target: "webworker", noExternal: true },
+      build: {
+        ssr: true,
+        outDir: edgeDir,
+        emptyOutDir: false,
+        minify: userOptions.build.edge.minify,
+        rollupOptions: {
+          input: { host: entryPath },
+          // The pair stays external: host.js sits NEXT TO render.js and
+          // consumer.js and imports them relatively — re-bundling them here
+          // would duplicate React per artifact.
+          external: (id: string) =>
+            id === `./${DEFAULT_CONFIG.EDGE.entryFileName}` ||
+            id === "./consumer.js" ||
+            id.endsWith(`/${DEFAULT_CONFIG.EDGE.entryFileName}`) ||
+            id.endsWith("/consumer.js"),
+          output: {
+            preserveModules: false,
+            format: "es",
+            paths: (id: string) =>
+              id.endsWith(`/${DEFAULT_CONFIG.EDGE.entryFileName}`)
+                ? `./${DEFAULT_CONFIG.EDGE.entryFileName}`
+                : id.endsWith("/consumer.js")
+                ? "./consumer.js"
+                : id,
+          },
+        },
+      },
+    });
+    logger.info(`${tag} portable host entry → ${join(edgeDir, "host.js")}`);
+  } catch (error) {
+    // Additive today; the edge runner's fatal tie-in (the entry is part of
+    // that paradigm's artifact set) lands with the runner branch.
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(`${tag} skipped — host entry build failed: ${message}`);
+  } finally {
+    rmSync(entryPath, { force: true });
+  }
+}

--- a/plugin/bundle/buildHostEntry.ts
+++ b/plugin/bundle/buildHostEntry.ts
@@ -80,10 +80,10 @@ const loadRender = async () => ({
     if (renderErrors.length > 0) throw renderErrors[0];
     return response;
   },
-  action: (request) => bundle.handleRouteAction(request),
+  action: (request, platform) => bundle.handleRouteAction(request, { platform }),
 });
 
-const handler = createHostFromManifest({
+export const handler = createHostFromManifest({
   manifest: MANIFEST,
   // Platform statics: the CDN/platform serves the emitted files; a known
   // artifact that still reaches the handler is answered plainly by the
@@ -92,7 +92,9 @@ const handler = createHostFromManifest({
   loadRender,
 });
 
-export default handler;
+// Mountable directly as a Cloudflare module worker; Vercel-style runtimes
+// that want the bare function import the named \`handler\`.
+export default { fetch: handler };
 `;
 
   try {
@@ -133,8 +135,15 @@ export default handler;
     });
     logger.info(`${tag} portable host entry → ${join(edgeDir, "host.js")}`);
   } catch (error) {
-    // Additive today; the edge runner's fatal tie-in (the entry is part of
-    // that paradigm's artifact set) lands with the runner branch.
+    // Under runner "edge" the entry is part of the paradigm's artifact set —
+    // a green build without it is a broken deploy. (Defensive read: the
+    // runner field ships on the resolved options with the runner branch.)
+    if ((userOptions as { runner?: string }).runner === "edge") {
+      throw new Error(
+        `${tag} host entry build failed and runner 'edge' treats it as a ` +
+          `serving artifact: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
     const message = error instanceof Error ? error.message : String(error);
     logger.warn(`${tag} skipped — host entry build failed: ${message}`);
   } finally {

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -136,7 +136,8 @@ export function createEdgeRenderHook(
 
   return async function edgeRender(
     route: string,
-    request: Request
+    request: Request,
+    ...platform: unknown[]
   ): Promise<Response | null> {
     // `route` arrives as the raw pathname from createRequestHandler; normalize it
     // the same way the document handler's getURL does, so both agree on the key.
@@ -150,7 +151,10 @@ export function createEdgeRenderHook(
       // Client navigation: the Root-only payload, from the same producer (and so
       // the same live props) the document path inlines on first paint.
       try {
-        const { headless } = await bundle.renderRouteToDocument(url, { request });
+        const { headless } = await bundle.renderRouteToDocument(url, {
+          request,
+          platform,
+        });
         return new Response(headless as unknown as BodyInit, {
           headers: {
             "content-type": "text/x-component; charset=utf-8",
@@ -177,7 +181,7 @@ export function createEdgeRenderHook(
       }
     }
 
-    const response = await (await getDocumentHandler())(request);
+    const response = await (await getDocumentHandler())(request, ...platform);
     // An unbaked route is a fall-through for a hook, not an answer.
     return response === NOT_HANDLED ? null : response;
   };
@@ -237,7 +241,8 @@ export function createEdgeRequestHandler(
   const render = createEdgeRenderHook(bundle, options);
 
   return async function edgeRequestHandler(
-    request: Request
+    request: Request,
+    ...platform: unknown[]
   ): Promise<Response> {
     const { pathname } = new URL(request.url);
 
@@ -250,7 +255,7 @@ export function createEdgeRequestHandler(
     }
 
     if (request.method === "GET" || request.method === "HEAD") {
-      const response = await render(pathname, request);
+      const response = await render(pathname, request, ...platform);
       if (response) return response;
     }
 

--- a/plugin/edge/createEdgeRequestHandler.ts
+++ b/plugin/edge/createEdgeRequestHandler.ts
@@ -251,7 +251,7 @@ export function createEdgeRequestHandler(
       request.headers.get(actionHeader) &&
       bundle.handleRouteAction
     ) {
-      return bundle.handleRouteAction(request, { projectRoot });
+      return bundle.handleRouteAction(request, { projectRoot, platform });
     }
 
     if (request.method === "GET" || request.method === "HEAD") {

--- a/plugin/edge/createEdgeRequestHandler.types.ts
+++ b/plugin/edge/createEdgeRequestHandler.types.ts
@@ -37,7 +37,7 @@ export type EdgeBundleExports = {
    */
   handleRouteAction?: (
     request: Request,
-    opts?: { projectRoot?: string }
+    opts?: { projectRoot?: string; platform?: unknown[] }
   ) => Promise<Response>;
   /** `bootstrapModules`: the content-hashed browser entry, baked at build time. */
   bootstrapModules?: string[];

--- a/plugin/edge/createEdgeRequestHandler.types.ts
+++ b/plugin/edge/createEdgeRequestHandler.types.ts
@@ -24,6 +24,7 @@ export type EdgeBundleExports = {
     opts?: {
       request?: Request;
       cssFiles?: Map<string, CssContent>;
+      platform?: unknown[];
       globalCss?: unknown;
     }
   ) => Promise<{
@@ -111,5 +112,6 @@ export type CreateEdgeRequestHandlerOptions = Omit<
  */
 export type EdgeRenderHook = (
   route: string,
-  request: Request
+  request: Request,
+  ...platform: unknown[]
 ) => Promise<Response | null>;

--- a/plugin/environments/createEnvironmentPlugin.ts
+++ b/plugin/environments/createEnvironmentPlugin.ts
@@ -584,6 +584,16 @@ export const createEnvironmentPlugin: VitePluginFn = (options): Plugin => {
               logger,
               viteBase: config.base,
             });
+            // Step 8: the portable host entry over the pair + its manifest
+            // (host-spec "The API") — after the manifest, which it inlines.
+            const { buildHostEntry } = await import(
+              "../bundle/buildHostEntry.js"
+            );
+            await buildHostEntry({
+              userOptions,
+              projectRoot: userOptions.projectRoot,
+              logger,
+            });
           },
         },
       };

--- a/plugin/helpers/handleServerAction.server.ts
+++ b/plugin/helpers/handleServerAction.server.ts
@@ -232,7 +232,7 @@ export async function resolveAndExecuteServerAction(
   }
 
   const args = await decodeActionBody(body, codec);
-  return executeServerAction(action, args, verbose, logger);
+  return executeServerAction(action, args, verbose, logger, options.platform);
 }
 
 /**

--- a/plugin/helpers/handleServerActionHelper.ts
+++ b/plugin/helpers/handleServerActionHelper.ts
@@ -6,6 +6,8 @@ import type { ServerResponse } from "node:http";
 import type { IncomingMessage } from "node:http";
 
 export type ServerActionHandlerOptions = {
+  /** The fetch runtime's extra handler arguments — the bindings seam. */
+  platform?: unknown[];
   projectRoot: string;
   verbose?: boolean;
   logger?: Logger;
@@ -545,13 +547,19 @@ export async function executeServerAction(
   action: Function,
   args: unknown[],
   verbose = false,
-  logger?: Logger
+  logger?: Logger,
+  platform?: unknown[]
 ): Promise<unknown> {
   if (verbose) {
     logger?.info(`[handleServerActionHelper] Executing action with args: ${JSON.stringify(args)}`);
   }
 
-  const result = await action(...args);
+  // The bindings seam (host-spec Resolution 4): every action receives a
+  // trailing ctx argument carrying the runtime's extra handler arguments
+  // (workerd's env/ctx; empty on Node/dev). Additive — an action that
+  // ignores it keeps working; one that declares it reads ctx.platform.
+  // Concurrency-safe by construction: no request-scoped globals.
+  const result = await action(...args, { platform: platform ?? [] });
   
   if (verbose) {
     logger?.info(`[handleServerActionHelper] Action executed successfully: ${JSON.stringify(result)}`);

--- a/plugin/helpers/resolvePageAndProps.ts
+++ b/plugin/helpers/resolvePageAndProps.ts
@@ -74,7 +74,11 @@ export const resolvePageAndProps: ResolvePageAndPropsFn =
               )
             )?.params ?? {}
           : {});
-      const loaderCtx: LoaderCtx = { params, request: handlerOptions.request };
+      const loaderCtx: LoaderCtx = {
+        params,
+        request: handlerOptions.request,
+        ...(handlerOptions.platform ? { platform: handlerOptions.platform } : {}),
+      };
 
       const resolvePagePromise = resolvePage({
         id: handlerOptions.pagePath,
@@ -344,6 +348,7 @@ export type ResolvePageAndPropsFn = <T extends PagePropOpt = PagePropOpt>(
     | "stripHtmlSuffix"
     | "params"
     | "request"
+    | "platform"
   > & {
     moduleBaseURL?: string;
     route?: string;

--- a/plugin/helpers/resolveProps.ts
+++ b/plugin/helpers/resolveProps.ts
@@ -10,6 +10,9 @@ export type LoaderCtx = {
   params: Record<string, string>;
   /** In-flight request; present only on the dev request thread (see CreateHandlerOptions). */
   request?: Request;
+  /** The fetch runtime's extra handler arguments (workerd's env/ctx) — the
+   *  bindings seam, threaded by createHost. Empty on Node hosts. */
+  platform?: unknown[];
 };
 
 type ResolvePropsOptions = {

--- a/plugin/host/index.ts
+++ b/plugin/host/index.ts
@@ -128,6 +128,8 @@ export function createHost(
         return response;
       },
       action: (request: Request) => bundle.handleRouteAction(request),
+      // (Node hosts have an empty platform; the executor appends the ctx
+      // uniformly, so action code behaves identically across hosts.)
     };
   };
 

--- a/plugin/stream/createEdgeHandler.client.ts
+++ b/plugin/stream/createEdgeHandler.client.ts
@@ -110,7 +110,10 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
           headers: { "content-type": "text/plain; charset=utf-8" },
         });
 
-  return async function edgeHandler(request: Request): Promise<Response> {
+  return async function edgeHandler(
+    request: Request,
+    ...platform: unknown[]
+  ): Promise<Response> {
     const url = getURL(request);
 
     // Full flash-free document: render the Html-wrapped `full` flight to a
@@ -122,7 +125,7 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
       try {
         // Pass the request so a loader can gate an authenticated route on
         // cookies/headers (the baked producer forwards it to props).
-        flights = await renderDocument(url, { request });
+        flights = await renderDocument(url, { request, platform });
       } catch (error) {
         if (isUnknownRoute(error)) return notFound(url, request);
         // Loader control flow: a redirect() answers with the 3xx itself; a
@@ -175,7 +178,7 @@ export const createEdgeHandler: CreateEdgeHandlerFn = function createEdgeHandler
 
     let rscStream: ReadableStream<Uint8Array>;
     try {
-      rscStream = await render!(url, request);
+      rscStream = await render!(url, request, ...platform);
     } catch (error) {
       // The producer is a closed manifest over `build.pages`; an unknown url is
       // a 404, not a 500. Everything else is a real failure — surface it.

--- a/plugin/stream/createEdgeHandler.types.ts
+++ b/plugin/stream/createEdgeHandler.types.ts
@@ -5,7 +5,10 @@ import type { RenderFlightToHtmlFn } from "./renderFlightToHtml.types.js";
  * A Web `fetch` handler: the standard edge-runtime entrypoint shape
  * (Cloudflare Workers, Deno Deploy, Vercel Edge, Bun, Node via an adapter).
  */
-export type EdgeFetchHandler = (request: Request) => Promise<Response>;
+export type EdgeFetchHandler = (
+  request: Request,
+  ...platform: unknown[]
+) => Promise<Response>;
 
 /**
  * Options for {@link CreateEdgeHandlerFn}. Composes the baked per-route flight
@@ -34,7 +37,8 @@ export type CreateEdgeHandlerOptions = {
    */
   render?: (
     url: string,
-    request?: Request
+    request?: Request,
+    ...platform: unknown[]
   ) => Promise<ReadableStream<Uint8Array>>;
   /**
    * The baked full-document producer: the `renderRouteToDocument` export of the
@@ -46,7 +50,7 @@ export type CreateEdgeHandlerOptions = {
    */
   renderDocument?: (
     url: string,
-    opts?: { request?: Request }
+    opts?: { request?: Request; platform?: unknown[] }
   ) => Promise<EdgeDocumentFlights>;
   /**
    * Base URL the client transport uses to resolve client-reference modules —

--- a/plugin/types.ts
+++ b/plugin/types.ts
@@ -1144,6 +1144,9 @@ export type CreateHandlerOptions<
    * across the worker boundary).
    */
   request?: Request;
+  /** The fetch runtime's extra handler arguments (workerd env/ctx) —
+   *  threaded into the loader ctx by hosts. Empty on Node. */
+  platform?: unknown[];
   /**
    * Cloneable stand-in for {@link request} sent to the RSC worker: the absolute
    * url + method + headers (enough for a loader to read cookies/headers to gate

--- a/plugin/worker/rsc/messageHandler.server.tsx
+++ b/plugin/worker/rsc/messageHandler.server.tsx
@@ -1385,8 +1385,10 @@ final buildConfig: ${JSON.stringify(buildConfig)}`
             );
           }
 
-          // Execute the server action
-          const result = await action(...decodedArgs);
+          // Execute the server action. The trailing ctx matches the sealed
+          // gate's shape (bindings seam) — dev has no platform, so it is
+          // empty, and action code behaves identically across environments.
+          const result = await action(...decodedArgs, { platform: [] });
 
           // Render `{ returnValue }` through the transport's flight renderer
           // so non-JSON values survive, and hand the finished payload to the

--- a/test/examples/host-edge-entry.test.ts
+++ b/test/examples/host-edge-entry.test.ts
@@ -91,7 +91,9 @@ async function setupFixture() {
       `  mode: "production",\n` +
       `  esbuild: { jsx: "automatic" },\n` +
       `  plugins: vitePluginReactServer({\n` +
-      `    runner: "edge",\n` +
+      // runner "isolated" until the edge-runner branch merges — the pair,
+      // manifest, and host entry emit identically under webpack transport.
+      `    runner: "isolated",\n` +
       `    transport: "webpack",\n` +
       `    moduleBase: "src",\n` +
       `    Page: fr.Page,\n` +

--- a/test/examples/host-edge-entry.test.ts
+++ b/test/examples/host-edge-entry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { mkdir, readdir, rm, writeFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { resolve, join } from "node:path";
@@ -20,6 +20,37 @@ import {
 // plainly, never re-rendered.
 const isolatedLeg = getCondition() !== REACT_CONDITION.server;
 
+// The portability claim ("mountable in a filesystem-less runtime") is proven
+// by actually mounting host.js in workerd, not by importing it in Node.
+// miniflare is deliberately NOT a dependency — the dedicated CI job installs
+// it (`npm i --no-save miniflare@4`) and sets VPRS_REQUIRE_MINIFLARE=1 so
+// its absence there fails loudly instead of green-skipping.
+const MINIFLARE = "miniflare";
+let Miniflare:
+  | (new (options: unknown) => {
+      dispatchFetch: (url: string, init?: RequestInit) => Promise<Response>;
+      dispose: () => Promise<void>;
+    })
+  | undefined;
+try {
+  ({ Miniflare } = await import(/* @vite-ignore */ MINIFLARE));
+} catch (error) {
+  if (process.env.VPRS_REQUIRE_MINIFLARE === "1") throw error;
+}
+
+async function collectModules(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, {
+    withFileTypes: true,
+    recursive: true,
+  })) {
+    if (entry.isFile() && /\.m?js$/.test(entry.name)) {
+      out.push(join(entry.parentPath, entry.name));
+    }
+  }
+  return out.sort();
+}
+
 const testDir = resolve(__dirname, "../fixtures/host-edge-entry.test");
 
 async function setupFixture() {
@@ -28,8 +59,10 @@ async function setupFixture() {
   await writeFile(
     join(testDir, "src/action.ts"),
     `"use server";\n` +
-      `export async function greet(n: number): Promise<string> {\n` +
-      `  return "entry:" + n;\n` +
+      `type Ctx = { platform?: Array<Record<string, unknown>> };\n` +
+      `export async function greet(n: number, ctx?: Ctx): Promise<string> {\n` +
+      `  const bound = (ctx?.platform?.[0] as { GREETING?: string } | undefined)?.GREETING;\n` +
+      `  return "entry:" + n + ":" + String(bound ?? "none");\n` +
       `}\n`
   );
   await writeFile(
@@ -144,16 +177,61 @@ describe.skipIf(!isolatedLeg)("generated portable host entry", () => {
       true
     );
     const mod = (await import(pathToFileURL(entryPath).href)) as {
-      default: typeof handler;
+      default: { fetch: typeof handler };
+      handler: typeof handler;
     };
-    expect(typeof mod.default).toBe("function");
-    handler = mod.default;
+    // The default is the module-worker mount; the bare function is named.
+    expect(typeof mod.default).toBe("object");
+    expect(typeof mod.default.fetch).toBe("function");
+    expect(typeof mod.handler).toBe("function");
+    handler = mod.default.fetch;
   }, 240000);
 
   afterAll(async () => {
     if (!process.env["KEEP_FIXTURE"])
       await rm(testDir, { recursive: true, force: true });
   });
+
+  it.skipIf(!Miniflare)(
+    "mounts in workerd: document render and platform-bound action in-isolate",
+    async () => {
+      const edgeDir = join(testDir, "dist/server-edge");
+      const hostPath = join(edgeDir, "host.js");
+      const chunkPaths = (await collectModules(edgeDir)).filter(
+        (p) => p !== hostPath
+      );
+      // No nodejs_compat: the entry must run without node shims, like the
+      // pair it imports. Bindings become workerd's env — platform[0].
+      const mf = new Miniflare!({
+        compatibilityDate: "2026-07-01",
+        modulesRoot: edgeDir,
+        modules: [
+          { type: "ESModule", path: hostPath },
+          ...chunkPaths.map((path) => ({ type: "ESModule", path })),
+        ],
+        bindings: { GREETING: "workerd" },
+      });
+      try {
+        const doc = await mf.dispatchFetch("http://edge.test/hello/bindings/");
+        expect(doc.status).toBe(200);
+        expect(await doc.text()).toContain("hello:bindings:workerd");
+
+        const { encodeReply } = await import(
+          "react-server-dom-esm/client.edge"
+        );
+        const act = await mf.dispatchFetch("http://edge.test/", {
+          method: "POST",
+          headers: { "x-rsc-action": "src/action.ts#greet" },
+          body: (await encodeReply([7])) as string,
+        });
+        expect(act.status).toBe(200);
+        expect(await act.text()).toContain('"entry:7:workerd"');
+      } finally {
+        await mf.dispose();
+      }
+    },
+    120000
+  );
 
   it("renders a dynamic match with baked imports and inlined manifest", async () => {
     const res = await handler(new Request("http://edge.test/hello/world/"));
@@ -181,7 +259,7 @@ describe.skipIf(!isolatedLeg)("generated portable host entry", () => {
     expect(body).toContain("index.html");
   });
 
-  it("routes action POSTs through the baked gate", async () => {
+  it("routes action POSTs through the baked gate — and platform reaches the action", async () => {
     const { encodeReply } = await import("react-server-dom-esm/client.edge");
     const body = await encodeReply([3]);
     const res = await handler(
@@ -189,10 +267,22 @@ describe.skipIf(!isolatedLeg)("generated portable host entry", () => {
         method: "POST",
         headers: { "x-rsc-action": "src/action.ts#greet" },
         body: body as string,
-      })
+      }),
+      { GREETING: "bound" },
+      { waitUntil: () => {} }
     );
     expect(res.status).toBe(200);
-    expect(await res.text()).toContain('"entry:3"');
+    expect(await res.text()).toContain('"entry:3:bound"');
+
+    // Without runtime arguments the ctx is present but empty.
+    const bare = await handler(
+      new Request("http://edge.test/", {
+        method: "POST",
+        headers: { "x-rsc-action": "src/action.ts#greet" },
+        body: (await encodeReply([4])) as string,
+      })
+    );
+    expect(await bare.text()).toContain('"entry:4:none"');
   });
 
   it("a miss is the 404 fallback document", async () => {

--- a/test/examples/host-edge-entry.test.ts
+++ b/test/examples/host-edge-entry.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  getCondition,
+  REACT_CONDITION,
+} from "../../plugin/config/getCondition.js";
+
+// The generated portable host entry (host-spec, "The API"): the build emits
+// dist/server-edge/host.js — a module that statically imports its pair and
+// inlines its manifest, exporting the fetch-shaped handler. It is the form a
+// filesystem-less runtime mounts (`export default { fetch: handler }`), and
+// the seam of Resolution 4: extra runtime arguments (workerd's env/ctx)
+// thread as `platform` into loader context, so binding-backed data has a
+// contract instead of a globalThis stash. Statics are the platform's job in
+// this form — a prerendered URL that still reaches the handler is answered
+// plainly, never re-rendered.
+const isolatedLeg = getCondition() !== REACT_CONDITION.server;
+
+const testDir = resolve(__dirname, "../fixtures/host-edge-entry.test");
+
+async function setupFixture() {
+  await rm(testDir, { recursive: true, force: true });
+  await mkdir(join(testDir, "src/routes/hello/$name"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/action.ts"),
+    `"use server";\n` +
+      `export async function greet(n: number): Promise<string> {\n` +
+      `  return "entry:" + n;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/Counter.client.tsx"),
+    `"use client";\n` +
+      `import * as React from "react";\n` +
+      `import { greet } from "../action.js";\n` +
+      `export function Counter() {\n` +
+      `  void greet;\n` +
+      `  return <button>{"c"}</button>;\n` +
+      `}\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/page.tsx"),
+    `import * as React from "react";\n` +
+      `import { Counter } from "./Counter.client.js";\n` +
+      `export const Page = () => (\n` +
+      `  <main><h1>{"host-edge-entry-home"}</h1><Counter /></main>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/hello/$name/page.tsx"),
+    `import * as React from "react";\n` +
+      `export const Page = ({ name, greeting }: { name: string; greeting: string }) => (\n` +
+      `  <article>{"hello:" + name + ":" + greeting}</article>\n` +
+      `);\n`
+  );
+  await writeFile(
+    join(testDir, "src/routes/hello/$name/props.ts"),
+    `type Ctx = { platform?: Array<Record<string, unknown>> };\n` +
+      `export const props = (url: string, ctx?: Ctx) => ({\n` +
+      `  name: url.split("/").filter(Boolean).pop() ?? "",\n` +
+      `  greeting: String(\n` +
+      `    (ctx?.platform?.[0] as { GREETING?: string } | undefined)?.GREETING ??\n` +
+      `      "none",\n` +
+      `  ),\n` +
+      `});\n`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\n` +
+      `import { startClient } from "vite-plugin-react-server/router/client";\n` +
+      `startClient({ moduleBaseURL: "/" });\n`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div id="root"></div>` +
+      `<script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "build.mjs"),
+    `import { createBuilder } from "vite";\n` +
+      `import { vitePluginReactServer } from "vite-plugin-react-server";\n` +
+      `import { fileRouter } from "vite-plugin-react-server/router";\n` +
+      `const fr = fileRouter("src/routes", { root: process.cwd() });\n` +
+      `const builder = await createBuilder({\n` +
+      `  configFile: false,\n` +
+      `  root: process.cwd(),\n` +
+      `  mode: "production",\n` +
+      `  esbuild: { jsx: "automatic" },\n` +
+      `  plugins: vitePluginReactServer({\n` +
+      `    runner: "edge",\n` +
+      `    transport: "webpack",\n` +
+      `    moduleBase: "src",\n` +
+      `    Page: fr.Page,\n` +
+      `    props: fr.props,\n` +
+      `    routePatterns: fr.routePatterns,\n` +
+      `    build: { pages: fr.build.pages, outDir: "dist" },\n` +
+      `    moduleBasePath: "",\n` +
+      `    moduleBaseURL: "/",\n` +
+      `    projectRoot: process.cwd(),\n` +
+      `  }),\n` +
+      `});\n` +
+      `await builder.buildApp();\n` +
+      `console.log("HOST_EDGE_ENTRY_BUILD_OK");\n` +
+      `process.exit(0);\n`
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {
+    /* already linked */
+  }
+}
+
+describe.skipIf(!isolatedLeg)("generated portable host entry", () => {
+  let handler: (
+    request: Request,
+    ...platform: unknown[]
+  ) => Promise<Response>;
+
+  beforeAll(async () => {
+    await setupFixture();
+    const proc = spawnSync("node", ["build.mjs"], {
+      cwd: testDir,
+      encoding: "utf8",
+      timeout: 180000,
+      env: { ...process.env, NODE_ENV: "production", NODE_OPTIONS: "" },
+    });
+    expect(
+      proc.stdout,
+      `build failed (status ${proc.status}):\n${proc.stderr}`
+    ).toContain("HOST_EDGE_ENTRY_BUILD_OK");
+
+    const entryPath = join(testDir, "dist/server-edge/host.js");
+    expect(existsSync(entryPath), "dist/server-edge/host.js missing").toBe(
+      true
+    );
+    const mod = (await import(pathToFileURL(entryPath).href)) as {
+      default: typeof handler;
+    };
+    expect(typeof mod.default).toBe("function");
+    handler = mod.default;
+  }, 240000);
+
+  afterAll(async () => {
+    if (!process.env["KEEP_FIXTURE"])
+      await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("renders a dynamic match with baked imports and inlined manifest", async () => {
+    const res = await handler(new Request("http://edge.test/hello/world/"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("hello:world");
+  });
+
+  it("threads the runtime's extra arguments as platform into loader context", async () => {
+    const res = await handler(
+      new Request("http://edge.test/hello/bindings/"),
+      { GREETING: "from-env" },
+      { waitUntil: () => {} }
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("hello:bindings:from-env");
+  });
+
+  it("statics are the platform's job — a prerendered URL is answered plainly", async () => {
+    const res = await handler(new Request("http://edge.test/"));
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    // A plain naming answer for the misrouted artifact, never a re-render
+    // and never the app's 404 document.
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    expect(body).toContain("index.html");
+  });
+
+  it("routes action POSTs through the baked gate", async () => {
+    const { encodeReply } = await import("react-server-dom-esm/client.edge");
+    const body = await encodeReply([3]);
+    const res = await handler(
+      new Request("http://edge.test/", {
+        method: "POST",
+        headers: { "x-rsc-action": "src/action.ts#greet" },
+        body: body as string,
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('"entry:3"');
+  });
+
+  it("a miss is the 404 fallback document", async () => {
+    const res = await handler(new Request("http://edge.test/no/such/route/"));
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+});


### PR DESCRIPTION
Stacked on #414 (base: feat/host-core). The third host slice: the build generates the portable entry the host spec promises — dist/server-edge/host.js, a module that statically imports its render/consumer pair, inlines its manifest, and mounts directly in a filesystem-less runtime.

**The generated entry** (build Step 8, buildHostEntry.ts): writes a synthetic entry importing ./render.js and ./consumer.js as externals plus the web-standard host core, then bundles it webworker-target with the pair mapped back to relative imports. The default export is the module-worker mount (`export default { fetch: handler }`) — a workerd deploy points its main at host.js with no wrapper; runtimes that want the bare function import the named `handler`. Statics are the platform's job in this form: a prerendered URL that still reaches the handler is answered plainly.

**The bindings seam end-to-end**: the runtime's extra handler arguments (workerd's env/ctx) thread as `platform` into loader context AND into server actions — executeServerAction appends a trailing ctx argument (`{ platform }`) to every action call, additive and concurrency-safe (no request-scoped globals). The dev worker appends the same ctx with an empty platform, so action code behaves identically across environments.

**Fatal under runner "edge"**: a failed host entry build throws (the entry is part of that paradigm's artifact set); other paradigms warn and skip. The runner field is read defensively until the runner branch merges.

**Proven on the platform**: the suite mounts host.js in real workerd via miniflare — document render with an env binding visible in loader context (`hello:bindings:workerd`), and an action round-trip carrying platform (`entry:7:workerd`) — and the miniflare CI job runs this suite fail-closed (VPRS_REQUIRE_MINIFLARE=1). The Node-import leg additionally pins the export shape and the empty-platform behavior.

Fixture runs `runner: "isolated"` until the runner branch merges (the pair, manifest, and entry emit identically under webpack transport); flipping it to `"edge"` is a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
