### PR TITLE
fix(dev): HMR refetches for content the server tree imports outside src

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,11 +301,14 @@ vitePluginReactServer({
 
 Nothing to set up: `startClient` (the one-line client entry from
 [Routing](./routing.md#client-side-navigation)) wires RSC HMR along with
-hydration and the client router — a server-component edit refetches the
-current route's flight automatically. Assembling the client entry by hand
-instead? `useRscHmr` from `vite-plugin-react-server/utils` is the same hook
-`startClient` uses, and `setupRscHmr()` is the non-React form (call it once in
-your entry; it refetches the current page's flight on server-component edits).
+hydration and the client router — an edit to anything the server tree
+imports refetches the current route's flight automatically: server
+components, loaders, and the content they read (markdown through
+`import.meta.glob(..., { query: "?raw" })`, JSON data), wherever it lives in
+the project. Assembling the client entry by hand instead? `useRscHmr` from
+`vite-plugin-react-server/utils` is the same hook `startClient` uses, and
+`setupRscHmr()` is the non-React form (call it once in your entry; it
+refetches the current page's flight on those edits).
 
 ## Next Steps
 

--- a/plugin/dev-server/devPluginShared.ts
+++ b/plugin/dev-server/devPluginShared.ts
@@ -110,3 +110,27 @@ export const clientOwnedCssModules = <M,>(
       }
     )
   );
+
+type ServerGraphLookup = {
+  environments?: Record<
+    string,
+    { moduleGraph?: { getModulesByFile(file: string): Set<unknown> | undefined } } | undefined
+  >;
+};
+
+/**
+ * True when the server environment's module graph imports `file`. Content
+ * the server tree reads without a script extension, or from outside the
+ * module base (markdown through `?raw` globs, JSON data), never matches the
+ * path/extension heuristics in the hotUpdate hooks; the graph knows exactly
+ * what the last render pulled in. node_modules stay out so a dependency's
+ * own churn does not refetch every open page.
+ */
+export function isServerGraphFile(
+  server: ServerGraphLookup | undefined,
+  file: string,
+): boolean {
+  if (!server || file.includes("/node_modules/")) return false;
+  const mods = server.environments?.["server"]?.moduleGraph?.getModulesByFile(file);
+  return !!mods && mods.size > 0;
+}

--- a/plugin/dev-server/plugin.client.ts
+++ b/plugin/dev-server/plugin.client.ts
@@ -2,7 +2,7 @@ import type { VitePluginFn } from "../../types.js";
 import { configureReactServer } from "./configureReactServer.client.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
-import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags, clientOwnedCssModules } from "./devPluginShared.js";
+import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags, clientOwnedCssModules, isServerGraphFile } from "./devPluginShared.js";
 import { getDevShellHeadProvider } from "./devShellHeadProvider.js";
 import { mergeDevShellHead } from "./devShellHead.js";
 import type { ConfigEnv } from "vite";
@@ -117,6 +117,12 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
       // ModuleRunner cache drops every reachable CSS module before the
       // next render asks for class-name hashes.
       const isCssFile = isInModuleBase && CSS_EXT.test(file);
+      // Content the server tree imports from outside the module base or
+      // without a script extension (markdown via `?raw` globs, JSON data).
+      // The worker re-reads it on the next render either way; without this
+      // the browser is never told to ask for that render.
+      const isServerContentFile =
+        !isSourceFile && !isCssFile && isServerGraphFile(server, file);
 
       // Skip client components — Vite owns client-side HMR (Fast Refresh
       // when `@vitejs/plugin-react` is installed, plain reload otherwise).
@@ -161,7 +167,7 @@ export const vitePluginReactDevServer: VitePluginFn = function _vitePluginReactS
         return clientOwnedCss as never[];
       }
 
-      const isServerFile = isSourceFile && !isClientFile;
+      const isServerFile = (isSourceFile && !isClientFile) || isServerContentFile;
       const shouldInvalidateWorker = isServerFile || isCssFile;
 
       if (shouldInvalidateWorker && hmrHandler) {

--- a/plugin/dev-server/plugin.server.ts
+++ b/plugin/dev-server/plugin.server.ts
@@ -3,7 +3,7 @@ import { configureReactServer } from "./configureReactServer.server.js";
 import { resolveOptions } from "../config/resolveOptions.js";
 import { CSS_EXT } from "./collectRunnerCss.js";
 import type { Plugin, ViteDevServer } from "vite";
-import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags, clientOwnedCssModules } from "./devPluginShared.js";
+import { emptyAutoDiscoveredFiles, isClientModuleFile, devFlightTransportTags, clientOwnedCssModules, isServerGraphFile } from "./devPluginShared.js";
 import { getDevShellHeadProvider } from "./devShellHeadProvider.js";
 import { mergeDevShellHead } from "./devShellHead.js";
 
@@ -63,8 +63,10 @@ export const vitePluginReactDevServer = function _vitePluginReactServerDevServer
       const projectRoot = userOptions.projectRoot || server?.config?.root || '';
       const normalizedFile = file.replace(projectRoot, '').replace(/^\/+/, '');
       const isSourceFile = normalizedFile.startsWith(moduleBase + '/');
-      
-      if (!isSourceFile) return;
+
+      // Outside the module base only files the server graph actually imports
+      // count (markdown via `?raw` globs, JSON data); see isServerGraphFile.
+      if (!isSourceFile && !isServerGraphFile(server, file)) return;
       
       // Client environment: Vite owns client-side HMR (Fast Refresh if
       // `@vitejs/plugin-react` is installed; plain reload otherwise).

--- a/test/dev/hmr.test.ts
+++ b/test/dev/hmr.test.ts
@@ -182,4 +182,51 @@ export const Page = () => <div>Version 2 Content</div>;`
     // The RSC stream should reflect the new props somehow
     // (exact verification depends on how props are used in the stream)
   }, 15000);
+
+  it("should push a refetch when content outside src changes", async () => {
+    // Markdown the page reads through a `?raw` glob: outside the module base
+    // and without a script extension, so path/extension heuristics never see
+    // it as a server edit. The server module graph does.
+    await mkdir(join(testDir, "content"), { recursive: true });
+    await writeFile(join(testDir, "content/note.md"), "note: first draft");
+    await writeAndNotify(
+      "src/page/props.ts",
+      `const notes = import.meta.glob("../../content/*.md", { query: "?raw", import: "default", eager: true });
+export const props = () => ({ note: Object.values(notes)[0] });`
+    );
+    await writeAndNotify(
+      "src/page/page.tsx",
+      `import React from "react";
+export const Page = ({ note }) => <div>{note}</div>;`
+    );
+    const before = await fetchUntil(`http://localhost:${port}/`, "first draft");
+    expect(before).toContain("first draft");
+    // The dev:ssr hook dedupes hotUpdate calls with a short processing
+    // window after each edit; let the two setup writes above clear it so the
+    // content edit below is judged on its own.
+    await sleep(300);
+
+    const events: Array<{ type: string; event?: string; data?: any }> = [];
+    const originalSend = server.ws.send.bind(server.ws);
+    server.ws.send = function (payload: any) {
+      if (payload && typeof payload === "object") events.push(payload);
+      return originalSend(payload);
+    };
+    try {
+      await writeAndNotify("content/note.md", "note: second draft");
+
+      const after = await fetchUntil(`http://localhost:${port}/`, "second draft");
+      expect(after).toContain("second draft");
+
+      const pushed = events.filter(
+        (e) =>
+          e.type === "custom" &&
+          e.event === "vite-plugin-react-server:server-component-update" &&
+          e.data?.file === "content/note.md"
+      );
+      expect(pushed.length).toBeGreaterThan(0);
+    } finally {
+      server.ws.send = originalSend;
+    }
+  }, 20000);
 });


### PR DESCRIPTION
## Why

In dev, `hotUpdate` only treated a change as a server-tree edit when the file sat under `moduleBase` with a script or CSS extension. Markdown read through `import.meta.glob(..., { query: "?raw" })` and JSON data outside `src/` never matched: the RSC worker re-read the file on the next render, but the browser was never sent `server-component-update`, so the open page stayed stale until a manual reload.

## What

- `isServerGraphFile(server, file)` (`devPluginShared.ts`): the file counts as a server edit when the `server` environment's module graph imports it, `node_modules` excluded. Both dev modes consult it once the path/extension checks fail: dev:ssr in `plugin.client.ts`, dev:rsc in `plugin.server.ts`.
- `test/dev/hmr.test.ts`: a `content/note.md` glob'd from `src/page/props.ts` on a real dev server. The edited content must render **and** the update event must be pushed for that file. Passes under both conditions.
- `docs/getting-started.md` states the contract: any file the server tree imports refetches the current route's flight.

## Not included

A browser e2e in `test/e2e/hmr.spec.ts`. The demo's only non-script server data, `src/data/pokedex.json`, is also a `vite.react.config.ts` dependency, so editing it restarts the dev server rather than exercising this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
