### PR TITLE
chore: the pre-INIT portless fallbacks diagnose loudly

### DIFF
--- a/plugin/worker/rsc/handlers.ts
+++ b/plugin/worker/rsc/handlers.ts
@@ -12,14 +12,20 @@ import type { MessagePort } from "node:worker_threads";
 export function createHandlers(fromWorker?: MessagePort, toWorker?: MessagePort): ServerStreamHandlers {
   // Create writable stream for fromWorker if available
   const messagePortWritable = fromWorker ? new MessagePortWritable(fromWorker, toWorker) : null;
-  // In two-port mode control messages go back through toWorker; otherwise they
-  // go through the single-port sendMessage channel.
+  // Control messages ride toWorker. A portless call means a render-path
+  // message arrived before INIT stored the ports — a protocol violation
+  // that used to degrade into silent single-port posts on parentPort;
+  // diagnose it loudly instead. (The sendMessage calls below — HMR,
+  // shutdown, action responses — are deliberate parentPort traffic, not
+  // this fallback.)
   const post = (payload: Parameters<typeof sendMessage>[0]) => {
-    if (toWorker) {
-      toWorker.postMessage(payload);
-    } else {
-      sendMessage(payload);
+    if (!toWorker) {
+      throw new Error(
+        `[rsc-worker] ${String(payload.type)} posted before INIT delivered ` +
+          `the message ports — the two-port protocol requires INIT first.`
+      );
     }
+    toWorker.postMessage(payload);
   };
   return {
     onRscRender: (id) => {
@@ -44,17 +50,15 @@ export function createHandlers(fromWorker?: MessagePort, toWorker?: MessagePort)
       });
     },
     onData: (id, data) => {
-      // In two-port mode, data goes through the writable stream
-      // In single-port mode, use the old message approach
-      if (messagePortWritable) {
-        // Data is handled by piping to messagePortWritable
-        // This method is called but the actual data flow is through the stream
-      } else {
-        sendMessage({
-          type: "RSC_CHUNK",
-          id: id,
-          chunk: data,
-        });
+      // Data flows by piping into messagePortWritable; this callback is
+      // informational in the two-port protocol. Reaching it portless is the
+      // same pre-INIT violation post() diagnoses.
+      if (!messagePortWritable) {
+        void data;
+        throw new Error(
+          `[rsc-worker] RSC data for ${id} before INIT delivered the ` +
+            `message ports — the two-port protocol requires INIT first.`
+        );
       }
     },
     onDataError: (id, error) => {

--- a/plugin/worker/rsc/handlers.ts
+++ b/plugin/worker/rsc/handlers.ts
@@ -21,8 +21,12 @@ export function createHandlers(fromWorker?: MessagePort, toWorker?: MessagePort)
   const post = (payload: Parameters<typeof sendMessage>[0]) => {
     if (!toWorker) {
       throw new Error(
-        `[rsc-worker] ${String(payload.type)} posted before INIT delivered ` +
-          `the message ports — the two-port protocol requires INIT first.`
+        `[rsc-worker] the worker was asked to render before it finished ` +
+          `initializing, so it has no channel to send ${String(payload.type)} ` +
+          `back on. In normal plugin use this is a bug in ` +
+          `vite-plugin-react-server, please report it: ` +
+          `https://github.com/nicobrinkkemper/vite-plugin-react-server/issues ` +
+          `(when driving the worker directly, INIT must be the first message).`
       );
     }
     toWorker.postMessage(payload);
@@ -56,8 +60,12 @@ export function createHandlers(fromWorker?: MessagePort, toWorker?: MessagePort)
       if (!messagePortWritable) {
         void data;
         throw new Error(
-          `[rsc-worker] RSC data for ${id} before INIT delivered the ` +
-            `message ports — the two-port protocol requires INIT first.`
+          `[rsc-worker] the worker produced render output for "${id}" before ` +
+            `it finished initializing, so it has no channel to send it on. ` +
+            `In normal plugin use this is a bug in vite-plugin-react-server, ` +
+            `please report it: ` +
+            `https://github.com/nicobrinkkemper/vite-plugin-react-server/issues ` +
+            `(when driving the worker directly, INIT must be the first message).`
         );
       }
     },


### PR DESCRIPTION
The rsc worker's `createHandlers` kept single-port fallback branches — `post()` degrading to parentPort and `onData` re-sending chunks as messages — reachable only when a render-path message arrives before INIT stores the two ports. That protocol violation used to become silent single-port traffic; both branches now throw naming the violation. The deliberate parentPort traffic (HMR signals, shutdown, dev action responses) is untouched — that channel is by design, not a fallback.

Two premises from the original trace had already aged out on main and needed no change: the zero-importer `handlers` default export is already gone, and `onPostpone` is now a real typed optional handler rather than a dead reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
