### PR TITLE
fix(scripts): test-dev-both-modes runs on stock macOS bash 3.2

### DIFF
--- a/scripts/test-dev-both-modes.sh
+++ b/scripts/test-dev-both-modes.sh
@@ -35,24 +35,28 @@ run_mode() {
   TEST_MODE="$label" NODE_OPTIONS="$node_options" npx vitest run "${ARGS[@]}"
 }
 
-declare -A RESULTS
-
+# Plain scalars, not `declare -A`: stock macOS ships bash 3.2, which has no
+# associative arrays, and `#!/usr/bin/env bash` resolves to it on any Mac
+# without a Homebrew bash ahead on PATH.
 run_mode "dev:rsc" "--conditions react-server"
-RESULTS["dev:rsc"]=$?
+rsc_code=$?
 
 run_mode "dev:ssr" ""
-RESULTS["dev:ssr"]=$?
+ssr_code=$?
 
-echo ""
-echo "=== summary ==="
-overall=0
-for mode in "dev:rsc" "dev:ssr"; do
-  code=${RESULTS[$mode]}
+report() {
+  local mode="$1" code="$2"
   if [ "$code" -eq 0 ]; then
     printf "  %-10s OK\n" "$mode"
   else
     printf "  %-10s FAIL (exit %d)\n" "$mode" "$code"
     overall=1
   fi
-done
+}
+
+echo ""
+echo "=== summary ==="
+overall=0
+report "dev:rsc" "$rsc_code"
+report "dev:ssr" "$ssr_code"
 exit $overall


### PR DESCRIPTION
## Why

`scripts/test-dev-both-modes.sh` (`npm run test:dev:both`) used `declare -A` to hold two exit codes. Stock macOS ships bash 3.2, which has no associative arrays, so on any Mac without a Homebrew bash ahead of `/bin/bash` on PATH the script dies before running a single test:

```
scripts/test-dev-both-modes.sh: line 38: declare: -A: invalid option
```

CI is `ubuntu-latest` only, so this never surfaced there — it only bites contributors running the suite locally on a Mac.

## What changed

- Two plain scalars (`rsc_code`, `ssr_code`) replace the associative array.
- A small `report` helper prints the summary lines and flips `overall`.
- Comment explains the constraint so it doesn't get reintroduced.

## Verification

- `/bin/bash -n` (3.2) syntax-checks clean.
- `/bin/bash scripts/test-dev-both-modes.sh test/dev/dev-server-env.test.ts` and the same under Homebrew bash 5.3 print identical output, 6/6 in both modes.
- A non-existent test path makes both modes FAIL and the script exits 1, as before.
- Full `npm run test:dev:both` on macOS 15.7 / Intel: 15 files, 48 tests, both modes OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
