### PR TITLE
ci: macOS lane — stock bash 3.2, dev suite both conditions, client half

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,3 +221,42 @@ jobs:
         env:
           VPRS_REQUIRE_BROWSER: "1"
         run: ./scripts/test-both.sh test/examples/transport-webpack-stream-static.test.ts
+
+  # macOS is where contributors run this suite by hand, and it is where the
+  # platform quietly diverges from every Linux lane above: stock /bin/bash is
+  # 3.2 (no associative arrays — scripts/test-dev-both-modes.sh died on it for
+  # months, unnoticed, #419), `localhost` resolves to an IPv6-only Vite bind,
+  # and file watching is FSEvents rather than inotify. Deliberately narrow —
+  # build, the dev suite under BOTH conditions via the STOCK shell, and the
+  # client half — so it stays cheap (macOS minutes bill at 10x) while still
+  # covering the shell + watcher + resolver surfaces that actually differ.
+  # Playwright is left to the Linux lanes on purpose: the Chromium download is
+  # the flaky, expensive part and proves nothing macOS-specific.
+  test-macos:
+    name: macOS (stock bash 3.2, dev suite both conditions, client half)
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Invoked through /bin/bash explicitly, not `npm run test:dev:both`, so
+      # a bash-4-ism in the script fails HERE instead of on a contributor's
+      # laptop. Homebrew bash is not on the runner's PATH ahead of /bin/bash.
+      - name: Dev suite, both conditions, under stock /bin/bash 3.2
+        run: |
+          /bin/bash --version | head -1
+          /bin/bash scripts/test-dev-both-modes.sh
+
+      - name: Client suite
+        run: npx vitest run

--- a/scripts/test-dev-both-modes.sh
+++ b/scripts/test-dev-both-modes.sh
@@ -35,24 +35,28 @@ run_mode() {
   TEST_MODE="$label" NODE_OPTIONS="$node_options" npx vitest run "${ARGS[@]}"
 }
 
-declare -A RESULTS
-
+# Plain scalars, not `declare -A`: stock macOS ships bash 3.2, which has no
+# associative arrays, and `#!/usr/bin/env bash` resolves to it on any Mac
+# without a Homebrew bash ahead on PATH.
 run_mode "dev:rsc" "--conditions react-server"
-RESULTS["dev:rsc"]=$?
+rsc_code=$?
 
 run_mode "dev:ssr" ""
-RESULTS["dev:ssr"]=$?
+ssr_code=$?
 
-echo ""
-echo "=== summary ==="
-overall=0
-for mode in "dev:rsc" "dev:ssr"; do
-  code=${RESULTS[$mode]}
+report() {
+  local mode="$1" code="$2"
   if [ "$code" -eq 0 ]; then
     printf "  %-10s OK\n" "$mode"
   else
     printf "  %-10s FAIL (exit %d)\n" "$mode" "$code"
     overall=1
   fi
-done
+}
+
+echo ""
+echo "=== summary ==="
+overall=0
+report "dev:rsc" "$rsc_code"
+report "dev:ssr" "$ssr_code"
 exit $overall


### PR DESCRIPTION
## Why

Every CI lane runs on `ubuntu-latest`, so nothing macOS-specific has ever been exercised in CI — even though macOS is where contributors run the suite by hand. `scripts/test-dev-both-modes.sh` died on stock `/bin/bash` 3.2 for months without anyone noticing (#419); this lane would have caught it on the first push.

Where macOS actually diverges from the Linux lanes:
- stock `/bin/bash` is 3.2 (no `declare -A`, `mapfile`, `${var,,}`, `[[ -v ]]`);
- `localhost` resolves to an IPv6-only Vite bind (`127.0.0.1` fails, `localhost` works);
- file watching is FSEvents, not inotify.

## What the lane runs

Deliberately narrow — macOS minutes bill at 10× — so it covers the surfaces above and nothing that the Linux lanes already prove:

1. `npm ci` + `npm run build`
2. `/bin/bash scripts/test-dev-both-modes.sh` — the dev suite under **both** resolution conditions, invoked through the stock shell explicitly so a bash-4-ism fails here instead of on a laptop
3. `npx vitest run` — the client half

Playwright is left to the Linux lanes on purpose: the Chromium download is the expensive, flaky part and proves nothing macOS-specific. `timeout-minutes: 20`.

Stacks on #419 (without it, step 2 fails as designed — which is the point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
