### PR TITLE
fix: the edge bake awaits async Page/props resolvers

### DIFF
--- a/plugin/bundle/buildEdgeBundle.ts
+++ b/plugin/bundle/buildEdgeBundle.ts
@@ -262,9 +262,15 @@ export async function buildEdgeBundle(opts: {
   // `{ key: { pagePath, propsPath, modules } }` line — shared by the enumerated
   // (exact-url) and dynamic (pattern) maps. Returns null when the built modules
   // can't be resolved.
-  const routeEntryLine = (key: string, resolveUrl: string): string | null => {
-    const pageSrc = routeSource(userOptions.Page, resolveUrl);
-    const propsSrc = routeSource(userOptions.props, resolveUrl);
+  const routeEntryLine = async (
+    key: string,
+    resolveUrl: string
+  ): Promise<string | null> => {
+    // UrlOpt resolvers may be async (Promise<string>) — the esm SSG path
+    // awaits them, and so must the bake, or every route of an async-resolver
+    // app is silently omitted and the pair never emits.
+    const pageSrc = await routeSource(userOptions.Page, resolveUrl);
+    const propsSrc = await routeSource(userOptions.props, resolveUrl);
     const pageAbs = resolveBuilt(pageSrc);
     // Props are optional by contract: a route may have a page.tsx with no
     // sibling props file (fileRouter returns undefined). Only a MISSING page
@@ -333,7 +339,7 @@ export async function buildEdgeBundle(opts: {
   // Enumerated routes → exact-url map (the flash-free prerendered set).
   const routeLines: string[] = [];
   for (const url of urls ?? []) {
-    const line = routeEntryLine(url, url);
+    const line = await routeEntryLine(url, url);
     if (line) routeLines.push(line);
     else
       logger.warn(
@@ -350,7 +356,10 @@ export async function buildEdgeBundle(opts: {
   // pass uses.
   const patternRouteLines: string[] = [];
   for (const pattern of userOptions.routePatterns ?? []) {
-    const line = routeEntryLine(pattern, patternProbeUrl(pattern, userOptions.routePatterns));
+    const line = await routeEntryLine(
+      pattern,
+      patternProbeUrl(pattern, userOptions.routePatterns)
+    );
     if (line) patternRouteLines.push(line);
     else
       logger.warn(

--- a/test/examples/edge-async-page.test.ts
+++ b/test/examples/edge-async-page.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import * as streamApi from "vite-plugin-react-server/stream";
+import { doBuild } from "../doBuild.js";
+
+// UrlOpt resolvers may be ASYNC (Promise<string>). The esm SSG path awaits
+// them; the edge bake must too — before the fix it saw a Promise where it
+// expected a string, omitted EVERY route ("could not resolve built
+// Page/props"), skipped the pair, and under transport webpack the freeze then
+// failed the whole build. Net: webpack transport (and the edge runner with
+// it) was incompatible with async resolvers.
+const renderFlightToHtml = (streamApi as any).renderFlightToHtml as
+  | typeof import("../../plugin/stream/renderFlightToHtml.client.js").renderFlightToHtml
+  | undefined;
+
+const testDir = resolve(__dirname, "../fixtures/edge-async-page.test");
+
+async function setupFixture() {
+  await mkdir(join(testDir, "src/page"), { recursive: true });
+  await writeFile(
+    join(testDir, "src/page/page.tsx"),
+    `export const Page = ({ name }: { name: string }) => <div id="root">Hello {name}</div>;`
+  );
+  await writeFile(
+    join(testDir, "src/page/props.ts"),
+    `export const props = (_url: string) => ({ name: "async-resolved" });`
+  );
+  await writeFile(
+    join(testDir, "index.html"),
+    `<!DOCTYPE html><html><head><meta charset="utf-8" /></head><body><div id="root"></div><script type="module" src="/src/client.tsx"></script></body></html>`
+  );
+  await writeFile(
+    join(testDir, "src/client.tsx"),
+    `"use client";\nexport const noop = true;`
+  );
+  await writeFile(
+    join(testDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        jsx: "react-jsx",
+        strict: true,
+      },
+      include: ["src"],
+    })
+  );
+  try {
+    await symlink(
+      resolve(__dirname, "../../node_modules"),
+      join(testDir, "node_modules"),
+      "dir"
+    );
+  } catch {}
+}
+
+describe.skipIf(!renderFlightToHtml)(
+  "edge bake with async Page/props resolvers",
+  () => {
+    beforeAll(async () => {
+      await rm(testDir, { recursive: true, force: true });
+      await setupFixture();
+      await doBuild({
+        projectRoot: testDir,
+        moduleBase: "src",
+        // ASYNC resolvers — the shape the bake used to drop on the floor.
+        Page: async (_url: string) => "src/page/page.tsx",
+        props: async (_url: string) => "src/page/props.ts",
+        transport: "webpack",
+        build: {
+          pages: ["/"],
+          outDir: "dist",
+          edge: true,
+        },
+      } as any);
+    }, 240000);
+
+    afterAll(async () => {
+      if (!process.env["KEEP_FIXTURE"])
+        await rm(testDir, { recursive: true, force: true });
+    });
+
+    it("emits the pair instead of omitting every route", () => {
+      expect(existsSync(join(testDir, "dist/server-edge/render.js"))).toBe(
+        true
+      );
+      expect(existsSync(join(testDir, "dist/server-edge/consumer.js"))).toBe(
+        true
+      );
+    });
+
+    it("renders the async-resolved route through the baked pair", async () => {
+      const { renderRouteToFlight } = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/render.js")).href
+      );
+      const { renderFlightToHtml: consume } = await import(
+        pathToFileURL(join(testDir, "dist/server-edge/consumer.js")).href
+      );
+      const html = await new Response(
+        await consume({ rscStream: await renderRouteToFlight("/") })
+      ).text();
+      expect(html).toContain("Hello ");
+      expect(html).toContain("async-resolved");
+    });
+  }
+);


### PR DESCRIPTION
UrlOpt resolvers may return `Promise<string>`, and the esm SSG path awaits them — but `buildEdgeBundle`'s route walk called them synchronously, saw a Promise where it expected a string, and omitted every route (`could not resolve built Page/props`). The producer baked empty, the pair was skipped, and under `transport: "webpack"` the freeze then failed the whole build: webpack transport (and the edge runner with it) was incompatible with async resolvers.

`routeEntryLine` now awaits the resolver in both the enumerated and dynamic-pattern walks. Pinned by a webpack-transport regression (`test/examples/edge-async-page.test.ts`) that builds with async resolvers and renders the route through the baked pair — verified red on the unfixed code (route omitted, suite errors in the freeze), 2/2 green with the fix. Full gate GATE_EXIT=0.

Once this and the host-manifest PR both land, the async-resolver variant there can flip from esm to webpack per its in-test note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
