### PR TITLE
fix: root-install edge bake stays free of node builtins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,29 @@ jobs:
       - name: Peer install on both tracks
         run: npm run test:peer-install
 
+  root-install-bake:
+    name: packed-consumer root-install edge bake
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # The layout the repo's own fixtures cannot take (they resolve the
+      # plugin by self-reference — always the hoisted path): the plugin
+      # installed at a consumer's root, a server page importing the package
+      # client barrel, edge bake on. Proves dist/server-edge stays free of
+      # statically-evaluated node builtins (bd y4l3's Cloudflare 10021 class).
+      - name: Root-install edge bake gate
+        run: npm run test:root-install-bake
+
   # The webpack bake pair on REAL workerd. The edge-bundle guard proves
   # "no node builtins" by static analysis; this job proves the runtime claims
   # by execution: one isolate, no nodejs_compat — boot, flight render,

--- a/package.json
+++ b/package.json
@@ -315,6 +315,7 @@
     "build:vite": "vite build",
     "test:package": "node scripts/verify-package-entrypoints.mjs",
     "test:peer-install": "./scripts/verify-peer-install.sh",
+    "test:root-install-bake": "./scripts/verify-root-install-bake.sh",
     "lint:package": "publint",
     "lint:no-bead-ids": "./scripts/check-no-bead-ids.sh",
     "verify:package": "npm run lint:package && npm run test:package && npm run lint:no-bead-ids",

--- a/plugin/bundle/buildConsumerBundle.ts
+++ b/plugin/bundle/buildConsumerBundle.ts
@@ -1,3 +1,4 @@
+import { sourceHasTopLevelClientDirective } from "react-server-loader/directives";
 import { build as viteBuild, type Logger } from "vite";
 import { createRequire } from "node:module";
 import { join } from "node:path";
@@ -111,6 +112,28 @@ export async function buildConsumerBundle(opts: {
   // a flight-referenceable module, and importing the entry eagerly executes
   // document access inside the bake — exclude the html-claimed graph roots.
   const htmlClaimed = new Set<string>();
+  // Only DIRECTIVE modules belong in the registry: flight payloads can
+  // reference exactly the modules that registered a client reference, i.e.
+  // sources carrying "use client" — first-party *.client.tsx and package
+  // modules alike (the root-install barrel case). Bundling every manifest
+  // chunk instead used to drag transport libraries in STATICALLY — the
+  // vendored CJS webpack flight client's interop preamble put
+  // `import { createRequire } from "node:module"` into consumer.js, which a
+  // fetch runtime's validator rejects at deploy while every Node-based
+  // check stays green. Fail closed: a key whose source can't be read is not
+  // a reference either — virtual chunks (rolldown's own runtime helper is a
+  // manifest entry, and its hosted copy carries that same preamble) have no
+  // source file, and a real reference always does.
+  const isReferenceSource = (key: string): boolean => {
+    try {
+      return sourceHasTopLevelClientDirective(
+        readFileSync(join(projectRoot, key), "utf8")
+      );
+    } catch {
+      return false;
+    }
+  };
+
   for (const [key, entry] of Object.entries(clientManifest)) {
     if (!key.endsWith(".html")) continue;
     htmlClaimed.add(key);
@@ -123,6 +146,7 @@ export async function buildConsumerBundle(opts: {
     if (htmlClaimed.has(key)) continue;
     const file = entry?.file;
     if (!file || !/\.[cm]?js$/.test(file)) continue;
+    if (!isReferenceSource(key)) continue;
     const abs = join(clientDir, file);
     if (!existsSync(abs)) continue;
 
@@ -290,11 +314,48 @@ export async function prerenderFlightToHtml(options) {
 `;
   writeFileSync(entryPath, entrySource, "utf8");
 
+  // Package client modules (the root-install barrel case) lazily reference
+  // their own transport runtime — rsl's webpack runtime and the vendored
+  // flight clients get HOSTED copies under dist/client. In the isolate those
+  // branches are dead: this bundle carries its own client.edge + globals, and
+  // registry modules are only ever rendered, never asked to decode flight.
+  // Bundling the hosted copies anyway dragged the node-flavored CJS client in
+  // and its interop preamble (`import { createRequire } from "node:module"`)
+  // failed fetch-runtime validators at deploy. Stub exactly those hosted
+  // copies — loudly, so a path that ever DOES reach one fails with a name,
+  // not a silent undefined. The entry's own rsl imports resolve from
+  // node_modules, not dist/client, and stay real.
+  // (rolldown resolves plain relative imports without consulting plugin
+  // resolveId, so the interception lives in `load`, keyed on the resolved
+  // absolute path.)
+  const isHostedTransportPath = (id: string): boolean =>
+    id.startsWith(clientDir) && /[\/]react-server-loader[\/]/.test(id);
+  const hostedTransportStub = {
+    name: "vprs:consumer-hosted-transport-stub",
+    load(id: string) {
+      if (!isHostedTransportPath(id)) return null;
+      return (
+        `const explain = () => { throw new Error(` +
+        `"[edge:consumer] a baked client module reached its hosted transport ` +
+        `runtime — dead in the isolate (the consumer carries its own ` +
+        `client.edge). This stub exists to keep node-flavored CJS out of ` +
+        `the bake."); };\n` +
+        `export default new Proxy(explain, { get: explain, apply: explain });\n` +
+        `export const createWebpackClient = explain;\n` +
+        `export const installWebpackGlobals = explain;\n` +
+        `export const createFromReadableStream = explain;\n` +
+        `export const createFromFetch = explain;\n` +
+        `export const encodeReply = explain;\n`
+      );
+    },
+  };
+
   try {
     await viteBuild({
       root: clientDir,
       logLevel: "warn",
       configFile: false,
+      plugins: [hostedTransportStub],
       // No react-server aliasing here — that is the producer's job. This graph
       // resolves React normally, which is what makes it the CLIENT half.
       define: { "process.env.NODE_ENV": JSON.stringify("production") },

--- a/scripts/edge-builtin-guard.mjs
+++ b/scripts/edge-builtin-guard.mjs
@@ -1,0 +1,43 @@
+// Shared assertion for edge-bake gates: dist/server-edge must carry no
+// statically-evaluated node builtin imports — a fetch runtime's validator
+// rejects them at deploy while every Node-based check stays green.
+// Usage: node scripts/edge-builtin-guard.mjs <path-to-dist/server-edge>
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { builtinModules } from "node:module";
+import { init, parse } from "es-module-lexer";
+
+const edgeDir = process.argv[2];
+if (!edgeDir) {
+  console.error("usage: node scripts/edge-builtin-guard.mjs <edge-dir>");
+  process.exit(2);
+}
+await init;
+const files = (await readdir(edgeDir, { recursive: true })).filter((f) =>
+  f.endsWith(".js")
+);
+if (files.length === 0) {
+  console.error(`✗ no .js bundles found in ${edgeDir}`);
+  process.exit(1);
+}
+const isBuiltin = (spec) =>
+  spec.startsWith("node:") || builtinModules.includes(spec);
+const offenders = [];
+for (const f of files) {
+  const code = await readFile(join(edgeDir, f), "utf8");
+  const [imports] = parse(code, f);
+  for (const imp of imports) {
+    if (!imp.n || !isBuiltin(imp.n)) continue;
+    if (imp.d > -1) continue; // dynamic import(): lazy, boot-safe
+    offenders.push(`${f}: ${imp.n}`);
+  }
+}
+if (offenders.length > 0) {
+  console.error(
+    "✗ statically-evaluated node builtins in the edge bake " +
+      "(a fetch runtime's validator rejects this at deploy):\n  " +
+      offenders.join("\n  ")
+  );
+  process.exit(1);
+}
+console.log("✓ dist/server-edge is free of static node builtin imports");

--- a/scripts/verify-root-install-bake.sh
+++ b/scripts/verify-root-install-bake.sh
@@ -22,7 +22,7 @@ react_stable="$(node -p "require('$root/package.json').peerDependencies.react.sp
 stable_rsl="$(node -p "require('$root/package.json').peerDependencies['react-server-loader'].split('||')[0].trim().replace(/^\^/, '')")"
 
 workdir="$(mktemp -d)"
-trap 'rm -rf "$workdir"' EXIT
+if [ "${KEEP:-}" != "1" ]; then trap 'rm -rf "$workdir"' EXIT; else echo "KEEP=1: $workdir"; fi
 
 echo "→ npm pack (the bytes a consumer installs)"
 (cd "$root" && npm pack --loglevel=error --pack-destination "$workdir" >/dev/null)
@@ -36,7 +36,7 @@ echo "→ root install: tarball + stable peers"
   npm pkg set type=module >/dev/null &&
   npm install --no-audit --no-fund --loglevel=error "$tarball" \
     "react@$react_stable" "react-dom@$react_stable" \
-    "react-server-loader@$stable_rsl" vite@^8)
+    "react-server-loader@$stable_rsl" vite@8.1.0)
 
 cat > "$dir/src/page/page.tsx" <<'EOF'
 import { Link } from "vite-plugin-react-server/router/client";

--- a/scripts/verify-root-install-bake.sh
+++ b/scripts/verify-root-install-bake.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Packed-consumer proof of the ROOT-INSTALL edge bake (bd y4l3): a server page
+# importing a PACKAGE module that carries "use client" (router/client's Link),
+# with the plugin installed at the project root — the one layout the repo's own
+# fixtures cannot take (their plugin resolves by self-reference, which is
+# always the hoisted path; the hoisted guard is edge-package-client-boundary).
+#
+# Under root install the main build hosts the client reference fine, but
+# buildEdgeBundle bakes the barrel statically: the vendored CJS webpack flight
+# client rides along and the bundler emits its CJS-interop preamble
+# (`import { createRequire } from "node:module"`) into dist/server-edge —
+# which a fetch runtime's validator rejects at deploy while every Node-based
+# check stays green. This gate makes that class fail HERE instead.
+#
+# NOTE: npm pack's prepack wipes dist and re-emits it with tsc; run
+# `npm run build` afterwards before any vitest gate.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+react_stable="$(node -p "require('$root/package.json').peerDependencies.react.split('||')[0].trim().replace(/^\^/, '')")"
+stable_rsl="$(node -p "require('$root/package.json').peerDependencies['react-server-loader'].split('||')[0].trim().replace(/^\^/, '')")"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+echo "→ npm pack (the bytes a consumer installs)"
+(cd "$root" && npm pack --loglevel=error --pack-destination "$workdir" >/dev/null)
+tarball="$(ls "$workdir"/vite-plugin-react-server-*.tgz)"
+
+dir="$workdir/consumer"
+mkdir -p "$dir/src/page"
+echo "→ root install: tarball + stable peers"
+(cd "$dir" &&
+  npm init -y >/dev/null &&
+  npm pkg set type=module >/dev/null &&
+  npm install --no-audit --no-fund --loglevel=error "$tarball" \
+    "react@$react_stable" "react-dom@$react_stable" \
+    "react-server-loader@$stable_rsl" vite@^8)
+
+cat > "$dir/src/page/page.tsx" <<'EOF'
+import { Link } from "vite-plugin-react-server/router/client";
+export const Page = ({ name }: { name: string }) => (
+  <div id="root">Hello {name} <Link to="/">home</Link></div>
+);
+EOF
+cat > "$dir/src/page/props.ts" <<'EOF'
+export const props = (_url: string) => ({ name: "root-install" });
+EOF
+cat > "$dir/src/client.tsx" <<'EOF'
+import { startClient } from "vite-plugin-react-server/router/client";
+startClient({ patterns: ["/"] });
+EOF
+cat > "$dir/index.html" <<'EOF'
+<!DOCTYPE html><html><head><meta charset="utf-8" /></head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>
+EOF
+cat > "$dir/vite.config.mjs" <<'EOF'
+import { defineConfig } from "vite";
+import { vitePluginReactServer } from "vite-plugin-react-server";
+
+export default defineConfig({
+  plugins: [
+    vitePluginReactServer({
+      runner: "isolated",
+      moduleBase: "src",
+      Page: "src/page/page.tsx",
+      props: "src/page/props.ts",
+      transport: "webpack",
+      build: { pages: ["/"], edge: true },
+    }),
+  ],
+});
+EOF
+
+echo "→ vite build --app (root-install consumer)"
+(cd "$dir" && npx vite build --app) 2>&1 | tail -20
+
+echo "→ guard: no statically-evaluated node builtins in dist/server-edge"
+(cd "$root" && node scripts/edge-builtin-guard.mjs "$dir/dist/server-edge")
+
+echo "✓ root-install edge bake is deploy-clean"

--- a/scripts/verify-root-install-bake.sh
+++ b/scripts/verify-root-install-bake.sh
@@ -78,4 +78,31 @@ echo "→ vite build --app (root-install consumer)"
 echo "→ guard: no statically-evaluated node builtins in dist/server-edge"
 (cd "$root" && node scripts/edge-builtin-guard.mjs "$dir/dist/server-edge")
 
+# Variant: ZERO client references (a server-only page). The registry filters
+# to nothing — the consumer must still emit with an empty registry (the
+# server-only-app contract), not skip, and stay builtin-free.
+dir2="$workdir/consumer-zero-refs"
+mkdir -p "$dir2/src/page"
+cp -r "$dir/node_modules" "$dir2/node_modules"
+cp "$dir/package.json" "$dir2/package.json"
+cp "$dir/index.html" "$dir2/index.html"
+cp "$dir/vite.config.mjs" "$dir2/vite.config.mjs"
+cp "$dir/src/client.tsx" "$dir2/src/client.tsx"
+cat > "$dir2/src/page/page.tsx" <<'EOF2'
+export const Page = ({ name }: { name: string }) => (
+  <div id="root">Hello {name}</div>
+);
+EOF2
+cat > "$dir2/src/page/props.ts" <<'EOF2'
+export const props = (_url: string) => ({ name: "zero-refs" });
+EOF2
+echo "→ vite build --app (zero client references)"
+(cd "$dir2" && npx vite build --app) 2>&1 | tail -4
+if [ ! -f "$dir2/dist/server-edge/consumer.js" ]; then
+  echo "✗ zero-reference build skipped the consumer bake — the empty registry must still emit" >&2
+  exit 1
+fi
+echo "→ guard: zero-reference bake"
+(cd "$root" && node scripts/edge-builtin-guard.mjs "$dir2/dist/server-edge")
+
 echo "✓ root-install edge bake is deploy-clean"


### PR DESCRIPTION
Fixes the silent deploy-killer found via the demo's Workers deploy: a server page importing a package module that carries \`"use client"\` (the router client barrel), with the plugin installed at the project root, built green everywhere — and Cloudflare's validator rejected the upload (code 10021, \`No such module node:module\`). The hoisted-install variant already fails loudly (#378); this is the root-install half, which no in-repo fixture could reproduce because fixtures resolve the plugin by self-reference.

**The gate first** (`scripts/verify-root-install-bake.sh`, new CI job `root-install-bake`): packs the tarball, installs it at a fresh consumer's root with stable peers, builds that failing shape, and runs a shared edge-builtin guard (`scripts/edge-builtin-guard.mjs`) over `dist/server-edge`. Red on main with exactly the deploy artifact (`consumer.js: node:module`); green with the fixes.

**Fix 1 — the consumer registry is filtered to directive modules, fail-closed.** Flight payloads can only reference modules that registered a client reference, i.e. sources carrying `"use client"`. The bake bundled every client-manifest chunk instead — including rolldown's own virtual runtime helper, a manifest entry with no source file whose hosted copy statically imports `node:module`. A key whose source can't be read is not a reference.

**Fix 2 — the hosted transport runtime is stubbed at bake time.** The barrel cluster lazily references its own transport plumbing (rsl's webpack runtime, the vendored flight clients); their hosted copies under `dist/client` carry node-flavored CJS interop. Those branches are dead in the isolate — the consumer bakes its own `client.edge` — so hosted copies resolve to a stub that throws with a name if anything ever reaches one. Implementation note: rolldown resolves plain relative imports without consulting plugin `resolveId`, so the interception lives in the `load` hook.

Regression proof: workerd-smoke (real workerd, no nodejs_compat), build-edge-bundle, and transport-webpack-stream-static all green (27 tests); full gate GATE_EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
